### PR TITLE
Test only change - Fix clock sync timing issues with tests using -DdbClockDelta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,11 @@
               <name>datasource.default</name>
               <value>${datasource.default}</value>
             </property>
+            <property>
+              <!-- transfer dbClockDelta parameter -->
+              <name>dbClockDelta</name>
+              <value>${dbClockDelta}</value>
+            </property>
           </systemProperties>
         </configuration>
       </plugin>

--- a/src/test/java/io/ebean/BaseTestCase.java
+++ b/src/test/java/io/ebean/BaseTestCase.java
@@ -30,9 +30,15 @@ public abstract class BaseTestCase {
    * Note: That some tests may use a Thread.sleep to wait, so that the local system clock
    * can catch up. So don't set that to a too high value.
    */
-  public static final int DB_CLOCK_DELTA = Integer.parseInt(System.getProperty("dbClockDelta", "100"));
+  public static final int DB_CLOCK_DELTA;
 
   static {
+    String s = System.getProperty("dbClockDelta");
+    if (s != null && !s.isEmpty()) {
+      DB_CLOCK_DELTA = Integer.parseInt(s);
+    } else {
+      DB_CLOCK_DELTA = 100;
+    }
     logger.debug("... preStart");
     if (!AgentLoader.loadAgentFromClasspath("ebean-agent", "debug=1")) {
       logger.info("avaje-ebeanorm-agent not found in classpath - not dynamically loaded");

--- a/src/test/java/io/ebean/BaseTestCase.java
+++ b/src/test/java/io/ebean/BaseTestCase.java
@@ -22,6 +22,16 @@ public abstract class BaseTestCase {
 
   protected static Logger logger = LoggerFactory.getLogger(BaseTestCase.class);
 
+  /**
+   * this is the clock delta that may occur between testing machine and db server.
+   * If the clock delta of DB server is in future, an "asOf" query may not find the
+   * correct entry.
+   *
+   * Note: That some tests may use a Thread.sleep to wait, so that the local system clock
+   * can catch up. So don't set that to a too high value.
+   */
+  public static final int DB_CLOCK_DELTA = Integer.parseInt(System.getProperty("dbClockDelta", "100"));
+
   static {
     logger.debug("... preStart");
     if (!AgentLoader.loadAgentFromClasspath("ebean-agent", "debug=1")) {

--- a/src/test/java/org/tests/history/TestHistoryInsert.java
+++ b/src/test/java/org/tests/history/TestHistoryInsert.java
@@ -34,7 +34,7 @@ public class TestHistoryInsert extends BaseTestCase {
     Ebean.save(user);
     logger.info("-- initial save");
 
-    Thread.sleep(100);
+    Thread.sleep(DB_CLOCK_DELTA); // wait, so that our system clock can catch up
     Timestamp afterInsert = new Timestamp(System.currentTimeMillis());
 
     List<SqlRow> history = fetchHistory(user);

--- a/src/test/java/org/tests/model/history/TestHistoryExclude.java
+++ b/src/test/java/org/tests/model/history/TestHistoryExclude.java
@@ -44,7 +44,7 @@ public class TestHistoryExclude extends BaseTestCase {
     prepare();
 
     HeLink linkFound = Ebean.find(HeLink.class)
-      .asOf(new Timestamp(System.currentTimeMillis()))
+      .asOf(new Timestamp(System.currentTimeMillis() + DB_CLOCK_DELTA))
       .setId(link.getId())
       .findOne();
 

--- a/src/test/java/org/tests/model/history/TestHistoryInclude.java
+++ b/src/test/java/org/tests/model/history/TestHistoryInclude.java
@@ -44,7 +44,7 @@ public class TestHistoryInclude extends BaseTestCase {
     prepare();
 
     HiLink linkFound = Ebean.find(HiLink.class)
-      .asOf(new Timestamp(System.currentTimeMillis()))
+      .asOf(new Timestamp(System.currentTimeMillis() + DB_CLOCK_DELTA))
       .setId(link.getId())
       .findOne();
 


### PR DESCRIPTION
This will solve some timing issues, when the clocks of db server and dev server are not in sync.
You can append a -DdbClockDelta argument for the test cases