### PR TITLE
ENH: Ability to add preconfigured DatabasePlatform to DbMigration - adds method DbMigration.addDatabasePlatform(DatabasePlatform databasePlatform, String prefix)

### DIFF
--- a/src/main/java/io/ebean/dbmigration/DbMigration.java
+++ b/src/main/java/io/ebean/dbmigration/DbMigration.java
@@ -103,6 +103,14 @@ public interface DbMigration {
   void addPlatform(Platform platform, String prefix);
 
   /**
+   * Add an additional databasePlatform to write the migration DDL.
+   * <p>
+   * Use this when you want to add preconfigured database platforms.
+   * </p>
+   */
+  void addDatabasePlatform(DatabasePlatform databasePlatform, String prefix);
+
+  /**
    * Generate the next migration xml file and associated apply and rollback sql scripts.
    * <p>
    * This does not run the migration or ddl scripts but just generates them.

--- a/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
@@ -183,6 +183,11 @@ public class DefaultDbMigration implements DbMigration {
     platforms.add(new Pair(getPlatform(platform), prefix));
   }
 
+  @Override
+  public void addDatabasePlatform(DatabasePlatform databasePlatform, String prefix) {
+    platforms.add(new Pair(databasePlatform, prefix));
+  }
+
   /**
    * Generate the next migration xml file and associated apply and rollback sql scripts.
    * <p>

--- a/src/test/java/io/ebeaninternal/dbmigration/DbMigrationGenerateTest.java
+++ b/src/test/java/io/ebeaninternal/dbmigration/DbMigrationGenerateTest.java
@@ -4,6 +4,9 @@ import io.ebean.EbeanServer;
 import io.ebean.EbeanServerFactory;
 import io.ebean.annotation.Platform;
 import io.ebean.config.ServerConfig;
+import io.ebean.config.dbplatform.DatabasePlatform;
+import io.ebean.config.dbplatform.IdType;
+import io.ebean.config.dbplatform.sqlserver.SqlServerPlatform;
 
 import org.junit.*;
 import org.slf4j.Logger;
@@ -52,7 +55,11 @@ public class DbMigrationGenerateTest {
     migration.addPlatform(Platform.POSTGRES, "postgres");
     migration.addPlatform(Platform.ORACLE, "oracle");
     migration.addPlatform(Platform.SQLITE, "sqlite");
-    migration.addPlatform(Platform.SQLSERVER, "sqlserver");
+
+    // we need sequence here, so that migration will work properly
+    DatabasePlatform sqlServer = new SqlServerPlatform();
+    sqlServer.getDbIdentity().setIdType(IdType.SEQUENCE);
+    migration.addDatabasePlatform(sqlServer, "sqlserver");
 
     ServerConfig config = new ServerConfig();
     config.setName("migrationtest");


### PR DESCRIPTION
We (=I) need some mechanism, to add a preconfigured database to dbmigration, so that we can control different settings of each platform.
maybe we can configre this in ebean.properties in a later step. I'm thinking of something like this

ebean.migration.sqlserver.idType=SEQUENCE
ebean.migration.sqlserver.stepSize=100
ebean.migration.oracle.idType=IDENTIY