### PR TITLE
Moving defaultservercache implementation to use nanoseconds

### DIFF
--- a/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
+++ b/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
@@ -13,7 +13,6 @@ import io.ebeaninternal.server.persist.BatchControl;
 import io.ebeanservice.docstore.api.DocStoreTransaction;
 
 import javax.persistence.PersistenceException;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 

--- a/src/main/java/io/ebeaninternal/server/persist/BatchedPstmtHolder.java
+++ b/src/main/java/io/ebeaninternal/server/persist/BatchedPstmtHolder.java
@@ -3,7 +3,6 @@ package io.ebeaninternal.server.persist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.persistence.PersistenceException;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;

--- a/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import javax.persistence.RollbackException;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;


### PR DESCRIPTION
As suggested previously by @rPraml the use of milliseconds to manage cache evictions could potentially be problematic. For instance, during DST jumps.

The PR changes the implementation to use nanoseconds instead.