### PR TITLE
Pass dataType to DataBind for Types.OTHER

### DIFF
--- a/src/main/java/io/ebeaninternal/server/persist/Binder.java
+++ b/src/main/java/io/ebeaninternal/server/persist/Binder.java
@@ -324,7 +324,7 @@ public class Binder {
           break;
 
         case java.sql.Types.OTHER:
-          b.setObject(data);
+          b.setObject(data, dataType);
           break;
 
         case java.sql.Types.JAVA_OBJECT:


### PR DESCRIPTION
This change allows to use ScalarType to allow to use Java enums in where() Expressions.