### PR TITLE
Removed EBean.getServer(...) dependency on the default server.

### DIFF
--- a/src/main/java/io/ebean/Ebean.java
+++ b/src/main/java/io/ebean/Ebean.java
@@ -141,43 +141,35 @@ public final class Ebean {
      */
     private EbeanServer defaultServer;
 
-    private ServerManager() {
-
-      try {
-        // skipDefaultServer is set by EbeanServerFactory
-        // ... when it is creating the primaryServer
-        if (PrimaryServer.isSkip()) {
-          // primary server being created by EbeanServerFactory
-          // ... so we should not try and create it here
-          logger.debug("PrimaryServer.isSkip()");
-
-        } else {
-          // look to see if there is a default server defined
-          String defaultName = PrimaryServer.getDefaultServerName();
-          logger.debug("defaultName:{}", defaultName);
-          if (defaultName != null && !defaultName.trim().isEmpty()) {
-            defaultServer = getWithCreate(defaultName.trim());
-          }
-        }
-      } catch (Throwable e) {
-        logger.error("Error trying to create the default EbeanServer", e);
-        throw new RuntimeException(e);
-      }
-    }
-
     private EbeanServer getDefaultServer() {
       if (defaultServer == null) {
-        String msg = "The default EbeanServer has not been defined?";
-        msg += " This is normally set via the ebean.datasource.default property.";
-        msg += " Otherwise it should be registered programmatically via registerServer()";
-        throw new PersistenceException(msg);
+        try {
+          // skipDefaultServer is set by EbeanServerFactory
+          // ... when it is creating the primaryServer
+          if (PrimaryServer.isSkip()) {
+            // primary server being created by EbeanServerFactory
+            // ... so we should not try and create it here
+            logger.debug("PrimaryServer.isSkip()");
+
+          } else {
+            // look to see if there is a default server defined
+            String defaultName = PrimaryServer.getDefaultServerName();
+            logger.debug("defaultName:{}", defaultName);
+            if (defaultName != null && !defaultName.trim().isEmpty()) {
+              defaultServer = getWithCreate(defaultName.trim());
+            }
+          }
+        } catch (Throwable e) {
+          logger.error("Error trying to create the default EbeanServer", e);
+          throw new RuntimeException(e);
+        }
       }
       return defaultServer;
     }
 
     private EbeanServer get(String name) {
       if (name == null || name.isEmpty()) {
-        return defaultServer;
+        return getDefaultServer();
       }
       // non-synchronized read
       EbeanServer server = concMap.get(name);

--- a/src/main/java/io/ebean/Ebean.java
+++ b/src/main/java/io/ebean/Ebean.java
@@ -139,29 +139,31 @@ public final class Ebean {
     /**
      * The 'default' EbeanServer.
      */
-    private EbeanServer defaultServer;
+    private volatile EbeanServer defaultServer;
 
     private EbeanServer getDefaultServer() {
-      if (defaultServer == null) {
-        try {
-          // skipDefaultServer is set by EbeanServerFactory
-          // ... when it is creating the primaryServer
-          if (PrimaryServer.isSkip()) {
-            // primary server being created by EbeanServerFactory
-            // ... so we should not try and create it here
-            logger.debug("PrimaryServer.isSkip()");
+      synchronized (monitor) {
+        if (defaultServer == null) {
+          try {
+            // skipDefaultServer is set by EbeanServerFactory
+            // ... when it is creating the primaryServer
+            if (PrimaryServer.isSkip()) {
+              // primary server being created by EbeanServerFactory
+              // ... so we should not try and create it here
+              logger.debug("PrimaryServer.isSkip()");
 
-          } else {
-            // look to see if there is a default server defined
-            String defaultName = PrimaryServer.getDefaultServerName();
-            logger.debug("defaultName:{}", defaultName);
-            if (defaultName != null && !defaultName.trim().isEmpty()) {
-              defaultServer = getWithCreate(defaultName.trim());
+            } else {
+              // look to see if there is a default server defined
+              String defaultName = PrimaryServer.getDefaultServerName();
+              logger.debug("defaultName:{}", defaultName);
+              if (defaultName != null && !defaultName.trim().isEmpty()) {
+                defaultServer = getWithCreate(defaultName.trim());
+              }
             }
+          } catch (Throwable e) {
+            logger.error("Error trying to create the default EbeanServer", e);
+            throw new RuntimeException(e);
           }
-        } catch (Throwable e) {
-          logger.error("Error trying to create the default EbeanServer", e);
-          throw new RuntimeException(e);
         }
       }
       return defaultServer;


### PR DESCRIPTION
Shifted the default server instantiation from the constructor into the
getDefaultServer method.

The problem is that EBean.getServer(...) cannot be used without EBean trying to make a connection to the default server, as this is performed in the constructor. So in the case that I just want to run tests against the test datasource, doing something like EBean.getServer("testdb"), the default server also has to be up and running, otherwise the tests won't run. If the default server is up, then tests run fine. This coupling has been removed with this change.