### PR TITLE
MultiValueBind improvements

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
+++ b/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
@@ -43,6 +43,7 @@ import io.ebeaninternal.server.deploy.parse.DeployUtil;
 import io.ebeaninternal.server.expression.DefaultExpressionFactory;
 import io.ebeaninternal.server.persist.Binder;
 import io.ebeaninternal.server.persist.DefaultPersister;
+import io.ebeaninternal.server.persist.platform.H2MultiValueBind;
 import io.ebeaninternal.server.persist.platform.MultiValueBind;
 import io.ebeaninternal.server.persist.platform.PostgresMultiValueBind;
 import io.ebeaninternal.server.query.CQueryEngine;
@@ -273,10 +274,18 @@ public class InternalConfiguration {
   }
 
   private MultiValueBind createMultiValueBind(Platform platform) {
-    // only Postgres at this stage
+    // only H2 & Postgres at this stage
     switch (platform) {
+      case H2:
+        return new H2MultiValueBind();
       case POSTGRES:
         return new PostgresMultiValueBind();
+      //case SQLSERVER: needs additional data types
+      //  return new SqlServerMultiValueBind();
+      //case ORACLE: needs additional data types
+      //  return new OracleMultiValueBind();
+      //case DB2: TODO: I can't get this to work, so fall back to default
+      //  return new Db2JdbcArrayHelp();
       default:
         return new MultiValueBind();
     }

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -117,8 +117,6 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
 
   private final short profileBeanId;
 
-  private final boolean multiValueSupported;
-
   public enum EntityType {
     ORM, EMBEDDED, VIEW, SQL, DOC
   }
@@ -405,7 +403,6 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
   public BeanDescriptor(BeanDescriptorMap owner, DeployBeanDescriptor<T> deploy) {
 
     this.owner = owner;
-    this.multiValueSupported = owner.isMultiValueSupported();
     this.serverName = owner.getServerName();
     this.entityType = deploy.getEntityType();
     this.properties = deploy.getProperties();
@@ -1685,7 +1682,7 @@ public class BeanDescriptor<T> implements MetaBeanInfo, BeanType<T> {
    * Return true if this type has a simple Id and the platform supports mutli-value binding.
    */
   public boolean isMultiValueIdSupported() {
-    return multiValueSupported && isSimpleId();
+    return idBinder.isMultiValueSupported();
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -257,11 +257,6 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
   }
 
   @Override
-  public boolean isMultiValueSupported() {
-    return multiValueBind.isSupported();
-  }
-
-  @Override
   public ServerConfig getServerConfig() {
     return serverConfig;
   }

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorMap.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorMap.java
@@ -37,11 +37,6 @@ public interface BeanDescriptorMap {
   NamingConvention getNamingConvention();
 
   /**
-   * Return true if multiple values can be bound as Array or Table Value and hence share the same query plan.
-   */
-  boolean isMultiValueSupported();
-
-  /**
    * Return the BeanDescriptor for a given class.
    */
   <T> BeanDescriptor<T> getBeanDescriptor(Class<T> entityType);

--- a/src/main/java/io/ebeaninternal/server/deploy/id/IdBinder.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/id/IdBinder.java
@@ -66,6 +66,11 @@ public interface IdBinder {
   boolean isComplexId();
 
   /**
+   * Return true, if multi values are supported. (Required for efficient queryPlan cache)
+   */
+  boolean isMultiValueSupported();
+
+  /**
    * Return the default order by that may need to be used if the query includes
    * a many property.
    */

--- a/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmbedded.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmbedded.java
@@ -144,6 +144,11 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
+  public boolean isMultiValueSupported() {
+    return false;
+  }
+
+  @Override
   public String getDefaultOrderBy() {
 
     StringBuilder sb = new StringBuilder();

--- a/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmpty.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmpty.java
@@ -66,6 +66,11 @@ public final class IdBinderEmpty implements IdBinder {
   }
 
   @Override
+  public boolean isMultiValueSupported() {
+    return false;
+  }
+
+  @Override
   public String getDefaultOrderBy() {
     // this should never happen?
     return "";

--- a/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
@@ -33,6 +33,8 @@ public final class IdBinderSimple implements IdBinder {
 
   private final MultiValueBind multiValueBind;
 
+  private final boolean multiValueSupported;
+
   @SuppressWarnings("rawtypes")
   private final ScalarType scalarType;
 
@@ -43,6 +45,7 @@ public final class IdBinderSimple implements IdBinder {
     this.expectedType = idProperty.getPropertyType();
     bindIdSql = InternString.intern(idProperty.getDbColumn() + " = ? ");
     this.multiValueBind = multiValueBind;
+    this.multiValueSupported = multiValueBind.isTypeSupported(idProperty.getJdbcType());
   }
 
   @Override
@@ -96,6 +99,10 @@ public final class IdBinderSimple implements IdBinder {
   @Override
   public boolean isComplexId() {
     return false;
+  }
+
+  public boolean isMultiValueSupported() {
+    return multiValueSupported;
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/server/expression/DocQueryContext.java
+++ b/src/main/java/io/ebeaninternal/server/expression/DocQueryContext.java
@@ -61,7 +61,7 @@ public interface DocQueryContext {
   /**
    * Write an In expression.
    */
-  void writeIn(String propertyName, Object[] values, boolean not) throws IOException;
+  void writeIn(String propertyName, Object[] values, boolean containsNull, boolean not) throws IOException;
 
   /**
    * Write an Id in expression.

--- a/src/main/java/io/ebeaninternal/server/expression/NamedParamHelp.java
+++ b/src/main/java/io/ebeaninternal/server/expression/NamedParamHelp.java
@@ -3,7 +3,6 @@ package io.ebeaninternal.server.expression;
 import io.ebeaninternal.api.SpiNamedParam;
 
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Helper for evaluating named parameters.
@@ -31,13 +30,13 @@ class NamedParamHelp {
   /**
    * Add the potentially named parameter(s) to the values.
    */
-  public static void valueAdd(List<Object> values, Object sourceValue) {
+  public static void valueAdd(Collection<Object> values, Object sourceValue) {
 
     Object value = value(sourceValue);
     if (value instanceof Collection) {
       values.addAll((Collection<?>) value);
     } else {
-      values.add(value);
+      values.add(value); // RPr: dead code?
     }
   }
 }

--- a/src/main/java/io/ebeaninternal/server/persist/platform/AbstractMultiValueBind.java
+++ b/src/main/java/io/ebeaninternal/server/persist/platform/AbstractMultiValueBind.java
@@ -33,11 +33,6 @@ import static java.sql.Types.VARCHAR;
 abstract class AbstractMultiValueBind extends MultiValueBind {
 
   @Override
-  public boolean isSupported() {
-    return true;
-  }
-
-  @Override
   public boolean isTypeSupported(int jdbcType) {
     return getArrayType(jdbcType) != null;
   }

--- a/src/main/java/io/ebeaninternal/server/persist/platform/H2MultiValueBind.java
+++ b/src/main/java/io/ebeaninternal/server/persist/platform/H2MultiValueBind.java
@@ -1,0 +1,82 @@
+package io.ebeaninternal.server.persist.platform;
+
+import static java.sql.Types.*;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import io.ebean.config.dbplatform.ExtraDbTypes;
+import io.ebeaninternal.server.type.DataBind;
+import io.ebeaninternal.server.type.ScalarType;
+
+/**
+ * Multi value binder that uses SqlServers Table-value parameters
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class H2MultiValueBind extends AbstractMultiValueBind {
+
+  @Override
+  public void bindMultiValues(DataBind dataBind, Collection<?> values, ScalarType<?> type, BindOne bindOne) throws SQLException {
+    String arrayType = getArrayType(type.getJdbcType());
+    if (arrayType == null) {
+      super.bindMultiValues(dataBind, values, type, bindOne);
+    } else {
+      dataBind.setObject(toArray(values, type));
+    }
+  }
+
+
+  @Override
+  protected String getArrayType(int dbType) {
+    switch(dbType) {
+      case TINYINT:
+      case SMALLINT:
+      case INTEGER:
+      case BIGINT:
+      case DECIMAL: // TODO: we have no info about precision here
+      case NUMERIC:
+        return "BIGINT";
+      case REAL:
+      case FLOAT:
+      case DOUBLE:
+        return "FLOAT";
+      case BIT:
+      case BOOLEAN:
+        return "BIT";
+      case DATE:
+        return "DATE";
+      case TIMESTAMP:
+      case TIME_WITH_TIMEZONE:
+      case TIMESTAMP_WITH_TIMEZONE:
+        return "TIMESTAMP";
+      //case LONGVARCHAR:
+      //case CLOB:
+      case CHAR:
+      case VARCHAR:
+      //case LONGNVARCHAR:
+      //case NCLOB:
+      case NCHAR:
+      case NVARCHAR:
+      case ExtraDbTypes.UUID:
+        return "VARCHAR";
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public String getInExpression(boolean not, ScalarType<?> type, int size) {
+    String arrayType = getArrayType(type.getJdbcType());
+    if (arrayType == null) {
+      return super.getInExpression(not, type, size);
+    }
+    StringBuilder sb = new StringBuilder();
+    if (not) {
+      sb.append(" not");
+    }
+    // Appended statements are written in uppercase, as ebean tries to match the words
+    // to properties. See TestIn::test_in_graphEdge. This will fil if "from" is lowercase
+    sb.append(" in (SELECT * FROM TABLE(X ").append(arrayType).append(" = ?)) ");
+    return sb.toString();
+  }
+}

--- a/src/main/java/io/ebeaninternal/server/persist/platform/MultiValueBind.java
+++ b/src/main/java/io/ebeaninternal/server/persist/platform/MultiValueBind.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 
 /**
- * Default implementation for multi value help.
+ * Default implementation for multi value bind.
  */
 public class MultiValueBind {
 
@@ -24,13 +24,6 @@ public class MultiValueBind {
       array[i++] = type.toJdbcType(value);
     }
     return array;
-  }
-
-  /**
-   * Defaults to not supported and using a bind value per element.
-   */
-  public boolean isSupported() {
-    return false;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/persist/platform/PostgresMultiValueBind.java
+++ b/src/main/java/io/ebeaninternal/server/persist/platform/PostgresMultiValueBind.java
@@ -14,8 +14,7 @@ public class PostgresMultiValueBind extends AbstractMultiValueBind {
     if (dbType == ExtraDbTypes.UUID) {
       return (not) ? " != all(?::uuid[])" : " = any(?::uuid[])";
     }
-    String arrayType = getArrayType(dbType);
-    if (arrayType == null) {
+    if (!isTypeSupported(dbType)) {
       return super.getInExpression(not, type, size);
     } else {
       return (not) ? " != all(?)" : " = any(?)";

--- a/src/test/java/io/ebean/BaseTestCase.java
+++ b/src/test/java/io/ebean/BaseTestCase.java
@@ -139,8 +139,10 @@ public abstract class BaseTestCase {
   protected void platformAssertIn(String sql, String containsIn) {
     if (isPostgres()) {
       assertThat(sql).contains(containsIn+" = any(");
+    } else if (isH2()){
+      assertThat(sql).contains(containsIn+" in (SELECT * FROM TABLE");
     } else {
-      assertThat(sql).contains(containsIn+" in ");
+      assertThat(sql).contains(containsIn+" in (?");
     }
     // H2 contains("where t0.name in (select * from table(x varchar = ?)");
   }
@@ -151,8 +153,10 @@ public abstract class BaseTestCase {
   protected void platformAssertNotIn(String sql, String containsIn) {
     if (isPostgres()) {
       assertThat(sql).contains(containsIn+" != all(");
+    } else if (isH2()){
+      assertThat(sql).contains(containsIn+" not in (SELECT * FROM TABLE");
     } else {
-      assertThat(sql).contains(containsIn+" not in ");
+      assertThat(sql).contains(containsIn+" not in (?");
     }
   }
 

--- a/src/test/java/io/ebeaninternal/server/querydefn/DefaultOrmQueryTest.java
+++ b/src/test/java/io/ebeaninternal/server/querydefn/DefaultOrmQueryTest.java
@@ -59,13 +59,35 @@ public class DefaultOrmQueryTest extends BaseTestCase {
   public void when_sameWhereWithDiffBindValues_then_planSame_bindDiff() {
 
     DefaultOrmQuery<Order> q1 = (DefaultOrmQuery<Order>) Ebean.find(Order.class).where().in("id", 1, 2, 3).query();
-    DefaultOrmQuery<Order> q2 = (DefaultOrmQuery<Order>) Ebean.find(Order.class).where().in("id", 2, 2, 3).query();
+    DefaultOrmQuery<Order> q2 = (DefaultOrmQuery<Order>) Ebean.find(Order.class).where().in("id", 2, 3, 4).query();
 
     prepare(q1, q2);
     assertThat(q1.createQueryPlanKey()).isEqualTo(q2.createQueryPlanKey());
     assertThat(q1.queryBindHash()).isNotEqualTo(q2.queryBindHash());
   }
 
+  @Test
+  public void when_sameDistinctWhereWithDiffBindValues_then_planSame_bindDiff() {
+    // there are 3 distinct values in each query
+    DefaultOrmQuery<Order> q1 = (DefaultOrmQuery<Order>) Ebean.find(Order.class).where().in("id", 1, 2, 3).query();
+    DefaultOrmQuery<Order> q2 = (DefaultOrmQuery<Order>) Ebean.find(Order.class).where().in("id", 2, 2, 2, 2, 3, 4).query();
+
+    prepare(q1, q2);
+    assertThat(q1.createQueryPlanKey()).isEqualTo(q2.createQueryPlanKey());
+    assertThat(q1.queryBindHash()).isNotEqualTo(q2.queryBindHash());
+  }
+  
+  @Test
+  public void when_sameWhereWithDiffBindValuesAndNull_then_planSame_bindDiff() {
+    // there are 3 distinct values in each query
+    DefaultOrmQuery<Order> q1 = (DefaultOrmQuery<Order>) Ebean.find(Order.class).where().in("id", 1, 2, null).query();
+    DefaultOrmQuery<Order> q2 = (DefaultOrmQuery<Order>) Ebean.find(Order.class).where().in("id", null, 2, 3).query();
+
+    prepare(q1, q2);
+    assertThat(q1.createQueryPlanKey()).isEqualTo(q2.createQueryPlanKey());
+    assertThat(q1.queryBindHash()).isNotEqualTo(q2.queryBindHash());
+  }
+  
   @Test
   public void when_sameWhereAndBindValues_then_planSameAndBind() {
 

--- a/src/test/java/org/tests/basic/TestIn.java
+++ b/src/test/java/org/tests/basic/TestIn.java
@@ -1,0 +1,233 @@
+package org.tests.basic;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import io.ebean.Query;
+
+import org.tests.model.basic.CKeyParent;
+import org.tests.model.basic.CKeyParentId;
+import org.tests.model.basic.Customer;
+import org.tests.model.basic.Order;
+import org.tests.model.basic.ResetBasicData;
+import org.tests.model.embedded.EAddress;
+import org.tests.model.embedded.EAddressStatus;
+import org.tests.model.embedded.EPerson;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.junit.Assert.*;
+
+public class TestIn extends BaseTestCase {
+
+  private final int maxParams;
+  public TestIn() {
+    if (isPostgres()) {
+      maxParams = 1100; //66000; 2^16 is the postgres limit. But this makes the CI server unhappy
+    } else if (isSqlServer()) {
+      maxParams = 2200;
+    } else {
+      maxParams = 1100;
+    }
+  }
+
+
+  @Test
+  public void test_in_many_integer() {
+    ResetBasicData.reset();
+    Object[] values = new Object[maxParams];
+    values[0] = 1;
+    values[1] = 2;
+    values[2] = 3;
+    for (int i = 3; i < values.length; i++) {
+      values[i] = -i;
+    }
+    Query<Order> query = Ebean.find(Order.class).where().in("id", values).le("id",4).query();
+
+    List<Order> list = query.findList();
+    assertEquals(3, list.size());
+  }
+
+  @Test
+  public void test_in_many_date() {
+    ResetBasicData.reset();
+    Object[] values = new Object[maxParams];
+
+    for (int i = 0; i < values.length; i++) {
+      values[i] = new Date(System.currentTimeMillis() + i * 86400000);
+    }
+    Query<Order> query = Ebean.find(Order.class).where().in("order_date", values).le("id",4).query();
+
+    List<Order> list = query.findList();
+    assertEquals(4, list.size());
+  }
+
+  @Test
+  public void test_in_many_datetime() {
+    ResetBasicData.reset();
+    Object[] values = new Object[maxParams];
+
+    values[0] = Ebean.find(Order.class, 3).getCretime();
+
+    for (int i = 1; i < values.length; i++) {
+      values[i] = new Timestamp(1234);
+    }
+    Query<Order> query = Ebean.find(Order.class).where().in("cretime", values).le("id",4).query();
+
+    List<Order> list = query.findList();
+    assertThat(list.size()).isGreaterThanOrEqualTo(1);
+  }
+
+
+  @Test
+  public void test_in_many_varchar() {
+    ResetBasicData.reset();
+    Object[] values = new Object[maxParams];
+
+    values[0] = "Rob";
+    values[1] = "Fiona";
+    for (int i = 2; i < values.length; i++) {
+      values[i] = "FooBar"+i;;
+    }
+    Query<Customer> query = Ebean.find(Customer.class).where().in("name", values).le("id",4).query();
+
+    List<Customer> list = query.findList();
+    assertThat(list.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void test_in_many_idin() {
+    ResetBasicData.reset();
+    Object[] values = new Object[maxParams];
+    values[0] = 1;
+    values[1] = 2;
+    values[2] = 3;
+    for (int i = 3; i < values.length; i++) {
+      values[i] = -i;
+    }
+    Query<Order> query = Ebean.find(Order.class).where().idIn(values).le("id",4).query();
+
+    List<Order> list = query.findList();
+    assertEquals(3, list.size());
+  }
+
+  @Test
+  public void test_in_many_delete() {
+    ResetBasicData.reset();
+    List<Integer> values = new ArrayList<>();
+    for (int i = 0; i < maxParams; i++) {
+      values.add(-i);
+    }
+    server().deleteAll(Order.class, values);
+
+  }
+  @Test
+  public void test_with_null() {
+    ResetBasicData.reset();
+
+    Query<Customer> query = Ebean.find(Customer.class).where().in("anniversary", new Object[1]).le("id",4).query();
+
+    List<Customer> list = query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is null");
+    assertThat(list.size()).isEqualTo(1);
+
+    query = Ebean.find(Customer.class).where().notIn("anniversary", new Object[1]).le("id",4).query();
+
+    list = query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is not null");
+    assertThat(list.size()).isEqualTo(3);
+
+    query = Ebean.find(Customer.class).where().eq("anniversary", null).le("id",4).query();
+
+    list = query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is null");
+    assertThat(list.size()).isEqualTo(1);
+
+    query = Ebean.find(Customer.class).where().ne("anniversary", null).le("id",4).query();
+
+    list = query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is not null");
+    assertThat(list.size()).isEqualTo(3);
+
+    Object[] values = new Object[maxParams];
+
+    values[0] = new Date(110,03,14);
+    values[1] = new Date(109,07,31);
+
+  }
+  @Test
+  public void test_many_with_null() {
+    ResetBasicData.reset();
+
+    Object[] values = new Object[maxParams];
+
+    values[0] = new Date(110,03,14);
+    values[1] = new Date(109,07,31);
+
+    Query<Customer> query = Ebean.find(Customer.class).where().in("anniversary", values).le("id",4).query();
+
+    List<Customer> list = query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is null");
+    assertThat(list.size()).isEqualTo(3);
+
+    query = Ebean.find(Customer.class).where().notIn("anniversary", values).le("id",4).query();
+
+    list = query.findList();
+    assertThat(query.getGeneratedSql()).doesNotContain(" is null");
+    assertThat(list.size()).isEqualTo(1);
+    values = new Object[] {values[0], values[1]};
+    query = Ebean.find(Customer.class).where().notIn("anniversary", values).le("id",4).query();
+
+    list = query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is null");
+    assertThat(list.size()).isEqualTo(2);
+  }
+
+  @Test
+  @Ignore // query for embedded is not supported
+  public void test_in_embedded() throws Exception {
+    EAddress addr1 = new EAddress();
+    addr1.setCity("Vilshofen");
+    addr1.setStreet("Furtgasse");
+    addr1.setSuburb("an der Donau");
+    addr1.setStatus(EAddressStatus.ONE);
+
+    EAddress addr2 = new EAddress();
+    addr2.setCity("Passau");
+    addr2.setStreet("Innstraße");
+    addr2.setSuburb("");
+    addr2.setStatus(EAddressStatus.TWO);
+
+    Object[] moreAddrs =  { addr1, addr2};
+    Query<EPerson> query = Ebean.find(EPerson.class).where().in("address", moreAddrs).query();
+    query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is null");
+  }
+
+  @Test
+  @Ignore // query for embedded is not supported
+  public void test_in_embedded_id() throws Exception {
+    CKeyParentId id1 = new CKeyParentId();
+    id1.setOneKey(42);
+    id1.setTwoKey("foo");
+    CKeyParentId id2 = new CKeyParentId();
+    id2.setOneKey(23);
+    id2.setTwoKey("bar");
+
+    Object[] oneKey = { id1 };
+    Object[] moreKeys =  { id1, id2};
+    Query<CKeyParent> query = Ebean.find(CKeyParent.class).where().idIn(oneKey).query();
+    query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is null");
+
+     query = Ebean.find(CKeyParent.class).where().idIn(moreKeys).query();
+    query.findList();
+    assertThat(query.getGeneratedSql()).contains(" is null");
+  }
+
+}

--- a/src/test/java/org/tests/basic/TestIn.java
+++ b/src/test/java/org/tests/basic/TestIn.java
@@ -7,6 +7,7 @@ import io.ebean.Query;
 import org.tests.model.basic.CKeyParent;
 import org.tests.model.basic.CKeyParentId;
 import org.tests.model.basic.Customer;
+import org.tests.model.basic.GraphEdge;
 import org.tests.model.basic.Order;
 import org.tests.model.basic.ResetBasicData;
 import org.tests.model.embedded.EAddress;
@@ -230,4 +231,16 @@ public class TestIn extends BaseTestCase {
     assertThat(query.getGeneratedSql()).contains(" is null");
   }
 
+  @Test
+  public void test_in_graphEdge() {
+    ResetBasicData.reset();
+    Object[] values = new Object[maxParams];
+    values[0] = 1;
+    values[1] = 2;
+    values[2] = 3;
+    for (int i = 3; i < values.length; i++) {
+      values[i] = -i;
+    }
+    Ebean.find(GraphEdge.class).where().idIn(values).query().findList();
+  }
 }

--- a/src/test/java/org/tests/basic/TestInEmpty.java
+++ b/src/test/java/org/tests/basic/TestInEmpty.java
@@ -4,6 +4,7 @@ import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.Query;
 import org.tests.model.basic.Order;
+import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
 import java.util.List;
@@ -15,6 +16,7 @@ public class TestInEmpty extends BaseTestCase {
 
   @Test
   public void test_in_empty() {
+    ResetBasicData.reset();
 
     Query<Order> query = Ebean.find(Order.class).where().in("id", new Object[0]).gt("id", 0)
       .query();
@@ -26,6 +28,7 @@ public class TestInEmpty extends BaseTestCase {
 
   @Test
   public void test_isIn_empty() {
+    ResetBasicData.reset();
 
     Query<Order> query = Ebean.find(Order.class).where().isIn("id", new Object[0]).gt("id", 0)
       .query();
@@ -37,6 +40,7 @@ public class TestInEmpty extends BaseTestCase {
 
   @Test
   public void test_notIn_empty() {
+    ResetBasicData.reset();
 
     Query<Order> query = Ebean.find(Order.class).where().notIn("id", new Object[0]).gt("id", 0)
       .query();

--- a/src/test/java/org/tests/model/basic/GraphEdge.java
+++ b/src/test/java/org/tests/model/basic/GraphEdge.java
@@ -1,0 +1,23 @@
+package org.tests.model.basic;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import java.io.Serializable;
+
+@Entity
+public class GraphEdge implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  Integer id;
+
+  // note: property is a reserved sql keyword. Resulting column: from_id
+  @ManyToOne
+  GraphNode from;
+
+  @ManyToOne
+  GraphNode to;
+
+}

--- a/src/test/java/org/tests/model/basic/GraphNode.java
+++ b/src/test/java/org/tests/model/basic/GraphNode.java
@@ -1,0 +1,19 @@
+package org.tests.model.basic;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Entity
+public class GraphNode implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  Integer id;
+
+  @OneToMany(mappedBy = "from")
+  List<GraphEdge> out;
+}


### PR DESCRIPTION
This PR 
- adds MultiValueBind for H2 (although there is no parameter limit in H2)
- determines if multi-id-value is supported differently
- changes the DocQueryContext::writeIn method (breaking-api)
- adds support for 'null' in "in-values" (this may break your code, especially `notIn(1,2,3)` will return everything, except 1,2,3 - also `null`)
- duplicate "in-values" are eliminated. `in(1,1,2,3,3)` will produce the same query & queryplan as `in(1,2,3)`

