### PR TITLE
FIX: deleting and adding same bean in beanCollection leads to deletion in DB

### DIFF
--- a/src/main/java/io/ebean/common/AbstractBeanCollection.java
+++ b/src/main/java/io/ebean/common/AbstractBeanCollection.java
@@ -175,6 +175,8 @@ abstract class AbstractBeanCollection<E> implements BeanCollection<E> {
   public void modifyAddition(E bean) {
     if (modifyAddListening) {
       getModifyHolder().modifyAddition(bean);
+    } else if (modifyRemoveListening) {
+      getModifyHolder().undoDeletion(bean);
     }
   }
 
@@ -182,6 +184,8 @@ abstract class AbstractBeanCollection<E> implements BeanCollection<E> {
   public void modifyRemoval(Object bean) {
     if (modifyRemoveListening) {
       getModifyHolder().modifyRemoval(bean);
+    } else if (modifyAddListening) {
+      getModifyHolder().undoAddition(bean);
     }
   }
 

--- a/src/main/java/io/ebean/common/BeanList.java
+++ b/src/main/java/io/ebean/common/BeanList.java
@@ -232,7 +232,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public void add(int index, E element) {
     checkReadOnly();
     init();
-    if (modifyAddListening) {
+    if (modifyListening) {
       modifyAddition(element);
     }
     list.add(index, element);
@@ -247,7 +247,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public boolean add(E o) {
     checkReadOnly();
     init();
-    if (modifyAddListening) {
+    if (modifyListening) {
       if (list.add(o)) {
         modifyAddition(o);
         return true;
@@ -262,7 +262,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public boolean addAll(Collection<? extends E> c) {
     checkReadOnly();
     init();
-    if (modifyAddListening) {
+    if (modifyListening) {
       // all elements in c are added (no contains checking)
       getModifyHolder().modifyAdditionAll(c);
     }
@@ -273,7 +273,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public boolean addAll(int index, Collection<? extends E> c) {
     checkReadOnly();
     init();
-    if (modifyAddListening) {
+    if (modifyListening) {
       // all elements in c are added (no contains checking)
       getModifyHolder().modifyAdditionAll(c);
     }
@@ -286,7 +286,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
     // TODO: when clear() and not initialised could be more clever
     // and fetch just the Id's
     initClear();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       for (E aList : list) {
         getModifyHolder().modifyRemoval(aList);
       }
@@ -380,7 +380,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public E remove(int index) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       E o = list.remove(index);
       modifyRemoval(o);
       return o;
@@ -392,7 +392,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public boolean remove(Object o) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       boolean isRemove = list.remove(o);
       if (isRemove) {
         modifyRemoval(o);
@@ -406,7 +406,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public boolean removeAll(Collection<?> beans) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       boolean changed = false;
       for (Object bean : beans) {
         if (list.remove(bean)) {
@@ -424,7 +424,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
   public boolean retainAll(Collection<?> retainBeans) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       boolean changed = false;
       Iterator<E> it = list.iterator();
       while (it.hasNext()) {

--- a/src/main/java/io/ebean/common/BeanMap.java
+++ b/src/main/java/io/ebean/common/BeanMap.java
@@ -211,7 +211,7 @@ public final class BeanMap<K, E> extends AbstractBeanCollection<E> implements Ma
   public void clear() {
     checkReadOnly();
     initClear();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       // add all beans to the removal list
       for (E bean : map.values()) {
         modifyRemoval(bean);
@@ -313,7 +313,7 @@ public final class BeanMap<K, E> extends AbstractBeanCollection<E> implements Ma
   public E remove(Object key) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       E o = map.remove(key);
       modifyRemoval(o);
       return o;

--- a/src/main/java/io/ebean/common/BeanSet.java
+++ b/src/main/java/io/ebean/common/BeanSet.java
@@ -210,7 +210,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
   public boolean add(E o) {
     checkReadOnly();
     init();
-    if (modifyAddListening) {
+    if (modifyListening) {
       if (set.add(o)) {
         modifyAddition(o);
         return true;
@@ -225,7 +225,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
   public boolean addAll(Collection<? extends E> addCollection) {
     checkReadOnly();
     init();
-    if (modifyAddListening) {
+    if (modifyListening) {
       boolean changed = false;
       for (E bean : addCollection) {
         if (set.add(bean)) {
@@ -243,7 +243,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
   public void clear() {
     checkReadOnly();
     initClear();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       for (E bean : set) {
         modifyRemoval(bean);
       }
@@ -285,7 +285,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
   public boolean remove(Object o) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       if (set.remove(o)) {
         modifyRemoval(o);
         return true;
@@ -299,7 +299,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
   public boolean removeAll(Collection<?> beans) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       boolean changed = false;
       for (Object bean : beans) {
         if (set.remove(bean)) {
@@ -316,7 +316,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
   public boolean retainAll(Collection<?> beans) {
     checkReadOnly();
     init();
-    if (modifyRemoveListening) {
+    if (modifyListening) {
       boolean changed = false;
       Iterator<?> it = set.iterator();
       while (it.hasNext()) {

--- a/src/main/java/io/ebean/common/ModifyHolder.java
+++ b/src/main/java/io/ebean/common/ModifyHolder.java
@@ -44,21 +44,29 @@ class ModifyHolder<E> implements Serializable {
     }
   }
 
+  boolean undoDeletion(E bean) {
+    return (bean != null) && modifyDeletions.remove(bean);
+  }
+  
   void modifyAddition(E bean) {
     if (bean != null) {
       // If it is to delete then just remove the deletion
-      if (!modifyDeletions.remove(bean)) {
+      if (!undoDeletion(bean)) {
         // Insert
         modifyAdditions.add(bean);
       }
     }
   }
 
+  boolean undoAddition(Object bean) {
+    return (bean != null) && modifyAdditions.remove(bean);
+  }
+  
   @SuppressWarnings("unchecked")
   void modifyRemoval(Object bean) {
     if (bean != null) {
       // If it is to be added then just remove the addition
-      if (!modifyAdditions.remove(bean)) {
+      if (!undoAddition(bean)) {
         modifyDeletions.add((E) bean);
       }
     }


### PR DESCRIPTION
This PR fixes an issue we had when sorting a BeanCollection (for display).
The problem was, that Collections.sort(beanCollection) removes and re-adds the bean to the collection.
Then only deletion was tracked and the bean was deleted in the database.
Now, if a bean is re-added that is marked for deletion, the deletion is undone
