### PR TITLE
Fix: query table entity or sql entity has no id

### DIFF
--- a/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -1107,6 +1107,9 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
   }
 
   public Object idEqualTo(String idName) {
+    if (idName == null) {
+      return null;
+    }
     if (list.size() == 1) {
       return list.get(0).getIdEqualTo(idName);
     }

--- a/src/test/java/org/tests/rawsql/TestOrderReportTotal.java
+++ b/src/test/java/org/tests/rawsql/TestOrderReportTotal.java
@@ -36,6 +36,11 @@ public class TestOrderReportTotal extends BaseTestCase {
     List<OrderAggregate> l2 = q2.findList();
     assertNotNull(l2);
 
+    Query<OrderAggregate> q3 = Ebean.createQuery(OrderAggregate.class).setRawSql(rawSql);
+    q3.where().eq("order_id", 1);
+
+    OrderAggregate orderAggregate = q3.findUnique();
+    assertNotNull(orderAggregate);
   }
 
   private RawSql getRawSql() {


### PR DESCRIPTION
When query table entity or sql entity，include NamedQuery which modified via code and RawSqlQuery which modified via code, findOne or findUnique will throw NullPointerException.