### PR TITLE
FIX: replaced some hard coded id columns

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -288,7 +288,7 @@ public class DefaultBeanLoader {
     }
 
     if (embeddedOwnerIndex > -1) {
-      query.select("id," + ebi.getProperty(embeddedOwnerIndex));
+      query.select(desc.getIdProperty().getName() + "," + ebi.getProperty(embeddedOwnerIndex));
     }
 
     // don't collect AutoTune usage profiling information

--- a/src/main/java/io/ebeaninternal/server/query/CQueryPlanRawSql.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryPlanRawSql.java
@@ -63,6 +63,7 @@ class CQueryPlanRawSql extends CQueryPlan {
    */
   private String foreignKeyPath(String logicalPropertyPath) {
     // trim the .id and replace with Id ... to reverse the auto fk mapping earlier
+    // CHECKME: what is if the PK is not named "id"
     return logicalPropertyPath.substring(0, logicalPropertyPath.length() - 3) + "Id";
   }
 }

--- a/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -435,7 +435,7 @@ public class SqlTreeBuilder {
       BeanProperty p = desc.findBeanProperty(propName);
       if (p == null) {
         logger.error("property [" + propName + "] not found on " + desc + " for query - excluding it.");
-        p = desc.findBeanProperty("id");
+        p = desc.getIdProperty();
         selectProps.add(p);
 
       } else if (p.isId()) {


### PR DESCRIPTION
I've found some hard-coded "id" strings. This will fail, if PK is not named "id"

@rbygrave Maybe you have a look at these corrections.

Cheers,
Roland