### PR TITLE
Remove unnecessary boxing and unboxing

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/type/LongToTimestampConverter.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/type/LongToTimestampConverter.java
@@ -12,7 +12,7 @@ public class LongToTimestampConverter implements ScalarTypeConverter<Long, Times
 
   public Timestamp unwrapValue(Long beanType) {
 
-    return new Timestamp(beanType.longValue());
+    return new Timestamp(beanType);
   }
 
   public Long wrapValue(Timestamp scalarType) {

--- a/src/test/java/com/avaje/tests/compositekeys/TestCore.java
+++ b/src/test/java/com/avaje/tests/compositekeys/TestCore.java
@@ -1,19 +1,12 @@
 package com.avaje.tests.compositekeys;
 
-import java.util.List;
-
 import com.avaje.ebean.Ebean;
 import com.avaje.ebean.Query;
 import com.avaje.ebean.Transaction;
-import com.avaje.tests.compositekeys.db.Item;
-import com.avaje.tests.compositekeys.db.ItemKey;
-import com.avaje.tests.compositekeys.db.Region;
-import com.avaje.tests.compositekeys.db.RegionKey;
-import com.avaje.tests.compositekeys.db.SubType;
-import com.avaje.tests.compositekeys.db.SubTypeKey;
-import com.avaje.tests.compositekeys.db.Type;
-import com.avaje.tests.compositekeys.db.TypeKey;
+import com.avaje.tests.compositekeys.db.*;
 import com.avaje.tests.lib.EbeanTestCase;
+
+import java.util.List;
 
 /**
  * Test some of the Avaje core functionality in conjunction with composite keys like
@@ -113,7 +106,7 @@ public class TestCore extends EbeanTestCase {
 //        qItems.where(Expr.eq("key.customer", Integer.valueOf(1)));
 
     // I want to discourage the direct use of Expr
-    qItems.where().eq("key.customer", Integer.valueOf(1));
+    qItems.where().eq("key.customer", 1);
     items = qItems.findList();
 
     assertNotNull(items);

--- a/src/test/java/com/avaje/tests/query/sqlquery/SqlQueryTests.java
+++ b/src/test/java/com/avaje/tests/query/sqlquery/SqlQueryTests.java
@@ -139,7 +139,7 @@ public class SqlQueryTests extends BaseTestCase {
       public boolean accept(SqlRow bean) {
         count.incrementAndGet();
         Integer id = bean.getInteger("id");
-        return id.intValue() < 3;
+        return id < 3;
       }
     });
 


### PR DESCRIPTION
This pull request remove unnecessary boxing and unboxing usage (deprecated since Java 5)

> Reports "boxing", e.g. wrapping of primitive values in objects. Boxing is unnecessary under Java 5 and newer, and can be safely removed.

> Reports "unboxing", e.g. explicit unwrapping of wrapped primitive values. Unboxing is unnecessary under Java 5 and newer, and can be safely removed.
