### PR TITLE
ENH: extra-ddl can contribute to "drop-all" script, otherwise the drop all script is not appyable to h2:file

### DIFF
--- a/src/main/java/io/ebeaninternal/dbmigration/DdlGenerator.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/DdlGenerator.java
@@ -127,6 +127,14 @@ public class DdlGenerator {
 
   protected void runDropSql() throws IOException {
     if (!createOnly) {
+      String ignoreExtraDdl = System.getProperty("ebean.ignoreExtraDdl");
+      if (!"true".equalsIgnoreCase(ignoreExtraDdl) && jaxbPresent) {
+        String extraApply = ExtraDdlXmlReader.buildExtra(server.getDatabasePlatform().getName(), true);
+        if (extraApply != null) {
+          runScript(false, extraApply, "extra-dll");
+        }
+      }
+
       if (dropAllContent == null) {
         dropAllContent = readFile(getDropFileName());
       }
@@ -142,7 +150,7 @@ public class DdlGenerator {
 
     String ignoreExtraDdl = System.getProperty("ebean.ignoreExtraDdl");
     if (!"true".equalsIgnoreCase(ignoreExtraDdl) && jaxbPresent) {
-      String extraApply = ExtraDdlXmlReader.buildExtra(server.getDatabasePlatform().getName());
+      String extraApply = ExtraDdlXmlReader.buildExtra(server.getDatabasePlatform().getName(), false);
       if (extraApply != null) {
         runScript(false, extraApply, "extra-dll");
       }

--- a/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
@@ -268,7 +268,8 @@ public class DefaultDbMigration implements DbMigration {
       if (extraDdl != null) {
         List<DdlScript> ddlScript = extraDdl.getDdlScript();
         for (DdlScript script : ddlScript) {
-          if (ExtraDdlXmlReader.matchPlatform(dbPlatform.getName(), script.getPlatforms())) {
+          if (script.isDrop() == false
+              && ExtraDdlXmlReader.matchPlatform(dbPlatform.getName(), script.getPlatforms())) {
             writeExtraDdl(migrationDir, script);
           }
         }

--- a/src/main/java/io/ebeaninternal/extraddl/model/DdlScript.java
+++ b/src/main/java/io/ebeaninternal/extraddl/model/DdlScript.java
@@ -37,6 +37,8 @@ public class DdlScript {
   protected String name;
   @XmlAttribute(name = "platforms")
   protected String platforms;
+  @XmlAttribute(name = "drop")
+  protected boolean drop;
 
   /**
    * Gets the value of the value property.
@@ -96,6 +98,20 @@ public class DdlScript {
    */
   public void setPlatforms(String value) {
     this.platforms = value;
+  }
+
+  /**
+   * Return if this a drop script.
+   */
+  public boolean isDrop() {
+    return drop;
+  }
+
+  /**
+   * Sets that this is a drop script.
+   */
+  public void setDrop(boolean drop) {
+    this.drop = drop;
   }
 
 }

--- a/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
+++ b/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
@@ -20,7 +20,7 @@ public class ExtraDdlXmlReader {
   /**
    * Return the combined extra DDL that should be run given the platform name.
    */
-  public static String buildExtra(String platformName) {
+  public static String buildExtra(String platformName, boolean drops) {
 
     ExtraDdl read = ExtraDdlXmlReader.read("/extra-ddl.xml");
     if (read == null) {
@@ -28,7 +28,8 @@ public class ExtraDdlXmlReader {
     }
     StringBuilder sb = new StringBuilder(300);
     for (DdlScript script : read.getDdlScript()) {
-      if (matchPlatform(platformName, script.getPlatforms())) {
+      if (script.isDrop() == drops
+          && matchPlatform(platformName, script.getPlatforms())) {
         logger.debug("include script {}", script.getName());
         String value = script.getValue();
         sb.append(value);

--- a/src/test/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReaderTest.java
+++ b/src/test/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReaderTest.java
@@ -17,7 +17,7 @@ public class ExtraDdlXmlReaderTest {
   @Test
   public void buildExtra_when_h2() {
 
-    String ddl = ExtraDdlXmlReader.buildExtra("h2");
+    String ddl = ExtraDdlXmlReader.buildExtra("h2", false);
 
     assertThat(ddl).contains("create or replace view order_agg_vw");
     assertThat(ddl).contains("-- h2 and postgres script");
@@ -27,7 +27,7 @@ public class ExtraDdlXmlReaderTest {
   @Test
   public void buildExtra_when_oracle() {
 
-    String ddl = ExtraDdlXmlReader.buildExtra("oracle");
+    String ddl = ExtraDdlXmlReader.buildExtra("oracle", false);
 
     assertThat(ddl).contains("create or replace view order_agg_vw");
     assertThat(ddl).doesNotContain("-- h2 and postgres script");
@@ -37,7 +37,7 @@ public class ExtraDdlXmlReaderTest {
   @Test
   public void buildExtra_when_mysql() {
 
-    String ddl = ExtraDdlXmlReader.buildExtra("mysql");
+    String ddl = ExtraDdlXmlReader.buildExtra("mysql", false);
 
     assertThat(ddl).contains("create or replace view order_agg_vw");
     assertThat(ddl).doesNotContain("-- h2 and postgres script");

--- a/src/test/resources/extra-ddl.xml
+++ b/src/test/resources/extra-ddl.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <extra-ddl xmlns="http://ebean-orm.github.io/xml/ns/extraddl">
 
+  <ddl-script name="order views" platforms="h2" drop="true">
+      drop view order_agg_vw if exists;
+  </ddl-script>
   <ddl-script name="order views" platforms="generic,db2,h2,postgres,oracle,mysql">
 
     create or replace view order_agg_vw as


### PR DESCRIPTION
I discovered this problem, when I tried to run the test case against a h2:file database, that the second run could not successfully run the drop-all script.

It's a small enhancement (and not really needed, because I do not use the drop-all script)
