### PR TITLE
Feature/postconstruct

### DIFF
--- a/src/main/java/com/avaje/ebean/EbeanServer.java
+++ b/src/main/java/com/avaje/ebean/EbeanServer.java
@@ -167,8 +167,9 @@ public interface EbeanServer {
   /**
    * Create a new instance of T that is an EntityBean.
    * <p>
-   * Generally not expected to be useful (now dynamic subclassing support was removed in
-   * favour of always using enhancement).
+   * Useful if you use BeanPostConstructListeners or &#64;PostConstruct Annotations.
+   * In this case you should not use "new Bean...()". Making all bean construtors protected
+   * could be a good idea here. 
    * </p>
    */
   <T> T createEntityBean(Class<T> type);

--- a/src/main/java/com/avaje/ebean/config/ServerConfig.java
+++ b/src/main/java/com/avaje/ebean/config/ServerConfig.java
@@ -11,6 +11,7 @@ import com.avaje.ebean.config.dbplatform.DbType;
 import com.avaje.ebean.event.BeanFindController;
 import com.avaje.ebean.event.BeanPersistController;
 import com.avaje.ebean.event.BeanPersistListener;
+import com.avaje.ebean.event.BeanPostConstructListener;
 import com.avaje.ebean.event.BeanPostLoad;
 import com.avaje.ebean.event.BeanQueryAdapter;
 import com.avaje.ebean.event.BulkTableEventListener;
@@ -329,6 +330,7 @@ public class ServerConfig {
   private List<BeanFindController> findControllers = new ArrayList<BeanFindController>();
   private List<BeanPersistController> persistControllers = new ArrayList<BeanPersistController>();
   private List<BeanPostLoad> postLoaders = new ArrayList<BeanPostLoad>();
+  private List<BeanPostConstructListener> postConstructListeners = new ArrayList<BeanPostConstructListener>();
   private List<BeanPersistListener> persistListeners = new ArrayList<BeanPersistListener>();
   private List<BeanQueryAdapter> queryAdapters = new ArrayList<BeanQueryAdapter>();
   private List<BulkTableEventListener> bulkTableEventListeners = new ArrayList<BulkTableEventListener>();
@@ -2056,6 +2058,16 @@ public class ServerConfig {
   }
 
   /**
+   * Register a BeanPostConstructListener instance.
+   * <p>
+   * Note alternatively you can use {@link #setPostConstructListeners(List)} to set
+   * all the BeanPostConstructListener instances.
+   * </p>
+   */
+  public void add(BeanPostConstructListener listener) {
+    postConstructListeners.add(listener);
+  } 
+  /**
    * Return the list of BeanFindController instances.
    */
   public List<BeanFindController> getFindControllers() {
@@ -2083,6 +2095,19 @@ public class ServerConfig {
     this.postLoaders = postLoaders;
   }
 
+  /**
+   * Return the list of BeanPostLoader instances.
+   */
+  public List<BeanPostConstructListener> getPostConstructListeners() {
+    return postConstructListeners;
+  }
+
+  /**
+   * Set the list of BeanPostLoader instances.
+   */
+  public void setPostConstructListeners(List<BeanPostConstructListener> listeners) {
+    this.postConstructListeners = listeners;
+  }
   /**
    * Return the BeanPersistController instances.
    */

--- a/src/main/java/com/avaje/ebean/event/BeanPostConstructListener.java
+++ b/src/main/java/com/avaje/ebean/event/BeanPostConstructListener.java
@@ -1,0 +1,41 @@
+package com.avaje.ebean.event;
+
+import com.avaje.ebean.EbeanServer;
+import com.avaje.ebeaninternal.server.deploy.BeanDescriptor;
+
+/**
+ * Fired after a bean is constructed, but not yet loaded from database.
+ * <p>
+ * Note: You MUST NOT set any default values, as in a following step, 
+ * properties will get unload. Use {@link BeanPostLoad} instead.
+ * 
+ * it's intended to do some dependency-injection here.
+ * If you plan to use this feature you should use {@link EbeanServer#createEntityBean(Class)}
+ * to create new beans.
+ * </p>
+ */
+public interface BeanPostConstructListener {
+
+  /**
+   * Return true if this BeanPostConstructListener instance should be registered
+   * for post construct on this entity type.
+   */
+  boolean isRegisterFor(Class<?> cls);
+
+  /**
+   * Called immediately after construction. Perform DI here.
+   */
+  void autowire(Object bean);
+  
+  /**
+   * Called after every &#64;PostConstruct annotated method of the bean is executed
+   */
+  void postConstruct(Object bean);
+  
+  /**
+   * Called after {@link EbeanServer#createEntityBean(Class)}. Only for new beans.
+   * intended to set default values here.
+   */
+  void postCreate(Object bean);
+
+}

--- a/src/main/java/com/avaje/ebeaninternal/server/core/DefaultContainer.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/DefaultContainer.java
@@ -194,6 +194,7 @@ public class DefaultContainer implements SpiContainer {
     bootup.addIdGenerators(serverConfig.getIdGenerators());
     bootup.addPersistControllers(serverConfig.getPersistControllers());
     bootup.addPostLoaders(serverConfig.getPostLoaders());
+    bootup.addPostConstructListeners(serverConfig.getPostConstructListeners());
     bootup.addFindControllers(serverConfig.getFindControllers());
     bootup.addPersistListeners(serverConfig.getPersistListeners());
     bootup.addQueryAdapters(serverConfig.getQueryAdapters());

--- a/src/main/java/com/avaje/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/DefaultServer.java
@@ -523,7 +523,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @SuppressWarnings("unchecked")
   public <T> T createEntityBean(Class<T> type) {
     BeanDescriptor<T> desc = getBeanDescriptor(type);
-    return (T) desc.createEntityBean();
+    return (T) desc.createEntityBean(true);
   }
 
   /**

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -20,6 +20,7 @@ import com.avaje.ebean.config.dbplatform.PlatformIdGenerator;
 import com.avaje.ebean.event.BeanFindController;
 import com.avaje.ebean.event.BeanPersistController;
 import com.avaje.ebean.event.BeanPersistListener;
+import com.avaje.ebean.event.BeanPostConstructListener;
 import com.avaje.ebean.event.BeanPostLoad;
 import com.avaje.ebean.event.BeanQueryAdapter;
 import com.avaje.ebean.event.changelog.BeanChange;
@@ -242,6 +243,7 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
   private volatile BeanPersistController persistController;
 
   private final BeanPostLoad beanPostLoad;
+  private final BeanPostConstructListener beanPostConstructListener;
 
   /**
    * Listens for post commit insert update and delete events.
@@ -424,6 +426,7 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
     this.beanFinder = deploy.getBeanFinder();
     this.persistController = deploy.getPersistController();
     this.persistListener = deploy.getPersistListener();
+    this.beanPostConstructListener = deploy.getPostConstructListener();
     this.beanPostLoad = deploy.getPostLoad();
     this.queryAdapter = deploy.getQueryAdapter();
     this.changeLogFilter = deploy.getChangeLogFilter();
@@ -1558,17 +1561,26 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
   @Override
   @SuppressWarnings("unchecked")
   public T createBean() {
-    return (T) createEntityBean();
+    return (T) createEntityBean(true);
   }
 
   /**
    * Creates a new EntityBean.
+   * The parameter <code>isNew</code> controls either this is a new bean (then
+   * {@link BeanPostConstructListener#postCreate(Object)} will be invoked) or
+   * a reference (then {@link BeanPostLoad#postLoad(Object)} will be invoked 
+   * on first access (lazy load) or immediately (eager load) 
    */
   @SuppressWarnings("unchecked")
-  public EntityBean createEntityBean() {
+  public EntityBean createEntityBean(boolean isNew) {
     try {
       EntityBean bean = (EntityBean) prototypeEntityBean._ebean_newInstance();
 
+      if (beanPostConstructListener != null) {
+        beanPostConstructListener.autowire(bean); // calls all registered listeners
+        beanPostConstructListener.postConstruct(bean); // calls first the @PostConstruct method and then the listeners
+      }
+      
       if (unloadProperties.length > 0) {
         // 'unload' any properties initialised in the default constructor
         EntityBeanIntercept ebi = bean._ebean_getIntercept();
@@ -1576,11 +1588,22 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
           ebi.setPropertyUnloaded(unloadProperties[i]);
         }
       }
+      if (beanPostConstructListener != null && isNew) {
+        beanPostConstructListener.postCreate(bean);
+        // if bean is not new, postLoad will be executed later in the bean's lifecycle
+      }
       return bean;
 
     } catch (Exception ex) {
       throw new PersistenceException(ex);
     }
+  }
+ 
+  /**
+   * Creates a new entitybean without invoking {@link BeanPostConstructListener#postCreate(Object)}
+   */
+  public EntityBean createEntityBean() {
+    return createEntityBean(false);
   }
 
   /**

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -107,6 +107,8 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
 
   private final PostLoadManager postLoadManager;
 
+  private final PostConstructManager postConstructManager;
+
   private final BeanFinderManager beanFinderManager;
 
   private final PersistListenerManager persistListenerManager;
@@ -219,6 +221,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
     this.beanLifecycleAdapterFactory = new BeanLifecycleAdapterFactory();
     this.persistControllerManager = new PersistControllerManager(bootupClasses);
     this.postLoadManager = new PostLoadManager(bootupClasses);
+    this.postConstructManager = new PostConstructManager(bootupClasses);
     this.persistListenerManager = new PersistListenerManager(bootupClasses);
     this.beanQueryAdapterManager = new BeanQueryAdapterManager(bootupClasses);
     this.beanFinderManager = new BeanFinderManager(bootupClasses);
@@ -624,10 +627,11 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
     int qa = beanQueryAdapterManager.getRegisterCount();
     int cc = persistControllerManager.getRegisterCount();
     int pl = postLoadManager.getRegisterCount();
+    int pc = postConstructManager.getRegisterCount();
     int lc = persistListenerManager.getRegisterCount();
     int fc = beanFinderManager.getRegisterCount();
 
-    logger.debug("BeanPersistControllers[" + cc + "] BeanFinders[" + fc + "] BeanPersistListeners[" + lc + "] BeanQueryAdapters[" + qa + "] BeanPostLoaders[" + pl + "]");
+    logger.debug("BeanPersistControllers[" + cc + "] BeanFinders[" + fc + "] BeanPersistListeners[" + lc + "] BeanQueryAdapters[" + qa + "] BeanPostLoaders[" + pl + "] BeanPostConstructors[" + pc + "]");
   }
 
   private void logStatus() {
@@ -1143,6 +1147,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
 
     persistControllerManager.addPersistControllers(descriptor);
     postLoadManager.addPostLoad(descriptor);
+    postConstructManager.addPostConstructListeners(descriptor);
     persistListenerManager.addPersistListeners(descriptor);
     beanQueryAdapterManager.addQueryAdapter(descriptor);
     beanFinderManager.addFindControllers(descriptor);

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/ChainedBeanPersistListener.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/ChainedBeanPersistListener.java
@@ -16,7 +16,7 @@ public class ChainedBeanPersistListener implements BeanPersistListener {
 	private final BeanPersistListener[] chain;
 	
 	/**
-	 * Construct adding 2 BeanPersistController's.
+	 * Construct adding 2 BeanPersistListener's.
 	 */
 	public ChainedBeanPersistListener(BeanPersistListener c1, BeanPersistListener c2) {
 		this(addList(c1, c2));
@@ -46,7 +46,7 @@ public class ChainedBeanPersistListener implements BeanPersistListener {
 	}
 	
 	/**
-	 * Construct given the list of BeanPersistController's.
+	 * Construct given the list of BeanPersistListener's.
 	 */
 	public ChainedBeanPersistListener(List<BeanPersistListener> list) {
 		this.list = list;
@@ -54,7 +54,7 @@ public class ChainedBeanPersistListener implements BeanPersistListener {
 	}
 	
 	/**
-	 * Register a new BeanPersistController and return the resulting chain.
+	 * Register a new BeanPersistListener and return the resulting chain.
 	 */
 	public ChainedBeanPersistListener register(BeanPersistListener c) {
 		if (list.contains(c)){
@@ -69,7 +69,7 @@ public class ChainedBeanPersistListener implements BeanPersistListener {
 	}
 	
 	/**
-	 * De-register a BeanPersistController and return the resulting chain.
+	 * De-register a BeanPersistListener and return the resulting chain.
 	 */
 	public ChainedBeanPersistListener deregister(BeanPersistListener c) {
 		if (!list.contains(c)){

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/ChainedBeanPostConstructListener.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/ChainedBeanPostConstructListener.java
@@ -1,0 +1,91 @@
+package com.avaje.ebeaninternal.server.deploy;
+
+import com.avaje.ebean.event.BeanPostConstructListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Handles multiple BeanPostLoad's for a given entity type.
+ */
+public class ChainedBeanPostConstructListener implements BeanPostConstructListener {
+
+	private final List<BeanPostConstructListener> list;
+
+	private final BeanPostConstructListener[] chain;
+
+	/**
+	 * Construct given the list of BeanPostCreate's.
+	 */
+	public ChainedBeanPostConstructListener(List<BeanPostConstructListener> list) {
+		this.list = list;
+		this.chain = list.toArray(new BeanPostConstructListener[list.size()]);
+	}
+	
+	/**
+	 * Register a new BeanPostCreate and return the resulting chain.
+	 */
+	public ChainedBeanPostConstructListener register(BeanPostConstructListener c) {
+		if (list.contains(c)){
+			return this;
+		} else {
+			List<BeanPostConstructListener> newList = new ArrayList<BeanPostConstructListener>();
+			newList.addAll(list);
+			newList.add(c);
+			
+			return new ChainedBeanPostConstructListener(newList);
+		}
+	}
+	
+	/**
+	 * De-register a BeanPostCreate and return the resulting chain.
+	 */
+	public BeanPostConstructListener deregister(BeanPostConstructListener c) {
+		if (!list.contains(c)){
+			return this;
+		} else {
+			ArrayList<BeanPostConstructListener> newList = new ArrayList<BeanPostConstructListener>();
+			newList.addAll(list);
+			newList.remove(c);
+			
+			return new ChainedBeanPostConstructListener(newList);
+		}
+	}
+
+  /**
+   * Return the size of the chain.
+   */
+  protected int size() {
+    return chain.length;
+  }
+
+  @Override
+  public boolean isRegisterFor(Class<?> cls) {
+    // never called
+    return false;
+  }
+
+  /**
+   * Fire postLoad on all registered BeanPostCreate implementations.
+   */
+  @Override
+	public void postConstruct(Object bean) {
+		for (int i = 0; i < chain.length; i++) {
+			chain[i].postConstruct(bean);
+		}
+	}
+
+  @Override
+  public void autowire(Object bean) {
+    for (int i = 0; i < chain.length; i++) {
+      chain[i].autowire(bean);
+    }
+  }
+  
+  @Override
+  public void postCreate(Object bean) {
+    for (int i = 0; i < chain.length; i++) {
+      chain[i].postCreate(bean);
+    }
+  }
+}

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/ChainedBeanPostLoad.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/ChainedBeanPostLoad.java
@@ -15,7 +15,7 @@ public class ChainedBeanPostLoad implements BeanPostLoad {
 	private final BeanPostLoad[] chain;
 
 	/**
-	 * Construct given the list of BeanPersistController's.
+	 * Construct given the list of BeanPostLoad's.
 	 */
 	public ChainedBeanPostLoad(List<BeanPostLoad> list) {
 		this.list = list;
@@ -23,7 +23,7 @@ public class ChainedBeanPostLoad implements BeanPostLoad {
 	}
 	
 	/**
-	 * Register a new BeanPersistController and return the resulting chain.
+	 * Register a new BeanPostLoad and return the resulting chain.
 	 */
 	public ChainedBeanPostLoad register(BeanPostLoad c) {
 		if (list.contains(c)){
@@ -38,7 +38,7 @@ public class ChainedBeanPostLoad implements BeanPostLoad {
 	}
 	
 	/**
-	 * De-register a BeanPersistController and return the resulting chain.
+	 * De-register a BeanPostLoad and return the resulting chain.
 	 */
 	public ChainedBeanPostLoad deregister(BeanPostLoad c) {
 		if (!list.contains(c)){

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/PostConstructManager.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/PostConstructManager.java
@@ -1,0 +1,42 @@
+package com.avaje.ebeaninternal.server.deploy;
+
+import com.avaje.ebean.event.BeanPostConstructListener;
+import com.avaje.ebeaninternal.server.core.bootup.BootupClasses;
+import com.avaje.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Default implementation for creating BeanControllers.
+ */
+public class PostConstructManager {
+
+  private static final Logger logger = LoggerFactory.getLogger(PostConstructManager.class);
+
+  private final List<BeanPostConstructListener> list;
+
+  public PostConstructManager(BootupClasses bootupClasses) {
+    this.list = bootupClasses.getBeanPostConstructoListeners();
+  }
+
+  public int getRegisterCount() {
+    return list.size();
+  }
+
+  /**
+   * Register BeanPostLoad listeners for a given entity type.
+   */
+  public void addPostConstructListeners(DeployBeanDescriptor<?> deployDesc) {
+
+    for (int i = 0; i < list.size(); i++) {
+      BeanPostConstructListener c = list.get(i);
+      if (c.isRegisterFor(deployDesc.getBeanType())) {
+        logger.debug("BeanPostLoad on[" + deployDesc.getFullName() + "] " + c.getClass().getName());
+        deployDesc.addPostConstructListener(c);
+      }
+    }
+  }
+
+}

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -11,6 +11,7 @@ import com.avaje.ebean.config.dbplatform.PlatformIdGenerator;
 import com.avaje.ebean.event.BeanFindController;
 import com.avaje.ebean.event.BeanPersistController;
 import com.avaje.ebean.event.BeanPersistListener;
+import com.avaje.ebean.event.BeanPostConstructListener;
 import com.avaje.ebean.event.BeanPostLoad;
 import com.avaje.ebean.event.BeanQueryAdapter;
 import com.avaje.ebean.event.changelog.ChangeLogFilter;
@@ -22,6 +23,7 @@ import com.avaje.ebeaninternal.server.deploy.BeanDescriptor.EntityType;
 import com.avaje.ebeaninternal.server.deploy.BeanDescriptorManager;
 import com.avaje.ebeaninternal.server.deploy.ChainedBeanPersistController;
 import com.avaje.ebeaninternal.server.deploy.ChainedBeanPersistListener;
+import com.avaje.ebeaninternal.server.deploy.ChainedBeanPostConstructListener;
 import com.avaje.ebeaninternal.server.deploy.ChainedBeanPostLoad;
 import com.avaje.ebeaninternal.server.deploy.ChainedBeanQueryAdapter;
 import com.avaje.ebeaninternal.server.deploy.IndexDefinition;
@@ -155,6 +157,7 @@ public class DeployBeanDescriptor<T> {
   private final List<BeanPersistListener> persistListeners = new ArrayList<BeanPersistListener>();
   private final List<BeanQueryAdapter> queryAdapters = new ArrayList<BeanQueryAdapter>();
   private final List<BeanPostLoad> postLoaders = new ArrayList<BeanPostLoad>();
+  private final List<BeanPostConstructListener> postConstructListeners = new ArrayList<BeanPostConstructListener>();
 
   private CacheOptions cacheOptions = CacheOptions.NO_CACHING;
 
@@ -533,6 +536,19 @@ public class DeployBeanDescriptor<T> {
     }
   }
 
+  /**
+   * Return the BeanPostCreate(could be a chain of them, 1 or null).
+   */
+  public BeanPostConstructListener getPostConstructListener() {
+    if (postConstructListeners.isEmpty()) {
+      return null;
+    } else if (postConstructListeners.size() == 1) {
+      return postConstructListeners.get(0);
+    } else {
+      return new ChainedBeanPostConstructListener(postConstructListeners);
+    }
+  }
+  
   public void addPersistController(BeanPersistController controller) {
     persistControllers.add(controller);
   }
@@ -549,6 +565,10 @@ public class DeployBeanDescriptor<T> {
     postLoaders.add(postLoad);
   }
 
+  public void addPostConstructListener(BeanPostConstructListener postConstructListener) {
+    postConstructListeners.add(postConstructListener);
+  }
+  
   public String getDraftTable() {
     return draftTable;
   }

--- a/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -178,8 +178,6 @@ public class DeployBeanDescriptor<T> {
 
   private String name;
 
-  private boolean processedRawSqlExtend;
-
   private ChangeLogFilter changeLogFilter;
 
   private String dbComment;

--- a/src/main/java/com/avaje/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/type/DefaultTypeManager.java
@@ -688,22 +688,22 @@ public final class DefaultTypeManager implements TypeManager, KnownImmutable {
 
     customScalarTypes.add(longToTimestamp);
 
-    List<Class<?>> foundTypes = bootupClasses.getScalarTypes();
+    List<Class<? extends ScalarType<?>>> foundTypes = bootupClasses.getScalarTypes();
 
     for (int i = 0; i < foundTypes.size(); i++) {
-      Class<?> cls = foundTypes.get(i);
+      Class<? extends ScalarType<?>> cls = foundTypes.get(i);
       try {
 
         ScalarType<?> scalarType;
         if (objectMapper == null) {
-          scalarType = (ScalarType<?>) cls.newInstance();
+          scalarType = cls.newInstance();
         } else {
           try {
             // first try objectMapper constructor
-            Constructor<?> constructor = cls.getConstructor(ObjectMapper.class);
-            scalarType = (ScalarType<?>) constructor.newInstance((ObjectMapper) objectMapper);
+            Constructor<? extends ScalarType<?>> constructor = cls.getConstructor(ObjectMapper.class);
+            scalarType = constructor.newInstance((ObjectMapper) objectMapper);
           } catch (NoSuchMethodException e) {
-            scalarType = (ScalarType<?>) cls.newInstance();
+            scalarType = cls.newInstance();
           }
         }
 
@@ -730,7 +730,7 @@ public final class DefaultTypeManager implements TypeManager, KnownImmutable {
   @SuppressWarnings({"unchecked", "rawtypes"})
   protected void initialiseScalarConverters(BootupClasses bootupClasses) {
 
-    List<Class<?>> foundTypes = bootupClasses.getScalarConverters();
+    List<Class<? extends ScalarTypeConverter<?, ?>>> foundTypes = bootupClasses.getScalarConverters();
 
     for (int i = 0; i < foundTypes.size(); i++) {
       Class<?> cls = foundTypes.get(i);
@@ -766,7 +766,7 @@ public final class DefaultTypeManager implements TypeManager, KnownImmutable {
 
   protected void initialiseCompoundTypes(BootupClasses bootupClasses) {
 
-    List<Class<?>> compoundTypes = bootupClasses.getCompoundTypes();
+    List<Class<? extends CompoundType<?>>> compoundTypes = bootupClasses.getCompoundTypes();
     for (int j = 0; j < compoundTypes.size(); j++) {
 
       Class<?> type = compoundTypes.get(j);

--- a/src/test/java/com/avaje/tests/history/TestHistoryInsert.java
+++ b/src/test/java/com/avaje/tests/history/TestHistoryInsert.java
@@ -54,6 +54,7 @@ public class TestHistoryInsert extends BaseTestCase {
 
     user.setName("Jim v3");
     user.setEmail("three@email.com");
+    Thread.sleep(10); // otherwise the timestamp of "whenModified" may not change
     Ebean.save(user);
 
     history = fetchHistory(user);

--- a/src/test/java/com/avaje/tests/lifecycle/TestLifecycleAnnotatedBean.java
+++ b/src/test/java/com/avaje/tests/lifecycle/TestLifecycleAnnotatedBean.java
@@ -2,6 +2,8 @@ package com.avaje.tests.lifecycle;
 
 import com.avaje.ebean.BaseTestCase;
 import com.avaje.ebean.Ebean;
+import com.avaje.ebeaninternal.api.SpiEbeanServer;
+import com.avaje.ebeaninternal.server.deploy.BeanDescriptor;
 import com.avaje.tests.model.basic.EBasicWithLifecycle;
 import org.junit.Test;
 
@@ -100,5 +102,61 @@ public class TestLifecycleAnnotatedBean extends BaseTestCase {
 
     assertThat(bean.getBuffer()).contains("postRemove1");
     assertThat(bean.getBuffer()).contains("postRemove2");
+  }
+  @Test
+  public void shouldExecutePostConstructMethodsWhenFindingBean() {
+
+    EBasicWithLifecycle bean = new EBasicWithLifecycle();
+    bean.setName("PostConstruct");
+
+    Ebean.save(bean);
+
+    EBasicWithLifecycle loaded = Ebean.find(EBasicWithLifecycle.class, bean.getId());
+    assertThat(loaded.getBuffer()).contains("postConstruct1");
+    assertThat(loaded.getBuffer()).contains("postConstruct2");
+    // assert also that postLoad was executed
+    assertThat(loaded.getBuffer()).contains("postLoad1");
+    assertThat(loaded.getBuffer()).contains("postLoad2");
+  }
+  
+  @Test
+  public void shouldExecutePostConstructMethodsWhenInstantiated() {
+    EBasicWithLifecycle bean = Ebean.getDefaultServer().createEntityBean(EBasicWithLifecycle.class);
+    bean.setName("PostConstruct");
+
+  
+    assertThat(bean.getBuffer()).contains("postConstruct1");
+    assertThat(bean.getBuffer()).contains("postConstruct2");
+    // assert also that postLoad is not executed now
+    assertThat(bean.getBuffer()).doesNotContain("postLoad1");
+    assertThat(bean.getBuffer()).doesNotContain("postLoad2");
+  }
+  
+  
+  
+  @Test
+  public void testLazyLoadBehaviour() {
+
+    EBasicWithLifecycle bean = new EBasicWithLifecycle();
+    bean.setName("LazyLoad");
+
+    Ebean.save(bean);
+
+    BeanDescriptor<EBasicWithLifecycle> desc = ((SpiEbeanServer)server()).getBeanDescriptor(EBasicWithLifecycle.class);
+    EBasicWithLifecycle loaded =  desc.createReference(false, false, bean.getId(), null);
+    
+    // Here you see the big difference.
+    // @PostLoad is executed always, also on lazy loaded beans
+    assertThat(loaded.getBuffer()).contains("postConstruct1");
+    assertThat(loaded.getBuffer()).contains("postConstruct2");
+    
+    // assert also that postLoad is not yet executed
+    assertThat(loaded.getBuffer()).doesNotContain("postLoad1");
+    assertThat(loaded.getBuffer()).doesNotContain("postLoad2");
+    
+    // now read name -> will load the bean
+    assertThat(loaded.getName()).isEqualTo("LazyLoad");
+    assertThat(loaded.getBuffer()).contains("postLoad1");
+    assertThat(loaded.getBuffer()).contains("postLoad2");
   }
 }

--- a/src/test/java/com/avaje/tests/model/basic/EBasicWithLifecycle.java
+++ b/src/test/java/com/avaje/tests/model/basic/EBasicWithLifecycle.java
@@ -1,5 +1,6 @@
 package com.avaje.tests.model.basic;
 
+import javax.annotation.PostConstruct;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.PostLoad;
@@ -96,6 +97,16 @@ public class EBasicWithLifecycle {
     buffer.append("postLoad2");
   }
 
+  @PostConstruct
+  public void postConstruct1() {
+    buffer.append("postConstruct1");
+  }
+
+  @PostConstruct
+  public void postConstruct2() {
+    buffer.append("postConstruct2");
+  }
+  
   public Long getId() {
     return id;
   }


### PR DESCRIPTION
Hello Rob,

here is a pull request for a feature we would need.

Background:
We use spring and our entity-beans should be auto-wire capable. We also need a mechanism to set default vaules for new beans. So we use the enhancement in this pull request together with this listener
```java
config.setPostConstructListeners(Arrays.asList(new BeanPostConstructListener() {
	public void autowire(final Object bean) {
		applicationContext.getAutowireCapableBeanFactory().autowireBean(bean);
	}
	public void postConstruct(final Object bean) {}

	public boolean isRegisterFor(final Class<?> cls) {
		return BaseModel.class.isAssignableFrom(cls);
	}

	public void postCreate(final Object bean) {
		((BaseModel) bean).setDefaults();
	}
}));
```

1.  autowire is called immediately after "_ebean_newInstance()". We pass the generated bean to Spring, so that it gets all autowired properties.
2. in the next step, the listener's postConstruct and the methods of the bean that are annotated with `javax.annotation.PostConstruct` are invoked.
3. if this is a new bean (= created with EbeanServer.createEntityBean) the listener's postCreate method is invoked, which can set default values in the bean.
(If there's a better way to set default values for new beans i'm willing to undo this change)

I tried to separate this pull request into compact commits.

cheers
Roland