### PR TITLE
FIX: do not set username and password for DbMigrationConfig

### DIFF
--- a/src/main/java/io/ebean/config/DbMigrationConfig.java
+++ b/src/main/java/io/ebean/config/DbMigrationConfig.java
@@ -465,12 +465,14 @@ public class DbMigrationConfig {
     metaTable = properties.get("migration.metaTable", metaTable);
     runPlaceholders = properties.get("migration.placeholders", runPlaceholders);
 
-    String adminUser = properties.get("datasource." + serverName + ".username", dbUsername);
-    adminUser = properties.get("datasource." + serverName + ".adminusername", adminUser);
+    //Do not set user and pass from "datasource.db.username"
+    //There is a null test in MigrationRunner::getConnection to handle this
+    //String adminUser = properties.get("datasource." + serverName + ".username", dbUsername);
+    String adminUser = properties.get("datasource." + serverName + ".adminusername", dbUsername);
     dbUsername = properties.get("migration.dbusername", adminUser);
 
-    String adminPwd = properties.get("datasource." + serverName + ".password", dbPassword);
-    adminPwd = properties.get("datasource." + serverName + ".adminpassword", adminPwd);
+    //String adminPwd = properties.get("datasource." + serverName + ".password", dbPassword);
+    String adminPwd = properties.get("datasource." + serverName + ".adminpassword", dbPassword);
     dbPassword = properties.get("migration.dbpassword", adminPwd);
     ddlHeader = properties.get("ddl.header", ddlHeader);
     if (ddlHeader != null && !ddlHeader.isEmpty()) {

--- a/src/test/java/io/ebean/config/DbMigrationConfigTest.java
+++ b/src/test/java/io/ebean/config/DbMigrationConfigTest.java
@@ -55,8 +55,9 @@ public class DbMigrationConfigTest {
     DbMigrationConfig migrationConfig = new DbMigrationConfig();
     migrationConfig.loadSettings(wrapper, "db");
 
-    assertEquals(migrationConfig.getDbUsername(),"banana");
-    assertEquals(migrationConfig.getDbPassword(),"apple");
+    // runnerConfig will fall back itsel to the correct password
+    assertEquals(migrationConfig.getDbUsername(),null);
+    assertEquals(migrationConfig.getDbPassword(),null);
   }
 
   @Test


### PR DESCRIPTION
The password should not be set to the same as the datasouce, because this prevents to use the MigrationRunner in conjunction with a multiTenantDatasource

If User and PW is null, the runner fall back to the passed dataSource
https://github.com/ebean-orm/ebean-migration/blob/2f60b57651658d02fb33806d86a78ebbe21954c5/src/main/java/io/ebean/migration/MigrationRunner.java#L75