### PR TITLE
FIX: bundle symbolic name in manifest

### DIFF
--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Premain-Class: io.ebean.enhance.agent.Transformer
 Automatic-Module-Name: io.ebean
 Bundle-ManifestVersion: 2
 Bundle-Name: Ebean-ORM
-Bundle-SymbolicName: com.avaje.ebean
+Bundle-SymbolicName: io.ebean
 Bundle-Version: 4.2.0
 Bundle-ClassPath: .
 Bundle-Vendor: avaje


### PR DESCRIPTION
I think com.avaje.ebean is wrong here