### PR TITLE
SqlServer 2016 history support.

### DIFF
--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServer2016HistorySupport.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServer2016HistorySupport.java
@@ -1,0 +1,38 @@
+package io.ebean.config.dbplatform.sqlserver;
+
+import io.ebean.config.dbplatform.DbStandardHistorySupport;
+
+/**
+ * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
+ */
+public class SqlServer2016HistorySupport extends DbStandardHistorySupport {
+
+    /**
+     * Return the ' as of timestamp ?' clause appended after the table name.
+     */
+    @Override
+    public String getAsOfViewSuffix(String asOfViewSuffix) {
+        return " for system_time as of ?";
+    }
+
+    @Override
+    public String getVersionsBetweenSuffix(String asOfViewSuffix) {
+        return " for system_time between ? and ?";
+    }
+
+    /**
+     * Returns the SQL Server specific effective start column.
+     */
+    @Override
+    public String getSysPeriodLower(String tableAlias, String sysPeriod) {
+        return tableAlias + "." + sysPeriod + "From";
+    }
+
+    /**
+     * Returns the SQL Server specific effective end column.
+     */
+    @Override
+    public String getSysPeriodUpper(String tableAlias, String sysPeriod) {
+        return tableAlias + "." + sysPeriod + "To";
+    }
+}

--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServer2016Platform.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServer2016Platform.java
@@ -1,0 +1,15 @@
+package io.ebean.config.dbplatform.sqlserver;
+
+import io.ebean.dbmigration.ddlgeneration.platform.MsSqlServer2016Ddl;
+
+/**
+ * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
+ */
+public class SqlServer2016Platform extends SqlServerPlatform {
+
+  public SqlServer2016Platform() {
+    super();
+    this.historySupport = new SqlServer2016HistorySupport();
+    this.platformDdl = new MsSqlServer2016Ddl(this);
+  }
+}

--- a/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/MsSqlServer2016Ddl.java
+++ b/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/MsSqlServer2016Ddl.java
@@ -1,0 +1,24 @@
+package io.ebean.dbmigration.ddlgeneration.platform;
+
+import io.ebean.config.ServerConfig;
+import io.ebean.config.dbplatform.DatabasePlatform;
+import io.ebean.dbmigration.ddlgeneration.DdlBuffer;
+import io.ebean.dbmigration.ddlgeneration.DdlWrite;
+import io.ebean.dbmigration.migration.AddHistoryTable;
+import io.ebean.dbmigration.migration.AlterColumn;
+import io.ebean.dbmigration.migration.DropHistoryTable;
+import io.ebean.dbmigration.model.MTable;
+
+import java.io.IOException;
+
+/**
+ * MS SQL Server 2016 platform specific DDL.
+ */
+public class MsSqlServer2016Ddl extends MsSqlServerDdl {
+
+  public MsSqlServer2016Ddl(DatabasePlatform platform) {
+    super(platform);
+    this.historyDdl = new MsSqlServer2016HistoryDdl();
+  }
+
+}

--- a/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/MsSqlServer2016HistoryDdl.java
+++ b/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/MsSqlServer2016HistoryDdl.java
@@ -1,0 +1,61 @@
+package io.ebean.dbmigration.ddlgeneration.platform;
+
+import io.ebean.config.ServerConfig;
+import io.ebean.dbmigration.ddlgeneration.DdlBuffer;
+import io.ebean.dbmigration.ddlgeneration.DdlWrite;
+import io.ebean.dbmigration.migration.AddHistoryTable;
+import io.ebean.dbmigration.migration.DropHistoryTable;
+import io.ebean.dbmigration.model.MTable;
+
+import java.io.IOException;
+
+/**
+ * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
+ */
+public class MsSqlServer2016HistoryDdl implements PlatformHistoryDdl {
+
+  private String systemPeriodStart;
+  private String systemPeriodEnd;
+
+  @Override
+  public void configure(ServerConfig serverConfig, PlatformDdl platformDdl) {
+    this.systemPeriodStart = serverConfig.getAsOfSysPeriod() + "From";
+    this.systemPeriodEnd = serverConfig.getAsOfSysPeriod() + "To";
+  }
+
+  @Override
+  public void createWithHistory(DdlWrite writer, MTable table) throws IOException {
+    String baseTable = table.getName();
+    enableSystemVersioning(writer, baseTable);
+  }
+
+  private void enableSystemVersioning(DdlWrite writer, String baseTable) throws IOException {
+    DdlBuffer apply = writer.applyHistory();
+    apply.append("alter table ").append(baseTable).newLine()
+      .append("    add ").append(systemPeriodStart).append(" datetime2 GENERATED ALWAYS AS ROW START NOT NULL DEFAULT SYSUTCDATETIME(),").newLine()
+      .append("        ").append(systemPeriodEnd).append("   datetime2 GENERATED ALWAYS AS ROW END   NOT NULL,").newLine()
+      .append("period for system_time (").append(systemPeriodStart).append("From, ").append(systemPeriodEnd).append("To)").endOfStatement();
+
+    apply.append("alter table ").append(baseTable).append("set (system_versioning = on)").endOfStatement();
+  }
+
+  @Override
+  public void dropHistoryTable(DdlWrite writer, DropHistoryTable dropHistoryTable) throws IOException {
+    String baseTable = dropHistoryTable.getBaseTable();
+    DdlBuffer apply = writer.applyHistory();
+    apply.append("alter table ").append(baseTable).append("set (system_versioning = off)").endOfStatement();
+    apply.append("alter table ").append(baseTable).append(" drop column ").append(systemPeriodStart).endOfStatement();
+    apply.append("alter table ").append(baseTable).append(" drop column ").append(systemPeriodEnd).endOfStatement();
+  }
+
+  @Override
+  public void addHistoryTable(DdlWrite writer, AddHistoryTable addHistoryTable) throws IOException {
+    String baseTable = addHistoryTable.getBaseTable();
+    enableSystemVersioning(writer, baseTable);
+  }
+
+  @Override
+  public void updateTriggers(DdlWrite write, HistoryTableUpdate baseTable) throws IOException {
+    // SQL Server 2016 does not need triggers
+  }
+}

--- a/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/PlatformHistoryDdl.java
+++ b/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/PlatformHistoryDdl.java
@@ -14,12 +14,12 @@ import java.io.IOException;
 public interface PlatformHistoryDdl {
 
   /**
-   * Configure typically reading the
+   * Configure typically reading the necessary parameters from ServerConfig and Platform.
    */
   void configure(ServerConfig serverConfig, PlatformDdl platformDdl);
 
   /**
-   * Add history support to the table using platform specific mechanism.
+   * Creates a new table and add history support to the table using platform specific mechanism.
    */
   void createWithHistory(DdlWrite writer, MTable table) throws IOException;
 

--- a/src/test/java/io/ebean/config/dbplatform/sqlserver/SqlServer2016PlatformTest.java
+++ b/src/test/java/io/ebean/config/dbplatform/sqlserver/SqlServer2016PlatformTest.java
@@ -1,0 +1,18 @@
+package io.ebean.config.dbplatform.sqlserver;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Vilmos Nagy  <vilmos.nagy@outlook.com>
+ */
+public class SqlServer2016PlatformTest {
+
+  @Test
+  public void testHistorySupport() {
+    SqlServer2016Platform platform = new SqlServer2016Platform();
+    assertTrue(platform.getHistorySupport() instanceof SqlServer2016HistorySupport);
+  }
+}


### PR DESCRIPTION
Hi Rob!

I've implemented the basic SQL2011 History support for SQL Server 2016.

I'm not totally sure about the DbMigration part - but the queries works pretty fine, if the `system_versioning`  is turned on the tables.

I'm not sure, how to distinguish SQL Server 2016 from previous SQL Servers, so currently I've to set this by hand in the `ServerConfig` instance.