### PR TITLE
SQL Server boolean mapping fix

### DIFF
--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
@@ -8,6 +8,8 @@ import io.ebean.config.dbplatform.DbType;
 import io.ebean.config.dbplatform.IdType;
 import io.ebean.dbmigration.ddlgeneration.platform.SqlServerDdl;
 
+import java.sql.Types;
+
 /**
  * Microsoft SQL Server platform.
  */
@@ -32,6 +34,7 @@ public class SqlServerPlatform extends DatabasePlatform {
     this.openQuote = "[";
     this.closeQuote = "]";
 
+    booleanDbType = Types.INTEGER;
     dbTypeMap.put(DbType.BOOLEAN, new DbPlatformType("bit default 0"));
 
     dbTypeMap.put(DbType.INTEGER, new DbPlatformType("integer", false));


### PR DESCRIPTION
Hi Rob,

I've got the following error with SQL Server, when I try to use SoftDelete (or filter on any boolean typed fields)

```
SEVERE: 
javax.persistence.PersistenceException: Query threw SQLException:Invalid column name 'false'. 
Bind values:[] 
Query was:
select count(*) from Users t0 where t0.deleted = false 


	at io.ebeaninternal.server.query.CQuery.createPersistenceException(CQuery.java:680)
	at io.ebeaninternal.server.query.CQueryEngine.findRowCount(CQueryEngine.java:158)
	at io.ebeaninternal.server.query.DefaultOrmQueryEngine.findRowCount(DefaultOrmQueryEngine.java:64)
	at io.ebeaninternal.server.core.OrmQueryRequest.findRowCount(OrmQueryRequest.java:304)
	at io.ebeaninternal.server.core.DefaultServer.findRowCountWithCopy(DefaultServer.java:1231)
	at io.ebeaninternal.server.core.DefaultServer.findCount(DefaultServer.java:1219)
	at io.ebeaninternal.server.querydefn.DefaultOrmQuery.findCount(DefaultOrmQuery.java:1165)
```

I think it's because the SqlServerPlatform do not set the `booleanDbType` like the OraclePlatform does.

With this fix the same query runs fine.

Thanks,