### PR TITLE
FIX: do not hit database if inherited entity has no children

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -589,7 +589,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     }
 
     InheritInfo inheritInfo = desc.getInheritInfo();
-    if (inheritInfo == null) {
+    if (inheritInfo == null || inheritInfo.getChildren().isEmpty()) {
       return (T) desc.contextRef(pc, null, false, id);
     }
 

--- a/src/main/java/io/ebeaninternal/server/deploy/InheritInfo.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/InheritInfo.java
@@ -165,7 +165,14 @@ public class InheritInfo {
   public BeanProperty[] localProperties() {
     return descriptor.propertiesLocal();
   }
-
+  
+  /**
+   * Return the children.
+   */
+  public ArrayList<InheritInfo> getChildren() {
+    return children;
+  }
+  
   /**
    * Get the bean property additionally looking in the sub types.
    */

--- a/src/test/java/org/tests/inheritance/TestInheritanceRefBean.java
+++ b/src/test/java/org/tests/inheritance/TestInheritanceRefBean.java
@@ -1,0 +1,40 @@
+package org.tests.inheritance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.avaje.ebeantest.LoggedSqlCollector;
+import org.avaje.test.model.rawsql.inherit.ChildA;
+import org.avaje.test.model.rawsql.inherit.ChildB;
+import org.avaje.test.model.rawsql.inherit.Parent;
+import org.junit.Test;
+
+import io.ebean.BaseTestCase;
+
+public class TestInheritanceRefBean extends BaseTestCase {
+
+    @Test
+    public void test() {
+      Parent a = new ChildA(42, "Bean A");
+      Parent b = new ChildB(43, "Bean B");
+      
+      server().save(a);
+      server().save(b);
+      Long idA = a.getId();
+      Long idB = b.getId();
+      
+      Parent test;
+      
+      LoggedSqlCollector.start();
+      test = server().getReference(ChildA.class, idA);
+      assertTrue(test instanceof ChildA);
+      assertEquals(0, LoggedSqlCollector.stop().size());
+      
+      LoggedSqlCollector.start();
+      test = server().getReference(Parent.class, idB);
+      assertTrue(test instanceof ChildB);
+      assertEquals(1, LoggedSqlCollector.stop().size());
+      
+      
+    }
+}


### PR DESCRIPTION
I had the problem when creating reference bean that every time the DB was hit. In my opinion it is not neccesary to do that if the bean class has no children.