### PR TITLE
Can handle one to many & many to one relations in docstore only entities

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -1038,6 +1038,13 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
     }
 
     if (prop.getMappedBy() == null) {
+      // if we are doc store only we are done
+      // this allowes the use of @OneToMany in @DocStore - Entities
+      if (info.getDescriptor().isDocStoreOnly()) {
+        prop.setUnidirectional();
+        return;
+      }
+      
       if (!findMappedBy(prop)) {
         makeUnidirectional(info, prop);
         return;

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -96,7 +96,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> {
 
     if (!isTransient) {
       //noinspection StatementWithEmptyBody
-      if (embedded) {
+      if (embedded || descriptor.isDocStoreOnly()) {
         // no imported or exported information
       } else if (!oneToOneExported) {
         importedId = createImportedId(this, targetDescriptor, tableJoin);

--- a/src/test/java/org/tests/docstore/CustomerReportTest.java
+++ b/src/test/java/org/tests/docstore/CustomerReportTest.java
@@ -1,0 +1,95 @@
+package org.tests.docstore;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.tests.model.basic.Customer;
+import org.tests.model.basic.Product;
+import org.tests.model.basic.ResetBasicData;
+import org.tests.model.docstore.CustomerReport;
+import org.tests.model.docstore.ProductReport;
+
+import io.ebean.BaseTestCase;
+import io.ebean.text.json.JsonReadOptions;
+
+public class CustomerReportTest extends BaseTestCase {
+  
+  
+  
+  @Test
+  public void testToJson() throws Exception {
+    ResetBasicData.reset();
+    
+
+    
+    String json = server().json().toJson(getCustomerReport());
+    
+    
+    assertThat(json).isEqualTo("{\"dtype\":\"CR\",\"friends\":[{\"id\":2},{\"id\":3}],\"customer\":{\"id\":1}}");
+  }
+  
+
+
+  @Test
+  public void testFromJson() throws Exception {
+    ResetBasicData.reset();
+    String json = "{\"dtype\":\"CR\",\"friends\":[{\"id\":2},{\"id\":3}],\"customer\":{\"id\":1}}";
+    
+    JsonReadOptions opts = new JsonReadOptions();
+    opts.setEnableLazyLoading(true);
+    CustomerReport report = server().json().toBean(CustomerReport.class, json, opts);
+   
+    assertThat(report.getCustomer().getName()).isEqualTo("Rob");
+    
+    assertThat(report.getFriends().get(0).getName()).isEqualTo("Cust NoAddress");
+    assertThat(report.getFriends().get(1).getName()).isEqualTo("Fiona");
+  }
+
+  
+  @Test
+  public void testEmbeddedDocs() throws Exception {
+    ResetBasicData.reset();
+    
+    CustomerReport report = getCustomerReport();
+    report.getEmbeddedReports().add(getProductReport());
+    
+    String json = server().json().toJson(report);
+    
+    assertThat(json).isEqualTo("{\"dtype\":\"CR\","
+        + "\"embeddedReports\":[{\"dtype\":\"PR\",\"title\":\"This is a good product\",\"product\":{\"id\":1}}],"
+        + "\"friends\":[{\"id\":2},{\"id\":3}],"
+        + "\"customer\":{\"id\":1}}");
+    
+    JsonReadOptions opts = new JsonReadOptions();
+    opts.setEnableLazyLoading(true);
+    report = server().json().toBean(CustomerReport.class, json, opts);
+    ProductReport ar = (ProductReport) report.getEmbeddedReports().get(0);
+    assertThat(ar.getTitle()).isEqualTo("This is a good product");
+    assertThat(ar.getProduct().getName()).isEqualTo("Chair");
+  }
+  
+  
+  private CustomerReport getCustomerReport() {
+    Customer customer = server().getReference(Customer.class, 1);
+    Customer friend1 = server().getReference(Customer.class, 2);
+    Customer friend2 = server().getReference(Customer.class, 3);
+    
+    CustomerReport report = new CustomerReport();
+    
+    report.setCustomer(customer);
+    report.setFriends(Arrays.asList(friend1, friend2));
+    return report;
+  }
+  
+  private ProductReport getProductReport() {
+    Product product = server().getReference(Product.class, 1);
+
+    ProductReport report = new ProductReport();
+    report.setTitle("This is a good product");
+    report.setProduct(product);
+    return report;
+  }
+}

--- a/src/test/java/org/tests/model/docstore/CustomerReport.java
+++ b/src/test/java/org/tests/model/docstore/CustomerReport.java
@@ -1,0 +1,45 @@
+package org.tests.model.docstore;
+
+import java.util.List;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.tests.model.basic.Customer;
+
+import io.ebean.annotation.DocStore;
+
+/**
+ * Entity that will stored as JSON in database
+ * 
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+@DocStore
+@DiscriminatorValue("CR")
+public class CustomerReport extends Report {
+
+  @OneToMany
+  private List<Customer> friends;
+
+  @ManyToOne
+  private Customer customer;
+
+  public void setCustomer(Customer customer) {
+    this.customer = customer;
+  }
+
+  public Customer getCustomer() {
+    return customer;
+  }
+
+  public void setFriends(List<Customer> friends) {
+    this.friends = friends;
+  }
+
+  public List<Customer> getFriends() {
+    return friends;
+  }
+
+}

--- a/src/test/java/org/tests/model/docstore/ProductReport.java
+++ b/src/test/java/org/tests/model/docstore/ProductReport.java
@@ -1,0 +1,23 @@
+package org.tests.model.docstore;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.ManyToOne;
+
+import org.tests.model.basic.Product;
+
+import io.ebean.annotation.DocStore;
+
+@DocStore
+@DiscriminatorValue("PR")
+public class ProductReport extends Report {
+
+  @ManyToOne
+  private Product product;
+  
+  public Product getProduct() {
+    return product;
+  }
+  public void setProduct(Product product) {
+    this.product = product;
+  }
+}

--- a/src/test/java/org/tests/model/docstore/Report.java
+++ b/src/test/java/org/tests/model/docstore/Report.java
@@ -1,0 +1,33 @@
+package org.tests.model.docstore;
+
+import java.util.List;
+
+import javax.persistence.Inheritance;
+import javax.persistence.OneToMany;
+
+import io.ebean.annotation.DocStore;
+
+@DocStore
+@Inheritance
+public class Report {
+  private String title;
+  
+  @OneToMany
+  private List<Report> embeddedReports;
+  
+  public void setTitle(String title) {
+    this.title = title;
+  }
+  
+  public String getTitle() {
+    return title;
+  }
+  
+  public List<Report> getEmbeddedReports() {
+    return embeddedReports;
+  }
+  
+  public void setEmbeddedReports(List<Report> embeddedReports) {
+    this.embeddedReports = embeddedReports;
+  }
+}


### PR DESCRIPTION
Hello Rob,

We use the ebean-json stuff in conjunction with docstore-only entitites to convert complex object graphs to JSON (and we refer to real entities, that will then lazy load)

Here we had the problem that @OneToMany relations did not work, as ebean thinks it requires a mappedBy field on the many-side. This is not true for docstore-only entities.

I added some unit-tests to provide a simple use case.

cheers
Roland