### PR TITLE
Test only change - FIX: more timing issues - mysql does not support resolution in millis

### DIFF
--- a/src/test/java/org/tests/draftable/DocLinkTest.java
+++ b/src/test/java/org/tests/draftable/DocLinkTest.java
@@ -175,7 +175,7 @@ public class DocLinkTest extends BaseTestCase {
 
     Link linkLive = server.publish(Link.class, link1.getId(), null);
     StrictAssertions.assertThat(linkLive.getComment()).isEqualTo(comment);
-    StrictAssertions.assertThat(linkLive.getWhenPublish()).isEqualTo(when);
+    StrictAssertions.assertThat(linkLive.getWhenPublish()).isEqualToIgnoringMillis(when);
 
     Link draft1b = Ebean.find(Link.class).setId(link1.getId()).asDraft().findOne();
     StrictAssertions.assertThat(draft1b.isDirty()).isFalse();

--- a/src/test/java/org/tests/query/embedded/TestMultipleEmbeddedLoading.java
+++ b/src/test/java/org/tests/query/embedded/TestMultipleEmbeddedLoading.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import java.util.Date;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -46,7 +47,7 @@ public class TestMultipleEmbeddedLoading extends BaseTestCase {
     // assert fetched bean populated as expected
     assertEquals(invoice.getId(), invoice2.getId());
     assertEquals(invoice.getState(), invoice2.getState());
-    assertEquals(invoice.getInvoiceDate(), invoice2.getInvoiceDate());
+    assertThat(invoice2.getInvoiceDate()).isEqualToIgnoringMillis(invoice.getInvoiceDate());
     assertEquals("2 Apple St", invoice.getBillAddress().getStreet());
     assertEquals("2 Apple St", invoice2.getBillAddress().getStreet());
 

--- a/src/test/java/org/tests/types/TestNewTypes.java
+++ b/src/test/java/org/tests/types/TestNewTypes.java
@@ -20,6 +20,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -52,7 +53,7 @@ public class TestNewTypes extends BaseTestCase {
     bean.setMonth(Month.SEPTEMBER);
 
     Ebean.save(bean);
-    Thread.sleep(10); // wait, to ensure that instant < Instant.now()
+    Thread.sleep(DB_CLOCK_DELTA); // wait, to ensure that instant < Instant.now()
     List<SomeNewTypesBean> list = Ebean.find(SomeNewTypesBean.class).where().lt("instant", Instant.now()).findList();
     assertTrue(!list.isEmpty());
 
@@ -97,9 +98,9 @@ public class TestNewTypes extends BaseTestCase {
     assertEquals(bean.getYear(), fetched.getYear());
     assertEquals(bean.getYearMonth(), fetched.getYearMonth());
     assertEquals(bean.getLocalDate(), fetched.getLocalDate());
-    assertEquals(bean.getLocalDateTime(), fetched.getLocalDateTime());
-    assertEquals(bean.getOffsetDateTime(), fetched.getOffsetDateTime());
-    assertEquals(bean.getInstant(), fetched.getInstant());
+    assertThat(fetched.getLocalDateTime()).isEqualToIgnoringNanos(bean.getLocalDateTime());
+    assertThat(fetched.getOffsetDateTime()).isEqualToIgnoringNanos(bean.getOffsetDateTime());
+    assertEquals(bean.getInstant().toEpochMilli() / 1000, fetched.getInstant().toEpochMilli() / 1000);
     assertEquals(bean.getPath(), fetched.getPath());
     assertEquals(bean.getPeriod(), fetched.getPeriod());
 
@@ -114,9 +115,9 @@ public class TestNewTypes extends BaseTestCase {
     assertEquals(bean.getYear(), toBean.getYear());
     assertEquals(bean.getYearMonth(), toBean.getYearMonth());
     assertEquals(bean.getLocalDate(), toBean.getLocalDate());
-    assertEquals(bean.getLocalDateTime(), toBean.getLocalDateTime());
-    assertEquals(bean.getOffsetDateTime(), toBean.getOffsetDateTime());
-    assertEquals(bean.getInstant(), toBean.getInstant());
+    assertThat(toBean.getLocalDateTime()).isEqualToIgnoringNanos(bean.getLocalDateTime());
+    assertThat(toBean.getOffsetDateTime()).isEqualToIgnoringNanos(bean.getOffsetDateTime());
+    assertEquals(bean.getInstant().toEpochMilli() / 1000, toBean.getInstant().toEpochMilli() / 1000);
     // FIXME: This test fails on Windows with: expected:<\tmp> but was:<C:\tmp>
     assertEquals(bean.getPath(), toBean.getPath());
     assertEquals(bean.getPeriod(), toBean.getPeriod());

--- a/src/test/java/org/tests/update/TestStatelessUpdate.java
+++ b/src/test/java/org/tests/update/TestStatelessUpdate.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -119,7 +120,7 @@ public class TestStatelessUpdate extends BaseTestCase {
     Customer result = Ebean.find(Customer.class, customer.getId());
 
     // assert
-    assertEquals(customer.getUpdtime().getTime(), result.getUpdtime().getTime());
+    assertThat(result.getUpdtime()).isEqualToIgnoringMillis(customer.getUpdtime());
   }
 
   /**

--- a/src/test/java/org/tests/update/TestUpdatePartial.java
+++ b/src/test/java/org/tests/update/TestUpdatePartial.java
@@ -7,6 +7,7 @@ import io.ebean.SqlRow;
 import org.tests.model.basic.Customer;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class TestUpdatePartial extends BaseTestCase {
@@ -69,6 +70,6 @@ public class TestUpdatePartial extends BaseTestCase {
     Customer customerWithoutChanges = Ebean.find(Customer.class, customer.getId());
     Ebean.save(customerWithoutChanges);
 
-    assertEquals(customer.getUpdtime().getTime(), customerWithoutChanges.getUpdtime().getTime());
+    assertThat(customerWithoutChanges.getUpdtime()).isEqualToIgnoringMillis(customer.getUpdtime());
   }
 }


### PR DESCRIPTION
mySql driver in combination with mariadb server 10.0 does not support resolution of milliseconds