### PR TITLE
Remove redundant local variables

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/server/grammer/EqlAdapterHelper.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/grammer/EqlAdapterHelper.java
@@ -132,8 +132,6 @@ class EqlAdapterHelper {
   }
 
   private String unquote(String value) {
-    String raw = value.substring(1, value.length() - 1);
-    //raw.replaceAll();
-    return raw;
+    return value.substring(1, value.length() - 1);
   }
 }

--- a/src/test/java/com/avaje/tests/model/ivo/converter/ExhangeCompoundType.java
+++ b/src/test/java/com/avaje/tests/model/ivo/converter/ExhangeCompoundType.java
@@ -14,9 +14,7 @@ public class ExhangeCompoundType implements CompoundType<ExhangeCMoneyRate> {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public CompoundTypeProperty<ExhangeCMoneyRate, ?>[] getProperties() {
-
-        CompoundTypeProperty[] props = {new RateProp(), new CMoneyProp()};
-        return props;
+        return new CompoundTypeProperty[]{new RateProp(), new CMoneyProp()};
     }
 
     static class RateProp implements CompoundTypeProperty<ExhangeCMoneyRate, Rate> {

--- a/src/test/java/com/avaje/tests/model/ivo/converter/JodaIntervalCompoundType.java
+++ b/src/test/java/com/avaje/tests/model/ivo/converter/JodaIntervalCompoundType.java
@@ -13,8 +13,7 @@ public class JodaIntervalCompoundType implements CompoundType<Interval>{
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public CompoundTypeProperty<Interval, ?>[] getProperties() {
-        CompoundTypeProperty[] props = {new Start(), new End()};
-        return props;
+        return new CompoundTypeProperty[]{new Start(), new End()};
     }
     
     static class Start implements CompoundTypeProperty<Interval, Long> {

--- a/src/test/java/com/avaje/tests/query/other/TestFindIterateHeapDump.java
+++ b/src/test/java/com/avaje/tests/query/other/TestFindIterateHeapDump.java
@@ -3,7 +3,6 @@ package com.avaje.tests.query.other;
 import com.avaje.ebean.BaseTestCase;
 import com.avaje.ebean.Ebean;
 import com.avaje.ebean.EbeanServer;
-import com.avaje.ebean.QueryEachConsumer;
 import com.avaje.tests.model.basic.EBasic;
 import com.sun.management.HotSpotDiagnosticMXBean;
 import org.junit.Ignore;
@@ -115,10 +114,8 @@ public class TestFindIterateHeapDump extends BaseTestCase {
    */
   private static HotSpotDiagnosticMXBean getHotspotMBean() {
     try {
-      MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-      HotSpotDiagnosticMXBean bean = ManagementFactory.newPlatformMXBeanProxy(server, HOTSPOT_BEAN_NAME,
-          HotSpotDiagnosticMXBean.class);
-      return bean;
+      final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+      return ManagementFactory.newPlatformMXBeanProxy(server, HOTSPOT_BEAN_NAME, HotSpotDiagnosticMXBean.class);
     } catch (RuntimeException re) {
       throw re;
     } catch (Exception exp) {


### PR DESCRIPTION
This pull request remove redundant local variables which are immediately returned. These variables add nothing to the comprehensibility of a method.