### PR TITLE
FIX: EnumToDbIntegerMap did not set 'integerType' -  …

### DIFF
--- a/src/main/java/io/ebeaninternal/server/type/EnumToDbIntegerMap.java
+++ b/src/main/java/io/ebeaninternal/server/type/EnumToDbIntegerMap.java
@@ -14,6 +14,19 @@ public class EnumToDbIntegerMap extends EnumToDbValueMap<Integer> {
     return Types.INTEGER;
   }
 
+  /**
+   * Construct with allowNulls defaulting to false and integerType=true
+   */
+  public EnumToDbIntegerMap() {
+    this(true);
+  }
+  /**
+   * Construct with  integerType=true
+   */
+  public EnumToDbIntegerMap(boolean allowNulls) {
+    super(allowNulls, true);
+  }
+  
   public void add(Object beanValue, Integer dbValue, String name) {
     addInternal(beanValue, dbValue, name);
   }


### PR DESCRIPTION
this leads to an incompatible quoting. Constraints like "check in ('1','2','3')" that is not accepted by hsqldb on integer columns.