### PR TITLE
Upgrade antlr4-runtime to prior version 4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
-      <version>4.5.3</version>
+      <version>4.6</version>
     </dependency>
 
     <!-- Jackson core used internally by Ebean -->


### PR DESCRIPTION
As requested on issue #933, this pull request upgrade the dependency _antlr4-runtime_ to prior version 4.6.