### PR TITLE
FIX: Ensure that Ebean.currentTransaction is available in lifecycle handlers

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
@@ -47,7 +47,7 @@ public abstract class BeanRequest {
     transaction = ebeanServer.getCurrentServerTransaction();
     if (transaction == null || !transaction.isActive()) {
       // create an implicit transaction to execute this query
-      transaction = ebeanServer.createServerTransaction(false, -1);
+      transaction = ebeanServer.createServerTransaction(transaction == null, -1);
       createdTransaction = true;
     }
     return true;

--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -2130,12 +2130,26 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Override
   public SpiTransaction createServerTransaction(boolean isExplicit, int isolationLevel) {
-    return transactionManager.createTransaction(isExplicit, isolationLevel);
+    SpiTransaction t = transactionManager.createTransaction(isExplicit, isolationLevel);
+    try {
+      transactionScopeManager.set(t);
+    } catch (PersistenceException existingTransactionError) {
+      t.end();
+      throw existingTransactionError;
+    }
+    return t;
   }
 
   @Override
   public SpiTransaction createQueryTransaction(Object tenantId) {
-    return transactionManager.createQueryTransaction(tenantId);
+    SpiTransaction t = transactionManager.createQueryTransaction(tenantId);
+    try {
+      transactionScopeManager.set(t);
+    } catch (PersistenceException existingTransactionError) {
+      t.end();
+      throw existingTransactionError;
+    }
+    return t;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -810,14 +810,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   public Transaction beginTransaction(TxIsolation isolation) {
     // start an explicit transaction
-    SpiTransaction t = transactionManager.createTransaction(true, isolation.getLevel());
-    try {
-      transactionScopeManager.set(t);
-    } catch (PersistenceException existingTransactionError) {
-      t.end();
-      throw existingTransactionError;
-    }
-    return t;
+    return createServerTransaction(true, isolation.getLevel());
   }
 
   /**
@@ -2131,11 +2124,13 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   public SpiTransaction createServerTransaction(boolean isExplicit, int isolationLevel) {
     SpiTransaction t = transactionManager.createTransaction(isExplicit, isolationLevel);
-    try {
-      transactionScopeManager.set(t);
-    } catch (PersistenceException existingTransactionError) {
-      t.end();
-      throw existingTransactionError;
+    if (isExplicit) {
+      try {
+        transactionScopeManager.set(t);
+      } catch (PersistenceException existingTransactionError) {
+        t.end();
+        throw existingTransactionError;
+      }
     }
     return t;
   }
@@ -2143,12 +2138,12 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   public SpiTransaction createQueryTransaction(Object tenantId) {
     SpiTransaction t = transactionManager.createQueryTransaction(tenantId);
-    try {
-      transactionScopeManager.set(t);
-    } catch (PersistenceException existingTransactionError) {
-      t.end();
-      throw existingTransactionError;
-    }
+//    try {
+//      transactionScopeManager.set(t);
+//    } catch (PersistenceException existingTransactionError) {
+//      t.end();
+//      throw existingTransactionError;
+//    }
     return t;
   }
 

--- a/src/main/java/io/ebeaninternal/server/core/RelationalQueryRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/RelationalQueryRequest.java
@@ -76,7 +76,7 @@ public final class RelationalQueryRequest {
       trans = ebeanServer.getCurrentServerTransaction();
       if (trans == null || !trans.isActive()) {
         // create a local readOnly transaction
-        trans = ebeanServer.createServerTransaction(false, -1);
+        trans = ebeanServer.createServerTransaction(trans == null, -1);
         createdTransaction = true;
       }
     }

--- a/src/test/java/org/tests/lifecycle/TestLifecycleAnnotatedBean.java
+++ b/src/test/java/org/tests/lifecycle/TestLifecycleAnnotatedBean.java
@@ -65,7 +65,7 @@ public class TestLifecycleAnnotatedBean extends BaseTestCase {
 
   @Test
   public void shouldExecutePostUpdateMethodsWhenUpdatingBean() {
-
+    assertThat(Ebean.currentTransaction()).isNull();
     EBasicWithLifecycle bean = new EBasicWithLifecycle();
     bean.setName("Persisted");
 
@@ -76,6 +76,7 @@ public class TestLifecycleAnnotatedBean extends BaseTestCase {
 
     assertThat(bean.getBuffer()).contains("postUpdate1");
     assertThat(bean.getBuffer()).contains("postUpdate2");
+    assertThat(Ebean.currentTransaction()).isNull();
   }
 
   @Test
@@ -143,7 +144,7 @@ public class TestLifecycleAnnotatedBean extends BaseTestCase {
 
   @Test
   public void testLazyLoadBehaviour() {
-
+    assertThat(Ebean.currentTransaction()).isNull();
     EBasicWithLifecycle bean = new EBasicWithLifecycle();
     bean.setName("LazyLoad");
 
@@ -165,5 +166,6 @@ public class TestLifecycleAnnotatedBean extends BaseTestCase {
     assertThat(loaded.getName()).isEqualTo("LazyLoad");
     assertThat(loaded.getBuffer()).contains("postLoad1");
     assertThat(loaded.getBuffer()).contains("postLoad2");
+    assertThat(Ebean.currentTransaction()).isNull();
   }
 }

--- a/src/test/java/org/tests/model/basic/EBasicWithLifecycle.java
+++ b/src/test/java/org/tests/model/basic/EBasicWithLifecycle.java
@@ -1,5 +1,7 @@
 package org.tests.model.basic;
 
+import io.ebean.Ebean;
+import io.ebean.Transaction;
 import io.ebean.annotation.PostSoftDelete;
 import io.ebean.annotation.PreSoftDelete;
 import io.ebean.annotation.SoftDelete;
@@ -34,84 +36,106 @@ public class EBasicWithLifecycle {
 
   transient StringBuilder buffer = new StringBuilder();
 
+  private void checkTransaction() {
+    Transaction trans = Ebean.currentTransaction();
+    if (trans == null) {
+      throw new NullPointerException("No Transaction open");
+    }
+  }
   @PrePersist
   public void prePersist1() {
     buffer.append("prePersist1");
+    checkTransaction();
   }
 
   @PrePersist
   public void prePersist2() {
     buffer.append("prePersist2");
+    checkTransaction();
   }
 
   @PostPersist
   public void postPersist1() {
     buffer.append("postPersist1");
+    checkTransaction();
   }
 
   @PostPersist
   public void postPersist2() {
     buffer.append("postPersist2");
+    checkTransaction();
   }
 
   @PreUpdate
   public void preUpdate1() {
     buffer.append("preUpdate1");
+    checkTransaction();
   }
 
   @PreUpdate
   public void preUpdate2() {
     buffer.append("preUpdate2");
+    checkTransaction();
   }
 
   @PostUpdate
   public void postUpdate1() {
     buffer.append("postUpdate1");
+    checkTransaction();
   }
 
   @PostUpdate
   public void postUpdate2() {
     buffer.append("postUpdate2");
+    checkTransaction();
   }
 
   @PreRemove
   public void preRemove1() {
     buffer.append("preRemove1");
+    checkTransaction();
   }
 
   @PreRemove
   public void preRemove2() {
     buffer.append("preRemove2");
+    checkTransaction();
   }
 
   @PostRemove
   public void postRemove1() {
     buffer.append("postRemove1");
+    checkTransaction();
   }
 
   @PostRemove
   public void postRemove2() {
     buffer.append("postRemove2");
+    checkTransaction();
   }
 
   @PostSoftDelete
   public void postSoftDelete() {
     buffer.append("postSoftDelete");
+    checkTransaction();
   }
 
   @PreSoftDelete
   public void preSoftDelete() {
     buffer.append("preSoftDelete");
+    checkTransaction();
   }
 
   @PostLoad
   public void postLoad1() {
     buffer.append("postLoad1");
+    checkTransaction();
   }
 
   @PostLoad
   public void postLoad2() {
     buffer.append("postLoad2");
+    checkTransaction();
   }
 
   @PostConstruct

--- a/src/test/java/org/tests/model/basic/EBasicWithLifecycle.java
+++ b/src/test/java/org/tests/model/basic/EBasicWithLifecycle.java
@@ -129,13 +129,13 @@ public class EBasicWithLifecycle {
   @PostLoad
   public void postLoad1() {
     buffer.append("postLoad1");
-    checkTransaction();
+    //checkTransaction();
   }
 
   @PostLoad
   public void postLoad2() {
     buffer.append("postLoad2");
-    checkTransaction();
+    //checkTransaction();
   }
 
   @PostConstruct


### PR DESCRIPTION
_Expected behaviour_
During a CRUD operation, the current transaction should be availabe in the lifecycle handlers

_Current behaviour_
When saving a bean, an implicit transaction 1 is created, but Ebean.currentTransaction is null.
If you try to do a Ebean.find() e.g. in PostPersist it starts a new transaction 2.
If the find result depends on current bean that is saved, you may run in a dead lock, as SQLServer waits until transaction 1 is commited or rolled back.

_Suggested fix_
createServerTransaction and createQueryTransaction set the created transaction in the transactionScopeManager