### PR TITLE
Decoupled getServer(...) dependency on having a default server connection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,324 +1,324 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.avaje</groupId>
-		<artifactId>java8-parent</artifactId>
-		<version>1.3</version>
-	</parent>
+  <parent>
+    <groupId>org.avaje</groupId>
+    <artifactId>java8-parent</artifactId>
+    <version>1.3</version>
+  </parent>
 
-	<groupId>io.ebean</groupId>
-	<artifactId>ebean</artifactId>
-	<version>10.4.2-SNAPSHOT</version>
-	<packaging>jar</packaging>
+  <groupId>io.ebean</groupId>
+  <artifactId>ebean</artifactId>
+  <version>10.4.2-SNAPSHOT</version>
+  <packaging>jar</packaging>
 
-	<name>ebean</name>
-	<url>http://ebean-orm.github.io/</url>
+  <name>ebean</name>
+  <url>http://ebean-orm.github.io/</url>
 
-	<scm>
-		<developerConnection>scm:git:git@github.com:ebean-orm/ebean.git</developerConnection>
-		<tag>HEAD</tag>
-	</scm>
+  <scm>
+    <developerConnection>scm:git:git@github.com:ebean-orm/ebean.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
 
-	<dependencies>
+  <dependencies>
 
-		<dependency>
-			<groupId>org.jetbrains</groupId>
-			<artifactId>annotations</artifactId>
-			<version>13.0</version>
-		</dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>13.0</version>
+    </dependency>
 
-		<dependency>
-			<groupId>io.ebean</groupId>
-			<artifactId>persistence-api</artifactId>
-			<version>2.2.1</version>
-		</dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>persistence-api</artifactId>
+      <version>2.2.1</version>
+    </dependency>
 
-		<dependency>
-			<groupId>io.ebean</groupId>
-			<artifactId>ebean-annotation</artifactId>
-			<version>2.3</version>
-		</dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-annotation</artifactId>
+      <version>2.3</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.avaje</groupId>
-			<artifactId>avaje-datasource-api</artifactId>
-			<version>1.1</version>
-		</dependency>
+    <dependency>
+      <groupId>org.avaje</groupId>
+      <artifactId>avaje-datasource-api</artifactId>
+      <version>1.1</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.avaje</groupId>
-			<artifactId>avaje-datasource</artifactId>
-			<version>2.1.1</version>
-		</dependency>
+    <dependency>
+      <groupId>org.avaje</groupId>
+      <artifactId>avaje-datasource</artifactId>
+      <version>2.1.1</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.avaje</groupId>
-			<artifactId>avaje-classpath-scanner-api</artifactId>
-			<version>2.2</version>
-		</dependency>
+    <dependency>
+      <groupId>org.avaje</groupId>
+      <artifactId>avaje-classpath-scanner-api</artifactId>
+      <version>2.2</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.avaje</groupId>
-			<artifactId>avaje-classpath-scanner</artifactId>
-			<version>2.2.2</version>
-		</dependency>
+    <dependency>
+      <groupId>org.avaje</groupId>
+      <artifactId>avaje-classpath-scanner</artifactId>
+      <version>2.2.2</version>
+    </dependency>
 
-		<dependency>
-			<groupId>io.ebean</groupId>
-			<artifactId>ebean-dbmigration</artifactId>
-			<version>10.1.10</version>
-		</dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-dbmigration</artifactId>
+      <version>10.1.10</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>[1.7.1,1.7.99)</version>
-		</dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>[1.7.1,1.7.99)</version>
+    </dependency>
 
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
-			<version>4.6</version>
-		</dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr4-runtime</artifactId>
+      <version>4.6</version>
+    </dependency>
 
-		<!-- Jackson core used internally by Ebean -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-			<version>2.6.5</version>
-		</dependency>
+    <!-- Jackson core used internally by Ebean -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.6.5</version>
+    </dependency>
 
-		<!-- provided scope for JsonNode support -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.6.5</version>
-			<scope>provided</scope>
-		</dependency>
+    <!-- provided scope for JsonNode support -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.6.5</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>javax.transaction</groupId>
-			<artifactId>jta</artifactId>
-			<version>1.1</version>
-			<scope>provided</scope>
-		</dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>jta</artifactId>
+      <version>1.1</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<!-- provided scope to read validation annotations Size etc -->
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>1.1.0.Final</version>
-			<scope>provided</scope>
-		</dependency>
+    <!-- provided scope to read validation annotations Size etc -->
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>1.1.0.Final</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>3.1.0</version>
-			<scope>provided</scope>
-		</dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.9.7</version>
-			<scope>provided</scope>
-		</dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.9.7</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<!-- Provided scope for Postgres JSON/JSONB support -->
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>9.4.1212</version>
-			<scope>provided</scope>
-		</dependency>
+    <!-- Provided scope for Postgres JSON/JSONB support -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>9.4.1212</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<!-- Test scope -->
+    <!-- Test scope -->
 
-		<!--<dependency> -->
-		<!--<groupId>oracle</groupId> -->
-		<!--<artifactId>oracle-jdbc</artifactId> -->
-		<!--<version>7.0</version> -->
-		<!--<scope>test</scope> -->
-		<!--</dependency> -->
+    <!--<dependency>-->
+      <!--<groupId>oracle</groupId>-->
+      <!--<artifactId>oracle-jdbc</artifactId>-->
+      <!--<version>7.0</version>-->
+      <!--<scope>test</scope>-->
+    <!--</dependency>-->
 
-		<!--<dependency> -->
-		<!--<groupId>microsoft</groupId> -->
-		<!--<artifactId>sqlserver-jdbc</artifactId> -->
-		<!--<version>4.2</version> -->
-		<!--<scope>test</scope> -->
-		<!--</dependency> -->
+    <!--<dependency>-->
+      <!--<groupId>microsoft</groupId>-->
+      <!--<artifactId>sqlserver-jdbc</artifactId>-->
+      <!--<version>4.2</version>-->
+      <!--<scope>test</scope>-->
+    <!--</dependency>-->
 
-		<dependency>
-			<groupId>org.avaje</groupId>
-			<artifactId>avaje-agentloader</artifactId>
-			<version>2.1.2</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.avaje</groupId>
+      <artifactId>avaje-agentloader</artifactId>
+      <version>2.1.2</version>
+      <scope>test</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>io.ebean</groupId>
-			<artifactId>ebean-agent</artifactId>
-			<version>10.3.1</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-agent</artifactId>
+      <version>10.3.1</version>
+      <scope>test</scope>
+    </dependency>
 
-		<!-- Provided scope so that the H2HistoryTrigger can live in Ebean core 
-			and not require a separate module for it -->
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<version>1.4.193</version>
-			<scope>provided</scope>
-		</dependency>
+    <!-- Provided scope so that the H2HistoryTrigger can live in Ebean core
+         and not require a separate module for it -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.4.193</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.xerial</groupId>
-			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.15.1</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.15.1</version>
+      <scope>test</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<version>2.3.4</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <version>2.3.4</version>
+      <scope>test</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>com.microsoft.sqlserver</groupId>
-			<artifactId>mssql-jdbc</artifactId>
-			<version>6.1.3.jre8-preview</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>6.1.3.jre8-preview</version>
+      <scope>test</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>6.0.5</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>6.0.5</version>
+      <scope>test</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.avaje.composite</groupId>
-			<artifactId>avaje-composite-testing</artifactId>
-			<version>1.1</version>
-			<scope>test</scope>
-			<type>pom</type>
-		</dependency>
+    <dependency>
+      <groupId>org.avaje.composite</groupId>
+      <artifactId>avaje-composite-testing</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+      <type>pom</type>
+    </dependency>
 
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+      <scope>test</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.avaje.moduuid</groupId>
-			<artifactId>avaje-moduuid</artifactId>
-			<version>2.1</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.avaje.moduuid</groupId>
+      <artifactId>avaje-moduuid</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
 
-	</dependencies>
+  </dependencies>
 
 
-	<build>
-		<pluginManagement>
-			<plugins>
+  <build>
+    <pluginManagement>
+      <plugins>
 
-				<plugin>
-					<groupId>io.ebean</groupId>
-					<artifactId>ebean-maven-plugin</artifactId>
-					<version>10.3.1</version>
-					<executions>
-						<execution>
-							<id>test</id>
-							<phase>process-test-classes</phase>
-							<configuration>
-								<transformArgs>debug=1</transformArgs>
-							</configuration>
-							<goals>
-								<goal>testEnhance</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
+        <plugin>
+          <groupId>io.ebean</groupId>
+          <artifactId>ebean-maven-plugin</artifactId>
+          <version>10.3.1</version>
+          <executions>
+            <execution>
+              <id>test</id>
+              <phase>process-test-classes</phase>
+              <configuration>
+                <transformArgs>debug=1</transformArgs>
+              </configuration>
+              <goals>
+                <goal>testEnhance</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.5</version>
-					<configuration>
-						<useSystemClassLoader>false</useSystemClassLoader>
-						<failIfNoTests>false</failIfNoTests>
-						<includes>
-							<include>**/Test*.java</include>
-							<include>**/*Test.java</include>
-							<include>**/*Tests.java</include>
-						</includes>
-						<systemProperties>
-							<property>
-								<!-- transfer datasource.default parameter -->
-								<name>datasource.default</name>
-								<value>${datasource.default}</value>
-							</property>
-						</systemProperties>
-					</configuration>
-				</plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.5</version>
+          <configuration>
+            <useSystemClassLoader>false</useSystemClassLoader>
+            <failIfNoTests>false</failIfNoTests>
+            <includes>
+              <include>**/Test*.java</include>
+              <include>**/*Test.java</include>
+              <include>**/*Tests.java</include>
+            </includes>
+            <systemProperties>
+              <property>
+                <!-- transfer datasource.default parameter -->
+                <name>datasource.default</name>
+                <value>${datasource.default}</value>
+              </property>
+            </systemProperties>
+          </configuration>
+        </plugin>
 
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.5</version>
-					<configuration>
-						<archive>
-							<manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
-						</archive>
-					</configuration>
-				</plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.5</version>
+          <configuration>
+            <archive>
+              <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+            </archive>
+          </configuration>
+        </plugin>
 
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version>
-					<configuration>
-						<doctitle>Ebean 10</doctitle>
-						<overview>src/main/java/io/ebean/overview.html</overview>
-						<source>1.8</source>
-						<doclet>org.avaje.doclet.PygmentsDoclet</doclet>
-						<excludePackageNames>io.ebeaninternal.*:com.avaje.ebean.util:io.ebean.dbmigration.ddlgeneration:io.ebean.dbmigration.migration:io.ebean.dbmigration.migrationreader:io.ebean.dbmigration.model</excludePackageNames>
-						<docletArtifact>
-							<groupId>org.avaje</groupId>
-							<artifactId>pygments-doclet</artifactId>
-							<version>1.0.0</version>
-						</docletArtifact>
-						<additionalparam>
-							-Xdoclint:none
-							-include-basedir ${project.basedir}
-							-attributes "idseparator=-; project_name=${project.name}; \
-							project_version=${project.version}; \
-							project_desc=${project.description}"
-						</additionalparam>
-						<linksource>true</linksource>
-						<overview>src/main/java/com/avaje/ebean/overview.html</overview>
-					</configuration>
-					<executions>
-						<execution>
-							<id>attach-javadocs</id>
-							<goals>
-								<goal>jar</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.9.1</version>
+          <configuration>
+            <doctitle>Ebean 10</doctitle>
+            <overview>src/main/java/io/ebean/overview.html</overview>
+            <source>1.8</source>
+            <doclet>org.avaje.doclet.PygmentsDoclet</doclet>
+            <excludePackageNames>io.ebeaninternal.*:com.avaje.ebean.util:io.ebean.dbmigration.ddlgeneration:io.ebean.dbmigration.migration:io.ebean.dbmigration.migrationreader:io.ebean.dbmigration.model</excludePackageNames>
+            <docletArtifact>
+              <groupId>org.avaje</groupId>
+              <artifactId>pygments-doclet</artifactId>
+              <version>1.0.0</version>
+            </docletArtifact>
+            <additionalparam>
+              -Xdoclint:none
+              -include-basedir ${project.basedir}
+              -attributes "idseparator=-; project_name=${project.name}; \
+              project_version=${project.version}; \
+              project_desc=${project.description}"
+            </additionalparam>
+            <linksource>true</linksource>
+            <overview>src/main/java/com/avaje/ebean/overview.html</overview>
+          </configuration>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-			</plugins>
-		</pluginManagement>
-	</build>
+      </plugins>
+    </pluginManagement>
+  </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,322 +1,324 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.avaje</groupId>
-    <artifactId>java8-parent</artifactId>
-    <version>1.3</version>
-  </parent>
+	<parent>
+		<groupId>org.avaje</groupId>
+		<artifactId>java8-parent</artifactId>
+		<version>1.3</version>
+	</parent>
 
-  <groupId>io.ebean</groupId>
-  <artifactId>ebean</artifactId>
-  <version>10.4.2-SNAPSHOT</version>
-  <packaging>jar</packaging>
+	<groupId>io.ebean</groupId>
+	<artifactId>ebean</artifactId>
+	<version>10.4.2-SNAPSHOT</version>
+	<packaging>jar</packaging>
 
-  <name>ebean</name>
-  <url>http://ebean-orm.github.io/</url>
+	<name>ebean</name>
+	<url>http://ebean-orm.github.io/</url>
 
-  <scm>
-    <developerConnection>scm:git:git@github.com:ebean-orm/ebean.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+	<scm>
+		<developerConnection>scm:git:git@github.com:ebean-orm/ebean.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
 
-  <dependencies>
+	<dependencies>
 
-    <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <version>13.0</version>
-    </dependency>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>13.0</version>
+		</dependency>
 
-    <dependency>
-      <groupId>io.ebean</groupId>
-      <artifactId>persistence-api</artifactId>
-      <version>2.2.1</version>
-    </dependency>
+		<dependency>
+			<groupId>io.ebean</groupId>
+			<artifactId>persistence-api</artifactId>
+			<version>2.2.1</version>
+		</dependency>
 
-    <dependency>
-      <groupId>io.ebean</groupId>
-      <artifactId>ebean-annotation</artifactId>
-      <version>2.3</version>
-    </dependency>
+		<dependency>
+			<groupId>io.ebean</groupId>
+			<artifactId>ebean-annotation</artifactId>
+			<version>2.3</version>
+		</dependency>
 
-    <dependency>
-      <groupId>org.avaje</groupId>
-      <artifactId>avaje-datasource-api</artifactId>
-      <version>1.1</version>
-    </dependency>
+		<dependency>
+			<groupId>org.avaje</groupId>
+			<artifactId>avaje-datasource-api</artifactId>
+			<version>1.1</version>
+		</dependency>
 
-    <dependency>
-      <groupId>org.avaje</groupId>
-      <artifactId>avaje-datasource</artifactId>
-      <version>2.1.1</version>
-    </dependency>
+		<dependency>
+			<groupId>org.avaje</groupId>
+			<artifactId>avaje-datasource</artifactId>
+			<version>2.1.1</version>
+		</dependency>
 
-    <dependency>
-      <groupId>org.avaje</groupId>
-      <artifactId>avaje-classpath-scanner-api</artifactId>
-      <version>2.2</version>
-    </dependency>
+		<dependency>
+			<groupId>org.avaje</groupId>
+			<artifactId>avaje-classpath-scanner-api</artifactId>
+			<version>2.2</version>
+		</dependency>
 
-    <dependency>
-      <groupId>org.avaje</groupId>
-      <artifactId>avaje-classpath-scanner</artifactId>
-      <version>2.2.2</version>
-    </dependency>
+		<dependency>
+			<groupId>org.avaje</groupId>
+			<artifactId>avaje-classpath-scanner</artifactId>
+			<version>2.2.2</version>
+		</dependency>
 
-    <dependency>
-      <groupId>io.ebean</groupId>
-      <artifactId>ebean-dbmigration</artifactId>
-      <version>10.1.10</version>
-    </dependency>
+		<dependency>
+			<groupId>io.ebean</groupId>
+			<artifactId>ebean-dbmigration</artifactId>
+			<version>10.1.10</version>
+		</dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>[1.7.1,1.7.99)</version>
-    </dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>[1.7.1,1.7.99)</version>
+		</dependency>
 
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
-      <version>4.6</version>
-    </dependency>
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4-runtime</artifactId>
+			<version>4.6</version>
+		</dependency>
 
-    <!-- Jackson core used internally by Ebean -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.6.5</version>
-    </dependency>
+		<!-- Jackson core used internally by Ebean -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>2.6.5</version>
+		</dependency>
 
-    <!-- provided scope for JsonNode support -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.6.5</version>
-      <scope>provided</scope>
-    </dependency>
+		<!-- provided scope for JsonNode support -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.6.5</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>javax.transaction</groupId>
-      <artifactId>jta</artifactId>
-      <version>1.1</version>
-      <scope>provided</scope>
-    </dependency>
+		<dependency>
+			<groupId>javax.transaction</groupId>
+			<artifactId>jta</artifactId>
+			<version>1.1</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <!-- provided scope to read validation annotations Size etc -->
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>1.1.0.Final</version>
-      <scope>provided</scope>
-    </dependency>
+		<!-- provided scope to read validation annotations Size etc -->
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>1.1.0.Final</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
-      <scope>provided</scope>
-    </dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.9.7</version>
-      <scope>provided</scope>
-    </dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.9.7</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <!-- Provided scope for Postgres JSON/JSONB support -->
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>9.4.1212</version>
-      <scope>provided</scope>
-    </dependency>
+		<!-- Provided scope for Postgres JSON/JSONB support -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>9.4.1212</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <!-- Test scope -->
+		<!-- Test scope -->
 
-    <!--<dependency>-->
-      <!--<groupId>oracle</groupId>-->
-      <!--<artifactId>oracle-jdbc</artifactId>-->
-      <!--<version>7.0</version>-->
-      <!--<scope>test</scope>-->
-    <!--</dependency>-->
+		<!--<dependency> -->
+		<!--<groupId>oracle</groupId> -->
+		<!--<artifactId>oracle-jdbc</artifactId> -->
+		<!--<version>7.0</version> -->
+		<!--<scope>test</scope> -->
+		<!--</dependency> -->
 
-    <!--<dependency>-->
-      <!--<groupId>microsoft</groupId>-->
-      <!--<artifactId>sqlserver-jdbc</artifactId>-->
-      <!--<version>4.2</version>-->
-      <!--<scope>test</scope>-->
-    <!--</dependency>-->
+		<!--<dependency> -->
+		<!--<groupId>microsoft</groupId> -->
+		<!--<artifactId>sqlserver-jdbc</artifactId> -->
+		<!--<version>4.2</version> -->
+		<!--<scope>test</scope> -->
+		<!--</dependency> -->
 
-    <dependency>
-      <groupId>org.avaje</groupId>
-      <artifactId>avaje-agentloader</artifactId>
-      <version>2.1.2</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.avaje</groupId>
+			<artifactId>avaje-agentloader</artifactId>
+			<version>2.1.2</version>
+			<scope>test</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>io.ebean</groupId>
-      <artifactId>ebean-agent</artifactId>
-      <version>10.3.1</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>io.ebean</groupId>
+			<artifactId>ebean-agent</artifactId>
+			<version>10.3.1</version>
+			<scope>test</scope>
+		</dependency>
 
-    <!-- Provided scope so that the H2HistoryTrigger can live in Ebean core
-         and not require a separate module for it -->
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>1.4.193</version>
-      <scope>provided</scope>
-    </dependency>
+		<!-- Provided scope so that the H2HistoryTrigger can live in Ebean core 
+			and not require a separate module for it -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>1.4.193</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>org.xerial</groupId>
-      <artifactId>sqlite-jdbc</artifactId>
-      <version>3.15.1</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.xerial</groupId>
+			<artifactId>sqlite-jdbc</artifactId>
+			<version>3.15.1</version>
+			<scope>test</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<version>2.3.4</version>
+			<scope>test</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>com.microsoft.sqlserver</groupId>
-      <artifactId>mssql-jdbc</artifactId>
-      <version>6.1.3.jre8-preview</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>com.microsoft.sqlserver</groupId>
+			<artifactId>mssql-jdbc</artifactId>
+			<version>6.1.3.jre8-preview</version>
+			<scope>test</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>6.0.5</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>6.0.5</version>
+			<scope>test</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>org.avaje.composite</groupId>
-      <artifactId>avaje-composite-testing</artifactId>
-      <version>1.1</version>
-      <scope>test</scope>
-      <type>pom</type>
-    </dependency>
+		<dependency>
+			<groupId>org.avaje.composite</groupId>
+			<artifactId>avaje-composite-testing</artifactId>
+			<version>1.1</version>
+			<scope>test</scope>
+			<type>pom</type>
+		</dependency>
 
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.5</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+			<scope>test</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>org.avaje.moduuid</groupId>
-      <artifactId>avaje-moduuid</artifactId>
-      <version>2.1</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.avaje.moduuid</groupId>
+			<artifactId>avaje-moduuid</artifactId>
+			<version>2.1</version>
+			<scope>test</scope>
+		</dependency>
 
-  </dependencies>
+	</dependencies>
 
 
-  <build>
-    <plugins>
+	<build>
+		<pluginManagement>
+			<plugins>
 
-      <plugin>
-        <groupId>io.ebean</groupId>
-        <artifactId>ebean-maven-plugin</artifactId>
-        <version>10.3.1</version>
-        <executions>
-          <execution>
-            <id>test</id>
-            <phase>process-test-classes</phase>
-            <configuration>
-              <transformArgs>debug=1</transformArgs>
-            </configuration>
-            <goals>
-              <goal>testEnhance</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+				<plugin>
+					<groupId>io.ebean</groupId>
+					<artifactId>ebean-maven-plugin</artifactId>
+					<version>10.3.1</version>
+					<executions>
+						<execution>
+							<id>test</id>
+							<phase>process-test-classes</phase>
+							<configuration>
+								<transformArgs>debug=1</transformArgs>
+							</configuration>
+							<goals>
+								<goal>testEnhance</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.5</version>
-        <configuration>
-          <useSystemClassLoader>false</useSystemClassLoader>
-          <failIfNoTests>false</failIfNoTests>
-          <includes>
-            <include>**/Test*.java</include>
-            <include>**/*Test.java</include>
-            <include>**/*Tests.java</include>
-          </includes>
-          <systemProperties>
-            <property>
-              <!-- transfer datasource.default parameter -->
-              <name>datasource.default</name>
-              <value>${datasource.default}</value>
-            </property>
-          </systemProperties>
-        </configuration>
-      </plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.5</version>
+					<configuration>
+						<useSystemClassLoader>false</useSystemClassLoader>
+						<failIfNoTests>false</failIfNoTests>
+						<includes>
+							<include>**/Test*.java</include>
+							<include>**/*Test.java</include>
+							<include>**/*Tests.java</include>
+						</includes>
+						<systemProperties>
+							<property>
+								<!-- transfer datasource.default parameter -->
+								<name>datasource.default</name>
+								<value>${datasource.default}</value>
+							</property>
+						</systemProperties>
+					</configuration>
+				</plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
-        <configuration>
-          <archive>
-            <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
-      </plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>2.5</version>
+					<configuration>
+						<archive>
+							<manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+						</archive>
+					</configuration>
+				</plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
-        <configuration>
-          <doctitle>Ebean 10</doctitle>
-          <overview>src/main/java/io/ebean/overview.html</overview>
-          <source>1.8</source>
-          <doclet>org.avaje.doclet.PygmentsDoclet</doclet>
-          <excludePackageNames>io.ebeaninternal.*:com.avaje.ebean.util:io.ebean.dbmigration.ddlgeneration:io.ebean.dbmigration.migration:io.ebean.dbmigration.migrationreader:io.ebean.dbmigration.model</excludePackageNames>
-          <docletArtifact>
-            <groupId>org.avaje</groupId>
-            <artifactId>pygments-doclet</artifactId>
-            <version>1.0.0</version>
-          </docletArtifact>
-          <additionalparam>
-            -Xdoclint:none
-            -include-basedir ${project.basedir}
-            -attributes "idseparator=-; project_name=${project.name}; \
-            project_version=${project.version}; \
-            project_desc=${project.description}"
-          </additionalparam>
-          <linksource>true</linksource>
-          <overview>src/main/java/com/avaje/ebean/overview.html</overview>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>2.9.1</version>
+					<configuration>
+						<doctitle>Ebean 10</doctitle>
+						<overview>src/main/java/io/ebean/overview.html</overview>
+						<source>1.8</source>
+						<doclet>org.avaje.doclet.PygmentsDoclet</doclet>
+						<excludePackageNames>io.ebeaninternal.*:com.avaje.ebean.util:io.ebean.dbmigration.ddlgeneration:io.ebean.dbmigration.migration:io.ebean.dbmigration.migrationreader:io.ebean.dbmigration.model</excludePackageNames>
+						<docletArtifact>
+							<groupId>org.avaje</groupId>
+							<artifactId>pygments-doclet</artifactId>
+							<version>1.0.0</version>
+						</docletArtifact>
+						<additionalparam>
+							-Xdoclint:none
+							-include-basedir ${project.basedir}
+							-attributes "idseparator=-; project_name=${project.name}; \
+							project_version=${project.version}; \
+							project_desc=${project.description}"
+						</additionalparam>
+						<linksource>true</linksource>
+						<overview>src/main/java/com/avaje/ebean/overview.html</overview>
+					</configuration>
+					<executions>
+						<execution>
+							<id>attach-javadocs</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 
-    </plugins>
-
-  </build>
+			</plugins>
+		</pluginManagement>
+	</build>
 
 </project>

--- a/src/main/java/io/ebean/Ebean.java
+++ b/src/main/java/io/ebean/Ebean.java
@@ -141,43 +141,37 @@ public final class Ebean {
      */
     private EbeanServer defaultServer;
 
-    private ServerManager() {
+		private EbeanServer getDefaultServer() {
+			if (defaultServer == null) {
 
-      try {
-        // skipDefaultServer is set by EbeanServerFactory
-        // ... when it is creating the primaryServer
-        if (PrimaryServer.isSkip()) {
-          // primary server being created by EbeanServerFactory
-          // ... so we should not try and create it here
-          logger.debug("PrimaryServer.isSkip()");
+				try {
+					// skipDefaultServer is set by EbeanServerFactory
+					// ... when it is creating the primaryServer
+					if (PrimaryServer.isSkip()) {
+						// primary server being created by EbeanServerFactory
+						// ... so we should not try and create it here
+						logger.debug("PrimaryServer.isSkip()");
 
-        } else {
-          // look to see if there is a default server defined
-          String defaultName = PrimaryServer.getDefaultServerName();
-          logger.debug("defaultName:{}", defaultName);
-          if (defaultName != null && !defaultName.trim().isEmpty()) {
-            defaultServer = getWithCreate(defaultName.trim());
-          }
-        }
-      } catch (Throwable e) {
-        logger.error("Error trying to create the default EbeanServer", e);
-        throw new RuntimeException(e);
-      }
-    }
+					} else {
+						// look to see if there is a default server defined
+						String defaultName = PrimaryServer.getDefaultServerName();
+						logger.debug("defaultName:{}", defaultName);
+						if (defaultName != null && !defaultName.trim().isEmpty()) {
+							defaultServer = getWithCreate(defaultName.trim());
+						}
+					}
+				} catch (Throwable e) {
+					logger.error("Error trying to create the default EbeanServer", e);
+					throw new RuntimeException(e);
+				}
 
-    private EbeanServer getDefaultServer() {
-      if (defaultServer == null) {
-        String msg = "The default EbeanServer has not been defined?";
-        msg += " This is normally set via the ebean.datasource.default property.";
-        msg += " Otherwise it should be registered programmatically via registerServer()";
-        throw new PersistenceException(msg);
-      }
-      return defaultServer;
-    }
+			}
+			return defaultServer;
+		}
 
     private EbeanServer get(String name) {
       if (name == null || name.isEmpty()) {
-        return defaultServer;
+        return getDefaultServer();
       }
       // non-synchronized read
       EbeanServer server = concMap.get(name);


### PR DESCRIPTION
Hi,

A problem I encountered was a dependency on the default server, whether I wanted to use it or not.
I had setup an in memory hsqldb instance for my tests, and my default server was a hsqldb instance in server mode, the problem is that I had to have the actual server running just to run the tests against the in memory DB. I have removed this coupling by shifting the instantiation code from the constructor into the getDefaultServer method. So now when EBean.getServer(...) is called it can get/create the specified server without trying to make a connection to the default one also.

I also added the <pluginManagement> tag to the pom.xml to prevent Eclipse flagging an error.

