### PR TITLE
REFACTOR: Created a "splitNames" in StringHelper

### DIFF
--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -28,6 +28,8 @@ import io.ebean.event.changelog.ChangeLogRegister;
 import io.ebean.event.readaudit.ReadAuditLogger;
 import io.ebean.event.readaudit.ReadAuditPrepare;
 import io.ebean.meta.MetaInfoManager;
+import io.ebean.util.StringHelper;
+
 import java.util.regex.Pattern;
 import org.avaje.datasource.DataSourceConfig;
 
@@ -76,8 +78,6 @@ import java.util.ServiceLoader;
  * @see EbeanServerFactory
  */
 public class ServerConfig {
-
-  private static final Pattern NAMES_SPLIT = Pattern.compile("[ ,;]");
 
   /**
    * The EbeanServer name.
@@ -2647,10 +2647,9 @@ public class ServerConfig {
 
     List<Class<?>> classes = new ArrayList<>();
 
-    String[] split = NAMES_SPLIT.split(classNames);
-    for (String aSplit : split) {
-      String cn = aSplit.trim();
-      if (!cn.isEmpty() && !"class".equalsIgnoreCase(cn)) {
+    String[] split = StringHelper.splitNames(classNames);
+    for (String cn : split) {
+      if (!"class".equalsIgnoreCase(cn)) {
         try {
           classes.add(Class.forName(cn));
         } catch (ClassNotFoundException e) {
@@ -2668,9 +2667,9 @@ public class ServerConfig {
 
     if (searchPackages != null) {
 
-      String[] entries = NAMES_SPLIT.split(searchPackages);
+      String[] entries = StringHelper.splitNames(searchPackages);
       for (String entry : entries) {
-        hitList.add(entry.trim());
+        hitList.add(entry);
       }
     }
     return hitList;

--- a/src/main/java/io/ebean/util/StringHelper.java
+++ b/src/main/java/io/ebean/util/StringHelper.java
@@ -3,6 +3,7 @@ package io.ebean.util;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Utility String class that supports String manipulation functions.
@@ -12,6 +13,10 @@ public class StringHelper {
   private static final char SINGLE_QUOTE = '\'';
 
   private static final char DOUBLE_QUOTE = '"';
+  
+  private static final Pattern SPLIT_NAMES = Pattern.compile("[\\s,;]+");
+  
+  private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
   /**
    * parses a String of the form name1='value1' name2='value2'. Note that you
@@ -552,4 +557,28 @@ public class StringHelper {
     return false;
   }
 
+  /**
+   * Splits at any whitespace "," or ";" and trims the result.
+   * It does not return empty entries.
+   */
+  public static String[] splitNames(String names) {
+    if (names == null || names.isEmpty()) {
+      return EMPTY_STRING_ARRAY;
+    }
+    String[] result = SPLIT_NAMES.split(names);
+    if (result.length == 0) {
+      return EMPTY_STRING_ARRAY; // don't know if this ever can happen
+    }
+    if ("".equals(result[0])) { //  = input string starts with whitespace
+      if (result.length == 1) { //  = input string contains only whitespace
+        return EMPTY_STRING_ARRAY;
+      } else {
+        String ret[] = new String[result.length-1]; // remove first entry
+        System.arraycopy(result, 1, ret, 0, ret.length);
+        return ret;
+      }
+    } else {
+      return result;
+    }
+  }
 }

--- a/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
+++ b/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
@@ -4,6 +4,8 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.ebean.util.StringHelper;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
@@ -15,8 +17,6 @@ import java.io.InputStream;
 public class ExtraDdlXmlReader {
 
   private static final Logger logger = LoggerFactory.getLogger(ExtraDdlXmlReader.class);
-
-  private static final Pattern PLATFORM_REGEX_SPLIT = Pattern.compile("[,;]");
 
   /**
    * Return the combined extra DDL that should be run given the platform name.
@@ -48,9 +48,8 @@ public class ExtraDdlXmlReader {
       return true;
     }
 
-    String[] names = PLATFORM_REGEX_SPLIT.split(platforms);
-    for (String name : names) {
-      if (name.trim().toLowerCase().contains(platformName)) {
+    for (String name : StringHelper.splitNames(platforms)) {
+      if (name.toLowerCase().contains(platformName)) {
         return true;
       }
     }

--- a/src/main/java/io/ebeaninternal/server/core/bootup/ManifestReader.java
+++ b/src/main/java/io/ebeaninternal/server/core/bootup/ManifestReader.java
@@ -4,6 +4,8 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.ebean.util.StringHelper;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -21,8 +23,6 @@ class ManifestReader {
   private static final Logger logger = LoggerFactory.getLogger(ManifestReader.class);
 
   private final Set<String> packageSet = new HashSet<>();
-
-  private static final Pattern PACKAGE_DELIMITER = Pattern.compile("[,; ]");
 
   /**
    * Read the packages from ebean.mf manifest files found as resources.
@@ -76,12 +76,8 @@ class ManifestReader {
    * Collect each individual package splitting by delimiters.
    */
   private void add(String packages) {
-    String[] split = PACKAGE_DELIMITER.split(packages);
-    for (String aSplit : split) {
-      String pkg = aSplit.trim();
-      if (!pkg.isEmpty()) {
-        packageSet.add(pkg);
-      }
+    for (String pkg : StringHelper.splitNames(packages)) {
+      packageSet.add(pkg);
     }
   }
 }

--- a/src/test/java/io/ebean/StringHelperTest.java
+++ b/src/test/java/io/ebean/StringHelperTest.java
@@ -1,0 +1,79 @@
+package io.ebean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.ebean.util.StringHelper;
+
+public class StringHelperTest {
+
+  
+  @Test
+  public void testSplitNames() {
+    assertThat(StringHelper.splitNames("")).hasSize(0);
+    assertThat(StringHelper.splitNames(" , ;")).hasSize(0);
+    assertThat(StringHelper.splitNames("foo bar")).containsExactly("foo", "bar");
+    assertThat(StringHelper.splitNames(" foo \n bar    ")).containsExactly("foo", "bar");
+    assertThat(StringHelper.splitNames(" foo , bar ;")).containsExactly("foo", "bar");
+    assertThat(StringHelper.splitNames("foo, bar")).containsExactly("foo", "bar");
+    assertThat(StringHelper.splitNames("foo, bar baz")).containsExactly("foo", "bar", "baz");
+    assertThat(StringHelper.splitNames("foo, bar\nbaz")).containsExactly("foo", "bar", "baz");
+  }
+  
+  @Test
+  public void testReplaceStringMulti() {
+    String content = "This is\na\rmultiline\r\ntext\n\r";
+    String[] multi = { "\r\n", "\r", "\n" };
+    content = StringHelper.replaceStringMulti(content, multi, "<br/>");
+    assertThat(content).isEqualTo("This is<br/>a<br/>multiline<br/>text<br/><br/>");
+  }
+  
+  @Test
+  public void testParseNameQuotedValue() {
+    String content = "name1='value1' name2='value2'";
+    Map<String, String> map = StringHelper.parseNameQuotedValue(content);
+    assertThat(map).containsEntry("name1", "value1").containsEntry("name2", "value2");
+    
+    // now check with double quotes
+    content = "name1=\"value1\" name2=\"value2\"";
+    map = StringHelper.parseNameQuotedValue(content);
+    assertThat(map).containsEntry("name1", "value1").containsEntry("name2", "value2");
+    
+    // now check mix
+    content = "name1=\"value'1\" name2='value\"2'";
+    map = StringHelper.parseNameQuotedValue(content);
+    assertThat(map).containsEntry("name1", "value'1").containsEntry("name2", "value\"2");
+  }
+  
+  @Test
+  public void testCountOccurances() {
+    String content = "blablabla, bla bla blubb, blubblubb blablub blubblabla ";
+    assertThat(StringHelper.countOccurances(content , "bla")).isEqualTo(8);
+    assertThat(StringHelper.countOccurances(content , "blubb")).isEqualTo(3);
+    assertThat(StringHelper.countOccurances(content , "blah")).isEqualTo(0);
+  }
+  
+  @Test
+  public void testDelimitedToMap() {
+    String content = "name1=blah; name2 = blubb ;name3\n=foo";
+    Map<String, String> map = StringHelper.delimitedToMap(content , ";", "=");
+    assertThat(map)
+      .containsEntry("name1", "blah")
+      .containsEntry("name2", " blubb ")  // white space is not trimmed
+      .containsEntry("name3", "foo");
+  }
+  
+  @Test
+  public void testDelimitedToArray() {
+    String content = "foo, bar, bla,blubb,,bla,   ,bla";
+    String[] arr = StringHelper.delimitedToArray(content, ",", true);
+    assertThat(arr).containsExactly("foo"," bar"," bla","blubb","","bla","   ","bla");
+    arr = StringHelper.delimitedToArray(content, ",", false);
+    assertThat(arr).containsExactly("foo"," bar"," bla","blubb","bla","   ","bla");
+  }
+}


### PR DESCRIPTION
 and use it in various places. Also wrote some tests for StringHelper.


The method replaces a common usage of this pattern: Pattern.compile("[ ,;]"), followed by a trim and an isEmpty check.

It changes the behaviour a bit
- it splits on every whitespace now (not only on space)
- it splits on "\s" "," and ";" (there are some places where only on "," or " "+"," was split)