### PR TITLE
Fix multi tenant bean change

### DIFF
--- a/src/main/java/io/ebean/event/changelog/BeanChange.java
+++ b/src/main/java/io/ebean/event/changelog/BeanChange.java
@@ -15,6 +15,11 @@ public class BeanChange {
   String table;
 
   /**
+   * The tenantId value.
+   */
+  Object tenantId;
+  
+  /**
    * The id value.
    */
   Object id;
@@ -37,8 +42,9 @@ public class BeanChange {
   /**
    * Construct with all the details.
    */
-  public BeanChange(String table, Object id, ChangeType type, Map<String, ValuePair> values) {
+  public BeanChange(String table, Object tenantId, Object id, ChangeType type, Map<String, ValuePair> values) {
     this.table = table;
+    this.tenantId = tenantId;
     this.id = id;
     this.type = type;
     this.eventTime = System.currentTimeMillis();
@@ -53,7 +59,7 @@ public class BeanChange {
 
   @Override
   public String toString() {
-    return "table:" + table + " id:" + id + " values:" + values;
+    return "table:" + table + " tenantId: " + tenantId + " id:" + id + " values:" + values;
   }
 
   /**
@@ -70,6 +76,20 @@ public class BeanChange {
     this.table = table;
   }
 
+  /**
+   * Return the tenant id.
+   */
+  public Object getTenantId() {
+    return tenantId;
+  }
+
+  /**
+   * Set the bean id (for JSON tools).
+   */
+  public void setTenantId(Object tenantId) {
+    this.tenantId = tenantId;
+  }
+  
   /**
    * Return the object id.
    */

--- a/src/main/java/io/ebeaninternal/server/changelog/ChangeJsonBuilder.java
+++ b/src/main/java/io/ebeaninternal/server/changelog/ChangeJsonBuilder.java
@@ -48,6 +48,9 @@ public class ChangeJsonBuilder {
     writeBeanTransactionDetails(gen, changeSet, position);
 
     gen.writeStringField("object", bean.getTable());
+    if (bean.getTenantId() != null) {
+      gen.writeStringField("tenantId", bean.getTenantId().toString());
+    }
     gen.writeStringField("objectId", bean.getId().toString());
     gen.writeStringField("change", bean.getType().getCode());
     gen.writeNumberField("eventTime", bean.getEventTime());

--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -314,7 +314,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Override
   public Object currentTenantId() {
-    return currentTenantProvider.currentId();
+    return currentTenantProvider == null ? null : currentTenantProvider.currentId();
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -837,7 +837,8 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
   }
 
   private BeanChange newBeanChange(Object id, ChangeType changeType, Map<String, ValuePair> values) {
-    return new BeanChange(getBaseTable(), id, changeType, values);
+    Object tenantId = ebeanServer.currentTenantId();
+    return new BeanChange(getBaseTable(), tenantId, id, changeType, values);
   }
 
   public SqlUpdate deleteById(Object id, List<Object> idList, boolean softDelete) {

--- a/src/test/java/io/ebeaninternal/server/changelog/Helper.java
+++ b/src/test/java/io/ebeaninternal/server/changelog/Helper.java
@@ -41,7 +41,7 @@ public class Helper {
     values.put("name", new ValuePair("rob", null));
     values.put("modified", new ValuePair(new Timestamp(System.currentTimeMillis()), null));
 
-    BeanChange bean = new BeanChange("mytable", startId + 1, ChangeType.INSERT, null);
+    BeanChange bean = new BeanChange("mytable", null, startId + 1, ChangeType.INSERT, null);
     bean.setValues(values);
     return bean;
   }
@@ -55,14 +55,14 @@ public class Helper {
 
     values.put("modified", new ValuePair(new Timestamp(System.currentTimeMillis()), null));
 
-    BeanChange bean = new BeanChange("mytable", startId + 2, ChangeType.UPDATE, null);
+    BeanChange bean = new BeanChange("mytable", null, startId + 2, ChangeType.UPDATE, null);
     bean.setValues(values);
     return bean;
   }
 
   @NotNull
   private BeanChange createDelete(long startId) {
-    return new BeanChange("mytable", startId + 3, ChangeType.DELETE, new HashMap<>());
+    return new BeanChange("mytable", null, startId + 3, ChangeType.DELETE, new HashMap<>());
   }
 
 }


### PR DESCRIPTION
Hello Rob,

added the tenant id to BeanChange - as BeanChanges are logged async - and currentTenantProvider is most likely a ThreadLocal, it is neccessary to store the tenantId of the originating thread.