### PR TITLE
FIX: potential NPE

### DIFF
--- a/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -255,7 +255,9 @@ public class JdbcTransaction implements SpiTransaction {
 
   @Override
   public void sendChangeLog(ChangeSet changesRequest) {
-    manager.sendChangeLog(changesRequest);
+    if (manager != null) {
+      manager.sendChangeLog(changesRequest);
+    }
   }
 
   @Override


### PR DESCRIPTION
manager can be null - eg when creted with new ExternalJdbcTransaction(conn)

don't know how and if this case can happen, but IF: what should happen with the changesRequest