### PR TITLE
use jackson configuration [SD]eserialization enum

### DIFF
--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
@@ -233,12 +233,16 @@ public class ScalarTypeEnumStandard {
 
     @Override
     public Object jsonRead(JsonParser parser) throws IOException {
-      return parser.readValueAs(enumType);
+      if(writer.getCodec() != null) {
+        return parser.readValueAs(enumType);
+      } else {
+        return parse(parser.getValueAsString());
+      }
     }
 
     @Override
     public void jsonWrite(JsonGenerator writer, Object value) throws IOException {
-      if(writer.getCodec() != null){
+      if(writer.getCodec() != null) {
         writer.writeObject(value);
       } else {
         writer.writeString(formatValue(value));

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
@@ -233,12 +233,12 @@ public class ScalarTypeEnumStandard {
 
     @Override
     public Object jsonRead(JsonParser parser) throws IOException {
-      return parse(parser.getValueAsString());
+      return parser.readValueAs(enumType);
     }
 
     @Override
     public void jsonWrite(JsonGenerator writer, Object value) throws IOException {
-      writer.writeString(formatValue(value));
+      writer.writeObject(value);
     }
 
     @Override

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
@@ -238,7 +238,7 @@ public class ScalarTypeEnumStandard {
 
     @Override
     public void jsonWrite(JsonGenerator writer, Object value) throws IOException {
-      writer.writeObject(value);
+      writer.writeString(formatValue(value));
     }
 
     @Override

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
@@ -238,7 +238,11 @@ public class ScalarTypeEnumStandard {
 
     @Override
     public void jsonWrite(JsonGenerator writer, Object value) throws IOException {
-      writer.writeString(formatValue(value));
+      if(writer.getCodec() != null){
+        writer.writeObject(value);
+      } else {
+        writer.writeString(formatValue(value));
+      }
     }
 
     @Override

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeEnumStandard.java
@@ -233,7 +233,7 @@ public class ScalarTypeEnumStandard {
 
     @Override
     public Object jsonRead(JsonParser parser) throws IOException {
-      if(writer.getCodec() != null) {
+      if(parser.getCodec() != null) {
         return parser.readValueAs(enumType);
       } else {
         return parse(parser.getValueAsString());


### PR DESCRIPTION
https://github.com/FasterXML/jackson-databind/wiki/Serialization-features 
https://github.com/FasterXML/jackson-databind/wiki/Deserialization-Features

keep jackson and ebean [SD]eserialization same
`objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_INDEX);`

use ebean in project with jackson
```
@Inject
private ObjectMapper objectMapper;
...
JsonFactory jsonFactory = objectMapper.getFactory();
ServerConfig config = ...;
config.setJsonFactory(jsonFactory);
```

so, In reality we use `ObjectMapper` not only use `JsonFactory`.
At use `ObjectMapper`, `codec` is used, use `Jackson` process, other use ebean embed