### PR TITLE
FIX: nvarchar(max) length specified differently…

### DIFF
--- a/src/main/java/io/ebean/config/dbplatform/DbPlatformType.java
+++ b/src/main/java/io/ebean/config/dbplatform/DbPlatformType.java
@@ -130,7 +130,9 @@ public class DbPlatformType implements ExtraDbTypes {
     if (canHaveLength || !strict) {
       // see if there is a precision/scale to add (or not)
       int len = deployLength != 0 ? deployLength : defaultLength;
-      if (len > 0) {
+      if (len == Integer.MAX_VALUE) {
+        sb.append("(max)"); // TODO: this is sqlserver specific
+      } else if (len > 0) {
         sb.append("(");
         sb.append(len);
         int scale = deployScale != 0 ? deployScale : defaultScale;

--- a/src/main/java/io/ebean/config/dbplatform/DbPlatformTypeParser.java
+++ b/src/main/java/io/ebean/config/dbplatform/DbPlatformTypeParser.java
@@ -30,7 +30,8 @@ class DbPlatformTypeParser {
 
       } else {
         String type = columnDefinition.substring(0, openPos);
-        int scale = Integer.parseInt(columnDefinition.substring(openPos + 1, closePos));
+        String strScale = columnDefinition.substring(openPos + 1, closePos);
+        int scale = strScale.equalsIgnoreCase("max") ? Integer.MAX_VALUE : Integer.parseInt(strScale);
         return new DbPlatformType(type, scale);
       }
     } catch (RuntimeException e) {

--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
@@ -62,8 +62,8 @@ public class SqlServerPlatform extends DatabasePlatform {
     dbTypeMap.put(DbType.TIME, new DbPlatformType("time"));
     dbTypeMap.put(DbType.TIMESTAMP, new DbPlatformType("datetime2"));
 
-    dbTypeMap.put(DbType.JSON, new DbPlatformType("nvarchar(max)"));
-    dbTypeMap.put(DbType.JSONB, new DbPlatformType("nvarchar(max)"));
+    dbTypeMap.put(DbType.JSON, new DbPlatformType("nvarchar", Integer.MAX_VALUE));
+    dbTypeMap.put(DbType.JSONB, new DbPlatformType("nvarchar", Integer.MAX_VALUE));
 
   }
 


### PR DESCRIPTION
 otherwise this leads to a ddl like this "nvarchar(max)(700)"

Yes, it's not nice, because `Integer.MAX_VALUE` is translated to `(max)` which is very sqlserver specific.
Maybe you have a better idea?