### PR TITLE
Test only change - FIX: introduced TransactionalTestCase, so that changes to DB are not persisted

### DIFF
--- a/src/test/java/io/ebean/TransactionalTestCase.java
+++ b/src/test/java/io/ebean/TransactionalTestCase.java
@@ -1,8 +1,3 @@
-/*
- * Licensed Materials - Property of FOCONIS AG
- * (C) Copyright FOCONIS AG.
- */
-
 package io.ebean;
 
 import org.junit.After;

--- a/src/test/java/io/ebean/TransactionalTestCase.java
+++ b/src/test/java/io/ebean/TransactionalTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed Materials - Property of FOCONIS AG
+ * (C) Copyright FOCONIS AG.
+ */
+
+package io.ebean;
+
+import org.junit.After;
+import org.junit.Before;
+import org.tests.model.basic.ResetBasicData;
+
+/**
+ * Transactional test case. Every test is coverered by a transaction, which is roll backed.
+ * So no changes will persist to database.
+ *
+ * Use this test case if you modify data in your test case, so that the test does not interfere
+ * other tests.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public abstract class TransactionalTestCase extends BaseTestCase {
+
+  @Before
+  public void startTransaction() {
+    ResetBasicData.reset();
+    Ebean.beginTransaction();
+  }
+
+  @After
+  public void endTransaction() {
+    Ebean.rollbackTransaction();
+    Ebean.endTransaction();
+  }
+}

--- a/src/test/java/org/tests/basic/TestDeleteByIdCollection.java
+++ b/src/test/java/org/tests/basic/TestDeleteByIdCollection.java
@@ -1,7 +1,8 @@
 package org.tests.basic;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
 import org.tests.model.basic.ResetBasicData;
@@ -11,7 +12,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TestDeleteByIdCollection extends BaseTestCase {
+public class TestDeleteByIdCollection extends TransactionalTestCase {
 
   @Test
   public void test() {

--- a/src/test/java/org/tests/basic/TestOrderByAnnotation.java
+++ b/src/test/java/org/tests/basic/TestOrderByAnnotation.java
@@ -1,8 +1,9 @@
 package org.tests.basic;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.Query;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
 import org.tests.model.basic.ResetBasicData;
@@ -11,12 +12,11 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class TestOrderByAnnotation extends BaseTestCase {
+public class TestOrderByAnnotation extends TransactionalTestCase {
 
   @Test
   public void testOrderBy() {
 
-    ResetBasicData.reset();
     Customer custTest = ResetBasicData.createCustAndOrder("testOrderByAnn");
 
     Customer customer = Ebean.find(Customer.class, custTest.getId());

--- a/src/test/java/org/tests/basic/TestPersistenceContext.java
+++ b/src/test/java/org/tests/basic/TestPersistenceContext.java
@@ -52,14 +52,13 @@ public class TestPersistenceContext extends BaseTestCase {
     Assert.assertTrue(oAfter != oBefore);
     Assert.assertTrue(oAfter != order);
 
-
-    Order testOrder = ResetBasicData.createOrderCustAndOrder("testPC");
-    Integer id = testOrder.getCustomer().getId();
-    Integer orderId = testOrder.getId();
-
     // start a persistence context
     Ebean.beginTransaction();
     try {
+      Order testOrder = ResetBasicData.createOrderCustAndOrder("testPC");
+      Integer id = testOrder.getCustomer().getId();
+      Integer orderId = testOrder.getId();
+
       Customer customer = Ebean.find(Customer.class)
         .setUseCache(false)
         .setId(id)

--- a/src/test/java/org/tests/basic/TestWhereAnnotation.java
+++ b/src/test/java/org/tests/basic/TestWhereAnnotation.java
@@ -1,8 +1,9 @@
 package org.tests.basic;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.Query;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
 import org.tests.model.basic.ResetBasicData;
@@ -11,12 +12,11 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class TestWhereAnnotation extends BaseTestCase {
+public class TestWhereAnnotation extends TransactionalTestCase {
 
   @Test
   public void testWhere() {
 
-    ResetBasicData.reset();
     Customer custTest = ResetBasicData.createCustAndOrder("testWhereAnn");
 
     Customer customer = Ebean.find(Customer.class, custTest.getId());

--- a/src/test/java/org/tests/basic/delete/TestDeleteByIdList.java
+++ b/src/test/java/org/tests/basic/delete/TestDeleteByIdList.java
@@ -33,6 +33,8 @@ public class TestDeleteByIdList extends BaseTestCase {
     Assert.assertEquals(2, orderIds.size());
 
     Ebean.deleteAll(Order.class, orderIds);
+    Ebean.delete(c0);
+    Ebean.delete(c1);
 
   }
 }

--- a/src/test/java/org/tests/basic/delete/TestDeleteCascadeById.java
+++ b/src/test/java/org/tests/basic/delete/TestDeleteCascadeById.java
@@ -32,7 +32,9 @@ public class TestDeleteCascadeById extends BaseTestCase {
     Order o = orders.get(0);
     Assert.assertNotNull(o);
 
+    // cleanup
     Ebean.delete(o);
+    Ebean.delete(cust);
 
   }
 }

--- a/src/test/java/org/tests/basic/join/TestSecondaryJoin.java
+++ b/src/test/java/org/tests/basic/join/TestSecondaryJoin.java
@@ -1,7 +1,8 @@
 package org.tests.basic.join;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Order;
 import org.tests.model.basic.Order.Status;
 import org.tests.model.basic.ResetBasicData;
@@ -9,7 +10,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-public class TestSecondaryJoin extends BaseTestCase {
+public class TestSecondaryJoin extends TransactionalTestCase {
 
   @Test
   public void test() {

--- a/src/test/java/org/tests/basic/one2one/TestOne2OneBookingInvoice.java
+++ b/src/test/java/org/tests/basic/one2one/TestOne2OneBookingInvoice.java
@@ -2,6 +2,7 @@ package org.tests.basic.one2one;
 
 import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,6 +42,14 @@ public class TestOne2OneBookingInvoice extends BaseTestCase {
     Assert.assertNotNull(b3);
     Assert.assertEquals(b1.getId(), b2.getId());
     Assert.assertSame(b1, b2);
+
+    // cleanup
+    ai.setBooking(null);
+    ci.setBooking(null);
+    Ebean.save(ai);
+    Ebean.save(ci);
+    Ebean.delete(b);
+
 
   }
 }

--- a/src/test/java/org/tests/basic/type/TestInetAddressType.java
+++ b/src/test/java/org/tests/basic/type/TestInetAddressType.java
@@ -1,7 +1,8 @@
 package org.tests.basic.type;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.EWithInetAddr;
 import org.junit.Assert;
 import org.junit.Test;
@@ -9,7 +10,7 @@ import org.junit.Test;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-public class TestInetAddressType extends BaseTestCase {
+public class TestInetAddressType extends TransactionalTestCase {
 
   @Test
   public void testIp4() throws UnknownHostException {

--- a/src/test/java/org/tests/batchload/TestLazyLoadEmptyCollection.java
+++ b/src/test/java/org/tests/batchload/TestLazyLoadEmptyCollection.java
@@ -1,21 +1,19 @@
 package org.tests.batchload;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.FetchConfig;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
-import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
 import java.util.List;
 
-public class TestLazyLoadEmptyCollection extends BaseTestCase {
+public class TestLazyLoadEmptyCollection extends TransactionalTestCase {
 
   @Test
   public void test() {
-
-    ResetBasicData.reset();
 
     Customer c = new Customer();
     c.setName("lazytest");

--- a/src/test/java/org/tests/batchload/TestSecondaryQueries.java
+++ b/src/test/java/org/tests/batchload/TestSecondaryQueries.java
@@ -1,9 +1,10 @@
 package org.tests.batchload;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.FetchConfig;
 import io.ebean.Query;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
 import org.tests.model.basic.ResetBasicData;
@@ -18,12 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class TestSecondaryQueries extends BaseTestCase {
+public class TestSecondaryQueries extends TransactionalTestCase {
 
   @Test
   public void fetchQuery() {
-
-    ResetBasicData.reset();
 
     LoggedSqlCollector.start();
 
@@ -42,8 +41,6 @@ public class TestSecondaryQueries extends BaseTestCase {
 
   @Test
   public void fetchLazy() {
-
-    ResetBasicData.reset();
 
     LoggedSqlCollector.start();
 
@@ -79,8 +76,6 @@ public class TestSecondaryQueries extends BaseTestCase {
   @Test
   public void fetchIterate() {
 
-    ResetBasicData.reset();
-
     LoggedSqlCollector.start();
 
     Iterator<Order> orders = Ebean.find(Order.class)
@@ -103,8 +98,6 @@ public class TestSecondaryQueries extends BaseTestCase {
   }
   @Test
   public void testSecQueryOneToMany() {
-
-    ResetBasicData.reset();
 
     Order testOrder = ResetBasicData.createOrderCustAndOrder("testSecQry10");
     Integer custId = testOrder.getCustomer().getId();
@@ -132,8 +125,6 @@ public class TestSecondaryQueries extends BaseTestCase {
 
   @Test
   public void testManyToOneWithManyPlusOneToMany() {
-
-    ResetBasicData.reset();
 
     Query<Order> query = Ebean.find(Order.class)
       .select("status")

--- a/src/test/java/org/tests/cascade/TestPrivateOwnedCascadeOrder.java
+++ b/src/test/java/org/tests/cascade/TestPrivateOwnedCascadeOrder.java
@@ -42,7 +42,7 @@ public class TestPrivateOwnedCascadeOrder extends BaseTestCase {
     // act
     TSMaster master1 = Ebean.find(master.getClass(), master.getId());
 
-    // Check Ebean deletes the existing c97 first as the unique values clash
+    // Check Ebean deletes the existing d96 first as the unique values clash
     Transaction transaction = Ebean.beginTransaction();
     try {
       master1.getDetails().clear();
@@ -53,5 +53,9 @@ public class TestPrivateOwnedCascadeOrder extends BaseTestCase {
     } finally {
       transaction.end();
     }
+
+    // Cleanup
+    Ebean.find(TSDetail.class).where().or().eq("name", "d97").eq("name", "d98").delete();
+    Ebean.delete(master1);
   }
 }

--- a/src/test/java/org/tests/query/other/TestFindWhereUsingEnumerated.java
+++ b/src/test/java/org/tests/query/other/TestFindWhereUsingEnumerated.java
@@ -2,13 +2,15 @@ package org.tests.query.other;
 
 import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.MNonEnum;
 import org.tests.model.basic.MNonUpdPropEntity;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestFindWhereUsingEnumerated extends BaseTestCase {
+public class TestFindWhereUsingEnumerated extends TransactionalTestCase {
 
   @Test
   public void test() {

--- a/src/test/java/org/tests/query/other/TestLikeEscaping.java
+++ b/src/test/java/org/tests/query/other/TestLikeEscaping.java
@@ -1,33 +1,33 @@
 package org.tests.query.other;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestLikeEscaping extends BaseTestCase {
+public class TestLikeEscaping extends TransactionalTestCase {
 
 
   @Test
   public void testLikeEscaping() {
-    ResetBasicData.reset();
     // Mysql, PgSql, H2 special chars: "_"  "%"
-    // MsSql special chars:  "_"  "%"  "[" AND different Quoting! 
+    // MsSql special chars:  "_"  "%"  "[" AND different Quoting!
     Ebean.save(ResetBasicData.createCustomer("Paul % Percentage", "*Star", "[none]", 0, null));
     Ebean.save(ResetBasicData.createCustomer("(none)", "More * Star", "[none]", 0, null));
-    
+
     Ebean.save(ResetBasicData.createCustomer("Paul %% Doublepercentage", "|Pipeway", "[other]", 1, null));
     Ebean.save(ResetBasicData.createCustomer("_Udo Underscore", "|Pipeway", "[other]", 1, null));
-    
+
     Ebean.save(ResetBasicData.createCustomer("Bodo \\ backslash", "\\BS", "[other]", 1, null));
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().contains("name", "Paul %%").findCount()
     ).isEqualTo(1);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().contains("name", "o \\ b").findCount()
     ).isEqualTo(1);
@@ -35,7 +35,7 @@ public class TestLikeEscaping extends BaseTestCase {
     assertThat(Ebean.find(Customer.class)
         .where().contains("name", "o \\\\ b").findCount()
     ).isEqualTo(0);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().startsWith("name", "_").findCount()
     ).isEqualTo(1);
@@ -43,7 +43,7 @@ public class TestLikeEscaping extends BaseTestCase {
     assertThat(Ebean.find(Customer.class)
         .where().startsWith("name", "_u").findCount()
     ).isEqualTo(0);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().istartsWith("name", "_U").findCount()
     ).isEqualTo(1);
@@ -51,40 +51,40 @@ public class TestLikeEscaping extends BaseTestCase {
     assertThat(Ebean.find(Customer.class)
         .where().startsWith("shippingAddress.line1", "|p").findCount()
     ).isEqualTo(0);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().startsWith("shippingAddress.line1", "|P").findCount()
     ).isEqualTo(2);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().startsWith("shippingAddress.line1", "\\B").findCount()
     ).isEqualTo(1);
-   
+
     assertThat(Ebean.find(Customer.class)
         .where().endsWith("billingAddress.line1", "]").findCount()
     ).isEqualTo(5);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().endsWith("billingAddress.line1", "[none]").findCount()
     ).isEqualTo(2);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().startsWith("billingAddress.line1", "[none]").findCount()
     ).isEqualTo(2);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().contains("billingAddress.line1", "[none]").findCount()
     ).isEqualTo(2);
-    
-    
+
+
     assertThat(Ebean.find(Customer.class)
         .where().contains("shippingAddress.line1", "*").findCount()
     ).isEqualTo(2);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().startsWith("shippingAddress.line1", "*").findCount()
     ).isEqualTo(1);
-    
+
     assertThat(Ebean.find(Customer.class)
         .where().endsWith("shippingAddress.line1", "*").findCount()
     ).isEqualTo(0);

--- a/src/test/java/org/tests/query/softdelete/TestSoftDeletePagingList.java
+++ b/src/test/java/org/tests/query/softdelete/TestSoftDeletePagingList.java
@@ -1,8 +1,9 @@
 package org.tests.query.softdelete;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.PagedList;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.onetoone.album.Cover;
 import org.ebeantest.LoggedSqlCollector;
 import org.junit.Test;
@@ -12,7 +13,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestSoftDeletePagingList extends BaseTestCase {
+public class TestSoftDeletePagingList extends TransactionalTestCase {
 
   @Test
   public void test() {

--- a/src/test/java/org/tests/refresh/TestRefreshWithMany.java
+++ b/src/test/java/org/tests/refresh/TestRefreshWithMany.java
@@ -1,8 +1,9 @@
 package org.tests.refresh;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.SqlRow;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
@@ -12,12 +13,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class TestRefreshWithMany extends BaseTestCase {
+public class TestRefreshWithMany extends TransactionalTestCase {
 
   @Test
   public void test() {
 
-    ResetBasicData.reset();
 
     Customer customer = ResetBasicData.createCustomer("refresher", "22 refresh set", "23 fresh", 9);
 

--- a/src/test/java/org/tests/text/json/TestTextJsonUpdateCascade.java
+++ b/src/test/java/org/tests/text/json/TestTextJsonUpdateCascade.java
@@ -1,8 +1,8 @@
 package org.tests.text.json;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
+import io.ebean.TransactionalTestCase;
 import io.ebean.text.json.JsonContext;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.MRole;
@@ -18,12 +18,10 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 
-public class TestTextJsonUpdateCascade extends BaseTestCase {
+public class TestTextJsonUpdateCascade extends TransactionalTestCase {
 
   @Test
   public void test() throws IOException {
-
-    ResetBasicData.reset();
 
     Customer c0 = ResetBasicData.createCustAndOrder("Test Json");
 

--- a/src/test/java/org/tests/transaction/TestPersistContextClear.java
+++ b/src/test/java/org/tests/transaction/TestPersistContextClear.java
@@ -21,11 +21,11 @@ public class TestPersistContextClear extends BaseTestCase {
 
     ResetBasicData.reset();
 
-    ResetBasicData.createOrderCustAndOrder("testPc");
     Order order0 = null;
 
     Transaction t = Ebean.beginTransaction();
     try {
+      ResetBasicData.createOrderCustAndOrder("testPc");
       SpiTransaction spiTxn = (SpiTransaction) t;
       PersistenceContext pc = spiTxn.getPersistenceContext();
 

--- a/src/test/java/org/tests/transaction/TestTransactionTryResources.java
+++ b/src/test/java/org/tests/transaction/TestTransactionTryResources.java
@@ -34,15 +34,18 @@ public class TestTransactionTryResources extends BaseTestCase {
 
     Document document = Document.find.asDraft(doc.getId());
     assertThat(document).isNotNull();
+
+    // cleanup
+    Ebean.delete(document);
   }
 
   @Test
   @IgnorePlatform(Platform.ORACLE) // does not support uncommited reads
   public void tryWithResources_catch() {
-
+    Document doc = null;
     try (Transaction transaction = Ebean.beginTransaction()) {
 
-      Document doc = new Document();
+      doc = new Document();
       doc.setTitle("tryWithResources_catch");
       doc.setBody("tryWithResources_catch_1");
       doc.save();
@@ -69,6 +72,10 @@ public class TestTransactionTryResources extends BaseTestCase {
         .findList();
 
       assertThat(docs).hasSize(1);
+      assertThat(doc).isNotNull();
+      // Cleanup
+      Ebean.delete(Document.class, doc.getId());
+      Ebean.delete(Document.class, doc3.getId());
     }
   }
 }

--- a/src/test/java/org/tests/update/TestStatelessUpdate.java
+++ b/src/test/java/org/tests/update/TestStatelessUpdate.java
@@ -1,8 +1,9 @@
 package org.tests.update;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
+import io.ebean.TransactionalTestCase;
+
 import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.EBasic;
@@ -20,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-public class TestStatelessUpdate extends BaseTestCase {
+public class TestStatelessUpdate extends TransactionalTestCase {
 
   private EbeanServer server = server();
 


### PR DESCRIPTION
This PR will improve the test cases, as they sometimes interfere each other. (Especially Eclipse executes test cases in a different order, so they will fail, but not in maven)

So I tried to cover them in a transaction where it is possible or tried to restore the original state afterwards.