### PR TITLE
DiscriminatorColumn length should be 31

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
@@ -112,7 +112,7 @@ public class DeployInheritInfo {
   public int getColumnLength(InheritInfo parent) {
     if (columnLength == 0) {
       if (parent == null) {
-        columnLength = 10;
+        columnLength = 31;
       } else {
         columnLength = parent.getColumnLength();
       }


### PR DESCRIPTION
The JPA specification, states that the DiscriminatorColumn default length should be 31, and not 10.

This is used to specify the length of the column for the `InheritanceType.SINGLE_TABLE` strategy.