### PR TITLE
Added the Serializable interface to classes that extend/implement a Comparator with an anonymous/typed class.

### DIFF
--- a/src/main/java/io/ebeaninternal/server/el/ElComparator.java
+++ b/src/main/java/io/ebeaninternal/server/el/ElComparator.java
@@ -1,11 +1,12 @@
 package io.ebeaninternal.server.el;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Comparator for use with the expression objects.
  */
-public interface ElComparator<T> extends Comparator<T> {
+public interface ElComparator<T> extends Comparator<T>, Serializable {
 
   /**
    * Compare given 2 beans.

--- a/src/main/java/io/ebeaninternal/server/el/ElComparatorCompound.java
+++ b/src/main/java/io/ebeaninternal/server/el/ElComparatorCompound.java
@@ -10,6 +10,8 @@ import java.util.Comparator;
  */
 public final class ElComparatorCompound<T> implements Comparator<T>, ElComparator<T> {
 
+  private static final long serialVersionUID = -1523163475050929750L;
+
   private final ElComparator<T>[] array;
 
   public ElComparatorCompound(ElComparator<T>[] array) {

--- a/src/main/java/io/ebeaninternal/server/el/ElComparatorProperty.java
+++ b/src/main/java/io/ebeaninternal/server/el/ElComparatorProperty.java
@@ -7,6 +7,8 @@ import java.util.Comparator;
  */
 public final class ElComparatorProperty<T> implements Comparator<T>, ElComparator<T> {
 
+  private static final long serialVersionUID = -2735738237263956073L;
+
   private final ElPropertyValue elGetValue;
 
   private final int nullOrder;

--- a/src/main/java/io/ebeaninternal/server/query/OrderVersionDesc.java
+++ b/src/main/java/io/ebeaninternal/server/query/OrderVersionDesc.java
@@ -2,15 +2,18 @@ package io.ebeaninternal.server.query;
 
 import io.ebean.Version;
 
+import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Comparator;
 
 /**
  * Compare Version beans in descending order with nulls last.
  */
-class OrderVersionDesc implements Comparator<Version<?>> {
+class OrderVersionDesc implements Comparator<Version<?>>, Serializable {
 
   static final OrderVersionDesc INSTANCE = new OrderVersionDesc();
+
+  private static final long serialVersionUID = -3681686029998263310L;
 
   @Override
   public int compare(Version<?> o1, Version<?> o2) {


### PR DESCRIPTION
Hello Rob and others.

Going over code analysis and I ran into this. I'm not entirely sure it's needed/necessary, but I did it anyway. Up to your judgment on how valuable/disruptive this is. I'm not sure it will actually do anything.

Basically, I did this: https://stackoverflow.com/a/8642040/5629413

And then added a serialversionUID for those classes.

But only for classes where the type passed along is either anonymous or `<T>`.

There are some Comparators left but those are for predefined classes used by ebean internally, so I didn't think it necessary.,