### PR TITLE
Fix / support JSON marshalling of BeanChange + add changeLogAsync option to ServerConfig

### DIFF
--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -368,6 +368,8 @@ public class ServerConfig {
 
   private ChangeLogRegister changeLogRegister;
 
+  private boolean changeLogAsync;
+
   private ReadAuditLogger readAuditLogger;
 
   private ReadAuditPrepare readAuditPrepare;
@@ -968,6 +970,20 @@ public class ServerConfig {
    */
   public void setChangeLogIncludeInserts(boolean changeLogIncludeInserts) {
     this.changeLogIncludeInserts = changeLogIncludeInserts;
+  }
+
+  /**
+   * Return true (default) if the changelog should be written async.
+   */
+  public boolean isChangeLogAsync() {
+    return changeLogAsync;
+  }
+
+  /**
+   * Sets if the changelog should be written async (default = true).
+   */
+  public void setChangeLogAsync(boolean changeLogAsync) {
+    this.changeLogAsync = changeLogAsync;
   }
 
   /**

--- a/src/main/java/io/ebean/event/changelog/BeanChange.java
+++ b/src/main/java/io/ebean/event/changelog/BeanChange.java
@@ -8,37 +8,43 @@ public class BeanChange {
   /**
    * The underling base table name.
    */
-  private final String type;
+  private String type;
 
   /**
    * The tenantId value.
    */
-  private final Object tenantId;
+  private Object tenantId;
 
   /**
    * The id value.
    */
-  private final Object id;
+  private Object id;
 
   /**
    * The INSERT, UPDATE or DELETE change type.
    */
-  private final ChangeType event;
+  private ChangeType event;
 
   /**
    * The time the bean change was created.
    */
-  private final long eventTime;
+  private long eventTime;
 
   /**
    * The change in JSON form.
    */
-  private final String data;
+  private String data;
 
   /**
    * The change in JSON form.
    */
-  private final String oldData;
+  private String oldData;
+
+  /**
+   * Constructor for JSON tools.
+   */
+  public BeanChange() {
+  }
 
   /**
    * Construct with change as JSON.

--- a/src/test/java/org/tests/changelog/TestChangeLog.java
+++ b/src/test/java/org/tests/changelog/TestChangeLog.java
@@ -67,6 +67,7 @@ public class TestChangeLog extends BaseTestCase {
     config.setDdlRun(true);
     config.setDefaultServer(false);
     config.setRegister(false);
+    config.setChangeLogAsync(false);
 
     config.addClass(EBasicChangeLog.class);
 
@@ -111,7 +112,7 @@ public class TestChangeLog extends BaseTestCase {
         assertEquals(changes.getUserIpAddress(), changes1.getUserIpAddress());
 
       } catch (Exception e) {
-        e.printStackTrace();
+        throw new AssertionError(e);
       }
     }
 


### PR DESCRIPTION
This PR fixes deserialization of the BeanChange and adds the ability to write changelog synchronious - and the test can detect failures 