### PR TITLE
Some changes that are possible in Java language level 7 and 8.

### DIFF
--- a/src/main/java/io/ebeaninternal/server/autotune/service/SortAutoTuneDocument.java
+++ b/src/main/java/io/ebeaninternal/server/autotune/service/SortAutoTuneDocument.java
@@ -23,19 +23,19 @@ public class SortAutoTuneDocument {
 
     ProfileDiff profileDiff = document.getProfileDiff();
     if (profileDiff != null) {
-      Collections.sort(profileDiff.getOrigin(), NAME_KEY_SORT);
+      profileDiff.getOrigin().sort(NAME_KEY_SORT);
     }
     ProfileNew profileNew = document.getProfileNew();
     if (profileNew != null) {
-      Collections.sort(profileNew.getOrigin(), NAME_KEY_SORT);
+      profileNew.getOrigin().sort(NAME_KEY_SORT);
     }
     ProfileEmpty profileEmpty = document.getProfileEmpty();
     if (profileEmpty != null) {
-      Collections.sort(profileEmpty.getOrigin(), KEY_SORT);
+      profileEmpty.getOrigin().sort(KEY_SORT);
     }
     List<Origin> origins = document.getOrigin();
     if (!origins.isEmpty()) {
-      Collections.sort(origins, NAME_KEY_SORT);
+      origins.sort(NAME_KEY_SORT);
     }
   }
 

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1992,7 +1992,7 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
   public void sort(List<T> list, String sortByClause) {
 
     ElComparator<T> comparator = getElComparator(sortByClause);
-    Collections.sort(list, comparator);
+    list.sort(comparator);
   }
 
   public ElComparator<T> getElComparator(String propNameOrSortBy) {

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -328,7 +328,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
       readEntityRelationships();
 
       List<BeanDescriptor<?>> list = new ArrayList<>(descMap.values());
-      Collections.sort(list, beanDescComparator);
+      list.sort(beanDescComparator);
       immutableDescriptorList = Collections.unmodifiableList(list);
 
       initialiseAll();

--- a/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -635,7 +635,7 @@ public class DeployBeanDescriptor<T> {
   public void sortProperties() {
 
     ArrayList<DeployBeanProperty> list = new ArrayList<>(propMap.values());
-    Collections.sort(list, PROP_ORDER);
+    list.sort(PROP_ORDER);
 
     propMap = new LinkedHashMap<>(list.size());
     for (DeployBeanProperty aList : list) {

--- a/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationBase.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationBase.java
@@ -218,8 +218,8 @@ public abstract class AnnotationBase {
     if (annotationType == null) {
       return null;
     }
-    Set<A> ret = new LinkedHashSet<A>();
-    findMetaAnnotations(annotatedElement, annotationType, ret, new HashSet<Annotation>());
+    Set<A> ret = new LinkedHashSet<>();
+    findMetaAnnotations(annotatedElement, annotationType, ret, new HashSet<>());
     return ret;
   }
 
@@ -264,7 +264,7 @@ public abstract class AnnotationBase {
     }
   }
 
-  private static final ConcurrentMap<Annotation, Method> valueMethods = new ConcurrentHashMap<Annotation, Method>();
+  private static final ConcurrentMap<Annotation, Method> valueMethods = new ConcurrentHashMap<>();
   private static final Method nullMethod = getNullMethod();
 
 

--- a/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -265,7 +265,7 @@ public class CQueryEngine {
       List<Version<T>> versions = cquery.readVersions();
       // just order in memory rather than use NULLS LAST as that
       // is not universally supported, not expect huge list here
-      Collections.sort(versions, OrderVersionDesc.INSTANCE);
+      versions.sort(OrderVersionDesc.INSTANCE);
       deriveVersionDiffs(versions, request);
 
       if (request.isLogSummary()) {

--- a/src/main/java/io/ebeaninternal/server/text/json/DJsonBeanReader.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/DJsonBeanReader.java
@@ -46,6 +46,6 @@ public class DJsonBeanReader<T> implements JsonBeanReader<T> {
 
   @Override
   public JsonBeanReader<T> forJson(JsonParser moreJson, boolean resetContext) {
-    return new DJsonBeanReader<T>(desc, readJson.forJson(moreJson, resetContext));
+    return new DJsonBeanReader<>(desc, readJson.forJson(moreJson, resetContext));
   }
 }


### PR DESCRIPTION
With Java7, it is not required to detail the class on the right hand side of a generic statement.

And with Java8, sorting can now also be done on the object itself, rather than using the static method Collections.sort