### PR TITLE
Ensured that setting a null id on Query throws an NPE

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1140,6 +1140,9 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
 	}
 
 	public DefaultOrmQuery<T> setId(Object id) {
+		if (id == null) {
+			throw new NullPointerException("The id is null");
+		}
 		this.id = id;
 		return this;
 	}


### PR DESCRIPTION
The following equivalent two lines of code exhibit different behaviour:

``` java
Ebean.find(Foo.class, null);
Ebean.find(Foo.class).where().idEq(null).findUnique();
```

In the first line, an NPE is thrown (as expected, you can't have a null id), in the second line, no NPE is thrown, rather, all rows of the table will be returned when the query is executed so if there was one row in the table, it will be returned even if it doesn't have a null id, and if there are multiple rows in the table, an exception will be thrown.  The idEq call has no effect when its value is null.

This pull request makes the two lines of code above exhibit the same behaviour.
