### PR TITLE
Setting entity concurrency mode via annotation

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/AnnotationClass.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/parse/AnnotationClass.java
@@ -147,6 +147,11 @@ public class AnnotationClass extends AnnotationParser {
 		if (cacheStrategy != null){
 			readCacheStrategy(cacheStrategy);
 		}
+		
+		EntityConcurrencyMode entityConcurrencyMode = cls.getAnnotation(EntityConcurrencyMode.class);
+        if (entityConcurrencyMode!=null) {
+            descriptor.setConcurrencyMode(entityConcurrencyMode.value());
+        }
 	}
 
 	private void readCacheStrategy(CacheStrategy cacheStrategy){


### PR DESCRIPTION
By default, all enities have ALL concurrency mode, without any API to change it to NONE, for example. Annotation @EntityConcurrencyMode makes it possible to define concurrency mode required.
