### PR TITLE
FIX: Oto relations must match datatype

### DIFF
--- a/src/test/java/org/tests/model/onetoone/OtoBChild.java
+++ b/src/test/java/org/tests/model/onetoone/OtoBChild.java
@@ -11,7 +11,7 @@ public class OtoBChild {
 
   @Id
   @Column(name = "master_id")
-  Integer id;
+  Long id;
 
   String child;
 
@@ -19,11 +19,11 @@ public class OtoBChild {
   @PrimaryKeyJoinColumn(name = "master_id", referencedColumnName = "id")
   OtoBMaster master;
 
-  public Integer getId() {
+  public Long getId() {
     return id;
   }
 
-  public void setId(Integer id) {
+  public void setId(Long id) {
     this.id = id;
   }
 


### PR DESCRIPTION
The datatype must match, otherwise oracle (or db2) will complain that they cannot create a foreign key between different datatypes