### PR TITLE
Fix/select distinct cascaded fetch with findSingleAttributeList() on associated property path

### DIFF
--- a/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -497,7 +497,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
    * Limit the number of fetch joins to Many properties, mark as query joins as needed.
    */
   private void markQueryJoins() {
-    detail.markQueryJoins(beanDescriptor, lazyLoadManyPath, isAllowOneManyFetch());
+    detail.markQueryJoins(beanDescriptor, lazyLoadManyPath, isAllowOneManyFetch(), type != Type.ATTRIBUTE);
   }
 
   private boolean isAllowOneManyFetch() {

--- a/src/test/java/io/ebeaninternal/server/querydefn/OrmQueryDetailTest.java
+++ b/src/test/java/io/ebeaninternal/server/querydefn/OrmQueryDetailTest.java
@@ -175,7 +175,7 @@ public class OrmQueryDetailTest extends BaseTestCase {
     OrmQueryDetail detail = new OrmQueryDetail();
     detail.fetch("details", null, null);
 
-    detail.markQueryJoins(orderDesc(), null, true);
+    detail.markQueryJoins(orderDesc(), null, true, true);
 
     assertThat(detail.getChunk("details", false).isQueryFetch()).isFalse();
   }
@@ -186,7 +186,7 @@ public class OrmQueryDetailTest extends BaseTestCase {
     OrmQueryDetail detail = new OrmQueryDetail();
     detail.fetch("details", null, null);
 
-    detail.markQueryJoins(orderDesc(), null, false);
+    detail.markQueryJoins(orderDesc(), null, false, true);
 
     assertThat(detail.getChunk("details", false).isQueryFetch()).isTrue();
   }
@@ -198,7 +198,7 @@ public class OrmQueryDetailTest extends BaseTestCase {
     detail.fetch("details", null, null);
     detail.fetch("customer.contacts", null, null);
 
-    detail.markQueryJoins(orderDesc(), null, true);
+    detail.markQueryJoins(orderDesc(), null, true, true);
 
     assertThat(detail.getChunk("details", false).isQueryFetch()).isFalse();
     assertThat(detail.getChunk("customer.contacts", false).isQueryFetch()).isTrue();
@@ -211,7 +211,7 @@ public class OrmQueryDetailTest extends BaseTestCase {
     detail.fetch("details", null, null);
     detail.fetch("customer.contacts", null, null);
 
-    detail.markQueryJoins(orderDesc(), null, false);
+    detail.markQueryJoins(orderDesc(), null, false, true);
 
     assertThat(detail.getChunk("details", false).isQueryFetch()).isTrue();
     assertThat(detail.getChunk("customer.contacts", false).isQueryFetch()).isTrue();

--- a/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -3,6 +3,8 @@ package org.tests.query.other;
 import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.Query;
+
+import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
 import org.avaje.test.model.rawsql.inherit.ChildA;
@@ -162,6 +164,20 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     assertThat(cities).contains("Auckland").containsNull();
   }
 
+  @Test
+  public void distinctWithCascadedFetch() {
+
+    ResetBasicData.reset();
+
+    Query<Contact> query = Ebean.find(Contact.class)
+        .setDistinct(true)
+        .fetch("customer.billingAddress","city");
+
+    List<String> cities = query.findSingleAttributeList();
+
+    assertThat(sqlOf(query)).contains("select distinct t2.city from contact t0 join o_customer t1 on t1.id = t0.customer_id  left join o_address t2 on t2.id = t1.billing_address_id");
+    assertThat(cities).contains("Auckland").containsNull();
+  }
   @Test
   public void distinctSelectOnInheritedBean() {
 


### PR DESCRIPTION
Hello Rob,

today we discovered an issue with non working "fetch single attribute" when a child attribute was queried.

It was not trivial to fix this, because "markQueryJoins" adds all missing IDs, so I added a flag if only empty OrmQueryProperties should be added.
Maybe you take a look at https://github.com/ebean-orm/ebean/pull/980 again and find a more common solution for this.

cheers
Roland