### PR TITLE
Batching exception safety

### DIFF
--- a/src/main/java/com/avaje/ebeaninternal/api/ScopedTransaction.java
+++ b/src/main/java/com/avaje/ebeaninternal/api/ScopedTransaction.java
@@ -6,11 +6,10 @@ import com.avaje.ebean.bean.PersistenceContext;
 import com.avaje.ebean.config.PersistBatch;
 import com.avaje.ebean.event.changelog.BeanChange;
 import com.avaje.ebean.event.changelog.ChangeSet;
+import com.avaje.ebeaninternal.server.core.PersistDeferredRelationship;
 import com.avaje.ebeaninternal.server.core.PersistRequest;
 import com.avaje.ebeaninternal.server.core.PersistRequestBean;
-import com.avaje.ebeaninternal.server.core.PersistDeferredRelationship;
 import com.avaje.ebeaninternal.server.persist.BatchControl;
-
 import javax.persistence.PersistenceException;
 import javax.persistence.RollbackException;
 import java.io.IOException;
@@ -367,6 +366,11 @@ public class ScopedTransaction implements SpiTransaction {
   @Override
   public void flushBatchOnCascade() {
     transaction.flushBatchOnCascade();
+  }
+
+  @Override
+  public void flushBatchOnRollback() {
+    transaction.flushBatchOnRollback();
   }
 
   @Override

--- a/src/main/java/com/avaje/ebeaninternal/api/SpiTransaction.java
+++ b/src/main/java/com/avaje/ebeaninternal/api/SpiTransaction.java
@@ -5,11 +5,10 @@ import com.avaje.ebean.annotation.DocStoreMode;
 import com.avaje.ebean.bean.PersistenceContext;
 import com.avaje.ebean.event.changelog.BeanChange;
 import com.avaje.ebean.event.changelog.ChangeSet;
+import com.avaje.ebeaninternal.server.core.PersistDeferredRelationship;
 import com.avaje.ebeaninternal.server.core.PersistRequest;
 import com.avaje.ebeaninternal.server.core.PersistRequestBean;
-import com.avaje.ebeaninternal.server.core.PersistDeferredRelationship;
 import com.avaje.ebeaninternal.server.persist.BatchControl;
-
 import java.sql.Connection;
 
 /**
@@ -117,6 +116,7 @@ public interface SpiTransaction extends Transaction {
    * Returning 0 implies to use the system wide default batch size.
    * </p>
    */
+  @Override
   int getBatchSize();
 
   /**
@@ -234,6 +234,8 @@ public interface SpiTransaction extends Transaction {
    * If batch mode was turned on for the request then flush the batch.
    */
   void flushBatchOnCascade();
+
+  void flushBatchOnRollback();
 
   /**
    * Mark the transaction explicitly as not being query only.

--- a/src/main/java/com/avaje/ebeaninternal/server/core/PersistRequestBean.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/core/PersistRequestBean.java
@@ -25,7 +25,6 @@ import com.avaje.ebeaninternal.server.transaction.BeanPersistIdMap;
 import com.avaje.ebeanservice.docstore.api.DocStoreUpdate;
 import com.avaje.ebeanservice.docstore.api.DocStoreUpdateContext;
 import com.avaje.ebeanservice.docstore.api.DocStoreUpdates;
-
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
 import java.io.IOException;
@@ -233,6 +232,15 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
     }
   }
 
+  @Override
+  public void rollbackTransIfRequired() {
+    if (batchOnCascadeSet) {
+      transaction.flushBatchOnRollback();
+      batchOnCascadeSet = false;
+    }
+    super.rollbackTransIfRequired();
+  }
+
   /**
    * Return true is this request was added to the JDBC batch.
    */
@@ -366,6 +374,7 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
   /**
    * Process the persist request updating the document store.
    */
+  @Override
   public void docStoreUpdate(DocStoreUpdateContext txn) throws IOException {
 
     switch (type) {
@@ -387,6 +396,7 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
   /**
    * Add this event to the queue entries in IndexUpdates.
    */
+  @Override
   public void addToQueue(DocStoreUpdates docStoreUpdates) {
     switch (type) {
       case INSERT:
@@ -550,6 +560,7 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
   /**
    * Return the bean associated with this request.
    */
+  @Override
   public T getBean() {
     return bean;
   }
@@ -700,6 +711,7 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
   /**
    * Set the generated key back to the bean. Only used for inserts with getGeneratedKeys.
    */
+  @Override
   public void setGeneratedKey(Object idValue) {
     if (idValue != null) {
       // remember it for logging summary
@@ -718,6 +730,7 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
   /**
    * Check for optimistic concurrency exception.
    */
+  @Override
   public final void checkRowCount(int rowCount) {
     if (ConcurrencyMode.VERSION == concurrencyMode && rowCount != 1) {
       String m = Message.msg("persist.conc2", "" + rowCount);
@@ -761,6 +774,7 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
   /**
    * Post processing.
    */
+  @Override
   public void postExecute() {
 
     changeLog();

--- a/src/main/java/com/avaje/ebeaninternal/server/persist/BatchControl.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/BatchControl.java
@@ -1,15 +1,13 @@
 package com.avaje.ebeaninternal.server.persist;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-
-import javax.persistence.PersistenceException;
-
 import com.avaje.ebeaninternal.api.SpiTransaction;
 import com.avaje.ebeaninternal.server.core.PersistRequest;
 import com.avaje.ebeaninternal.server.core.PersistRequestBean;
 import com.avaje.ebeaninternal.server.deploy.BeanDescriptor;
+import javax.persistence.PersistenceException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 
 /**
  * Controls the batch ordering of persist requests.
@@ -224,6 +222,14 @@ public final class BatchControl {
    */
   public void flushReset() throws PersistenceException {
     flush(true);
+  }
+
+  /**
+   * Clears the batch, discarding all batched statements.
+   */
+  public void clear() {
+    pstmtHolder.clear();
+    beanHoldMap.clear();
   }
 
   /**

--- a/src/main/java/com/avaje/ebeaninternal/server/persist/BatchedPstmtHolder.java
+++ b/src/main/java/com/avaje/ebeaninternal/server/persist/BatchedPstmtHolder.java
@@ -1,11 +1,9 @@
 package com.avaje.ebeaninternal.server.persist;
 
+import javax.persistence.PersistenceException;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
-
-import javax.persistence.PersistenceException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,13 +117,17 @@ public class BatchedPstmtHolder {
     }
 
     // clear the batch cache
-    stmtMap.clear();
-    maxSize = 0;
+    clear();
 
     if (firstError != null) {
       String msg = "Error when batch flush on sql: " + errorSql;
       throw new PersistenceException(msg, firstError);
     }
+  }
+
+  public void clear() {
+    stmtMap.clear();
+    maxSize = 0;
   }
 
   /**

--- a/src/test/java/com/avaje/tests/batchinsert/TestBatchOnCascadeExceptionHandling.java
+++ b/src/test/java/com/avaje/tests/batchinsert/TestBatchOnCascadeExceptionHandling.java
@@ -1,0 +1,105 @@
+package com.avaje.tests.batchinsert;
+
+import com.avaje.ebean.BaseTestCase;
+import com.avaje.ebean.Ebean;
+import com.avaje.ebean.EbeanServer;
+import com.avaje.ebean.Transaction;
+import com.avaje.ebean.config.PersistBatch;
+import com.avaje.ebeaninternal.api.SpiTransaction;
+import com.avaje.ebeaninternal.server.persist.BatchControl;
+import com.avaje.tests.model.basic.EBasicWithUniqueCon;
+import com.avaje.tests.model.basic.EOptOneB;
+import com.avaje.tests.model.basic.EOptOneC;
+import javax.persistence.PersistenceException;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.StrictAssertions.assertThat;
+
+public class TestBatchOnCascadeExceptionHandling extends BaseTestCase {
+
+  @Test
+  public void testBatchScenarioWithSavepoint() throws SQLException {
+    EbeanServer server = Ebean.getDefaultServer();
+    Transaction txn = server.beginTransaction();
+    try {
+      server.save(createEntityWithName("before-savepoint"));
+      txn.flushBatch();
+      Savepoint sp = txn.getConnection().setSavepoint();
+      try {
+        server.save(createEntityWithName("confict"));
+        server.save(createEntityWithName("confict")); // unique key violation
+      } catch (PersistenceException e) {
+        txn.getConnection().rollback(sp);
+        server.save(createEntityWithName("after-savepoint"));
+      }
+
+      txn.commit();
+    } finally {
+      txn.end();
+    }
+
+    assertThat(server.find(EBasicWithUniqueCon.class).where().eq("name", "before-savepoint").findList()).isNotEmpty();
+    assertThat(server.find(EBasicWithUniqueCon.class).where().eq("name", "after-savepoint").findList()).isNotEmpty();
+    assertThat(server.find(EBasicWithUniqueCon.class).where().eq("name", "confict").findList()).isEmpty();
+  }
+
+  @Test
+  public void testBatchedInsertFailure() {
+    final EbeanServer server = Ebean.getDefaultServer();
+    server.save(createEntityWithName("foo"));
+    testBatchOnCascadeIsExceptionSafe(server, () -> {
+      server.save(createEntityWithName("foo")); // duplicate name on insert
+    });
+  }
+
+  @Test
+  public void testBatchedUpdateFailure() {
+    final EbeanServer server = Ebean.getDefaultServer();
+    server.save(createEntityWithName("bla"));
+    final EBasicWithUniqueCon bar = createEntityWithName("bar");
+    server.save(bar);
+    testBatchOnCascadeIsExceptionSafe(server, () -> {
+      bar.setName("bla");
+      server.save(bar); // duplicate name on update
+    });
+  }
+
+  @Test
+  public void testBatchedDeleteFailure() {
+    final EbeanServer server = Ebean.getDefaultServer();
+    final EOptOneC c = new EOptOneC();
+    server.save(c);
+    final EOptOneB b = new EOptOneB();
+    b.setC(c);
+    server.save(b);
+    testBatchOnCascadeIsExceptionSafe(server, () -> {
+      server.delete(c); // foreign key violation
+    });
+  }
+
+  protected void testBatchOnCascadeIsExceptionSafe(EbeanServer server, Runnable failingOperation) {
+    Transaction txn = server.beginTransaction();
+    assertThat(txn.getBatch()).isSameAs(PersistBatch.NONE);
+    assertThat(txn.getBatchOnCascade()).isSameAs(PersistBatch.ALL);
+
+    try {
+      failingOperation.run();
+      Assertions.fail("PersistenceException expected");
+    } catch (PersistenceException e) {
+      assertThat(txn.getBatch()).as("batch mode").isSameAs(PersistBatch.NONE); // should not have changed
+      BatchControl bc = ((SpiTransaction) txn).getBatchControl();
+      assertThat(bc == null || bc.isEmpty()).as("batch emtpy").isTrue();
+    } finally {
+      txn.end();
+    }
+  }
+
+  protected EBasicWithUniqueCon createEntityWithName(String name) {
+    EBasicWithUniqueCon it = new EBasicWithUniqueCon();
+    it.setName(name);
+    return it;
+  }
+}


### PR DESCRIPTION
This adds some tests for exception safety around batchOnCascade handling, plus a second commit with my attempt at fixing the issue.

The `testBatchScenarioWithSavepoint` is the scenario motivating this for me: I've got code in a few places where I use a save point to make an insert or update that may fail due to a constraint violation. If it does fail, I want to be able to roll  back to the save point and take a different course of action (e.g. update an existing record instead of creating a new one etc). This kind of code broke after upgrading from ebean 7.5 to 8, because the batch and batch mode do not get correctly reset when an operation fails.

Additional tests and changes might be required when working with batching enabled at the top level, I haven't tested.