### PR TITLE
[ModifyAware] Noticed that this boolean parameter was ignored.

### DIFF
--- a/src/main/java/io/ebean/text/json/EJson.java
+++ b/src/main/java/io/ebean/text/json/EJson.java
@@ -158,7 +158,12 @@ public class EJson {
     if (list == null) {
       return null;
     }
-    return ((ModifyAwareList) list).asSet();
+
+    if (modifyAware) {
+      return ((ModifyAwareList) list).asSet();
+    } else {
+      return new LinkedHashSet<>(list);
+    }
   }
 
   /**


### PR DESCRIPTION
After some quick analysis, implemented the way it probably should be used.

Of course, this could have been on purpose, please advise. There are 2 places in the production code where this is used, once with true, once with false.

Here: https://github.com/ebean-orm/ebean/blob/master/src/main/java/io/ebeaninternal/server/type/ScalarTypeArraySet.java#L126

And here: https://github.com/ebean-orm/ebean/blob/master/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java#L77

And I personally don't have a way of testing the influence of this change. It just seemed like the parameter was ignored.