### PR TITLE
Use Double.compare and Float.compare to do comparison of floating point values.

### DIFF
--- a/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -1027,7 +1027,7 @@ public final class EntityBeanIntercept implements Serializable {
 
     if (state == STATE_NEW) {
       setLoadedProperty(propertyIndex);
-    } else if (oldValue != newValue) {
+    } else if (Double.compare(oldValue, newValue) != 0) {
       setChangedPropertyValue(propertyIndex, intercept, oldValue);
     } else {
       return null;
@@ -1042,7 +1042,7 @@ public final class EntityBeanIntercept implements Serializable {
 
     if (state == STATE_NEW) {
       setLoadedProperty(propertyIndex);
-    } else if (oldValue != newValue) {
+    } else if (Float.compare(oldValue, newValue) != 0) {
       setChangedPropertyValue(propertyIndex, intercept, oldValue);
     } else {
       return null;

--- a/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
@@ -2,7 +2,6 @@ package io.ebeaninternal.server.core;
 
 import io.ebean.QueryIterator;
 import io.ebean.Version;
-import io.ebean.bean.BeanCollection;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeanservice.docstore.api.DocQueryRequest;

--- a/src/main/java/io/ebeaninternal/server/deploy/DeployDocPropertyOptions.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/DeployDocPropertyOptions.java
@@ -60,7 +60,7 @@ public class DeployDocPropertyOptions {
   }
 
   private void setBoost(float boost) {
-    if (boost != 1) {
+    if (Float.compare(boost, 1.0F) != 0) {
       mapping.setBoost(boost);
     }
   }

--- a/src/main/java/io/ebeanservice/docstore/api/mapping/DocPropertyOptions.java
+++ b/src/main/java/io/ebeanservice/docstore/api/mapping/DocPropertyOptions.java
@@ -229,7 +229,7 @@ public class DocPropertyOptions {
     if (docMapping.store()) {
       store = true;
     }
-    if (docMapping.boost() != 1) {
+    if (Float.compare(docMapping.boost(), 1.0F) != 0) {
       boost = docMapping.boost();
     }
     if (!"".equals(docMapping.nullValue())) {


### PR DESCRIPTION
Something small I noticed while looking at some code, not sure if it's needed/wanted. 

I changed some boolean checks to use the recommended method of comparing floating point values in Java.

Using `==` for this can be unreliable both in terms of actual value and the possibility of `NaN` values.

The Oracle JDK8 source code for Float comparison looks like this:

```
public static int compare(float f1, float f2) {
        if (f1 < f2)
            return -1;           // Neither val is NaN, thisVal is smaller
        if (f1 > f2)
            return 1;            // Neither val is NaN, thisVal is larger

        // Cannot use floatToRawIntBits because of possibility of NaNs.
        int thisBits    = Float.floatToIntBits(f1);
        int anotherBits = Float.floatToIntBits(f2);

        return (thisBits == anotherBits ?  0 : // Values are equal
                (thisBits < anotherBits ? -1 : // (-0.0, 0.0) or (!NaN, NaN)
                 1));                          // (0.0, -0.0) or (NaN, !NaN)
    }
```
And Double comparison is identical.

EDIT: Weren't there usually unit tests that got run by Travis or something?