### PR TITLE
Fix: Bug when calculating order by clause with primary keys and distinct queries

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -176,7 +176,7 @@ public final class OrmQueryRequest<T> extends BeanRequest implements BeanQueryRe
     if (query.isRawSql()) {
       return new DeployPropertyParserMap(query.getRawSql().getColumnMapping().getMapping());
     } else {
-      return beanDescriptor.createDeployPropertyParser();
+      return beanDescriptor.createDeployPropertyParser(query.isDistinct());
     }
   }
 

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1409,8 +1409,8 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
     }
   }
 
-  public DeployPropertyParser createDeployPropertyParser() {
-    return new DeployPropertyParser(this);
+  public DeployPropertyParser createDeployPropertyParser(boolean distinct) {
+    return new DeployPropertyParser(this, distinct);
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/deploy/DeployPropertyParser.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/DeployPropertyParser.java
@@ -19,8 +19,11 @@ public final class DeployPropertyParser extends DeployParser {
 
   private final Set<String> includes = new HashSet<>();
 
-  public DeployPropertyParser(BeanDescriptor<?> beanDescriptor) {
+  private final boolean distinct;
+
+  public DeployPropertyParser(BeanDescriptor<?> beanDescriptor, boolean distinct) {
     this.beanDescriptor = beanDescriptor;
+    this.distinct = distinct;
   }
 
   @Override
@@ -30,7 +33,15 @@ public final class DeployPropertyParser extends DeployParser {
 
   @Override
   public String getDeployWord(String expression) {
-    ElPropertyDeploy elProp = beanDescriptor.getElPropertyDeploy(expression);
+    
+    ElPropertyDeploy elProp;
+    // we can't use the BeanFkProperty for distinct queries in combination with orderBy
+    if (distinct) {
+      elProp = beanDescriptor.getElGetValue(expression);
+    } else {
+      elProp = beanDescriptor.getElPropertyDeploy(expression);
+    }
+    
     if (elProp == null) {
       return null;
     } else {

--- a/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -331,7 +331,12 @@ public class TestQuerySingleAttribute extends BaseTestCase {
 
     assertThat(sqlOf(query)).contains("select distinct t2.id from contact t0 join o_customer t1 on t1.id = t0.customer_id"
         + "  left join o_address t2 on t2.id = t1.billing_address_id  order by t2.id");
-    assertThat(ids).containsSequence((short) 5, (short) 3, (short) 1, null);
+    if (isH2()) {
+      // H2 & Postgres behave different in sorting.
+      assertThat(ids).containsSequence((short) 5, (short) 3, (short) 1, null);
+    } else {
+      assertThat(ids).containsSequence(null, (short) 5, (short) 3, (short) 1);
+    }
   }
 
 }

--- a/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -299,4 +299,39 @@ public class TestQuerySingleAttribute extends BaseTestCase {
         + "join rawinherit_parent_rawinherit_data t1 on t0.id = t1.rawinherit_data_id "
         + "join parent t2 on t1.rawinherit_parent_id = t2.id");
   }
+  
+  @Test
+  public void distinctWithOrderByPk() {
+
+    ResetBasicData.reset();
+
+    Query<Contact> query = Ebean.find(Contact.class)
+        .setDistinct(true)
+        .fetch("customer","id")
+        .orderBy().desc("customer.id");
+
+    List<Integer> ids = query.findSingleAttributeList();
+    // @rob
+    // assertThat(sqlOf(query)).contains("select distinct t0.customer_id from contact t0  order by t0.customer_id");
+    assertThat(sqlOf(query)).contains("select distinct t1.id from contact t0 join o_customer t1 on t1.id = t0.customer_id  order by t1.id");
+    assertThat(ids).containsSequence(4, 3, 2, 1);
+  }
+  
+  @Test
+  public void distinctWithCascadedFetchOrderByPk() {
+
+    ResetBasicData.reset();
+
+    Query<Contact> query = Ebean.find(Contact.class)
+        .setDistinct(true)
+        .fetch("customer.billingAddress","id")
+        .orderBy().desc("customer.billingAddress.id");
+
+    List<Short> ids = query.findSingleAttributeList();
+
+    assertThat(sqlOf(query)).contains("select distinct t2.id from contact t0 join o_customer t1 on t1.id = t0.customer_id"
+        + "  left join o_address t2 on t2.id = t1.billing_address_id  order by t2.id");
+    assertThat(ids).containsSequence((short) 5, (short) 3, (short) 1, null);
+  }
+
 }


### PR DESCRIPTION
When using `select distinct col_name ... order by col_name` col_name in select was t1.id and col_name in order by was t0.parent_id 