### PR TITLE
Wrong alter table / alter column DDL was generated

### DIFF
--- a/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/MySqlDdl.java
+++ b/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/MySqlDdl.java
@@ -71,6 +71,7 @@ public class MySqlDdl extends PlatformDdl {
     String tableName = alter.getTableName();
     String columnName = alter.getColumnName();
     String type = alter.getType() != null ? alter.getType() : alter.getCurrentType();
+    type = convert(type, false);
     boolean notnull = (alter.isNotnull() != null) ? alter.isNotnull() : Boolean.TRUE.equals(alter.isCurrentNotnull());
     String notnullClause = notnull ? " not null" : "";
 

--- a/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/PlatformDdl.java
+++ b/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/PlatformDdl.java
@@ -376,7 +376,7 @@ public class PlatformDdl {
    */
   public String alterColumnType(String tableName, String columnName, String type) {
 
-    return "alter table " + tableName + " " + alterColumn + " " + columnName + " " + columnSetType + type;
+    return "alter table " + tableName + " " + alterColumn + " " + columnName + " " + columnSetType + convert(type, false);
   }
 
   /**

--- a/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/SqlServerDdl.java
+++ b/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/SqlServerDdl.java
@@ -70,6 +70,7 @@ public class SqlServerDdl extends PlatformDdl {
     String tableName = alter.getTableName();
     String columnName = alter.getColumnName();
     String type = alter.getType() != null ? alter.getType() : alter.getCurrentType();
+    type = convert(type, false);
     boolean notnull = (alter.isNotnull() != null) ? alter.isNotnull() : Boolean.TRUE.equals(alter.isCurrentNotnull());
     String notnullClause = notnull ? " not null" : "";
 

--- a/src/test/java/io/ebean/dbmigration/ddlgeneration/platform/PlatformDdl_AlterColumnTest.java
+++ b/src/test/java/io/ebean/dbmigration/ddlgeneration/platform/PlatformDdl_AlterColumnTest.java
@@ -68,7 +68,7 @@ public class PlatformDdl_AlterColumnTest {
     assertEquals("alter table mytab alter column acol type varchar(20)", sql);
 
     sql = oraDdl.alterColumnType("mytab", "acol", "varchar(20)");
-    assertEquals("alter table mytab modify acol varchar(20)", sql);
+    assertEquals("alter table mytab modify acol varchar2(20)", sql);
 
     sql = mysqlDdl.alterColumnType("mytab", "acol", "varchar(20)");
     assertNull(sql);


### PR DESCRIPTION
Hello Rob,

this PR fixes wrong DDL generation for postgres:

*before*
```SQL
alter table my_table alter column my_column type clob;
```
=> clob not supported by postgres (related to #909)
*now*
```SQL
alter table my_table alter column my_column type text;
```

I think it was also wrong for sqlserver & mysql - the unit test for oracle seems to be wrong also.

cheers
Roland


