### PR TITLE
FIX: DDL process comment change correctly & drop references when index is dropped

### DIFF
--- a/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/DdlHelp.java
+++ b/src/main/java/io/ebean/dbmigration/ddlgeneration/platform/DdlHelp.java
@@ -1,0 +1,22 @@
+package io.ebean.dbmigration.ddlgeneration.platform;
+
+public class DdlHelp {
+  public static final String DROP_DEFAULT = "DROP DEFAULT";
+  
+  public static final String DROP_COMMENT = "DROP COMMENT";
+  
+  /**
+   * Return true if the default value is the special DROP DEFAULT value.
+   */
+  public static boolean isDropDefault(String defaultValue) {
+    return DROP_DEFAULT.equals(defaultValue);
+  }
+  
+  /**
+   * Return true if the default value is the special DROP DEFAULT value.
+   */
+  public static boolean isDropComment(String comment) {
+    return DROP_COMMENT.equals(comment);
+  }
+  
+}

--- a/src/main/java/io/ebean/dbmigration/model/MColumn.java
+++ b/src/main/java/io/ebean/dbmigration/model/MColumn.java
@@ -1,5 +1,6 @@
 package io.ebean.dbmigration.model;
 
+import io.ebean.dbmigration.ddlgeneration.platform.DdlHelp;
 import io.ebean.dbmigration.migration.AlterColumn;
 import io.ebean.dbmigration.migration.Column;
 
@@ -313,14 +314,18 @@ public class MColumn {
     if (different(defaultValue, newColumn.defaultValue)) {
       AlterColumn alter = getAlterColumn(tableName, tableWithHistory);
       if (newColumn.defaultValue == null) {
-        alter.setDefaultValue("DROP DEFAULT");
+        alter.setDefaultValue(DdlHelp.DROP_DEFAULT);
       } else {
         alter.setDefaultValue(newColumn.defaultValue);
       }
     }
     if (different(comment, newColumn.comment)) {
       AlterColumn alter = getAlterColumn(tableName, tableWithHistory);
-      alter.setComment(newColumn.comment);
+      if (newColumn.comment == null) {
+        alter.setComment(DdlHelp.DROP_COMMENT);
+      } else {
+        alter.setComment(newColumn.comment);
+      }
     }
     if (different(checkConstraint, newColumn.checkConstraint)) {
       AlterColumn alter = getAlterColumn(tableName, tableWithHistory);
@@ -388,6 +393,7 @@ public class MColumn {
     }
     if (hasValue(alterColumn.getDropForeignKey())) {
       foreignKeyName = null;
+      references = null;
     }
     if (hasValue(alterColumn.getDropForeignKeyIndex())) {
       foreignKeyIndex = null;
@@ -405,6 +411,9 @@ public class MColumn {
     }
     if (hasValue(alterColumn.getDefaultValue())) {
       defaultValue = alterColumn.getDefaultValue();
+      if (DdlHelp.isDropDefault(defaultValue)) {
+        defaultValue = null;
+      }
     }
     if (hasValue(alterColumn.getCheckConstraint())) {
       checkConstraint = alterColumn.getCheckConstraint();
@@ -426,6 +435,12 @@ public class MColumn {
     }
     if (hasValue(alterColumn.getForeignKeyIndex())) {
       foreignKeyIndex = alterColumn.getForeignKeyIndex();
+    }
+    if (hasValue(alterColumn.getComment())) {
+      comment = alterColumn.getComment();
+      if (DdlHelp.isDropComment(comment)) {
+        comment = null;
+      }
     }
 
   }

--- a/src/main/java/io/ebean/dbmigration/model/ModelContainer.java
+++ b/src/main/java/io/ebean/dbmigration/model/ModelContainer.java
@@ -1,7 +1,9 @@
 package io.ebean.dbmigration.model;
 
+import io.ebean.dbmigration.ddlgeneration.platform.DdlHelp;
 import io.ebean.dbmigration.migration.AddColumn;
 import io.ebean.dbmigration.migration.AddHistoryTable;
+import io.ebean.dbmigration.migration.AddTableComment;
 import io.ebean.dbmigration.migration.AlterColumn;
 import io.ebean.dbmigration.migration.ChangeSet;
 import io.ebean.dbmigration.migration.ChangeSetType;
@@ -132,6 +134,10 @@ public class ModelContainer {
         applyChange((AddHistoryTable) change);
       } else if (change instanceof DropHistoryTable) {
         applyChange((DropHistoryTable) change);
+      } else if (change instanceof AddTableComment) {
+        applyChange((AddTableComment) change);          
+      } else {
+        throw new IllegalArgumentException("No rule for " + change);
       }
     }
   }
@@ -158,6 +164,18 @@ public class ModelContainer {
       throw new IllegalStateException("Table [" + change.getBaseTable() + "] does not exist in model?");
     }
     table.setWithHistory(false);
+  }
+  
+  private void applyChange(AddTableComment change) {
+    MTable table = tables.get(change.getName());
+    if (table == null) {
+      throw new IllegalStateException("Table [" + change.getName() + "] does not exist in model?");
+    }
+    if (DdlHelp.isDropComment(change.getComment())) {
+      table.setComment(null);
+    } else {
+      table.setComment(change.getComment());
+    }
   }
 
   /**


### PR DESCRIPTION
Changes were not applied correctly and subsequent calls will produce new versions.

How to reproduce:
```java
    assertThat(migration.generateMigration()).isEqualTo("1.1");
    assertThat(migration.generateMigration()).isNull(); // subsequent call fails
```
(I will add a the test cases later)


Also added a class "DdlHelp" where I want to put various static utility functions. Good idea? Good name?

