### PR TITLE
NEW: flag to control, if javax.validation NotNull annotation should generate a NotNull column or not

### DIFF
--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -470,6 +470,14 @@ public class ServerConfig {
    */
   private boolean disableL2Cache;
 
+
+  /**
+   * Should the javax.validation.constraints.NotNull enforce a notNull column in DB.
+   * If set to false, you have to use io.ebean.annotation.NotNull to explicityl create
+   * a not null column.
+   */
+  private boolean useJavaxValidationNotNull = true;
+
   /**
    * Generally we want to perform L2 cache notification in the background and not impact
    * the performance of executing transactions.
@@ -2740,6 +2748,7 @@ public class ServerConfig {
     explicitTransactionBeginMode = p.getBoolean("explicitTransactionBeginMode", explicitTransactionBeginMode);
     autoCommitMode = p.getBoolean("autoCommitMode", autoCommitMode);
     useJtaTransactionManager = p.getBoolean("useJtaTransactionManager", useJtaTransactionManager);
+    useJavaxValidationNotNull = p.getBoolean("useJavaxValidationNotNull", useJavaxValidationNotNull);
     autoReadOnlyDataSource = p.getBoolean("autoReadOnlyDataSource", autoReadOnlyDataSource);
 
     backgroundExecutorSchedulePoolSize = p.getInt("backgroundExecutorSchedulePoolSize", backgroundExecutorSchedulePoolSize);
@@ -2957,6 +2966,27 @@ public class ServerConfig {
    */
   public void setDisableL2Cache(boolean disableL2Cache) {
     this.disableL2Cache = disableL2Cache;
+  }
+
+  /**
+   * Returns if we use javax.validation.constraints.NotNull
+   */
+  public boolean isUseJavaxValidationNotNull() {
+    return useJavaxValidationNotNull;
+  }
+
+  /**
+   * Controlws when Ebean should generate a <code>NOT NULL</code> column.
+   * If an <code>io.ebean.annotation.NotNull</code> is present, Ebean generates
+   * <code>NOT NULL</code> columns
+   * If set to <code>true</code> (default) Ebean generates also
+   * <code>NOT NULL</code> columns when a <code>&x64;javax.validation.contstraints.NotNull</code>
+   * annotation is present (and it is in <code>Default</code> group.)
+   * If set to <code>false</code> the <code>&x64;javax.validation.contstraints.NotNull</code> is
+   * ignored
+   */
+  public void setUseJavaxValidationNotNull(boolean useJavaxValidationNotNull) {
+    this.useJavaxValidationNotNull = useJavaxValidationNotNull;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationParser.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationParser.java
@@ -97,6 +97,9 @@ public abstract class AnnotationParser extends AnnotationBase {
    * can be applied to DDL generation.
    */
   protected boolean isEbeanValidationGroups(Class<?>[] groups) {
+    if (!util.isUseJavaxValidationNotNull()) {
+      return false;
+    }
     if (groups.length == 0
       || groups.length == 1 && javax.validation.groups.Default.class.isAssignableFrom(groups[0])) {
       return true;

--- a/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
@@ -60,6 +60,8 @@ public class DeployUtil {
 
   private final Encryptor bytesEncryptor;
 
+  private final boolean useJavaxValidationNotNull;
+
   public DeployUtil(TypeManager typeMgr, ServerConfig serverConfig) {
 
     this.typeManager = typeMgr;
@@ -70,6 +72,7 @@ public class DeployUtil {
 
     Encryptor be = serverConfig.getEncryptor();
     this.bytesEncryptor = be != null ? be : new SimpleAesEncryptor();
+    this.useJavaxValidationNotNull = serverConfig.isUseJavaxValidationNotNull();
   }
 
   public TypeManager getTypeManager() {
@@ -294,4 +297,7 @@ public class DeployUtil {
     return type.equals(String.class);
   }
 
+  public boolean isUseJavaxValidationNotNull() {
+    return useJavaxValidationNotNull;
+  }
 }


### PR DESCRIPTION
This controls the behaviour of the javax.validation.constraints.NotNull annotation, which we use for bean validation but do not want to use for DDL not null generation.

We have the concrete problem, when we alter a table and add additional columns, that the operation will fail, when the column is `not null` in DDL 