### PR TITLE
Warning suppressions.

### DIFF
--- a/src/main/java/io/ebean/text/json/EJson.java
+++ b/src/main/java/io/ebean/text/json/EJson.java
@@ -123,6 +123,7 @@ public class EJson {
   /**
    * Parse the json returning as a List taking into account the current token.
    */
+  @SuppressWarnings("unchecked")
   public static List<Object> parseList(JsonParser parser, JsonToken currentToken) throws IOException {
     return (List<Object>) EJsonReader.parse(parser, currentToken, false);
   }

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -2774,6 +2774,7 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
   /**
    * Set the version value returning it in primitive long form.
    */
+  @SuppressWarnings("unchecked")
   public long setVersion(EntityBean entityBean, Object versionValue) {
     versionProperty.setValueIntercept(entityBean, versionValue);
     return versionProperty.scalarType.asVersion(versionValue);
@@ -2782,6 +2783,7 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
   /**
    * Return the version value in primitive long form (if exists and set).
    */
+  @SuppressWarnings("unchecked")
   public long getVersion(EntityBean entityBean) {
     if (versionProperty == null) {
       return 0;

--- a/src/main/java/io/ebeaninternal/server/text/json/DJsonBeanReader.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/DJsonBeanReader.java
@@ -46,6 +46,6 @@ public class DJsonBeanReader<T> implements JsonBeanReader<T> {
 
   @Override
   public JsonBeanReader<T> forJson(JsonParser moreJson, boolean resetContext) {
-    return new DJsonBeanReader(desc, readJson.forJson(moreJson, resetContext));
+    return new DJsonBeanReader<T>(desc, readJson.forJson(moreJson, resetContext));
   }
 }

--- a/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
@@ -59,7 +59,7 @@ public class DJsonContext implements JsonContext {
     this.jsonFactory = (jsonFactory != null) ? jsonFactory : new JsonFactory();
     this.defaultObjectMapper = this.server.getServerConfig().getObjectMapper();
     this.defaultInclude = this.server.getServerConfig().getJsonInclude();
-    this.jsonScalar = new DJsonScalar(typeManager);
+    this.jsonScalar = new DJsonScalar(this.typeManager);
   }
 
   @Override
@@ -128,7 +128,7 @@ public class DJsonContext implements JsonContext {
   }
 
   @Override
-  public <T> DJsonBeanReader createBeanReader(Class<T> cls, JsonParser parser, JsonReadOptions options) throws JsonIOException {
+  public <T> DJsonBeanReader<T> createBeanReader(Class<T> cls, JsonParser parser, JsonReadOptions options) throws JsonIOException {
 
     BeanDescriptor<T> desc = getDescriptor(cls);
     ReadJson readJson = new ReadJson(desc, parser, options, determineObjectMapper(options));
@@ -136,7 +136,7 @@ public class DJsonContext implements JsonContext {
   }
 
   @Override
-  public <T> DJsonBeanReader createBeanReader(BeanType<T> beanType, JsonParser parser, JsonReadOptions options) throws JsonIOException {
+  public <T> DJsonBeanReader<T> createBeanReader(BeanType<T> beanType, JsonParser parser, JsonReadOptions options) throws JsonIOException {
 
     BeanDescriptor<T> desc = (BeanDescriptor<T>) beanType;
     ReadJson readJson = new ReadJson(desc, parser, options, determineObjectMapper(options));

--- a/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -16,7 +16,6 @@ import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeanservice.docstore.api.mapping.DocPropertyType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.joda.time.DateMidnight;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
@@ -804,7 +803,7 @@ public final class DefaultTypeManager implements TypeManager {
       typeMap.put(LocalDateTime.class, new ScalarTypeJodaLocalDateTime(mode));
       typeMap.put(DateTime.class, new ScalarTypeJodaDateTime(mode));
       typeMap.put(LocalDate.class, new ScalarTypeJodaLocalDate());
-      typeMap.put(DateMidnight.class, new ScalarTypeJodaDateMidnight());
+      typeMap.put(org.joda.time.DateMidnight.class, new ScalarTypeJodaDateMidnight());
 
       String jodaLocalTimeMode = config.getJodaLocalTimeMode();
       if ("normal".equalsIgnoreCase(jodaLocalTimeMode)) {

--- a/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -250,6 +250,7 @@ public final class DefaultTypeManager implements TypeManager {
    * can have many classes if it uses method overrides and we need to register all
    * the variations/classes for the enum.
    */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
   public void addEnumType(ScalarType<?> scalarType, Class<? extends Enum> enumClass) {
 
@@ -791,9 +792,9 @@ public final class DefaultTypeManager implements TypeManager {
   }
 
   /**
-   * Detect if Joda classes are in the classpath and if so register the Joda
-   * data types.
+   * Detect if Joda classes are in the classpath and if so register the Joda data types.
    */
+  @SuppressWarnings("deprecation")
   private void initialiseJodaTypes(JsonConfig.DateTime mode, ServerConfig config) {
 
     // detect if Joda classes are in the classpath

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateMidnight.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateMidnight.java
@@ -9,6 +9,7 @@ import java.sql.Types;
 /**
  * ScalarType for Joda DateMidnight. This maps to a JDBC Date.
  */
+@SuppressWarnings("deprecation")
 public class ScalarTypeJodaDateMidnight extends ScalarTypeBaseDate<DateMidnight> {
 
   /**

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateMidnight.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateMidnight.java
@@ -1,7 +1,6 @@
 package io.ebeaninternal.server.type;
 
 import io.ebeaninternal.server.core.BasicTypeConverter;
-import org.joda.time.DateMidnight;
 
 import java.sql.Date;
 import java.sql.Types;
@@ -10,43 +9,43 @@ import java.sql.Types;
  * ScalarType for Joda DateMidnight. This maps to a JDBC Date.
  */
 @SuppressWarnings("deprecation")
-public class ScalarTypeJodaDateMidnight extends ScalarTypeBaseDate<DateMidnight> {
+public class ScalarTypeJodaDateMidnight extends ScalarTypeBaseDate<org.joda.time.DateMidnight> {
 
   /**
    * Instantiates a new scalar type joda date midnight.
    */
   public ScalarTypeJodaDateMidnight() {
-    super(DateMidnight.class, false, Types.DATE);
+    super(org.joda.time.DateMidnight.class, false, Types.DATE);
   }
 
   @Override
-  public long convertToMillis(DateMidnight value) {
+  public long convertToMillis(org.joda.time.DateMidnight value) {
     return value.getMillis();
   }
 
   @Override
-  public DateMidnight convertFromDate(Date ts) {
-    return new DateMidnight(ts.getTime());
+  public org.joda.time.DateMidnight convertFromDate(Date ts) {
+    return new org.joda.time.DateMidnight(ts.getTime());
   }
 
   @Override
-  public Date convertToDate(DateMidnight t) {
+  public Date convertToDate(org.joda.time.DateMidnight t) {
     return new Date(t.getMillis());
   }
 
   @Override
   public Object toJdbcType(Object value) {
-    if (value instanceof DateMidnight) {
-      return new Date(((DateMidnight) value).getMillis());
+    if (value instanceof org.joda.time.DateMidnight) {
+      return new Date(((org.joda.time.DateMidnight) value).getMillis());
     }
     return BasicTypeConverter.toDate(value);
   }
 
   @Override
-  public DateMidnight toBeanType(Object value) {
+  public org.joda.time.DateMidnight toBeanType(Object value) {
     if (value instanceof java.util.Date) {
-      return new DateMidnight(((java.util.Date) value).getTime());
+      return new org.joda.time.DateMidnight(((java.util.Date) value).getTime());
     }
-    return (DateMidnight) value;
+    return (org.joda.time.DateMidnight) value;
   }
 }


### PR DESCRIPTION
Went over compilation warnings with Xlint. Only imports for DateMidnight are left, as they cannot receive a suppression annotation.

DateMidnight has been deprecated. The source code states:

```
 * @deprecated The time of midnight does not exist in some time zones
 * where the daylight saving time forward shift skips the midnight hour.
 * Use {@link LocalDate} to represent a date without a time zone.
 * Or use {@link DateTime} to represent a full date and time, perhaps
 * using {@link DateTime#withTimeAtStartOfDay()} to get an instant at the
 * start of a day.
```

I doubt it can be migrated, since user projects depending on it, though deprecated, will continue to need the support for it. That's the kind of change that can break projects if not announced.

So I just added suppression statements.