### PR TITLE
commit transaction only if active (hides root case exception when findIterate query throws)

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -288,7 +288,7 @@ public final class OrmQueryRequest<T> extends BeanRequest implements BeanQueryRe
    */
   @Override
   public void endTransIfRequired() {
-    if (createdTransaction) {
+    if (createdTransaction && transaction.isActive()) {
       transaction.commit();
     }
   }


### PR DESCRIPTION
Hello Rob, when transaction is not active, it throws a "Transaction is inactive" exception

happened here
```
public <T> QueryIterator<T> findIterate(Query<T> query, Transaction t) {

    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query, t);
    try {
      request.initTransIfRequired();
      return request.findIterate();

    } catch (RuntimeException ex) {
      request.endTransIfRequired(); // <---- // throws again an exeption and hides the runtime-exception
      throw ex;
    }
  }
```