### PR TITLE
Backport to JDK 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.avaje.ebeanorm</groupId>
         <artifactId>avaje-ebeanorm-mavenenhancer</artifactId>
         <version>3.3.2</version>

--- a/src/main/java/com/avaje/ebean/bean/ObjectGraphNode.java
+++ b/src/main/java/com/avaje/ebean/bean/ObjectGraphNode.java
@@ -1,7 +1,6 @@
 package com.avaje.ebean.bean;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 /**
  * Identifies a unique node of an object graph.
@@ -70,7 +69,7 @@ public final class ObjectGraphNode implements Serializable {
   
   public int hashCode() {
     int hc = 31 * originQueryPoint.hashCode();
-    hc = 31 * hc + Objects.hashCode(path);
+    hc = 31 * hc + (path == null ? 0 : path.hashCode());
     return hc;
   }
   
@@ -83,7 +82,7 @@ public final class ObjectGraphNode implements Serializable {
     }
     
     ObjectGraphNode e = (ObjectGraphNode) obj;
-    return Objects.equals(e.path, path) 
+    return  ((e.path == path) || (e.path != null && e.path.equals(path)))
         && e.originQueryPoint.equals(originQueryPoint);
   }
 }

--- a/src/main/java/com/avaje/ebeaninternal/api/HashQueryPlan.java
+++ b/src/main/java/com/avaje/ebeaninternal/api/HashQueryPlan.java
@@ -1,7 +1,5 @@
 package com.avaje.ebeaninternal.api;
 
-import java.util.Objects;
-
 /**
  * A hash for a query plan.
  */
@@ -26,7 +24,7 @@ public class HashQueryPlan {
   public int hashCode() {
     int hc = planHash;
     hc = hc * 31 + bindCount;
-    hc = hc * 31 + Objects.hashCode(rawSql);
+    hc = hc * 31 + (rawSql == null ? 0 : rawSql.hashCode());
     return hc;
   }
   
@@ -41,6 +39,6 @@ public class HashQueryPlan {
     HashQueryPlan e = (HashQueryPlan) obj;
     return e.planHash == planHash 
         && e.bindCount == bindCount
-        && Objects.equals(e.rawSql, rawSql);
+        &&  ((e.rawSql == rawSql) || (e.rawSql != null && e.rawSql.equals(rawSql)));
   }
 }

--- a/src/main/java/com/avaje/ebeaninternal/api/HashQueryPlanBuilder.java
+++ b/src/main/java/com/avaje/ebeaninternal/api/HashQueryPlanBuilder.java
@@ -1,7 +1,5 @@
 package com.avaje.ebeaninternal.api;
 
-import java.util.Objects;
-
 /**
  * Used to build HashQueryPlan instances.
  */
@@ -33,7 +31,7 @@ public class HashQueryPlanBuilder {
    * Add an object to the hash calculation.
    */
   public HashQueryPlanBuilder add(Object object) {
-    planHash = planHash * 31 + Objects.hashCode(object);
+    planHash = planHash * 31 + (object == null ? 0 : object.hashCode());
     return this;
   }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/expression/AllEqualsExpression.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/expression/AllEqualsExpression.java
@@ -3,7 +3,6 @@ package com.avaje.ebeaninternal.server.expression;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 
 import com.avaje.ebean.event.BeanQueryRequest;
@@ -115,7 +114,7 @@ class AllEqualsExpression implements SpiExpression {
     
     int hc = 31;
     for (Object value : propMap.values()) {
-      hc = hc * 31 + Objects.hashCode(value);      
+      hc = hc * 31 + (value == null ? 0 : value.hashCode());
     }
 
     return hc;


### PR DESCRIPTION
Replaced all uses of ju.Objects.hashCode and ju.Objects.equals with a copy of their implementations inlined into the code.

Also changed source/target for compiler plugin.

To test, I compiled my own avaje launchagent against 6, and changed to use that in the pom, compiled/tested the whole project using JDK 7, then ran mvn surefire:test using JDK 6 - running surefire:test ensures that mvn doesn't try to recompile everything against 6, since that's not possible because of some of the delegate classes having delegate methods to JDK 7 jdbc classes.
