### PR TITLE
Sequence-generators are now tenant aware

### DIFF
--- a/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -302,7 +302,7 @@ public class DatabasePlatform {
    * @param ds        the TenantDataSourceProvider
    * @param seqName   the name of the sequence
    * @param batchSize the number of sequences that should be loaded
-   * @param currentTenantProvider the current tenant provider
+   * @param currentTenantProvider the current tenant provider or null if you do not want tenant aware id generators.
    */
   public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, 
       int batchSize, CurrentTenantProvider currentTenantProvider) {

--- a/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -2,18 +2,19 @@ package io.ebean.config.dbplatform;
 
 import io.ebean.BackgroundExecutor;
 import io.ebean.Query;
+import io.ebean.config.CurrentTenantProvider;
 import io.ebean.config.CustomDbTypeMapping;
 import io.ebean.config.DbTypeConfig;
 import io.ebean.PersistBatch;
 import io.ebean.Platform;
 import io.ebean.config.ServerConfig;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.dbmigration.ddlgeneration.DdlHandler;
 import io.ebean.dbmigration.ddlgeneration.platform.PlatformDdl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -298,11 +299,13 @@ public class DatabasePlatform {
    *
    * @param be        the BackgroundExecutor that can be used to load the sequence if
    *                  desired
-   * @param ds        the DataSource
+   * @param ds        the TenantDataSourceProvider
    * @param seqName   the name of the sequence
    * @param batchSize the number of sequences that should be loaded
+   * @param currentTenantProvider the current tenant provider
    */
-  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
+  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, 
+      int batchSize, CurrentTenantProvider currentTenantProvider) {
     return null;
   }
 

--- a/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
+++ b/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
@@ -2,16 +2,23 @@ package io.ebean.config.dbplatform;
 
 import io.ebean.BackgroundExecutor;
 import io.ebean.Transaction;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import javax.sql.DataSource;
+
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Database sequence based IdGenerator.
@@ -21,41 +28,53 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
   private static final Logger logger = LoggerFactory.getLogger(SequenceIdGenerator.class);
 
   /**
-   * Used to synchronise the idList access.
-   */
-  protected final Object monitor = new Object();
-
-  /**
-   * Used to synchronise background loading (loadBatchInBackground).
-   */
-  protected final Object backgroundLoadMonitor = new Object();
-
-  /**
    * The actual sequence name.
    */
   protected final String seqName;
 
-  protected final DataSource dataSource;
+  protected final TenantDataSourceProvider dataSourceProvider;
 
   protected final BackgroundExecutor backgroundExecutor;
 
-  protected final ArrayList<Long> idList = new ArrayList<>(50);
-
   protected final int batchSize;
-
-  protected int currentlyBackgroundLoading;
+  
+  private final ConcurrentMap<Object, IdLoader> idLoaders;
+  
+  private final IdLoader idLoader;
+  
+  private final CurrentTenantProvider currentTenantProvider;
 
   /**
    * Construct given a dataSource and sql to return the next sequence value.
    */
-  public SequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
+  public SequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, int batchSize, 
+      CurrentTenantProvider currentTenantProvider) {
     this.backgroundExecutor = be;
-    this.dataSource = ds;
+    this.dataSourceProvider = ds;
     this.seqName = seqName;
     this.batchSize = batchSize;
+    this.currentTenantProvider = currentTenantProvider;
+    if (currentTenantProvider != null) {
+      idLoader = null;
+      idLoaders = new ConcurrentHashMap<>();
+    } else {
+      idLoader = new IdLoader(dataSourceProvider.dataSource(null));
+      idLoaders = null;
+    }
   }
 
   public abstract String getSql(int batchSize);
+
+  /**
+   * Converts the resultset into IDs
+   */
+  protected List<Long> processResult(ResultSet rset, int loadSize) throws SQLException {
+    List<Long> newIds = new ArrayList<>(loadSize);
+    while (rset.next()) {
+      newIds.add(rset.getLong(1));
+   }
+   return newIds;
+  }
 
   /**
    * Returns the sequence name.
@@ -73,6 +92,182 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
     return true;
   }
 
+  /**
+   * A per tenant instance for loading beans
+   * @author Roland Praml, FOCONIS AG
+   *
+   */
+  protected class IdLoader {
+    
+    /**
+     * Used to synchronise the idList access.
+     */
+    protected final Object monitor = new Object();
+    
+    /**
+     * Used to synchronise background loading (loadBatchInBackground).
+     */
+    protected final Object backgroundLoadMonitor = new Object();
+    
+    protected final ArrayList<Long> idList = new ArrayList<>(50);
+
+    protected final Object tenantId;
+    
+    protected final DataSource dataSource;
+    
+    protected int currentlyBackgroundLoading;
+    
+    protected IdLoader(DataSource ds) {
+      tenantId = null;
+      this.dataSource = ds;
+    }
+    
+    protected IdLoader(Object tenantId, DataSource ds) {
+      this.tenantId = tenantId;
+      this.dataSource = ds;
+    }
+    
+    public Object nextId(Transaction t) {
+      synchronized (monitor) {
+
+        if (idList.isEmpty()) {
+          loadMoreIds(batchSize, t);
+        }
+        Long nextId = idList.remove(0);
+
+        if (batchSize > 1) {
+          if (idList.size() <= batchSize / 2) {
+            loadBatchInBackground();
+          }
+        }
+
+        return nextId;
+      }
+      
+    }
+    
+    /**
+     * Load another batch of Id's using a background thread.
+     */
+    protected void loadBatchInBackground() {
+
+      // single threaded processing...
+      synchronized (backgroundLoadMonitor) {
+
+        if (currentlyBackgroundLoading > 0) {
+          // skip as already background loading
+          logger.debug("... skip background sequence load (another load in progress)");
+          return;
+        }
+
+        currentlyBackgroundLoading = batchSize;
+
+        backgroundExecutor.execute(() -> {
+          loadMoreIds(batchSize, null);
+          synchronized (backgroundLoadMonitor) {
+            currentlyBackgroundLoading = 0;
+          }
+        });
+      }
+    }
+    
+    protected void loadMoreIds(final int numberToLoad, Transaction t) {
+
+      List<Long> newIds = getMoreIds(numberToLoad, t);
+
+      if (logger.isDebugEnabled()) {
+        logger.debug("... seq: {} loaded: {} tenant: {} ids: {}",seqName,numberToLoad, tenantId, newIds);
+      }
+
+      synchronized (monitor) {
+        idList.addAll(newIds);
+      }
+    }
+    
+
+    /**
+     * Get more Id's by executing a query and reading the Id's returned.
+     */
+    @SuppressWarnings("null")
+    protected List<Long> getMoreIds(int loadSize, Transaction t) {
+
+      String sql = getSql(loadSize);
+      
+
+      boolean useTxnConnection = t != null;
+
+      Connection c = null;
+      Statement pstmt = null;
+      ResultSet rset = null;
+      try {
+        c = useTxnConnection ? t.getConnection() : dataSource.getConnection();
+
+        pstmt = c.createStatement();
+        rset = pstmt.executeQuery(sql);
+
+        List<Long> newIds = processResult(rset, loadSize);
+        if (newIds.isEmpty()) {
+          throw new PersistenceException("Always expecting more than 1 row from " + sql);
+        }
+        return newIds;
+      } catch (SQLException e) {
+        if (e.getMessage().contains("Database is already closed")) {
+          String msg = "Error getting SEQ when DB shutting down " + e.getMessage();
+          logger.info(msg);
+          System.out.println(msg);
+          return new ArrayList<>();
+        } else {
+          throw new PersistenceException("Error getting sequence nextval", e);
+        }
+      } finally {
+        if (useTxnConnection) {
+          closeResources(null, pstmt, rset);
+        } else {
+          closeResources(c, pstmt, rset);
+        }
+      }
+    }
+
+    /**
+     * Close the JDBC resources.
+     */
+    protected void closeResources(Connection c, Statement pstmt, ResultSet rset) {
+      try {
+        if (rset != null) {
+          rset.close();
+        }
+      } catch (SQLException e) {
+        logger.error("Error closing ResultSet", e);
+      }
+      try {
+        if (pstmt != null) {
+          pstmt.close();
+        }
+      } catch (SQLException e) {
+        logger.error("Error closing PreparedStatement", e);
+      }
+      try {
+        if (c != null) {
+          c.close();
+        }
+      } catch (SQLException e) {
+        logger.error("Error closing Connection", e);
+      }
+    }
+  }
+  
+  /**
+   * Returns the IdLoader for this requestContext.
+   * @param requestContext
+   * @return
+   */
+  protected IdLoader getIdLoader(Object tenantId, DataSource ds) {
+    if (idLoader != null) {
+      return idLoader;
+    } else {
+      return idLoaders.computeIfAbsent(tenantId, id ->  new IdLoader(id, ds));
+    }
+  }
   /**
    * If allocateSize is large load some sequences in a background thread.
    * <p>
@@ -97,10 +292,12 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
    * Called by preAllocateIds when we know that a large number of Id's is going
    * to be needed shortly.
    */
-  protected void loadLargeAllocation(final int allocateSize) {
+  protected void loadLargeAllocation( final int allocateSize) {
     // preAllocateIds was called with a relatively large batchSize
     // so we will just go ahead and load those anyway in background
-    backgroundExecutor.execute(() -> loadMoreIds(allocateSize, null));
+    final Object tenantId = currentTenantProvider == null ? null : currentTenantProvider.currentId(); // read ID of this thread
+    DataSource ds = dataSourceProvider.dataSource(tenantId); // we MUST fetch the DS outside the BE-Thread
+    backgroundExecutor.execute(() -> getIdLoader(tenantId, ds).loadMoreIds(allocateSize, null));
   }
 
   /**
@@ -111,132 +308,9 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
    */
   @Override
   public Object nextId(Transaction t) {
-    synchronized (monitor) {
-
-      if (idList.isEmpty()) {
-        loadMoreIds(batchSize, t);
-      }
-      Long nextId = idList.remove(0);
-
-      if (batchSize > 1) {
-        if (idList.size() <= batchSize / 2) {
-          loadBatchInBackground();
-        }
-      }
-
-      return nextId;
-    }
-  }
-
-  /**
-   * Load another batch of Id's using a background thread.
-   */
-  protected void loadBatchInBackground() {
-
-    // single threaded processing...
-    synchronized (backgroundLoadMonitor) {
-
-      if (currentlyBackgroundLoading > 0) {
-        // skip as already background loading
-        logger.debug("... skip background sequence load (another load in progress)");
-        return;
-      }
-
-      currentlyBackgroundLoading = batchSize;
-
-      backgroundExecutor.execute(() -> {
-        loadMoreIds(batchSize, null);
-        synchronized (backgroundLoadMonitor) {
-          currentlyBackgroundLoading = 0;
-        }
-      });
-    }
-  }
-
-  protected void loadMoreIds(final int numberToLoad, Transaction t) {
-
-    ArrayList<Long> newIds = getMoreIds(numberToLoad, t);
-
-    if (logger.isDebugEnabled()) {
-      logger.debug("... seq:" + seqName + " loaded:" + numberToLoad + " ids:" + newIds);
-    }
-
-    synchronized (monitor) {
-      idList.addAll(newIds);
-    }
-  }
-
-  /**
-   * Get more Id's by executing a query and reading the Id's returned.
-   */
-  protected ArrayList<Long> getMoreIds(int loadSize, Transaction t) {
-
-    String sql = getSql(loadSize);
-
-    ArrayList<Long> newIds = new ArrayList<>(loadSize);
-
-    boolean useTxnConnection = t != null;
-
-    Connection c = null;
-    PreparedStatement pstmt = null;
-    ResultSet rset = null;
-    try {
-      c = useTxnConnection ? t.getConnection() : dataSource.getConnection();
-
-      pstmt = c.prepareStatement(sql);
-      rset = pstmt.executeQuery();
-      while (rset.next()) {
-        newIds.add(rset.getLong(1));
-      }
-      if (newIds.isEmpty()) {
-        throw new PersistenceException("Always expecting more than 1 row from " + sql);
-      }
-
-      return newIds;
-
-    } catch (SQLException e) {
-      if (e.getMessage().contains("Database is already closed")) {
-        String msg = "Error getting SEQ when DB shutting down " + e.getMessage();
-        logger.info(msg);
-        System.out.println(msg);
-        return newIds;
-      } else {
-        throw new PersistenceException("Error getting sequence nextval", e);
-      }
-    } finally {
-      if (useTxnConnection) {
-        closeResources(null, pstmt, rset);
-      } else {
-        closeResources(c, pstmt, rset);
-      }
-    }
-  }
-
-  /**
-   * Close the JDBC resources.
-   */
-  protected void closeResources(Connection c, PreparedStatement pstmt, ResultSet rset) {
-    try {
-      if (rset != null) {
-        rset.close();
-      }
-    } catch (SQLException e) {
-      logger.error("Error closing ResultSet", e);
-    }
-    try {
-      if (pstmt != null) {
-        pstmt.close();
-      }
-    } catch (SQLException e) {
-      logger.error("Error closing PreparedStatement", e);
-    }
-    try {
-      if (c != null) {
-        c.close();
-      }
-    } catch (SQLException e) {
-      logger.error("Error closing Connection", e);
-    }
+    final Object tenantId = currentTenantProvider == null ? null : currentTenantProvider.currentId();
+    DataSource ds = dataSourceProvider.dataSource(tenantId);
+    return getIdLoader(tenantId, ds).nextId(t);
   }
 
 }

--- a/src/main/java/io/ebean/config/dbplatform/db2/DB2Platform.java
+++ b/src/main/java/io/ebean/config/dbplatform/db2/DB2Platform.java
@@ -2,6 +2,8 @@ package io.ebean.config.dbplatform.db2;
 
 import io.ebean.BackgroundExecutor;
 import io.ebean.Platform;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.config.dbplatform.DbType;
@@ -9,7 +11,6 @@ import io.ebean.config.dbplatform.PlatformIdGenerator;
 import io.ebean.config.dbplatform.SqlErrorCodes;
 import io.ebean.dbmigration.ddlgeneration.platform.DB2Ddl;
 
-import javax.sql.DataSource;
 import java.sql.Types;
 
 /**
@@ -47,9 +48,9 @@ public class DB2Platform extends DatabasePlatform {
    */
   @Override
   public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be,
-                                                       DataSource ds, String seqName, int batchSize) {
+      TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
 
-    return new DB2SequenceIdGenerator(be, ds, seqName, batchSize);
+    return new DB2SequenceIdGenerator(be, ds, seqName, batchSize, currentTenantProvider);
   }
 
 }

--- a/src/main/java/io/ebean/config/dbplatform/db2/DB2SequenceIdGenerator.java
+++ b/src/main/java/io/ebean/config/dbplatform/db2/DB2SequenceIdGenerator.java
@@ -1,9 +1,9 @@
 package io.ebean.config.dbplatform.db2;
 
 import io.ebean.BackgroundExecutor;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.SequenceIdGenerator;
-
-import javax.sql.DataSource;
 
 /**
  * DB2 specific sequence Id Generator.
@@ -16,8 +16,8 @@ public class DB2SequenceIdGenerator extends SequenceIdGenerator {
   /**
    * Construct given a dataSource and sql to return the next sequence value.
    */
-  public DB2SequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
-    super(be, ds, seqName, batchSize);
+  public DB2SequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
+    super(be, ds, seqName, batchSize, currentTenantProvider);
     this.baseSql = "values nextval for " + seqName;
     this.unionBaseSql = " union " + baseSql;
   }

--- a/src/main/java/io/ebean/config/dbplatform/h2/H2Platform.java
+++ b/src/main/java/io/ebean/config/dbplatform/h2/H2Platform.java
@@ -3,6 +3,8 @@ package io.ebean.config.dbplatform.h2;
 import io.ebean.BackgroundExecutor;
 import io.ebean.Platform;
 import io.ebean.Query;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.config.dbplatform.DbType;
@@ -10,8 +12,6 @@ import io.ebean.config.dbplatform.IdType;
 import io.ebean.config.dbplatform.PlatformIdGenerator;
 import io.ebean.config.dbplatform.SqlErrorCodes;
 import io.ebean.dbmigration.ddlgeneration.platform.H2Ddl;
-
-import javax.sql.DataSource;
 
 /**
  * H2 specific platform.
@@ -52,10 +52,10 @@ public class H2Platform extends DatabasePlatform {
    * sequence values.
    */
   @Override
-  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be, DataSource ds,
-                                                       String seqName, int batchSize) {
+  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be,
+      TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
 
-    return new H2SequenceIdGenerator(be, ds, seqName, batchSize);
+    return new H2SequenceIdGenerator(be, ds, seqName, batchSize, currentTenantProvider);
   }
 
   @Override

--- a/src/main/java/io/ebean/config/dbplatform/h2/H2SequenceIdGenerator.java
+++ b/src/main/java/io/ebean/config/dbplatform/h2/H2SequenceIdGenerator.java
@@ -1,9 +1,9 @@
 package io.ebean.config.dbplatform.h2;
 
 import io.ebean.BackgroundExecutor;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.SequenceIdGenerator;
-
-import javax.sql.DataSource;
 
 /**
  * H2 specific sequence Id Generator.
@@ -16,8 +16,8 @@ public class H2SequenceIdGenerator extends SequenceIdGenerator {
   /**
    * Construct given a dataSource and sql to return the next sequence value.
    */
-  public H2SequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
-    super(be, ds, seqName, batchSize);
+  public H2SequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
+    super(be, ds, seqName, batchSize, currentTenantProvider);
     this.baseSql = "select " + seqName + ".nextval";
     this.unionBaseSql = " union " + baseSql;
   }

--- a/src/main/java/io/ebean/config/dbplatform/hsqldb/HsqldbPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/hsqldb/HsqldbPlatform.java
@@ -2,6 +2,8 @@ package io.ebean.config.dbplatform.hsqldb;
 
 import io.ebean.BackgroundExecutor;
 import io.ebean.Platform;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.config.dbplatform.DbType;
@@ -10,8 +12,6 @@ import io.ebean.config.dbplatform.PlatformIdGenerator;
 import io.ebean.config.dbplatform.h2.H2DbEncrypt;
 import io.ebean.config.dbplatform.h2.H2SequenceIdGenerator;
 import io.ebean.dbmigration.ddlgeneration.platform.HsqldbDdl;
-
-import javax.sql.DataSource;
 
 /**
  * H2 specific platform.
@@ -33,9 +33,10 @@ public class HsqldbPlatform extends DatabasePlatform {
   }
 
   @Override
-  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
+  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be,
+      TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
 
-    return new H2SequenceIdGenerator(be, ds, seqName, batchSize);
+    return new H2SequenceIdGenerator(be, ds, seqName, batchSize, currentTenantProvider);
   }
 
 }

--- a/src/main/java/io/ebean/config/dbplatform/mysql/MySqlPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/mysql/MySqlPlatform.java
@@ -3,6 +3,8 @@ package io.ebean.config.dbplatform.mysql;
 import io.ebean.BackgroundExecutor;
 import io.ebean.Platform;
 import io.ebean.Query;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.config.dbplatform.DbType;
@@ -11,7 +13,6 @@ import io.ebean.config.dbplatform.PlatformIdGenerator;
 import io.ebean.config.dbplatform.SqlErrorCodes;
 import io.ebean.dbmigration.ddlgeneration.platform.MySqlDdl;
 
-import javax.sql.DataSource;
 import java.sql.Types;
 
 /**
@@ -69,7 +70,7 @@ public class MySqlPlatform extends DatabasePlatform {
    */
   @Override
   public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be,
-                                                       DataSource ds, String seqName, int batchSize) {
+      TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
 
     return null;
   }

--- a/src/main/java/io/ebean/config/dbplatform/oracle/OraclePlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/oracle/OraclePlatform.java
@@ -2,6 +2,8 @@ package io.ebean.config.dbplatform.oracle;
 
 import io.ebean.BackgroundExecutor;
 import io.ebean.Platform;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.Query;
 import io.ebean.config.dbplatform.BasicSqlAnsiLimiter;
 import io.ebean.config.dbplatform.DatabasePlatform;
@@ -12,7 +14,6 @@ import io.ebean.config.dbplatform.PlatformIdGenerator;
 import io.ebean.config.dbplatform.RownumSqlLimiter;
 import io.ebean.dbmigration.ddlgeneration.platform.Oracle10Ddl;
 
-import javax.sql.DataSource;
 import java.sql.Types;
 
 /**
@@ -64,9 +65,10 @@ public class OraclePlatform extends DatabasePlatform {
   }
 
   @Override
-  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
+  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be,
+      TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
 
-    return new OracleSequenceIdGenerator(be, ds, seqName, batchSize);
+    return new OracleSequenceIdGenerator(be, ds, seqName, batchSize, currentTenantProvider);
   }
 
   @Override

--- a/src/main/java/io/ebean/config/dbplatform/oracle/OracleSequenceIdGenerator.java
+++ b/src/main/java/io/ebean/config/dbplatform/oracle/OracleSequenceIdGenerator.java
@@ -1,9 +1,9 @@
 package io.ebean.config.dbplatform.oracle;
 
 import io.ebean.BackgroundExecutor;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.SequenceIdGenerator;
-
-import javax.sql.DataSource;
 
 /**
  * Oracle specific sequence Id Generator.
@@ -15,8 +15,8 @@ public class OracleSequenceIdGenerator extends SequenceIdGenerator {
   /**
    * Construct given a dataSource and sql to return the next sequence value.
    */
-  public OracleSequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
-    super(be, ds, seqName, batchSize);
+  public OracleSequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
+    super(be, ds, seqName, batchSize, currentTenantProvider);
     this.baseSql = "select " + seqName + ".nextval, a from (select level as a FROM dual CONNECT BY level <= ";
   }
 

--- a/src/main/java/io/ebean/config/dbplatform/postgres/PostgresPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/postgres/PostgresPlatform.java
@@ -3,7 +3,9 @@ package io.ebean.config.dbplatform.postgres;
 import io.ebean.BackgroundExecutor;
 import io.ebean.Platform;
 import io.ebean.Query;
+import io.ebean.config.CurrentTenantProvider;
 import io.ebean.config.ServerConfig;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.config.dbplatform.DbType;
@@ -13,7 +15,6 @@ import io.ebean.config.dbplatform.SqlErrorCodes;
 import io.ebean.dbmigration.ddlgeneration.DdlHandler;
 import io.ebean.dbmigration.ddlgeneration.platform.PostgresDdl;
 
-import javax.sql.DataSource;
 import java.sql.Types;
 
 /**
@@ -103,9 +104,10 @@ public class PostgresPlatform extends DatabasePlatform {
    * Create a Postgres specific sequence IdGenerator.
    */
   @Override
-  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
+  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be,
+      TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
 
-    return new PostgresSequenceIdGenerator(be, ds, seqName, batchSize);
+    return new PostgresSequenceIdGenerator(be, ds, seqName, batchSize, currentTenantProvider);
   }
 
   @Override

--- a/src/main/java/io/ebean/config/dbplatform/postgres/PostgresSequenceIdGenerator.java
+++ b/src/main/java/io/ebean/config/dbplatform/postgres/PostgresSequenceIdGenerator.java
@@ -1,9 +1,9 @@
 package io.ebean.config.dbplatform.postgres;
 
 import io.ebean.BackgroundExecutor;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.SequenceIdGenerator;
-
-import javax.sql.DataSource;
 
 /**
  * Postgres specific sequence Id Generator.
@@ -15,8 +15,8 @@ public class PostgresSequenceIdGenerator extends SequenceIdGenerator {
   /**
    * Construct given a dataSource and sql to return the next sequence value.
    */
-  public PostgresSequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
-    super(be, ds, seqName, batchSize);
+  public PostgresSequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
+    super(be, ds, seqName, batchSize, currentTenantProvider);
     this.baseSql = "select nextval('" + seqName + "'), s.generate_series from (select generate_series from generate_series(1,";
   }
 

--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
@@ -1,11 +1,14 @@
 package io.ebean.config.dbplatform.sqlserver;
 
-import io.ebean.PersistBatch;
+import io.ebean.BackgroundExecutor;
 import io.ebean.Platform;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.config.dbplatform.DbType;
 import io.ebean.config.dbplatform.IdType;
+import io.ebean.config.dbplatform.PlatformIdGenerator;
 import io.ebean.config.dbplatform.SqlErrorCodes;
 import io.ebean.dbmigration.ddlgeneration.platform.SqlServerDdl;
 
@@ -19,23 +22,22 @@ public class SqlServerPlatform extends DatabasePlatform {
   public SqlServerPlatform() {
     super();
     this.platform = Platform.SQLSERVER;
-    // effectively disable persistBatchOnCascade mode for SQL Server
-    // due to lack of support for getGeneratedKeys in batch mode
-    this.persistBatchOnCascade = PersistBatch.NONE;
     this.idInExpandedForm = true;
     this.selectCountWithAlias = true;
     this.sqlLimiter = new SqlServerSqlLimiter();
     this.basicSqlLimiter = new SqlServerBasicSqlLimiter();
     this.platformDdl = new SqlServerDdl(this);
     this.historySupport = new SqlServerHistorySupport();
-    this.dbIdentity.setIdType(IdType.IDENTITY);
-    this.dbIdentity.setSupportsGetGeneratedKeys(true);
-    this.dbIdentity.setSupportsIdentity(true);
+    dbIdentity.setIdType(IdType.SEQUENCE);
+    // Not using getGeneratedKeys as instead we will
+    // batch load sequences which enables JDBC batch execution
+    dbIdentity.setSupportsGetGeneratedKeys(false);
+    dbIdentity.setSupportsSequence(true);
 
     this.exceptionTranslator =
       new SqlErrorCodes()
         .addAcquireLock("1222")
-        .addDuplicateKey("2601","2627")
+        .addDuplicateKey("2601","2627","23000")
         .addDataIntegrity("544","8114","8115")
         .build();
 
@@ -61,6 +63,16 @@ public class SqlServerPlatform extends DatabasePlatform {
     dbTypeMap.put(DbType.TIME, new DbPlatformType("time"));
     dbTypeMap.put(DbType.TIMESTAMP, new DbPlatformType("datetime2"));
 
+  }
+
+  /**
+   * Create a SqlServer specific sequence IdGenerator.
+   */
+  @Override
+  public PlatformIdGenerator createSequenceIdGenerator(BackgroundExecutor be,
+      TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
+
+    return new SqlServerSequenceIdGenerator(be, ds, seqName, batchSize, currentTenantProvider);
   }
 
 }

--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerSequenceIdGenerator.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerSequenceIdGenerator.java
@@ -1,0 +1,47 @@
+package io.ebean.config.dbplatform.sqlserver;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.ebean.BackgroundExecutor;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.TenantDataSourceProvider;
+import io.ebean.config.dbplatform.SequenceIdGenerator;
+
+/**
+ * SQLServer specific sequence Id Generator.
+ */
+public class SqlServerSequenceIdGenerator extends SequenceIdGenerator {
+
+  private final String sql1;
+  private final String sql2;
+
+  /**
+   * Construct given a dataSource and sql to return the next sequence value.
+   */
+  public SqlServerSequenceIdGenerator(BackgroundExecutor be, TenantDataSourceProvider ds, String seqName, int batchSize, CurrentTenantProvider currentTenantProvider) {
+    super(be, ds, seqName, batchSize, currentTenantProvider);
+    this.sql1 = "DECLARE @res sql_variant; EXEC sp_sequence_get_range @sequence_name = N'" + seqName +"', @range_size = ";
+    this.sql2 = ", @range_first_value = @res OUTPUT; SELECT CAST(@res AS bigint)"  ;
+  }
+
+  @Override
+  public String getSql(int batchSize) {
+    StringBuilder sb = new StringBuilder(sql1).append(batchSize).append(sql2);
+    return sb.toString();
+  }
+  
+  @Override
+  protected List<Long> processResult(ResultSet rset, int loadSize) throws SQLException {
+    List<Long> newIds = new ArrayList<>(loadSize);
+    if (rset.next()) {
+      long start = rset.getLong(1);
+      for (int i = 0; i < loadSize; i++) {
+        newIds.add(start++);
+      }
+   }
+   return newIds;
+  }
+}

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -159,7 +159,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
 
   private final TenantDataSourceProvider dataSource;
   
-  private final CurrentTenantProvider currentTenantProvider;
+  private final CurrentTenantProvider dynamicDatasourceTenantProvider;
 
   private final DatabasePlatform databasePlatform;
 
@@ -201,7 +201,11 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
     this.dbSequenceBatchSize = serverConfig.getDatabaseSequenceBatchSize();
     this.backgroundExecutor = config.getBackgroundExecutor();
     this.dataSource = serverConfig.getTenantDataSourceProvider();
-    this.currentTenantProvider = serverConfig.getCurrentTenantProvider();
+    if (serverConfig.getTenantMode().isDynamicDataSource()) {
+      this.dynamicDatasourceTenantProvider = serverConfig.getCurrentTenantProvider();
+    } else {
+      this.dynamicDatasourceTenantProvider = null; // on non dynamic datasources, we do not generate sequence generators per tenant
+    }
     this.encryptKeyManager = serverConfig.getEncryptKeyManager();
     this.databasePlatform = serverConfig.getDatabasePlatform();
     this.idBinderFactory = new IdBinderFactory(databasePlatform.isIdInExpandedForm());
@@ -1280,7 +1284,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
   }
 
   private PlatformIdGenerator createSequenceIdGenerator(String seqName) {
-    return databasePlatform.createSequenceIdGenerator(backgroundExecutor, dataSource, seqName, dbSequenceBatchSize, currentTenantProvider);
+    return databasePlatform.createSequenceIdGenerator(backgroundExecutor, dataSource, seqName, dbSequenceBatchSize, dynamicDatasourceTenantProvider);
   }
 
   private void createByteCode(DeployBeanDescriptor<?> deploy) {

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -5,10 +5,12 @@ import io.ebean.Model;
 import io.ebean.RawSqlBuilder;
 import io.ebean.bean.BeanCollection;
 import io.ebean.bean.EntityBean;
+import io.ebean.config.CurrentTenantProvider;
 import io.ebean.config.EncryptKey;
 import io.ebean.config.EncryptKeyManager;
 import io.ebean.config.NamingConvention;
 import io.ebean.config.ServerConfig;
+import io.ebean.config.TenantDataSourceProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbHistorySupport;
 import io.ebean.config.dbplatform.DbIdentity;
@@ -155,7 +157,9 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
 
   private final DbIdentity dbIdentity;
 
-  private final DataSource dataSource;
+  private final TenantDataSourceProvider dataSource;
+  
+  private final CurrentTenantProvider currentTenantProvider;
 
   private final DatabasePlatform databasePlatform;
 
@@ -196,7 +200,8 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
     this.docStoreFactory = config.getDocStoreFactory();
     this.dbSequenceBatchSize = serverConfig.getDatabaseSequenceBatchSize();
     this.backgroundExecutor = config.getBackgroundExecutor();
-    this.dataSource = serverConfig.getDataSource();
+    this.dataSource = serverConfig.getTenantDataSourceProvider();
+    this.currentTenantProvider = serverConfig.getCurrentTenantProvider();
     this.encryptKeyManager = serverConfig.getEncryptKeyManager();
     this.databasePlatform = serverConfig.getDatabasePlatform();
     this.idBinderFactory = new IdBinderFactory(databasePlatform.isIdInExpandedForm());
@@ -1275,7 +1280,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
   }
 
   private PlatformIdGenerator createSequenceIdGenerator(String seqName) {
-    return databasePlatform.createSequenceIdGenerator(backgroundExecutor, dataSource, seqName, dbSequenceBatchSize);
+    return databasePlatform.createSequenceIdGenerator(backgroundExecutor, dataSource, seqName, dbSequenceBatchSize, currentTenantProvider);
   }
 
   private void createByteCode(DeployBeanDescriptor<?> deploy) {


### PR DESCRIPTION
Hello Rob,

please take a look at this PR. This makes SequenceGenerators tenant-aware.

FYI: We will use TenantMode DB (instead SCHEMA) now in conjunction with SqlServer due several reasons:
- setSchema is not supported by the driver (required too much hacks in ebean)
- better separation of data (we have to use different db credentials on different servers for each tenant)

=> We dropped the idea to switch the tenant during transaction. A transaction always run for one tenant.
