### PR TITLE
no effective code change: add some try-with resources

### DIFF
--- a/src/main/java/io/ebean/dbmigration/DbMigration.java
+++ b/src/main/java/io/ebean/dbmigration/DbMigration.java
@@ -263,10 +263,10 @@ public class DbMigration {
     logger.info("writing repeatable script {}", fullName);
 
     File file = new File(migrationDir, fullName);
-    FileWriter writer = new FileWriter(file);
-    writer.write(script.getValue());
-    writer.flush();
-    writer.close();
+    try (FileWriter writer = new FileWriter(file)) {
+      writer.write(script.getValue());
+      writer.flush();
+    }
   }
 
   private String repeatableMigrationName(String scriptName) {

--- a/src/main/java/io/ebean/dbmigration/migrationreader/MigrationXmlReader.java
+++ b/src/main/java/io/ebean/dbmigration/migrationreader/MigrationXmlReader.java
@@ -37,10 +37,8 @@ public class MigrationXmlReader {
    */
   public static Migration read(File migrationFile) {
 
-    try {
-      try (FileInputStream is = new FileInputStream(migrationFile)) {
-        return read(is);
-      }
+    try (FileInputStream is = new FileInputStream(migrationFile)) {
+      return read(is);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/main/java/io/ebean/dbmigration/migrationreader/MigrationXmlWriter.java
+++ b/src/main/java/io/ebean/dbmigration/migrationreader/MigrationXmlWriter.java
@@ -26,9 +26,8 @@ public class MigrationXmlWriter {
    */
   public void write(Migration migration, File file) {
 
-    try {
+    try (FileWriter writer = new FileWriter(file)) {
 
-      FileWriter writer = new FileWriter(file);
       writer.write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
       writer.write("<!DOCTYPE xml>\n");
       if (comment != null) {
@@ -43,8 +42,6 @@ public class MigrationXmlWriter {
       marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
 
       marshaller.marshal(migration, writer);
-
-      writer.close();
 
     } catch (IOException | JAXBException e) {
       throw new RuntimeException(e);

--- a/src/main/java/io/ebean/text/json/EJsonWriter.java
+++ b/src/main/java/io/ebean/text/json/EJsonWriter.java
@@ -23,8 +23,7 @@ class EJsonWriter {
 
   static String write(Object object) throws IOException {
     StringWriter writer = new StringWriter(200);
-    JsonGenerator jsonGenerator = write(object, writer);
-    jsonGenerator.close();
+    write(object, writer).close();
     return writer.toString();
   }
 

--- a/src/main/java/io/ebeaninternal/server/changelog/ChangeJsonBuilder.java
+++ b/src/main/java/io/ebeaninternal/server/changelog/ChangeJsonBuilder.java
@@ -30,12 +30,12 @@ public class ChangeJsonBuilder {
    */
   public void writeBeanJson(Writer writer, BeanChange bean, ChangeSet changeSet, int position) throws IOException {
 
-    JsonGenerator generator = jsonFactory.createGenerator(writer);
-
-    writeBeanChange(generator, bean, changeSet, position);
-
-    generator.flush();
-    generator.close();
+    try (JsonGenerator generator = jsonFactory.createGenerator(writer)) {
+  
+      writeBeanChange(generator, bean, changeSet, position);
+  
+      generator.flush();
+    }
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -359,9 +359,9 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
       List<XmEbean> mappings = new ArrayList<>();
       while (resources.hasMoreElements()) {
         URL url = resources.nextElement();
-        InputStream is = url.openStream();
-        mappings.add(XmlMappingReader.read(is));
-        is.close();
+        try (InputStream is = url.openStream()) {
+          mappings.add(XmlMappingReader.read(is));
+        }
       }
 
       for (XmEbean mapping : mappings) {

--- a/src/main/java/io/ebeaninternal/server/persist/BatchedPstmt.java
+++ b/src/main/java/io/ebeaninternal/server/persist/BatchedPstmt.java
@@ -115,18 +115,13 @@ public class BatchedPstmt {
   private void getGeneratedKeys() throws SQLException {
 
     int index = 0;
-    ResultSet rset = pstmt.getGeneratedKeys();
-    try {
+    try (ResultSet rset = pstmt.getGeneratedKeys()) {
       while (rset.next()) {
         Object idValue = rset.getObject(1);
         list.get(index).setGeneratedKey(idValue);
         index++;
       }
-    } finally {
-      if (rset != null) {
-        rset.close();
-      }
-    }
+    } 
   }
 
 }

--- a/src/main/java/io/ebeaninternal/server/readaudit/DefaultReadAuditLogger.java
+++ b/src/main/java/io/ebeaninternal/server/readaudit/DefaultReadAuditLogger.java
@@ -35,9 +35,8 @@ public class DefaultReadAuditLogger implements ReadAuditLogger {
    */
   @Override
   public void queryPlan(ReadAuditQueryPlan queryPlan) {
-    try {
-      StringWriter writer = new StringWriter(defaultQueryBuffer);
-      JsonGenerator gen = jsonFactory.createGenerator(writer);
+    StringWriter writer = new StringWriter(defaultQueryBuffer);
+    try (JsonGenerator gen = jsonFactory.createGenerator(writer)) {
 
       gen.writeStartObject();
       String beanType = queryPlan.getBeanType();
@@ -54,7 +53,6 @@ public class DefaultReadAuditLogger implements ReadAuditLogger {
       }
       gen.writeEndObject();
       gen.flush();
-      gen.close();
 
       queryLogger.info(writer.toString());
 

--- a/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
@@ -306,10 +306,10 @@ public class DJsonContext implements JsonContext {
     StringWriter writer = new StringWriter(500);
     try (JsonGenerator gen = createGenerator(writer)){
       toJsonInternal(value, gen, options);
-      return writer.toString();
     } catch (IOException e) {
       throw new JsonIOException(e);
     }
+    return writer.toString();
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
@@ -303,11 +303,9 @@ public class DJsonContext implements JsonContext {
   }
 
   private String toJsonString(Object value, JsonWriteOptions options) throws JsonIOException {
-    try {
-      StringWriter writer = new StringWriter(500);
-      JsonGenerator gen = createGenerator(writer);
+    StringWriter writer = new StringWriter(500);
+    try (JsonGenerator gen = createGenerator(writer)){
       toJsonInternal(value, gen, options);
-      gen.close();
       return writer.toString();
     } catch (IOException e) {
       throw new JsonIOException(e);

--- a/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
+++ b/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
@@ -217,11 +217,10 @@ public class RsetDataReader implements DataReader {
 
   protected byte[] getBinaryLob(InputStream in) throws SQLException {
 
-    try {
-      if (in == null) {
-        return null;
-      }
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
+    if (in == null) {
+      return null;
+    }
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 
       byte[] buf = new byte[bufferSize];
       int len;
@@ -234,7 +233,6 @@ public class RsetDataReader implements DataReader {
         data = null;
       }
       in.close();
-      out.close();
       return data;
 
     } catch (IOException e) {

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeFile.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeFile.java
@@ -124,10 +124,10 @@ public class ScalarTypeFile extends ScalarTypeBase<File> {
   @Override
   public File jsonRead(JsonParser parser) throws IOException {
     File tempFile = File.createTempFile(prefix, suffix, directory);
-    OutputStream os = getOutputStream(tempFile);
-    parser.readBinaryValue(os);
-    os.flush();
-    os.close();
+    try (OutputStream os = getOutputStream(tempFile)) {
+      parser.readBinaryValue(os);
+      os.flush();
+    }
     return tempFile;
   }
 

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonNode.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonNode.java
@@ -68,11 +68,8 @@ public abstract class ScalarTypeJsonNode extends ScalarTypeBase<JsonNode> {
       if (is == null) {
         return null;
       }
-      try {
-        InputStreamReader reader = new InputStreamReader(is);
-        JsonNode tree = parse(reader);
-        reader.close();
-        return tree;
+      try (InputStreamReader reader = new InputStreamReader(is)) {
+        return parse(reader);
       } catch (IOException e) {
         throw new SQLException("Error reading Blob stream from DB", e);
       }


### PR DESCRIPTION
I've added some try-with-resources in this PR - none of them should change the actual behavior.

But there are still some candidates - e.g. in InsertHandler
```java
PreparedStatement stmt = null;
    ResultSet rset = null;
    try {
      stmt = conn.prepareStatement(selectLastInsertedId);
      rset = stmt.executeQuery();
      setGeneratedKey(rset);
    } finally {
      try {
        if (rset != null) {
          rset.close();
        }
      } catch (SQLException ex) {
        logger.warn("Error closing ResultSet for fetchGeneratedKeyUsingSelect?", ex);
      }
      try {
        if (stmt != null) {
          stmt.close();
        }
      } catch (SQLException ex) {
        logger.warn("Error closing Statement for fetchGeneratedKeyUsingSelect?", ex);
      }
    }
```

which CAN be refactored to
```java
    try (PreparedStatement stmt = conn.prepareStatement(selectLastInsertedId);
        ResultSet rset = stmt.executeQuery()){
      setGeneratedKey(rset);
    }
```
but this means, the behavior will change

There is one suggestion how to deal with this problem: 
http://stackoverflow.com/questions/6889697/close-resource-quietly-using-try-with-resources
```
    boolean success = false;
    try (PreparedStatement stmt = conn.prepareStatement(selectLastInsertedId);
        ResultSet rset = stmt.executeQuery()){
      setGeneratedKey(rset);
      success = true;
    } catch (SQLException ex) {
      if (!success) throw ex;
      logger.warn("Error closing Statement or Resultset for fetchGeneratedKeyUsingSelect?", ex);
    }
```
