### PR TITLE
FIX: Passing MDC through background-executor

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/DefaultBackgroundExecutor.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultBackgroundExecutor.java
@@ -4,7 +4,10 @@ import io.ebeaninternal.api.SpiBackgroundExecutor;
 import io.ebeaninternal.server.lib.DaemonExecutorService;
 import io.ebeaninternal.server.lib.DaemonScheduleThreadPool;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import org.slf4j.MDC;
 
 /**
  * The default implementation of the BackgroundExecutor.
@@ -28,12 +31,38 @@ public class DefaultBackgroundExecutor implements SpiBackgroundExecutor {
    */
   @Override
   public void execute(Runnable r) {
-    pool.execute(r);
+    final Map<String, String> map = MDC.getCopyOfContextMap(); 
+
+    if(map == null) {
+      pool.execute(r);
+    } else {
+      pool.execute(() -> { 
+        MDC.setContextMap(map);
+        try {
+          r.run();
+        } finally {
+          MDC.clear();
+        }
+      });
+    }
   }
 
   @Override
   public void executePeriodically(Runnable r, long delay, TimeUnit unit) {
-    schedulePool.scheduleWithFixedDelay(r, delay, delay, unit);
+    final Map<String, String> map = MDC.getCopyOfContextMap(); 
+
+    if(map == null) {
+      schedulePool.scheduleWithFixedDelay(r, delay, delay, unit);
+    } else {
+      schedulePool.scheduleWithFixedDelay(() -> { 
+        MDC.setContextMap(map);
+        try {
+          r.run();
+        } finally {
+          MDC.clear();
+        }
+      }, delay, delay, unit);
+    }
   }
 
   @Override


### PR DESCRIPTION
We use SLF4J and we put some information in the MDC (current user and so on)
This information is not available to the changelog-log writer as it writes the logs in the background

This fix copies the current MDC-map to the background tasks from where they are invoked