### PR TITLE
New Mode to control queryCache behavior

### DIFF
--- a/src/main/java/io/ebean/CacheMode.java
+++ b/src/main/java/io/ebean/CacheMode.java
@@ -1,0 +1,48 @@
+package io.ebean;
+/**
+ * 
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public enum CacheMode {
+  /**
+   * Do not use cache.
+   */
+  OFF(false, false),
+  
+  /**
+   * Use the cace (query & store the resut)
+   */
+  ON(true, true), 
+  
+  /**
+   * Do not read from cache, but write retrived value to cache.
+   * Use this, if you want to get the fresh value from database and a CacheMode.ON query will follow.
+   */
+  RECACHE(false, true),
+  
+  /**
+   * Query the cache for value. If it is there, use it, otherwise hit database but do NOT put the value
+   * into the cache. (this mode is for completeness. There's probably no use case for this)
+   */
+  QUERY_ONLY(true,false);
+ 
+  
+  private boolean get;
+  private boolean put;
+
+  private CacheMode(boolean get, boolean put) {
+    this.get = get;
+    this.put = put;
+  }
+  
+  
+  public boolean isGet() {
+    return get;
+  }
+  
+  public boolean isPut() {
+    return put;
+  }
+  
+}

--- a/src/main/java/io/ebean/ExpressionList.java
+++ b/src/main/java/io/ebean/ExpressionList.java
@@ -442,12 +442,20 @@ public interface ExpressionList<T> {
   Query<T> setUseCache(boolean useCache);
 
   /**
-   * Set to true to use the query for executing this query.
+   * Set the cache mode to use the query for executing this query.
    *
    * @see Query#setUseQueryCache(boolean)
    */
-  Query<T> setUseQueryCache(boolean useCache);
+  Query<T> setUseQueryCache(CacheMode useCache);
 
+  /**
+   * Use {@link #setUseQueryCache(CacheMode)}.
+   */
+  @Deprecated
+  default Query<T> setUseQueryCache(boolean enabled) {
+    return setUseQueryCache(enabled ? CacheMode.ON : CacheMode.OFF);
+  }
+  
   /**
    * Set to true if this query should execute against the doc store.
    * <p>

--- a/src/main/java/io/ebean/Query.java
+++ b/src/main/java/io/ebean/Query.java
@@ -1324,7 +1324,15 @@ public interface Query<T> {
   /**
    * Set this to true to use the query cache.
    */
-  Query<T> setUseQueryCache(boolean useQueryCache);
+  Query<T> setUseQueryCache(CacheMode useQueryCache);
+  
+  /**
+   * Use {@link #setUseQueryCache(CacheMode)}.
+   */
+  @Deprecated
+  default Query<T> setUseQueryCache(boolean enabled) {
+    return setUseQueryCache(enabled ? CacheMode.ON : CacheMode.OFF);
+  }
 
   /**
    * Set to true if this query should execute against the doc store.

--- a/src/main/java/io/ebeaninternal/api/SpiQuery.java
+++ b/src/main/java/io/ebeaninternal/api/SpiQuery.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.api;
 
+import io.ebean.CacheMode;
 import io.ebean.EbeanServer;
 import io.ebean.ExpressionList;
 import io.ebean.OrderBy;
@@ -583,9 +584,9 @@ public interface SpiQuery<T> extends Query<T> {
   boolean isUseBeanCache();
 
   /**
-   * Return true if this query should use/check the query cache.
+   * Return the cache mode if this query should use/check the query cache.
    */
-  boolean isUseQueryCache();
+  CacheMode getUseQueryCache();
 
   /**
    * Return true if the beans from this query should be loaded into the bean

--- a/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.core;
 
+import io.ebean.CacheMode;
 import io.ebean.PersistenceContextScope;
 import io.ebean.QueryIterator;
 import io.ebean.Version;
@@ -464,11 +465,15 @@ public final class OrmQueryRequest<T> extends BeanRequest implements BeanQueryRe
   @SuppressWarnings("unchecked")
   public Object getFromQueryCache() {
 
-    if (!query.isUseQueryCache()) {
+    if (query.getUseQueryCache() == CacheMode.OFF) {
+      return null;
+    } else {
+      cacheKey = query.queryHash();
+    }
+    
+    if (!query.getUseQueryCache().isGet()) {
       return null;
     }
-
-    cacheKey = query.queryHash();
 
     Object cached = beanDescriptor.queryCacheGet(cacheKey);
 

--- a/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
@@ -2,7 +2,6 @@ package io.ebeaninternal.server.core;
 
 import io.ebean.QueryIterator;
 import io.ebean.Version;
-import io.ebean.bean.BeanCollection;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeanservice.docstore.api.DocQueryRequest;

--- a/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebean.CacheMode;
 import io.ebean.Expression;
 import io.ebean.ExpressionFactory;
 import io.ebean.ExpressionList;
@@ -481,7 +482,7 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
   }
 
   @Override
-  public Query<T> setUseQueryCache(boolean useCache) {
+  public Query<T> setUseQueryCache(CacheMode useCache) {
     return query.setUseQueryCache(useCache);
   }
 

--- a/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebean.CacheMode;
 import io.ebean.Expression;
 import io.ebean.ExpressionList;
 import io.ebean.FetchPath;
@@ -768,7 +769,7 @@ class JunctionExpression<T> implements SpiJunction<T>, SpiExpression, Expression
   }
 
   @Override
-  public Query<T> setUseQueryCache(boolean useCache) {
+  public Query<T> setUseQueryCache(CacheMode useCache) {
     return exprList.setUseQueryCache(useCache);
   }
 

--- a/src/main/java/io/ebeaninternal/server/query/DefaultOrmQueryEngine.java
+++ b/src/main/java/io/ebeaninternal/server/query/DefaultOrmQueryEngine.java
@@ -71,7 +71,7 @@ public class DefaultOrmQueryEngine implements OrmQueryEngine {
 
     flushJdbcBatchOnQuery(request);
     int result = queryEngine.findCount(request);
-    if (request.getQuery().isUseQueryCache()) {
+    if (request.getQuery().getUseQueryCache().isPut()) {
       request.putToQueryCache(result);
     }
     return result;
@@ -88,7 +88,7 @@ public class DefaultOrmQueryEngine implements OrmQueryEngine {
   public <A> List<A> findSingleAttributeList(OrmQueryRequest<?> request) {
     flushJdbcBatchOnQuery(request);
     List<A> result = queryEngine.findSingleAttributeList(request);
-    if (!result.isEmpty() && request.getQuery().isUseQueryCache()) {
+    if (!result.isEmpty() && request.getQuery().getUseQueryCache().isPut()) {
       // load the query result into the query cache
       request.putToQueryCache(result);
     }
@@ -137,7 +137,7 @@ public class DefaultOrmQueryEngine implements OrmQueryEngine {
       }
     }
 
-    if (!result.isEmpty() && query.isUseQueryCache()) {
+    if (!result.isEmpty() && query.getUseQueryCache().isPut()) {
       // load the query result into the query cache
       request.putToQueryCache(result);
     }

--- a/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.querydefn;
 
+import io.ebean.CacheMode;
 import io.ebean.EbeanServer;
 import io.ebean.Expression;
 import io.ebean.ExpressionFactory;
@@ -195,7 +196,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
 
   private boolean excludeBeanCache;
 
-  private Boolean useQueryCache;
+  private CacheMode useQueryCache = CacheMode.OFF;
 
   private Boolean readOnly;
 
@@ -1094,9 +1095,13 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
   }
 
   @Override
-  public boolean isUseQueryCache() {
+  public CacheMode getUseQueryCache() {
     // not using L2 cache for asDraft() query
-    return !isAsDraft() && Boolean.TRUE.equals(useQueryCache);
+    if (isAsDraft()) {
+      return CacheMode.OFF;
+    } else {
+      return useQueryCache;
+    }
   }
 
   @Override
@@ -1106,7 +1111,7 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
   }
 
   @Override
-  public DefaultOrmQuery<T> setUseQueryCache(boolean useQueryCache) {
+  public DefaultOrmQuery<T> setUseQueryCache(CacheMode useQueryCache) {
     this.useQueryCache = useQueryCache;
     return this;
   }


### PR DESCRIPTION
Hello Rob, thanks for the cache (it was 2 days too late, becaue on tuesday we implemented a "select count" cache in our application)
Here It was possible to "recache" a value, that means, get the value from DB and store it in the cache.
What do you think about this change in this PR