### PR TITLE
Bugfix/softdelete calls wrong lifecycle method

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/core/PersistRequestBean.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/PersistRequestBean.java
@@ -787,10 +787,14 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
         controller.postInsert(this);
         break;
       case UPDATE:
+      case SOFT_DELETE:
+    	  /*
+    	   * In the previous version, in case SOFT_DELETE the method controller.postDelete was called. However,
+    	   * this lead to an inconsistent situation, because first controller.preUpdate is called.
+    	   */
         controller.postUpdate(this);
         break;
       case DELETE:
-      case SOFT_DELETE:
         controller.postDelete(this);
         break;
       default:

--- a/src/main/java/com/avaje/ebeaninternal/server/persist/Binder.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/Binder.java
@@ -149,12 +149,14 @@ public class Binder {
         if (param.isInParam()) {
           value = param.getInValue();
           if (bindLog != null) {
+            if (bindLog.length() > 0) {
+              bindLog.append(", ");
+            }
             if (param.isEncryptionKey()) {
               bindLog.append("****");
             } else {
               bindLog.append(value);
             }
-            bindLog.append(", ");
           }
           if (value == null) {
             // this doesn't work for query predicates

--- a/src/main/java/com/avaje/ebeaninternal/server/persist/dml/DmlHandler.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/dml/DmlHandler.java
@@ -165,6 +165,9 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
   @Override
   public void bind(Object value, int sqlType) throws SQLException {
     if (logLevelSql) {
+      if (bindLog.length() > 0) {
+        bindLog.append(",");
+      }
       if (value == null) {
         bindLog.append("null");
       } else {
@@ -175,7 +178,6 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
           bindLog.append(sval);
         }
       }
-      bindLog.append(",");
     }
     dataBind.setObject(value, sqlType);
   }
@@ -207,6 +209,9 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
   private void bindInternal(boolean log, Object value, BeanProperty prop) throws SQLException {
 
     if (log) {
+      if (bindLog.length() > 0) {
+        bindLog.append(",");
+      }
       if (prop.isLob()) {
         bindLog.append("[LOB]");
       } else {
@@ -216,7 +221,6 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
         }
         bindLog.append(sv);
       }
-      bindLog.append(",");
     }
     // do the actual binding to PreparedStatement
     prop.bind(dataBind, value);


### PR DESCRIPTION
the lifecycle calls when soft-deleting an entity were "preUpdate" / "postDelete" - which is definitiefly wrong.
it should either call "preUpdate" / "postUpdate" or "preDelete" / "postDelete" (or pre/postSoftDelete?)

As soft delete/undelete is technically just an update, I think it is ok to call pre/postUpdate now.

I also have fixed some trailing commas in the debug outputs.

cheers
Roland
