### PR TITLE
Use "Collection.addAll(...)" rather than manually copying arrays

### DIFF
--- a/src/main/java/com/avaje/ebean/dbmigration/ddlgeneration/platform/util/IndexColumns.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/ddlgeneration/platform/util/IndexColumns.java
@@ -1,6 +1,7 @@
 package com.avaje.ebean.dbmigration.ddlgeneration.platform.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -21,9 +22,7 @@ public class IndexColumns {
    * Construct representing index.
    */
   public IndexColumns(String[] columnNames) {
-    for (int i = 0; i < columnNames.length; i++) {
-      columns.add(columnNames[i]);
-    }
+    Collections.addAll(columns, columnNames);
   }
 
   /**

--- a/src/main/java/com/avaje/ebean/dbmigration/model/MIndex.java
+++ b/src/main/java/com/avaje/ebean/dbmigration/model/MIndex.java
@@ -4,6 +4,7 @@ import com.avaje.ebean.dbmigration.migration.CreateIndex;
 import com.avaje.ebean.dbmigration.migration.DropIndex;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -32,9 +33,7 @@ public class MIndex {
   public MIndex(String indexName, String tableName, String[] columnNames) {
     this.tableName = tableName;
     this.indexName = indexName;
-    for (int i = 0; i < columnNames.length; i++) {
-      this.columns.add(columnNames[i]);
-    }
+    Collections.addAll(this.columns, columnNames);
   }
 
   public MIndex(CreateIndex createIndex) {
@@ -101,7 +100,6 @@ public class MIndex {
    * Return true if the index has changed.
    */
   private boolean changed(MIndex newIndex) {
-
     if (!tableName.equals(newIndex.getTableName())) {
       return true;
     }
@@ -119,12 +117,9 @@ public class MIndex {
 
 
   private List<String> split(String columns) {
-
     List<String> colList = new ArrayList<>();
     String[] cols = columns.split(",");
-    for (int i = 0; i <cols.length; i++) {
-      colList.add(cols[i]);
-    }
+    Collections.addAll(colList, cols);
     return colList;
   }
 

--- a/src/main/java/com/avaje/ebeaninternal/server/changelog/DefaultChangeLogRegister.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/changelog/DefaultChangeLogRegister.java
@@ -7,6 +7,7 @@ import com.avaje.ebean.event.changelog.ChangeLogFilter;
 import com.avaje.ebean.event.changelog.ChangeLogRegister;
 import com.avaje.ebeaninternal.server.deploy.parse.AnnotationBase;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -42,9 +43,7 @@ public class DefaultChangeLogRegister implements ChangeLogRegister {
     }
 
     Set<String> updateProps = new HashSet<>();
-    for (int i = 0; i < updatesThatInclude.length; i++) {
-      updateProps.add(updatesThatInclude[i]);
-    }
+    Collections.addAll(updateProps, updatesThatInclude);
 
     return new UpdateFilter(insertModeInclude(changeLog.inserts()), updateProps);
   }

--- a/src/main/java/com/avaje/ebeaninternal/server/persist/dmlbind/BindableList.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/dmlbind/BindableList.java
@@ -1,12 +1,13 @@
 package com.avaje.ebeaninternal.server.persist.dmlbind;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.avaje.ebean.bean.EntityBean;
 import com.avaje.ebeaninternal.server.core.PersistRequestBean;
 import com.avaje.ebeaninternal.server.persist.dml.GenerateDmlRequest;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * List of Bindable items.
@@ -38,9 +39,7 @@ public class BindableList implements Bindable {
   }
 
   public void addAll(List<Bindable> list) {
-    for (int i = 0; i < items.length; i++) {
-      list.add(items[i]);
-    }
+    Collections.addAll(list, items);
   }
 
   public void addToUpdate(PersistRequestBean<?> request, List<Bindable> list) {


### PR DESCRIPTION
This pull request remove copying of array contents to a collection where each element is added individually using a for loop.

For better performance, `Collection.addAll(Arrays.asList())` or `Collections.addAll()` usage are recommended.