### PR TITLE
FIX: JtaTransaction is TenantMode.DB aware

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -360,7 +360,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Override
   public DataSource getDataSource() {
-    return transactionManager.getDataSource();
+    return transactionManager.getDataSourceSupplier().getDataSource();
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.persistence.PersistenceException;
-import javax.sql.DataSource;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.NotSupportedException;
@@ -31,7 +30,7 @@ public class JtaTransactionManager implements ExternalTransactionManager {
   /**
    * The data source.
    */
-  private DataSource dataSource;
+  private DataSourceSupplier dataSourceSupplier;
 
   /**
    * The Ebean transaction manager.
@@ -59,7 +58,7 @@ public class JtaTransactionManager implements ExternalTransactionManager {
     // the public API and hence the Object type and casting here
 
     this.transactionManager = (TransactionManager) txnMgr;
-    this.dataSource = transactionManager.getDataSource();
+    this.dataSourceSupplier = transactionManager.getDataSourceSupplier();
     this.serverName = transactionManager.getServerName();
   }
 
@@ -121,7 +120,7 @@ public class JtaTransactionManager implements ExternalTransactionManager {
 
     // "wrap" it in a Ebean specific JtaTransaction
     String txnId = String.valueOf(System.currentTimeMillis());
-    JtaTransaction newTrans = new JtaTransaction(txnId, true, ut, dataSource, transactionManager);
+    JtaTransaction newTrans = new JtaTransaction(txnId, true, ut, dataSourceSupplier.getDataSource(), transactionManager);
 
     // create and register transaction listener
     JtaTxnListener txnListener = createJtaTxnListener(newTrans);

--- a/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -207,8 +206,8 @@ public class TransactionManager {
     return serverName;
   }
 
-  public DataSource getDataSource() {
-    return dataSourceSupplier.getDataSource();
+  public DataSourceSupplier getDataSourceSupplier() {
+    return dataSourceSupplier;
   }
 
   /**


### PR DESCRIPTION
Hello Rob, can you take a look at this. This should make JTA transactions tenant-aware in TenantMode.DB
(otherwise, the DB is used that was selected when construction the TransactionFactory)