### PR TITLE
[collation-bin] fixed table and column name spelling to match exact case

### DIFF
--- a/src/test/java/org/tests/compositekeys/db/Item.java
+++ b/src/test/java/org/tests/compositekeys/db/Item.java
@@ -23,10 +23,10 @@ public class Item {
   private int region;
 
   @Embedded
-  @AttributeOverride(name = "lastUpdated", column = @Column(name = "DATE_MODIFIED"))
-  @AttributeOverride(name = "created", column = @Column(name = "DATE_CREATED"))
-  @AttributeOverride(name = "updatedBy", column = @Column(name = "MODIFIED_BY"))
-  @AttributeOverride(name = "createdBy", column = @Column(name = "CREATED_BY"))
+  @AttributeOverride(name = "lastUpdated", column = @Column(name = "date_modified"))
+  @AttributeOverride(name = "created", column = @Column(name = "date_created"))
+  @AttributeOverride(name = "updatedBy", column = @Column(name = "modified_by"))
+  @AttributeOverride(name = "createdBy", column = @Column(name = "created_by"))
   private AuditInfo auditInfo = new AuditInfo();
 
   @Version

--- a/src/test/java/org/tests/compositekeys/db/ItemKey.java
+++ b/src/test/java/org/tests/compositekeys/db/ItemKey.java
@@ -7,7 +7,7 @@ import javax.persistence.Embeddable;
 public class ItemKey {
   private int customer;
 
-  @Column(name = "itemNumber")
+  @Column(name = "itemnumber")
   private String itemNumber;
 
   public int getCustomer() {

--- a/src/test/java/org/tests/compositekeys/db/ParcelLocation.java
+++ b/src/test/java/org/tests/compositekeys/db/ParcelLocation.java
@@ -15,7 +15,7 @@ public class ParcelLocation {
   private String location;
 
   @OneToOne
-  @JoinColumn(name = "parcelId", referencedColumnName = "parcelId")
+  @JoinColumn(name = "parcelid", referencedColumnName = "parcelid")
   private Parcel parcel;
 
   public Long getParcelLocId() {

--- a/src/test/java/org/tests/model/basic/Phone.java
+++ b/src/test/java/org/tests/model/basic/Phone.java
@@ -27,7 +27,7 @@ public class Phone implements Serializable {
 
   @Id
   @GeneratedValue(strategy = javax.persistence.GenerationType.AUTO)
-  @Column(name = "ID", unique = true, nullable = false)
+  @Column(name = "id", unique = true, nullable = false)
   public Long getId() {
     return id;
   }
@@ -36,7 +36,7 @@ public class Phone implements Serializable {
     this.id = id;
   }
 
-  @Column(name = "PHONE_NUMBER", nullable = false, unique = true, columnDefinition = "varchar(7)")
+  @Column(name = "phone_number", nullable = false, unique = true, columnDefinition = "varchar(7)")
   public String getPhoneNumber() {
     return phoneNumber;
   }
@@ -47,7 +47,7 @@ public class Phone implements Serializable {
 
   @NotNull
   @ManyToOne(targetEntity = Person.class, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  @JoinColumn(name = "PERSON_ID", nullable = false)
+  @JoinColumn(name = "person_id", nullable = false)
   public Person getPerson() {
     return person;
   }

--- a/src/test/java/org/tests/model/carwheeltruck/TTruck.java
+++ b/src/test/java/org/tests/model/carwheeltruck/TTruck.java
@@ -13,7 +13,7 @@ import javax.persistence.InheritanceType;
 @DiscriminatorValue("truck")
 public class TTruck extends TCar {
 
-  @Column(name = "truckLoad")
+  @Column(name = "truckload")
   Long load;
 
   public Long getLoad() {

--- a/src/test/java/org/tests/model/selfref/ResourceFile.java
+++ b/src/test/java/org/tests/model/selfref/ResourceFile.java
@@ -20,7 +20,7 @@ public class ResourceFile extends BaseResourceFile {
   private static final long serialVersionUID = 1L;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = true)
-  @JoinColumn(name = "parentResourceFileId", nullable = true)
+  @JoinColumn(name = "parentresourcefileid", nullable = true)
   private ResourceFile parent;
 
   @OneToMany(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY, mappedBy = "parent")

--- a/src/test/java/org/tests/model/survey/Category.java
+++ b/src/test/java/org/tests/model/survey/Category.java
@@ -21,7 +21,7 @@ public class Category {
   }
 
   @ManyToOne
-  @JoinColumn(name = "surveyObjectId")
+  @JoinColumn(name = "surveyobjectid")
   private Survey survey;
 
   @OneToMany(mappedBy = "category", cascade = {CascadeType.PERSIST, CascadeType.MERGE})

--- a/src/test/java/org/tests/model/survey/Group.java
+++ b/src/test/java/org/tests/model/survey/Group.java
@@ -24,7 +24,7 @@ public class Group {
   }
 
   @ManyToOne
-  @JoinColumn(name = "categoryObjectId")
+  @JoinColumn(name = "categoryobjectid")
   private Category category;
 
   @OneToMany(mappedBy = "group", cascade = {CascadeType.PERSIST, CascadeType.MERGE})

--- a/src/test/java/org/tests/model/survey/Question.java
+++ b/src/test/java/org/tests/model/survey/Question.java
@@ -17,7 +17,7 @@ public class Question {
   }
 
   @ManyToOne
-  @JoinColumn(name = "groupObjectId")
+  @JoinColumn(name = "groupobjectid")
   private Group group;
 
   private int sequenceNumber;

--- a/src/test/java/org/tests/singleTableInheritance/model/PalletLocation.java
+++ b/src/test/java/org/tests/singleTableInheritance/model/PalletLocation.java
@@ -20,7 +20,7 @@ public class PalletLocation {
   private Integer id;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  @JoinColumn(name = "ZONE_SID")
+  @JoinColumn(name = "zone_sid")
   private Zone zone;
 
   public Integer getId() {

--- a/src/test/java/org/tests/singleTableInheritance/model/Warehouse.java
+++ b/src/test/java/org/tests/singleTableInheritance/model/Warehouse.java
@@ -19,13 +19,13 @@ public class Warehouse {
   private Integer id;
 
   @ManyToOne//(optional = false) //todo: should this be nullable with assertions made?
-  @JoinColumn(name = "officeZoneId")
+  @JoinColumn(name = "officezoneid")
   private ZoneInternal officeZone;
 
   @ManyToMany(cascade = CascadeType.PERSIST)
   @JoinTable(name = "warehousesshippingzones",
-    joinColumns = {@JoinColumn(name = "warehouseId", referencedColumnName = "ID")},
-    inverseJoinColumns = {@JoinColumn(name = "shippingZoneId", referencedColumnName = "ID")}
+    joinColumns = {@JoinColumn(name = "warehouseid", referencedColumnName = "id")},
+    inverseJoinColumns = {@JoinColumn(name = "shippingzoneid", referencedColumnName = "id")}
   )
   private Set<ZoneExternal> shippingZones;
 

--- a/src/test/resources/assert/changeset-apply.txt
+++ b/src/test/resources/assert/changeset-apply.txt
@@ -877,10 +877,10 @@ create table item (
   units                         varchar(255),
   type                          integer,
   region                        integer,
-  DATE_MODIFIED                 timestamp,
-  DATE_CREATED                  timestamp,
-  MODIFIED_BY                   varchar(255),
-  CREATED_BY                    varchar(255),
+  date_modified                 timestamp,
+  date_created                  timestamp,
+  modified_by                   varchar(255),
+  created_by                    varchar(255),
   version                       bigint not null,
   constraint pk_item primary key (customer,itemNumber)
 );

--- a/src/test/resources/assert/changeset-pg-apply.sql
+++ b/src/test/resources/assert/changeset-pg-apply.sql
@@ -777,10 +777,10 @@ create table item (
   units                         varchar(255),
   type                          integer,
   region                        integer,
-  DATE_MODIFIED                 timestamp,
-  DATE_CREATED                  timestamp,
-  MODIFIED_BY                   varchar(255),
-  CREATED_BY                    varchar(255),
+  date_modified                 timestamp,
+  date_created                  timestamp,
+  modified_by                   varchar(255),
+  created_by                    varchar(255),
   version                       bigint not null,
   constraint pk_item primary key (customer,itemNumber)
 );


### PR DESCRIPTION
Hello Rob,

this PR fixes the exact spelling in @Column and @JoinColumn annotations, so that it matches the spelling in DDL.

**Background**
I'm running tests against a mssql database with *Latin1_General_100_BIN2* collation, which means case sensitive sorting and comparing, also for table and column names :-(

so `SELECT myid FROM ...` will work, `SELECT myId FROM ...` not

I have to say that I am not very happy with this change, a better solution would probably be to honor DbConstraintNaming in @Column / @JoinColumn annotations