### PR TITLE
Query self-referenced table returning reference object in the result

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/query/SqlTreeNodeBean.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/query/SqlTreeNodeBean.java
@@ -55,7 +55,7 @@ public class SqlTreeNodeBean implements SqlTreeNode {
 	/**
 	 * The hash of the partialProps (calculate once).
 	 */
-	final int partialHash;
+	int partialHash;
 	
 	final BeanProperty[] properties;
 	
@@ -79,7 +79,7 @@ public class SqlTreeNodeBean implements SqlTreeNode {
 	
 	final String prefix;
 	
-	final Set<String> includedProps;
+	Set<String> includedProps;
 
 	final Map<String,String> pathMap;
 	
@@ -200,12 +200,15 @@ public class SqlTreeNodeBean implements SqlTreeNode {
             }
             
             // when both localBean and contextBean are partial objects
-            if(cb._ebean_getIntercept().getLoadedProps().containsAll(includedProps)) {
+            if(cb._ebean_getIntercept().getLoadedProps().containsAll(partialProps)) {
                 // don't reload if contextBean has all the properties which are included for localBean
                 return false;
             } else {
                 // otherwise reload, need to add the loadedProps of context bean to the incluededProps of localBean
-                includedProps.addAll(cb._ebean_getIntercept().getLoadedProps());
+                partialProps.addAll(cb._ebean_getIntercept().getLoadedProps());
+                // recalculate partialHash and includedProps
+                partialHash = partialProps.hashCode();
+                includedProps = LoadedPropertiesCache.get(partialHash, partialProps, desc);
                 return true;
             }
         }


### PR DESCRIPTION
_I figured out that this issue belongs to this module rather than where I originally posted - https://github.com/rbygrave/avaje-ebeanorm/issues/1 - so I closed that one and created this one here._

_Created from google group https://groups.google.com/d/topic/ebean/55L7_s_yFJo/discussion_

I come in to the a problem when trying to query against a self-referenced table recently. _There is a similar post here https://groups.google.com/d/topic/play-framework/Bi0x40OvHPM/discussion in play-framework group._

**Problem Description**
Query against a table containing self-referenced FK returns a list containing some reference object, thus any further usage of that reference object will invoke another query (lazy load) against the database. If I use Ebean.createJsonContext().toJsonString to conver the result to JSON, the reference object will only be something like {"id": 1}.

I created a sample project on github https://github.com/peter-fu/ebean-self-ref-sample demonstrating the issue.

Best Regards,
Peter
