### PR TITLE
Invalid SQL when firstRow set but not maxRows

### DIFF
--- a/src/main/java/com/avaje/ebean/config/dbplatform/LimitOffsetSqlLimiter.java
+++ b/src/main/java/com/avaje/ebean/config/dbplatform/LimitOffsetSqlLimiter.java
@@ -31,13 +31,12 @@ public class LimitOffsetSqlLimiter implements SqlLimiter {
       maxRows = maxRows + 1;
     }
 
-    sb.append(" ").append(NEW_LINE).append(LIMIT).append(" ");
-    if (maxRows > 0) {
-      sb.append(maxRows);
-    }
-    if (firstRow > 0) {
-      sb.append(" ").append(OFFSET).append(" ");
-      sb.append(firstRow);
+    if (maxRows > 0 || firstRow > 0) {
+      sb.append(" ").append(NEW_LINE).append(LIMIT).append(" ").append(maxRows);
+      if (firstRow > 0) {
+        sb.append(" ").append(OFFSET).append(" ");
+        sb.append(firstRow);
+      }
     }
 
     String sql = request.getDbPlatform().completeSql(sb.toString(), request.getOrmQuery());

--- a/src/test/java/com/avaje/tests/basic/TestLimitQuery.java
+++ b/src/test/java/com/avaje/tests/basic/TestLimitQuery.java
@@ -16,17 +16,94 @@ import com.avaje.tests.model.basic.ResetBasicData;
 
 public class TestLimitQuery extends BaseTestCase {
 
-  @Test
+	@Test
 	public void testNothing() {
 		
 	}
 
-  @Test
+	@Test
 	public void testLimitWithMany() {
 		rob();
 		rob();
 	}
-  
+
+	@Test
+	public void testMaxRowsZeroWithFirstRow() {
+		ResetBasicData.reset();
+
+		SpiEbeanServer server = (SpiEbeanServer)Ebean.getServer(null);
+		boolean h2Db = "h2".equals(server.getDatabasePlatform().getName());
+
+		Query<Order> query = Ebean.find(Order.class)
+			.setAutofetch(false)
+			.fetch("details")
+			.where().gt("details.id", 0)
+			.setMaxRows(0)
+			.setFirstRow(3);
+
+		List<Order> list = query.findList();
+
+		String sql = query.getGeneratedSql();
+		boolean hasLimit = sql.indexOf("limit 0") > -1;
+		boolean hasOffset = sql.indexOf("offset 3") > -1;
+
+		if (h2Db) {
+			Assert.assertTrue(hasLimit);
+			Assert.assertTrue(hasOffset);
+		}
+	}
+
+	@Test
+	public void testMaxRowsWithFirstRowZero() {
+		ResetBasicData.reset();
+
+		SpiEbeanServer server = (SpiEbeanServer)Ebean.getServer(null);
+		boolean h2Db = "h2".equals(server.getDatabasePlatform().getName());
+
+		Query<Order> query = Ebean.find(Order.class)
+			.setAutofetch(false)
+			.fetch("details")
+			.where().gt("details.id", 0)
+			.setMaxRows(3)
+			.setFirstRow(0);
+
+		List<Order> list = query.findList();
+
+		String sql = query.getGeneratedSql();
+		boolean hasLimit = sql.indexOf("limit 4") > -1;
+		boolean hasOffset = sql.indexOf("offset") > -1;
+
+		if (h2Db) {
+			Assert.assertTrue(hasLimit);
+			Assert.assertFalse(hasOffset);
+		}
+	}
+
+	@Test
+	public void testDefaults() {
+		ResetBasicData.reset();
+
+		SpiEbeanServer server = (SpiEbeanServer)Ebean.getServer(null);
+		boolean h2Db = "h2".equals(server.getDatabasePlatform().getName());
+
+		Query<Order> query = Ebean.find(Order.class)
+			.setAutofetch(false)
+			.fetch("details")
+			.where().gt("details.id", 0)
+			.query();
+
+		List<Order> list = query.findList();
+
+		String sql = query.getGeneratedSql();
+		boolean hasLimit = sql.indexOf("limit") > -1;
+		boolean hasOffset = sql.indexOf("offset") > -1;
+
+		if (h2Db) {
+			Assert.assertFalse(hasLimit);
+			Assert.assertFalse(hasOffset);
+		}
+	}
+
 	private void rob() {
 		ResetBasicData.reset();
 		
@@ -43,7 +120,7 @@ public class TestLimitQuery extends BaseTestCase {
 		List<Order> list = query.findList();
 		
 		Assert.assertTrue("sz > 0", list.size() > 0);
-	
+
 		String sql = query.getGeneratedSql();
 		boolean hasDetailsJoin = sql.indexOf("join o_order_detail") > -1;
 		boolean hasLimit = sql.indexOf("limit 11") > -1;
@@ -69,7 +146,7 @@ public class TestLimitQuery extends BaseTestCase {
 		hasLimit = sql.indexOf("limit 11") > -1;
 		hasSelectedDetails = sql.indexOf("od.id") > -1;
 		hasDistinct = sql.indexOf("select distinct") > -1;
-	
+
 		Assert.assertFalse("no join with maxRows",hasDetailsJoin);
 		Assert.assertFalse(hasSelectedDetails);
 		Assert.assertFalse(hasDistinct);


### PR DESCRIPTION
Having a query with e.g. `maxRows` set to 0 and `firstRow` set to 3 will generate SQL like

```
select t0.foo c0 from sometable t0 where (t0.foo = ? )   
limit  offset 3
```

Resulting in SQL throwing `Undeclared variable: offset`

Now the notion of a query with `limit 0` is rather absurd as it will actually affect zero rows no matter what, but running query with invalid SQL is a bit unforgiving.

So either run it with `limit 0` if offset is set? Or just skip the limit/offset clause altogether?
