### PR TITLE
[#428] Fixing ManyToMany association saving bug

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/persist/DefaultPersister.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/DefaultPersister.java
@@ -777,11 +777,10 @@ public final class DefaultPersister implements Persister {
 			if (saveMany.isCascade()) {
 				// Need explicit Cascade to save the beans on other side
 				saveAssocManyDetails(saveMany, false, saveMany.isUpdateNullProperties());
-				// for ManyToMany save the 'relationship' via inserts/deletes
-				// into/from the intersection table
-				saveAssocManyIntersection(saveMany, saveMany.isDeleteMissingChildren());
 			}
-
+			// for ManyToMany save the 'relationship' via inserts/deletes
+			// into/from the intersection table
+			saveAssocManyIntersection(saveMany, saveMany.isDeleteMissingChildren());
 		} else {
 			if (saveMany.isCascade()) {
 				saveAssocManyDetails(saveMany, saveMany.isDeleteMissingChildren(), saveMany.isUpdateNullProperties());


### PR DESCRIPTION
Fixes bug where ManyToMany associations are not saved, unless configured to cascade.  The target entities shouldn't be saved unless cascade is set, but the association itself should be saved regardless.
