### PR TITLE
Remove redundant "public" modifier for interface methods

### DIFF
--- a/src/test/java/com/avaje/tests/idkeys/TestGeneratedKeys.java
+++ b/src/test/java/com/avaje/tests/idkeys/TestGeneratedKeys.java
@@ -1,15 +1,15 @@
 package com.avaje.tests.idkeys;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
 import com.avaje.ebean.Transaction;
 import com.avaje.ebean.config.dbplatform.IdType;
 import com.avaje.ebeaninternal.api.SpiEbeanServer;
 import com.avaje.tests.idkeys.db.GenKeyIdentity;
 import com.avaje.tests.idkeys.db.GenKeySequence;
 import com.avaje.tests.lib.EbeanTestCase;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  * Test various key generation strategies.
@@ -78,7 +78,6 @@ public class TestGeneratedKeys extends EbeanTestCase
                 }
                 catch (SQLException e)
                 {
-                    ;
                 }
             }
         }

--- a/src/test/java/com/avaje/tests/model/interfaces/IAddress.java
+++ b/src/test/java/com/avaje/tests/model/interfaces/IAddress.java
@@ -1,6 +1,6 @@
 package com.avaje.tests.model.interfaces;
 
 public interface IAddress {
-	public String getStreet();
-	public void setStreet(String s);
+	String getStreet();
+	void setStreet(String s);
 }

--- a/src/test/java/com/avaje/tests/model/interfaces/IPerson.java
+++ b/src/test/java/com/avaje/tests/model/interfaces/IPerson.java
@@ -1,6 +1,6 @@
 package com.avaje.tests.model.interfaces;
 
 public interface IPerson {
-	public IAddress getDefaultAddress();
-	public void setDefaultAddress(IAddress address);
+	IAddress getDefaultAddress();
+	void setDefaultAddress(IAddress address);
 }


### PR DESCRIPTION
This pull request propose these modifications:

- Using "public" modifier on interface methods is redundant
- Remove extra semicolon
