### PR TITLE
make Transaction interface extends Closeable

### DIFF
--- a/src/main/java/com/avaje/ebean/Transaction.java
+++ b/src/main/java/com/avaje/ebean/Transaction.java
@@ -3,12 +3,13 @@ package com.avaje.ebean;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
 import javax.persistence.RollbackException;
+import java.io.Closeable;
 import java.sql.Connection;
 
 /**
  * The Transaction object. Typically representing a JDBC or JTA transaction.
  */
-public interface Transaction {
+public interface Transaction extends Closeable {
 
   /**
    * Read Committed transaction isolation. Same as

--- a/src/main/java/com/avaje/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -1,5 +1,6 @@
 package com.avaje.ebeaninternal.server.transaction;
 
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -686,5 +687,16 @@ public class JdbcTransaction implements SpiTransaction {
 
   public final TransactionManager getTransactionManger() {
     return manager;
+  }
+
+  /**
+   * Alias for end(), which enables this class to be used in try-with-resources.
+   */
+  public void close() throws IOException {
+    try {
+        end();
+    } catch (PersistenceException ex) {
+        throw new IOException(ex);
+    }
   }
 }

--- a/src/main/java/com/avaje/ebeaninternal/server/transaction/JtaTransaction.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/transaction/JtaTransaction.java
@@ -95,7 +95,7 @@ public class JtaTransaction extends JdbcTransaction {
                     }
                     notifyRollback(e);
                 } finally {
-                    close();
+                    closeConnection();
                 }
             } catch (Exception ex) {
                 throw new PersistenceException(ex);
@@ -107,7 +107,7 @@ public class JtaTransaction extends JdbcTransaction {
     /**
      * Close the underlying connection.
      */
-    private void close() throws SQLException {
+    private void closeConnection() throws SQLException {
         if (connection != null) {
             connection.close();
             connection = null;


### PR DESCRIPTION
To avoid method name conflict, JtaTransaction#close was renamed to
closeConnection()
