### PR TITLE
Once again, Static code analysis

### DIFF
--- a/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -3,6 +3,7 @@ package io.ebean.bean;
 import io.ebean.Ebean;
 import io.ebean.ValuePair;
 
+import java.util.Arrays;
 import javax.persistence.EntityNotFoundException;
 import javax.persistence.PersistenceException;
 import java.beans.PropertyChangeEvent;
@@ -1101,7 +1102,7 @@ public final class EntityBeanIntercept implements Serializable {
 
     if (state == STATE_NEW) {
       setLoadedProperty(propertyIndex);
-    } else if (!areEqualChars(oldValue, newValue)) {
+    } else if (!Arrays.equals(oldValue, newValue)) {
       setChangedPropertyValue(propertyIndex, intercept, oldValue);
     } else {
       return null;
@@ -1116,53 +1117,11 @@ public final class EntityBeanIntercept implements Serializable {
 
     if (state == STATE_NEW) {
       setLoadedProperty(propertyIndex);
-    } else if (!areEqualBytes(oldValue, newValue)) {
+    } else if (!Arrays.equals(oldValue, newValue)) {
       setChangedPropertyValue(propertyIndex, intercept, oldValue);
     } else {
       return null;
     }
     return (pcs == null) ? null : new PropertyChangeEvent(owner, getProperty(propertyIndex), oldValue, newValue);
-  }
-
-  private static boolean areEqualBytes(byte[] b1, byte[] b2) {
-    if (b1 == null) {
-      return (b2 == null);
-
-    } else if (b2 == null) {
-      return false;
-
-    } else if (b1 == b2) {
-      return true;
-
-    } else if (b1.length != b2.length) {
-      return false;
-    }
-    for (int i = 0; i < b1.length; i++) {
-      if (b1[i] != b2[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private static boolean areEqualChars(char[] b1, char[] b2) {
-    if (b1 == null) {
-      return (b2 == null);
-
-    } else if (b2 == null) {
-      return false;
-
-    } else if (b1 == b2) {
-      return true;
-
-    } else if (b1.length != b2.length) {
-      return false;
-    }
-    for (int i = 0; i < b1.length; i++) {
-      if (b1[i] != b2[i]) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/src/main/java/io/ebean/config/ClassLoadConfig.java
+++ b/src/main/java/io/ebean/config/ClassLoadConfig.java
@@ -118,7 +118,7 @@ public class ClassLoadConfig {
   /**
    * Wraps the preferred, caller and context class loaders.
    */
-  protected class ClassLoaderContext {
+  protected static class ClassLoaderContext {
 
     /**
      * Optional - if set only use this classLoader (no fallback).

--- a/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
+++ b/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
@@ -162,9 +162,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
     }
 
     synchronized (monitor) {
-      for (Long newId : newIds) {
-        idList.add(newId);
-      }
+      idList.addAll(newIds);
     }
   }
 

--- a/src/main/java/io/ebean/dbmigration/model/MTable.java
+++ b/src/main/java/io/ebean/dbmigration/model/MTable.java
@@ -376,9 +376,7 @@ public class MTable {
       }
     }
     if (includeDropped && !droppedColumns.isEmpty()) {
-      for (String droppedColumn : droppedColumns) {
-        columnNames.add(droppedColumn);
-      }
+      columnNames.addAll(droppedColumns);
     }
     return columnNames;
   }

--- a/src/main/java/io/ebean/dbmigration/model/visitor/VisitAllUsing.java
+++ b/src/main/java/io/ebean/dbmigration/model/visitor/VisitAllUsing.java
@@ -127,7 +127,7 @@ public class VisitAllUsing {
    * Helper used to visit all the inheritInfo/BeanDescriptor in
    * the inheritance hierarchy (to add their 'local' properties).
    */
-  protected class InheritChildVisitor implements InheritInfoVisitor {
+  protected static class InheritChildVisitor implements InheritInfoVisitor {
 
     private final VisitAllUsing owner;
     private final BeanPropertyVisitor pv;

--- a/src/main/java/io/ebeaninternal/server/autotune/service/SortAutoTuneDocument.java
+++ b/src/main/java/io/ebeaninternal/server/autotune/service/SortAutoTuneDocument.java
@@ -6,7 +6,6 @@ import io.ebeaninternal.server.autotune.model.ProfileDiff;
 import io.ebeaninternal.server.autotune.model.ProfileEmpty;
 import io.ebeaninternal.server.autotune.model.ProfileNew;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 

--- a/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanPersistController.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanPersistController.java
@@ -62,8 +62,7 @@ public class ChainedBeanPersistController implements BeanPersistController {
     if (list.contains(c)) {
       return this;
     } else {
-      ArrayList<BeanPersistController> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanPersistController> newList = new ArrayList<>(list);
       newList.add(c);
 
       return new ChainedBeanPersistController(newList);
@@ -77,8 +76,7 @@ public class ChainedBeanPersistController implements BeanPersistController {
     if (!list.contains(c)) {
       return this;
     } else {
-      ArrayList<BeanPersistController> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanPersistController> newList = new ArrayList<>(list);
       newList.remove(c);
 
       return new ChainedBeanPersistController(newList);

--- a/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanPersistListener.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanPersistListener.java
@@ -60,8 +60,7 @@ public class ChainedBeanPersistListener implements BeanPersistListener {
     if (list.contains(c)) {
       return this;
     } else {
-      List<BeanPersistListener> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanPersistListener> newList = new ArrayList<>(list);
       newList.add(c);
 
       return new ChainedBeanPersistListener(newList);
@@ -75,8 +74,7 @@ public class ChainedBeanPersistListener implements BeanPersistListener {
     if (!list.contains(c)) {
       return this;
     } else {
-      ArrayList<BeanPersistListener> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanPersistListener> newList = new ArrayList<>(list);
       newList.remove(c);
 
       return new ChainedBeanPersistListener(newList);

--- a/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanPostLoad.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanPostLoad.java
@@ -29,8 +29,7 @@ public class ChainedBeanPostLoad implements BeanPostLoad {
     if (list.contains(c)) {
       return this;
     } else {
-      List<BeanPostLoad> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanPostLoad> newList = new ArrayList<>(list);
       newList.add(c);
 
       return new ChainedBeanPostLoad(newList);
@@ -44,8 +43,7 @@ public class ChainedBeanPostLoad implements BeanPostLoad {
     if (!list.contains(c)) {
       return this;
     } else {
-      ArrayList<BeanPostLoad> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanPostLoad> newList = new ArrayList<>(list);
       newList.remove(c);
 
       return new ChainedBeanPostLoad(newList);

--- a/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanQueryAdapter.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/ChainedBeanQueryAdapter.java
@@ -36,8 +36,7 @@ public class ChainedBeanQueryAdapter implements BeanQueryAdapter {
     if (list.contains(c)) {
       return this;
     } else {
-      List<BeanQueryAdapter> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanQueryAdapter> newList = new ArrayList<>(list);
       newList.add(c);
 
       return new ChainedBeanQueryAdapter(newList);
@@ -51,8 +50,7 @@ public class ChainedBeanQueryAdapter implements BeanQueryAdapter {
     if (!list.contains(c)) {
       return this;
     } else {
-      ArrayList<BeanQueryAdapter> newList = new ArrayList<>();
-      newList.addAll(list);
+      List<BeanQueryAdapter> newList = new ArrayList<>(list);
       newList.remove(c);
 
       return new ChainedBeanQueryAdapter(newList);

--- a/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -36,7 +36,6 @@ import javax.persistence.MappedSuperclass;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;

--- a/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/io/ebeaninternal/server/query/DefaultDbSqlContext.java
+++ b/src/main/java/io/ebeaninternal/server/query/DefaultDbSqlContext.java
@@ -347,7 +347,7 @@ class DefaultDbSqlContext implements DbSqlContext {
 
   @Override
   public String toString() {
-    return "DefaultDbSqlContext: " + sb.toString();
+    return "DefaultDbSqlContext: " + sb;
   }
 
 }

--- a/src/main/java/io/ebeaninternal/server/query/SqlTreeProperties.java
+++ b/src/main/java/io/ebeaninternal/server/query/SqlTreeProperties.java
@@ -4,6 +4,7 @@ import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.server.deploy.BeanProperty;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -39,10 +40,7 @@ public class SqlTreeProperties {
   }
 
   public void add(BeanProperty[] props) {
-    //noinspection ManualArrayToCollectionCopy
-    for (BeanProperty prop : props) {
-      propsList.add(prop);
-    }
+    propsList.addAll(Arrays.asList(props));
   }
 
   public void add(BeanProperty prop) {

--- a/src/main/java/io/ebeaninternal/server/transaction/DefaultPersistenceContext.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/DefaultPersistenceContext.java
@@ -134,12 +134,7 @@ public final class DefaultPersistenceContext implements PersistenceContext {
 
   private ClassContext getClassContext(Class<?> rootType) {
 
-    ClassContext classMap = typeCache.get(rootType);
-    if (classMap == null) {
-      classMap = new ClassContext();
-      typeCache.put(rootType, classMap);
-    }
-    return classMap;
+    return typeCache.computeIfAbsent(rootType, k -> new ClassContext());
   }
 
   private static class ClassContext {

--- a/src/main/java/io/ebeaninternal/server/type/ModifyAwareList.java
+++ b/src/main/java/io/ebeaninternal/server/type/ModifyAwareList.java
@@ -178,8 +178,6 @@ public class ModifyAwareList<E> implements List<E>, ModifyAwareOwner {
    */
   public ModifyAwareSet<E> asSet() {
 
-    LinkedHashSet<E> set = new LinkedHashSet<>();
-    set.addAll(list);
-    return new ModifyAwareSet<>(owner, set);
+    return new ModifyAwareSet<>(owner, new LinkedHashSet<>(list));
   }
 }


### PR DESCRIPTION
Hello again @rbygrave @rPraml and all others.

Here's a few static code analysis recommendations, mostly focussed on performance and language level options.

This PR is mostly focussed on lists which get instantiated with default size and then `addAll` is performed on them. Most Collection/subclass of Collection constructors have a variant that takes an existing Collection. That's one step less.

Some `for` constructs that only copy an existing list, replaced by `addAll` where possible.

Some unused imports, removed.

A single `computeIfAbsent` option was found.

2 inner classes made static, which causes them to not get internally linked to the outer class, which is sort of pointless if the inner class holds no actual reference to a field/method of the outer class. But the JVM does it anyway unless you make it static, or so I've been lead to believe.

Also, I found a manually written comparison of primitive arrays, one per type. `Arrays.equals` performs exactly this functionality. I had a look at the source code and it's even 2 steps shorter than the code manually written here. Clever use of code constructs in the JDK implementation.

It's a bit of a mixed bag, so let me know if you want me to separate this up a bit.

Next up: Intellij detected 18 cases of `tail recursion` that can be replaced. But that's for after this PR is resolved.