### PR TITLE
Only throwing warning for autocommit when needed

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -349,7 +349,7 @@ public class DefaultContainer implements SpiContainer {
     Connection c = null;
     try {
       c = serverConfig.getDataSource().getConnection();
-      if (c.getAutoCommit()) {
+      if (!serverConfig.isAutoCommitMode() && c.getAutoCommit()) {
         logger.warn("DataSource [{}] has autoCommit defaulting to true!", serverConfig.getName());
       }
       return true;


### PR DESCRIPTION
The warning considering autocommit being set to true can be annoying when you choose to use autocommit in your application. This change should make the DefaultContainer only throw this warning when the ServerConfig is not set to use autocommit-friendly TransactionManager.