### PR TITLE
NEW: server.autostart can be disabled, so no migration is run

### DIFF
--- a/src/main/java/io/ebean/EbeanServer.java
+++ b/src/main/java/io/ebean/EbeanServer.java
@@ -1850,4 +1850,10 @@ public interface EbeanServer {
    * </p>
    */
   <T> Set<String> validateQuery(Query<T> query);
+
+  /**
+   * Execute the DDL generator manually (this makes only sense if {@link ServerConfig#isAutostart() is false)
+   * @param online
+   */
+  void executeDdlGenerator(boolean online);
 }

--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -368,6 +368,11 @@ public class ServerConfig {
   private boolean updatesDeleteMissingChildren = true;
 
   /**
+   * Should the server start all
+   */
+  private boolean autostart = true;
+
+  /**
    * Database type configuration.
    */
   private DbTypeConfig dbTypeConfig = new DbTypeConfig();
@@ -2230,6 +2235,14 @@ public class ServerConfig {
     this.updatesDeleteMissingChildren = updatesDeleteMissingChildren;
   }
 
+  public boolean isAutostart() {
+    return autostart;
+  }
+
+  public void setAutostart(boolean autostart) {
+    this.autostart = autostart;
+  }
+
   /**
    * Return true if the ebeanServer should collection query statistics by ObjectGraphNode.
    */
@@ -2768,6 +2781,8 @@ public class ServerConfig {
 
     boolean defaultDeleteMissingChildren = p.getBoolean("defaultDeleteMissingChildren", updatesDeleteMissingChildren);
     updatesDeleteMissingChildren = p.getBoolean("updatesDeleteMissingChildren", defaultDeleteMissingChildren);
+
+    autostart = p.getBoolean("autostart", autostart);
 
     if (p.get("batch.mode") != null || p.get("persistBatching") != null) {
       throw new IllegalArgumentException("Property 'batch.mode' or 'persistBatching' is being set but no longer used. Please change to use 'persistBatchMode'");

--- a/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -143,6 +143,9 @@ public class DefaultContainer implements SpiContainer {
       // generate and run DDL if required
       // if there are any other tasks requiring action in their plugins, do them as well
       if (!DbOffline.isGenerateMigration()) {
+        if (serverConfig.isAutostart()) {
+        	server.executeDdlGenerator(online);
+        }
         server.executePlugins(online);
 
         // initialise prior to registering with clusterManager
@@ -154,7 +157,9 @@ public class DefaultContainer implements SpiContainer {
           }
         }
         // start any services after registering with clusterManager
-        server.start();
+        if (serverConfig.isAutostart()) {
+          server.start();
+        }
       }
       DbOffline.reset();
       return server;

--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -286,14 +286,17 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     }
   }
 
+  @Override
+  public void executeDdlGenerator(boolean online) {
+    if (!serverConfig.isDocStoreOnly()) {
+      ddlGenerator.execute(online);
+    }
+  }
   /**
    * Execute all the plugins with an online flag indicating the DB is up or not.
    */
   public void executePlugins(boolean online) {
 
-    if (!serverConfig.isDocStoreOnly()) {
-      ddlGenerator.execute(online);
-    }
     for (Plugin plugin : serverPlugins) {
       plugin.online(online);
     }

--- a/src/test/java/io/ebeaninternal/api/TDSpiEbeanServer.java
+++ b/src/test/java/io/ebeaninternal/api/TDSpiEbeanServer.java
@@ -843,4 +843,9 @@ public class TDSpiEbeanServer implements SpiEbeanServer {
   public void slowQueryCheck(long executionTimeMicros, int rowCount, SpiQuery<?> query) {
 
   }
+
+  @Override
+  public void executeDdlGenerator(boolean online) {
+
+  }
 }


### PR DESCRIPTION
This is mainly to control executeDdl (so it would be OK if we rename this)