### PR TITLE
#1043 Fix. RawSql should automatically map upper-case column alias to lower-case bean property

### DIFF
--- a/src/main/java/io/ebean/util/CamelCaseHelper.java
+++ b/src/main/java/io/ebean/util/CamelCaseHelper.java
@@ -12,7 +12,7 @@ public class CamelCaseHelper {
 
     String[] vals = underscore.split("_");
     if (vals.length == 1) {
-      return underscore;
+      return isUpperCase(underscore) ? underscore.toLowerCase() : underscore;
     }
 
     StringBuilder result = new StringBuilder();
@@ -28,5 +28,14 @@ public class CamelCaseHelper {
     }
 
     return result.toString();
+  }
+
+  private static boolean isUpperCase(String underscore) {
+    for (int i = 0; i < underscore.length(); i++) {
+      if (Character.isLowerCase(underscore.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/test/java/io/ebean/util/CamelCaseHelperTest.java
+++ b/src/test/java/io/ebean/util/CamelCaseHelperTest.java
@@ -25,7 +25,7 @@ public class CamelCaseHelperTest {
     assertEquals(CamelCaseHelper.toCamelFromUnderscore("helloThere"), "helloThere");
     assertEquals(CamelCaseHelper.toCamelFromUnderscore("helloThereJim"), "helloThereJim");
     assertEquals(CamelCaseHelper.toCamelFromUnderscore("hello"), "hello");
-    assertEquals(CamelCaseHelper.toCamelFromUnderscore("HELLO"), "HELLO");
+    assertEquals(CamelCaseHelper.toCamelFromUnderscore("HELLO"), "hello");
   }
 
 }


### PR DESCRIPTION
Please see issue #1043 