### PR TITLE
Add support for bang paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 

--- a/src/main/java/com/avaje/ebeaninternal/server/core/XmlConfigLoader.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/XmlConfigLoader.java
@@ -1,176 +1,71 @@
 package com.avaje.ebeaninternal.server.core;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.jar.JarFile;
-import java.util.zip.ZipEntry;
-
-import com.avaje.ebean.config.GlobalProperties;
-import com.avaje.ebeaninternal.api.ClassUtil;
 import com.avaje.ebeaninternal.server.lib.util.Dnode;
 import com.avaje.ebeaninternal.server.lib.util.DnodeReader;
-import com.avaje.ebeaninternal.server.util.ClassPathReader;
-import com.avaje.ebeaninternal.server.util.DefaultClassPathReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
 /**
  * Used to read the orm.xml and ebean-orm.xml configuration files.
- * 
+ *
  * @author rbygrave
+ * @author Richard Vowles - http://plus.google.com/RichardVowles
  */
 public class XmlConfigLoader {
 
-    private static final Logger logger = LoggerFactory.getLogger(XmlConfigLoader.class);
-    
-    private final ClassPathReader classPathReader;
+	private static final Logger logger = LoggerFactory.getLogger(XmlConfigLoader.class);
 
-    private final Object[] classPaths;
-  
-    
-    public XmlConfigLoader(ClassLoader classLoader){
-        
-        if (classLoader == null) {
-            classLoader = getClass().getClassLoader();
-        }
-        
-        String cn = GlobalProperties.get("ebean.classpathreader", null);
-        if (cn != null){
-            // use a user defined classPathReader
-            logger.info("Using ["+cn+"] to read the searchable class path");
-            this.classPathReader = (ClassPathReader)ClassUtil.newInstance(cn, this.getClass());
-        } else {
-            this.classPathReader = new DefaultClassPathReader();
-        }
-        
-        this.classPaths = classPathReader.readPath(classLoader);
-    }
-    
-    public XmlConfig load() {
-        List<Dnode> ormXml = search("META-INF/orm.xml");
-        List<Dnode> ebeanOrmXml = search("META-INF/ebean-orm.xml");
-        
-        return new XmlConfig(ormXml, ebeanOrmXml);
-    }
-    
-    public List<Dnode> search(String searchFor) {
-        
-        ArrayList<Dnode> xmlList = new ArrayList<Dnode>();
+	private final ClassLoader classLoader;
 
-        String charsetName = Charset.defaultCharset().name();
+	public XmlConfigLoader(ClassLoader classLoader) {
 
-        for (int h = 0; h < classPaths.length; h++) {
+		if (classLoader == null) {
+			classLoader = getClass().getClassLoader();
+		}
 
-            try {
-                // for each class path ...
-                File classPath;
-                if (URL.class.isInstance(classPaths[h])) {
-                    classPath = new File(((URL) classPaths[h]).getFile());
-                } else {
-                    classPath = new File(classPaths[h].toString());
-                }
+		this.classLoader = classLoader;
+	}
 
-                // URL Decode the path replacing %20 to space characters.
-                String path = URLDecoder.decode(classPath.getAbsolutePath(), charsetName);
+	public XmlConfig load() {
+		List<Dnode> ormXml = search("META-INF/orm.xml");
+		List<Dnode> ebeanOrmXml = search("META-INF/ebean-orm.xml");
 
-                classPath = new File(path);
+		return new XmlConfig(ormXml, ebeanOrmXml);
+	}
 
-                if (classPath.isDirectory()) {
-                    checkDir(searchFor, xmlList, classPath);
+	public List<Dnode> search(String resourceName) {
+		ArrayList<Dnode> xmlList = new ArrayList<Dnode>();
 
-                } else if (classPath.getName().endsWith(".jar") || classPath.getName().endsWith(".war") || classPath.getName().endsWith(".war!/WEB-INF/classes")) {
-                    checkJar(searchFor, xmlList, classPath);
-                  
-                } else {
-                    // this is not expected
-                    String msg = "Not a Jar or Directory? " + classPath.getAbsolutePath();
-                    logger.error(msg);
-                }
+		try {
+			Enumeration<URL> resources = classLoader.getResources(resourceName);
 
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
+			while (resources.hasMoreElements()) {
+				URL url = resources.nextElement();
 
-        return xmlList;
-        
-    }
+				InputStream is = url.openStream();
+				processInputStream(xmlList, is);
+				is.close();
+			}
+		} catch (IOException e) {
+			logger.error("Unable to find resources {}", resourceName);
+		}
 
-    private void processInputStream(ArrayList<Dnode> xmlList, InputStream is) throws IOException {
-      
-        DnodeReader reader = new DnodeReader();
-        Dnode xmlDoc = reader.parseXml(is);
-        is.close();
-        
-        xmlList.add(xmlDoc);
-    }
-    
-    private void checkFile(String searchFor, ArrayList<Dnode> xmlList, File dir) throws IOException {
+		return xmlList;
+	}
 
-        File f = new File(dir, searchFor);
-        if (f.exists()){
-            FileInputStream fis = new FileInputStream(f);
-            BufferedInputStream is = new BufferedInputStream(fis);
-            processInputStream(xmlList, is);
-        }
-    }
-    
-    private void checkDir(String searchFor, ArrayList<Dnode> xmlList, File dir) throws IOException {
+	private void processInputStream(ArrayList<Dnode> xmlList, InputStream is) throws IOException {
 
-        checkFile(searchFor, xmlList, dir);
-        
-        if (dir.getPath().endsWith("classes")) {
-            // see if this is part of webapp and look for META-INF/searchFor
-            // relative to the WEB-INF/classes directory
-            File parent = dir.getParentFile();
-            if (parent != null && parent.getPath().endsWith("WEB-INF")){
-                parent = parent.getParentFile();
-                if (parent != null){
-                    File metaInf = new File(parent, "META-INF");
-                    if (metaInf.exists()){
-                        checkFile(searchFor, xmlList, metaInf);
-                    }
-                }
-            }
-        }
-    }
-    
-    private void checkJar(String searchFor, ArrayList<Dnode> xmlList, File classPath) throws IOException {
-        
-        String fileName = classPath.getName();
-        if (fileName.toLowerCase().startsWith("surefire")){
-            return;
-        }
-        if (classPath.getAbsolutePath().endsWith(".war!/WEB-INF/classes")) {
-           classPath = new File(classPath.getAbsolutePath().substring(0, classPath.getAbsolutePath().lastIndexOf('!')));
-        }
-        JarFile module = null;
-        try {
-            module = new JarFile(classPath);
-            ZipEntry entry = module.getEntry(searchFor);
-            if (entry != null){
-                InputStream is = module.getInputStream(entry); 
-                processInputStream(xmlList, is);
-            }
-        } catch (Exception e) {
-            logger.info("Unable to check jar file "+fileName+" for ebean-orm.xml");
-        } finally {
-            if (module != null){
-                module.close();
-            }
-        }
-    }
+		DnodeReader reader = new DnodeReader();
+		Dnode xmlDoc = reader.parseXml(is);
+		is.close();
 
-    
+		xmlList.add(xmlDoc);
+	}
 }

--- a/src/main/java/com/avaje/ebeaninternal/server/util/ClassPathSearchFilter.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/util/ClassPathSearchFilter.java
@@ -181,7 +181,7 @@ public class ClassPathSearchFilter {
 		Iterator<String> incIt = set.iterator();
 		while (incIt.hasNext()) {
 			String val = incIt.next();
-			if (match.startsWith(val)) {
+			if (match.contains(val)) {
 				return true;
 			}
 		}

--- a/src/test/java/com/avaje/ebeaninternal/server/util/ClassPathSearchTests.java
+++ b/src/test/java/com/avaje/ebeaninternal/server/util/ClassPathSearchTests.java
@@ -1,0 +1,114 @@
+package com.avaje.ebeaninternal.server.util;
+
+import junit.framework.Assert;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+/**
+ * This ensures that the ClassPathSearch supports normal file:file.jar files as well as jar/war files
+ * with bang paths. Bang paths typically look like this as a url:
+ *
+ * jar:file:/path/to/file.war!/WEB-INF/classes
+ *
+ * author: Richard Vowles - http://plus.google.com/RichardVowles
+ */
+public class ClassPathSearchTests {
+
+	private static final String WEB_INF_CLASSES = "WEB-INF/classes/";
+
+	private void runAsserts(List<Class<?>> found, URLClassLoader cl, ClassPathSearch search,
+	                        URL jar, URL jarBang) throws ClassNotFoundException {
+
+		assert found.size() == 2;
+		assert found.contains(cl.loadClass(SimpleJarBangClass.class.getName()));
+		assert found.contains(cl.loadClass(SimpleJarClass.class.getName()));
+
+		assert search.getJarHits().contains(new File(jar.getFile()).getName());
+		assert search.getJarHits().contains(new File(jarBang.getFile().split("!")[0]).getName());
+	}
+
+	@Test
+	public void ensureClassPathFindsClassesInBangPaths() throws IOException, ClassNotFoundException {
+		URL jar = setupJar();
+		URL jarBang = setupJarBang();
+
+		URLClassLoader cl = new URLClassLoader(new URL[] { jar, jarBang});
+
+		ClassPathSearchFilter filter = new ClassPathSearchFilter();
+		filter.includePackage("com.avaje.ebeaninternal.server");
+		filter.includeJar("WEB-INF");
+
+		ClassPathSearch search = new ClassPathSearch(cl, filter, new ClassPathSearchMatcher() {
+			@Override
+			public boolean isMatch(Class<?> cls) {
+				return true;
+			}
+		});
+
+		List<Class<?>> found = search.findClasses();
+
+		Assert.assertEquals(1, found.size());
+		assert found.contains(cl.loadClass(SimpleJarBangClass.class.getName()));
+
+		assert search.getJarHits().contains(new File(jarBang.getFile().split("!")[0]).getName());
+
+		filter = new ClassPathSearchFilter();
+		filter.includePackage("com.avaje.ebeaninternal.server");
+		filter.includeJar("bang");
+
+		search = new ClassPathSearch(cl, filter, new ClassPathSearchMatcher() {
+			@Override
+			public boolean isMatch(Class<?> cls) {
+				return true;
+			}
+		});
+
+		runAsserts(search.findClasses(), cl, search, jar, jarBang);
+	}
+
+	private URL createJar(Class clazz, File jarFile, String offset) throws IOException {
+		FileOutputStream stream = new FileOutputStream(jarFile);
+		JarOutputStream jarOutputStream = new JarOutputStream(stream);
+		String clazzPath = clazz.getPackage().getName().replace(".", "/") + "/" + clazz.getSimpleName() + ".class";
+		JarEntry entry = new JarEntry(offset + clazzPath);
+		jarOutputStream.putNextEntry(entry);
+		InputStream classStream = getClass().getResourceAsStream("/" + clazzPath);
+		IOUtils.copy(classStream, jarOutputStream);
+
+		if (offset != null) { // copy the same file in, with a different offset
+			entry = new JarEntry("random/" + clazzPath);
+			jarOutputStream.putNextEntry(entry);
+			classStream = getClass().getResourceAsStream("/" + clazzPath);
+			IOUtils.copy(classStream, jarOutputStream);
+		}
+
+		jarOutputStream.close();
+		stream.close();
+
+		if (offset.length() > 0) {
+			return new URL("jar:" + jarFile.toURI().toString() + "!/" + offset);
+		} else {
+			return jarFile.toURI().toURL();
+		}
+	}
+
+	private URL setupJarBang() throws IOException {
+		File jarFile = File.createTempFile("bang", ".war");
+		return createJar(SimpleJarBangClass.class, jarFile, WEB_INF_CLASSES);
+	}
+
+	private URL setupJar() throws IOException {
+		File jarFile = File.createTempFile("nobang", ".jar");
+		return createJar(SimpleJarClass.class, jarFile, "");
+	}
+}

--- a/src/test/java/com/avaje/ebeaninternal/server/util/SimpleJarBangClass.java
+++ b/src/test/java/com/avaje/ebeaninternal/server/util/SimpleJarBangClass.java
@@ -1,0 +1,9 @@
+package com.avaje.ebeaninternal.server.util;
+
+/**
+ * Exists only for including in the jar for the Class Path Search Tests.
+ *
+ * author: Richard Vowles - http://plus.google.com/RichardVowles
+ */
+public class SimpleJarBangClass {
+}

--- a/src/test/java/com/avaje/ebeaninternal/server/util/SimpleJarClass.java
+++ b/src/test/java/com/avaje/ebeaninternal/server/util/SimpleJarClass.java
@@ -1,0 +1,9 @@
+package com.avaje.ebeaninternal.server.util;
+
+/**
+ * Exists only for the purpose of putting in a jar for the ClassPathSearchTests.
+ *
+ * author: Richard Vowles - http://plus.google.com/RichardVowles
+ */
+public class SimpleJarClass {
+}

--- a/src/test/java/com/avaje/tests/unitinternal/TestXmlConfigLoader.java
+++ b/src/test/java/com/avaje/tests/unitinternal/TestXmlConfigLoader.java
@@ -1,14 +1,28 @@
 package com.avaje.tests.unitinternal;
 
-import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.avaje.ebean.BaseTestCase;
 import com.avaje.ebeaninternal.server.core.XmlConfigLoader;
 import com.avaje.ebeaninternal.server.lib.util.Dnode;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+/**
+ * Tests basic xml loading functionality across multiple jars and inside our own test structure.
+ *
+ * @author Rob Bygrave
+ * @author Richard Vowles - http://plus.google.com/RichardVowles
+ */
 public class TestXmlConfigLoader extends BaseTestCase {
 
   @Test
@@ -16,10 +30,62 @@ public class TestXmlConfigLoader extends BaseTestCase {
 
     XmlConfigLoader xmlConfigLoader = new XmlConfigLoader(null);
 
-    List<Dnode> ebeanOrmXml = xmlConfigLoader.search("META-INF/ebean-orm.xml");
+    List<Dnode> ebeanOrmXml = xmlConfigLoader.search(META_INF_EBEAN_ORM_XML);
 
     Assert.assertNotNull(ebeanOrmXml);
     Assert.assertTrue("Found ebean-orm.xml", ebeanOrmXml.size() > 0);
 
   }
+
+	private static final String META_INF_EBEAN_ORM_XML = "META-INF/ebean-orm.xml";
+	private static final String META_INF_ORM_XML = "META-INF/orm.xml";
+	private static final String WEB_INF_CLASSES = "WEB-INF/classes/";
+
+	@Test
+	public void ensureEbeanOrmStillLoads() throws IOException {
+		URL jar = setupJar();
+		URL jarBang = setupJarBang();
+
+		URLClassLoader cl = new URLClassLoader(new URL[] { jar, jarBang}, getClass().getClassLoader());
+
+		XmlConfigLoader loader = new XmlConfigLoader(cl);
+
+		Assert.assertEquals(3, loader.search(META_INF_EBEAN_ORM_XML).size()); // 1 in parent, 2 in ours
+		Assert.assertEquals(2, loader.search(META_INF_ORM_XML).size()); // 2 in ours
+
+	}
+
+	private URL createJar(File jarFile, String offset) throws IOException {
+		FileOutputStream stream = new FileOutputStream(jarFile);
+		JarOutputStream jarOutputStream = new JarOutputStream(stream);
+
+		JarEntry entry = new JarEntry(offset + META_INF_EBEAN_ORM_XML);
+		jarOutputStream.putNextEntry(entry);
+		InputStream classStream = getClass().getResourceAsStream("/" + META_INF_EBEAN_ORM_XML);
+		IOUtils.copy(classStream, jarOutputStream);
+
+		entry = new JarEntry(offset + META_INF_ORM_XML);
+		jarOutputStream.putNextEntry(entry);
+		classStream = getClass().getResourceAsStream("/" + META_INF_EBEAN_ORM_XML);
+		IOUtils.copy(classStream, jarOutputStream);
+
+		jarOutputStream.close();
+		stream.close();
+
+		if (offset.length() > 0) {
+			return new URL("jar:" + jarFile.toURI().toString() + "!/" + offset);
+		} else {
+			return jarFile.toURI().toURL();
+		}
+	}
+
+	private URL setupJarBang() throws IOException {
+		File jarFile = File.createTempFile("bang", ".war");
+		return createJar(jarFile, WEB_INF_CLASSES);
+	}
+
+	private URL setupJar() throws IOException {
+		File jarFile = File.createTempFile("nobang", ".jar");
+		return createJar(jarFile, "");
+	}
 }


### PR DESCRIPTION
Hiya Rob,

This patch adds support for bang paths. We are moving to a unexpanded jar which uses war style bang paths (jar:file:/path/to/file.war!/WEB-INF/classes/) with the Bathe Plugin and Bathe Booter. 

The XmlConfigLoader has been changed to load using getResources() which means no class path scanning is needed, but the ClassPathSearch has increased in complexity. I have included tests for all changes.

Hopefully its ok...
