### PR TITLE
NEW: Json supports migration and enforcing to write reference beans only

### DIFF
--- a/src/main/java/io/ebean/text/json/JsonReadOptions.java
+++ b/src/main/java/io/ebean/text/json/JsonReadOptions.java
@@ -25,6 +25,8 @@ public class JsonReadOptions {
 
   protected Object loadContext;
 
+  private JsonVersionMigrationHandler versionMigrationHandler;
+
   /**
    * Default constructor.
    */
@@ -116,4 +118,17 @@ public class JsonReadOptions {
     this.loadContext = loadContext;
   }
 
+  /**
+   * Set the version migration handler.
+   */
+  public void setVersionMigrationHandler(JsonVersionMigrationHandler versionMigrationHandler) {
+    this.versionMigrationHandler = versionMigrationHandler;
+  }
+
+  /**
+   * returns the version migration handler.
+   */
+  public JsonVersionMigrationHandler getVersionMigrationHandler() {
+    return versionMigrationHandler;
+  }
 }

--- a/src/main/java/io/ebean/text/json/JsonVersionMigrationHandler.java
+++ b/src/main/java/io/ebean/text/json/JsonVersionMigrationHandler.java
@@ -1,0 +1,18 @@
+package io.ebean.text.json;
+
+import java.io.IOException;
+
+import io.ebean.plugin.BeanType;
+import io.ebeaninternal.server.text.json.ReadJson; // FIXME: should not import ebeaninternal here
+
+/**
+ * This handler can perform JSON migration. (Similar to migration scripts)
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+@FunctionalInterface
+public interface JsonVersionMigrationHandler {
+
+  ReadJson migrate(ReadJson readJson, BeanType<?> beanType) throws IOException;
+
+}

--- a/src/main/java/io/ebean/text/json/JsonVersionWriter.java
+++ b/src/main/java/io/ebean/text/json/JsonVersionWriter.java
@@ -1,0 +1,17 @@
+package io.ebean.text.json;
+
+import io.ebean.plugin.BeanType;
+/**
+ * Can be applied to JsonWriteOptions to write a json data version in front of the bean.
+ *
+ * Use it in conjunction with {@link JsonVersionMigrationHandler} to convert older json versions back to your beans.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+@FunctionalInterface
+public interface JsonVersionWriter {
+
+  void writeVersion(JsonWriter writer, BeanType<?> beanType);
+
+}

--- a/src/main/java/io/ebean/text/json/JsonWriteOptions.java
+++ b/src/main/java/io/ebean/text/json/JsonWriteOptions.java
@@ -24,6 +24,10 @@ public class JsonWriteOptions {
 
   protected Map<String, JsonWriteBeanVisitor<?>> visitorMap;
 
+  private boolean forceReference;
+
+  private JsonVersionWriter versionWriter;
+
   /**
    * Parse and return a PathProperties from nested string format like
    * (a,b,c(d,e),f(g)) where "c" is a path containing "d" and "e" and "f" is a
@@ -114,5 +118,33 @@ public class JsonWriteOptions {
    */
   public void setObjectMapper(Object objectMapper) {
     this.objectMapper = objectMapper;
+  }
+
+  /**
+   * Should child beans be written as reference only.
+   */
+  public boolean isForceReference() {
+    return forceReference;
+  }
+
+  /**
+   * Controls, if child beans are written as reference only.
+   */
+  public void setForceReference(boolean forceReference) {
+    this.forceReference = forceReference;
+  }
+
+  /**
+   * Returns the {@link JsonVersionWriter}
+   */
+  public JsonVersionWriter getVersionWriter() {
+    return versionWriter;
+  }
+
+  /**
+   * Sets the {@link JsonVersionWriter}.
+   */
+  public void setVersionWrite(JsonVersionWriter versionWriter) {
+    this.versionWriter = versionWriter;
   }
 }

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorJsonHelp.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorJsonHelp.java
@@ -26,6 +26,7 @@ public class BeanDescriptorJsonHelp<T> {
   public void jsonWrite(SpiJsonWriter writeJson, EntityBean bean, String key) throws IOException {
 
     writeJson.writeStartObject(key);
+    writeJson.writeBeanVersion(desc);
 
     if (inheritInfo == null) {
       jsonWriteProperties(writeJson, bean);
@@ -86,6 +87,9 @@ public class BeanDescriptorJsonHelp<T> {
         throw new JsonParseException(parser, "Unexpected token " + token + " - expecting start_object", parser.getCurrentLocation());
       }
     }
+    // migrate and fetch potential new parser
+    jsonRead = jsonRead.migrate(desc);
+    parser = jsonRead.getParser();
 
     if (desc.inheritInfo == null) {
       return jsonReadObject(jsonRead, path);

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -723,6 +723,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> {
     BeanProperty idProperty = targetDescriptor.getIdProperty();
     if (idProperty != null) {
       writeJson.writeStartObject(name);
+      writeJson.writeBeanVersion(targetDescriptor);
       idProperty.jsonWriteForInsert(writeJson, childBean);
       writeJson.writeEndObject();
     }

--- a/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/DJsonContext.java
@@ -14,6 +14,7 @@ import io.ebean.text.json.JsonIOException;
 import io.ebean.text.json.JsonReadOptions;
 import io.ebean.text.json.JsonWriteBeanVisitor;
 import io.ebean.text.json.JsonWriteOptions;
+import io.ebean.text.json.JsonVersionWriter;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiJsonContext;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
@@ -354,9 +355,18 @@ public class DJsonContext implements SpiJsonContext {
   }
 
   private WriteJson createWriteJson(JsonGenerator gen, JsonWriteOptions options) {
-    FetchPath pathProps = (options == null) ? null : options.getPathProperties();
-    Map<String, JsonWriteBeanVisitor<?>> visitors = (options == null) ? null : options.getVisitorMap();
-    return new WriteJson(server, gen, pathProps, visitors, determineObjectMapper(options), determineInclude(options));
+    FetchPath pathProps = null;
+    boolean forceReference = false;
+    JsonVersionWriter versionWriter = null;
+    Map<String, JsonWriteBeanVisitor<?>> visitors = null;
+    if (options != null) {
+      forceReference = options.isForceReference();
+      versionWriter = options.getVersionWriter();
+      pathProps = options.getPathProperties();
+      visitors = options.getVisitorMap();
+    }
+    return new WriteJson(server, gen, pathProps, visitors, determineObjectMapper(options),
+        determineInclude(options), versionWriter, forceReference);
   }
 
   private <T> void toJsonFromCollection(Collection<T> collection, String key, JsonGenerator gen, JsonWriteOptions options) throws IOException {

--- a/src/main/java/io/ebeaninternal/server/text/json/ReadJson.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/ReadJson.java
@@ -5,6 +5,7 @@ import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.bean.PersistenceContext;
 import io.ebean.text.json.JsonReadBeanVisitor;
 import io.ebean.text.json.JsonReadOptions;
+import io.ebean.text.json.JsonVersionMigrationHandler;
 import io.ebeaninternal.api.LoadContext;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.loadcontext.DLoadContext;
@@ -44,6 +45,8 @@ public class ReadJson {
 
   private final LoadContext loadContext;
 
+  private final JsonVersionMigrationHandler versionMigrationHandler;
+
   /**
    * Construct with parser and readOptions.
    */
@@ -54,7 +57,7 @@ public class ReadJson {
     this.objectMapper = objectMapper;
     this.persistenceContext = initPersistenceContext(readOptions);
     this.loadContext = initLoadContext(desc, readOptions);
-
+    this.versionMigrationHandler = (readOptions == null) ? null : readOptions.getVersionMigrationHandler();
     // only create visitorMap, pathStack if needed ...
     this.visitorMap = (readOptions == null) ? null : readOptions.getVisitorMap();
     this.pathStack = (visitorMap == null && loadContext == null) ? null : new PathStack();
@@ -69,6 +72,7 @@ public class ReadJson {
     this.pathStack = source.pathStack;
     this.visitorMap = source.visitorMap;
     this.objectMapper = source.objectMapper;
+    this.versionMigrationHandler = source.versionMigrationHandler;
     if (resetContext) {
       this.persistenceContext = new DefaultPersistenceContext();
       this.loadContext = source.loadContext;
@@ -215,6 +219,10 @@ public class ReadJson {
    */
   public Object readValueUsingObjectMapper(Class<?> propertyType) throws IOException {
     return getObjectMapper().readValue(parser, propertyType);
+  }
+
+  public ReadJson migrate(BeanDescriptor<?> desc) throws IOException {
+    return versionMigrationHandler == null ? this : versionMigrationHandler.migrate(this, desc);
   }
 
 }

--- a/src/main/java/io/ebeaninternal/server/text/json/SpiJsonWriter.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/SpiJsonWriter.java
@@ -65,4 +65,9 @@ public interface SpiJsonWriter extends JsonWriter {
    * Write the bean properties.
    */
   <T> void writeBean(BeanDescriptor<T> desc, EntityBean bean);
+
+  /**
+   * Writes the (optional) dataversion of the bean
+   */
+  void writeBeanVersion(BeanDescriptor<?> desc);
 }

--- a/src/main/java/io/ebeaninternal/server/text/json/WriteJson.java
+++ b/src/main/java/io/ebeaninternal/server/text/json/WriteJson.java
@@ -8,6 +8,7 @@ import io.ebean.config.JsonConfig;
 import io.ebean.text.json.EJson;
 import io.ebean.text.json.JsonIOException;
 import io.ebean.text.json.JsonWriteBeanVisitor;
+import io.ebean.text.json.JsonVersionWriter;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanProperty;
@@ -38,11 +39,16 @@ public class WriteJson implements SpiJsonWriter {
 
   private final JsonConfig.Include include;
 
+  private final JsonVersionWriter versionWriter;
+
+  private final boolean forceReference;
+
   /**
    * Construct for full bean use (normal).
    */
   public WriteJson(SpiEbeanServer server, JsonGenerator generator, FetchPath fetchPath,
-                   Map<String, JsonWriteBeanVisitor<?>> visitors, Object objectMapper, JsonConfig.Include include) {
+      Map<String, JsonWriteBeanVisitor<?>> visitors, Object objectMapper, JsonConfig.Include include,
+      JsonVersionWriter versionWriter, boolean forceReference) {
 
     this.server = server;
     this.generator = generator;
@@ -52,6 +58,8 @@ public class WriteJson implements SpiJsonWriter {
     this.include = include;
     this.parentBeans = new ArrayStack<>();
     this.pathStack = new PathStack();
+    this.versionWriter = versionWriter;
+    this.forceReference = forceReference;
   }
 
   /**
@@ -66,6 +74,8 @@ public class WriteJson implements SpiJsonWriter {
     this.objectMapper = null;
     this.parentBeans = null;
     this.pathStack = null;
+    this.versionWriter = null;
+    this.forceReference = false;
   }
 
   /**
@@ -398,9 +408,10 @@ public class WriteJson implements SpiJsonWriter {
   private <T> WriteBean createWriteBean(BeanDescriptor<T> desc, EntityBean bean) {
 
     String path = pathStack.peekWithNull();
+    boolean doForceReference = this.forceReference && !parentBeans.isEmpty() && !desc.isDocStoreOnly();
     JsonWriteBeanVisitor<?> visitor = (visitors == null) ? null : visitors.get(path);
     if (fetchPath == null) {
-      return new WriteBean(desc, bean, visitor);
+      return new WriteBean(desc, bean, visitor, versionWriter, doForceReference);
     }
 
     boolean explicitAllProps = false;
@@ -411,7 +422,7 @@ public class WriteJson implements SpiJsonWriter {
         currentIncludeProps = null;
       }
     }
-    return new WriteBean(desc, explicitAllProps, currentIncludeProps, bean, visitor);
+    return new WriteBean(desc, explicitAllProps, currentIncludeProps, bean, visitor, versionWriter, doForceReference);
   }
 
   @Override
@@ -445,28 +456,35 @@ public class WriteJson implements SpiJsonWriter {
   public static class WriteBean {
 
     final boolean explicitAllProps;
+    final boolean forceReference;
     final Set<String> currentIncludeProps;
     final BeanDescriptor<?> desc;
     final EntityBean currentBean;
+    final JsonVersionWriter writeVersion;
 
     @SuppressWarnings("rawtypes")
     final JsonWriteBeanVisitor visitor;
 
-    WriteBean(BeanDescriptor<?> desc, EntityBean currentBean, JsonWriteBeanVisitor<?> visitor) {
-      this(desc, false, null, currentBean, visitor);
+    WriteBean(BeanDescriptor<?> desc, EntityBean currentBean, JsonWriteBeanVisitor<?> visitor,
+        JsonVersionWriter writeVersion, boolean preferReference) {
+      this(desc, false, null, currentBean, visitor, writeVersion, preferReference);
     }
 
-    WriteBean(BeanDescriptor<?> desc, boolean explicitAllProps, Set<String> currentIncludeProps, EntityBean currentBean, JsonWriteBeanVisitor<?> visitor) {
+    WriteBean(BeanDescriptor<?> desc, boolean explicitAllProps, Set<String> currentIncludeProps, EntityBean currentBean,
+        JsonWriteBeanVisitor<?> visitor, JsonVersionWriter writeVersion, boolean forceReference) {
       super();
       this.desc = desc;
       this.currentBean = currentBean;
       this.explicitAllProps = explicitAllProps;
       this.currentIncludeProps = currentIncludeProps;
+      this.writeVersion = writeVersion;
+      this.forceReference = forceReference;
       this.visitor = visitor;
     }
 
     private boolean isReferenceOnly() {
-      return !explicitAllProps && currentIncludeProps == null && currentBean._ebean_getIntercept().isReference();
+      return forceReference
+          || (!explicitAllProps && currentIncludeProps == null && currentBean._ebean_getIntercept().isReference());
     }
 
     private boolean isIncludeProperty(BeanProperty prop) {
@@ -575,5 +593,10 @@ public class WriteJson implements SpiJsonWriter {
     return d;
   }
 
-
+  @Override
+  public void writeBeanVersion(BeanDescriptor<?> desc) {
+    if (versionWriter != null) {
+      versionWriter.writeVersion(this, desc);
+    }
+  }
 }

--- a/src/test/java/io/ebeaninternal/server/text/json/WriteJsonDirtyTest.java
+++ b/src/test/java/io/ebeaninternal/server/text/json/WriteJsonDirtyTest.java
@@ -42,7 +42,7 @@ public class WriteJsonDirtyTest {
     JsonFactory jsonFactory = new JsonFactory();
     JsonGenerator generator = jsonFactory.createGenerator(writer);
 
-    WriteJson writeJson = new WriteJson(server, generator, null, null, null, null);
+    WriteJson writeJson = new WriteJson(server, generator, null, null, null, null, null, false);
     descriptor.jsonWriteDirty(writeJson, entityBean, dirtyProperties);
 
     generator.flush();

--- a/src/test/java/org/tests/query/other/TestFindWhereUsingEnumerated.java
+++ b/src/test/java/org/tests/query/other/TestFindWhereUsingEnumerated.java
@@ -1,6 +1,5 @@
 package org.tests.query.other;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import org.tests.model.basic.MNonEnum;
 import org.tests.model.basic.MNonUpdPropEntity;

--- a/src/test/java/org/tests/text/json/TestJsonVersioning.java
+++ b/src/test/java/org/tests/text/json/TestJsonVersioning.java
@@ -1,0 +1,256 @@
+package org.tests.text.json;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import io.ebean.plugin.BeanType;
+import io.ebean.text.json.JsonIOException;
+import io.ebean.text.json.JsonReadOptions;
+import io.ebean.text.json.JsonVersionMigrationHandler;
+import io.ebean.text.json.JsonVersionWriter;
+import io.ebean.text.json.JsonWriteOptions;
+import io.ebean.text.json.JsonWriter;
+import io.ebeaninternal.server.text.json.ReadJson;
+
+import org.tests.model.basic.Order;
+import org.tests.model.basic.OrderShipment;
+import org.tests.model.basic.ResetBasicData;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+/**
+ * This test case demonstrates, what happens in the lifetime of json models, and how the JSON-migration works.
+ *
+ * (it is a good idea, to keep a version information from the beginning.)
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class TestJsonVersioning extends BaseTestCase {
+
+  @Before
+  public void prepare() {
+    ResetBasicData.reset();
+    Ebean.getServerCacheManager().getBeanCache(Order.class).clear();
+  }
+  /**
+   * This is a very simple JsonVersionMigrationHander that writes "_v=23" for Order beans,
+   * "_v=17" for OrderShipment beans and "_v=1" for all other beans. In practice you will read
+   * this version from the model class as static field (similar to SERIAL_VERSION_UID)
+   *
+   * @author Roland Praml, FOCONIS AG
+   *
+   */
+  private static class TestJsonVersionWriter implements JsonVersionWriter {
+
+    @Override
+    public void writeVersion(JsonWriter writer, BeanType<?> beanType) {
+      if (beanType.getBeanType().equals(Order.class)) {
+        writer.writeNumberField("_v", 23);
+      } else if (beanType.getBeanType().equals(OrderShipment.class)) {
+        writer.writeNumberField("_v", 17);
+      } else {
+        writer.writeNumberField("_v", 1);
+      }
+    }
+  }
+
+  /**
+   * This is a sample to demonstrate, how JSON migration can work.
+   *
+   * Writing JSON migration can get complex, so it is always better to spend enough time when designing
+   * your dataModel.
+   *
+   * @author Roland Praml, FOCONIS AG
+   *
+   */
+  private static class TestJsonVersionMigrationHandler implements JsonVersionMigrationHandler {
+
+    @Override
+    public ReadJson migrate(ReadJson readJson, BeanType<?> beanType) throws IOException {
+
+      int version = getVersion(readJson);
+
+      if (beanType.getBeanType().equals(Order.class)) {
+        // === Order migration path
+        if (version == 22) { // in version 22->23 we had a typo in shipments
+          readJson = update(readJson, mig-> mig.set("shipments", mig.remove("shipmetns")));
+          version = 23;
+        }
+        if (version == 23) { // current version
+          return readJson;
+        }
+      } else if (beanType.getBeanType().equals(OrderShipment.class)) {
+        // === OrderShipment migration path
+        if (version == 15) { // in version 15->16 we have changed the field name "updatedtime" -> "cretime"
+          // and changed the resolution from seconds to millis
+          readJson = update(readJson, mig-> mig.put("updtime", mig.remove("updatedtime").longValue() * 1000));
+          readJson = update(readJson, mig-> mig.put("createdtime", mig.get("createdtime").longValue() * 1000));
+          version = 16;
+        }
+        if (version == 16) { // in version 16->17 we have changed the field name "createdtime" -> "cretime"
+          readJson = update(readJson, mig-> mig.set("cretime", mig.remove("createdtime")));
+          version = 17;
+        }
+        if (version == 17) { // current version
+          return readJson;
+        }
+      } else {
+        // all other beans that have no migration path.
+        if (version == 1) { // current version
+          return readJson;
+        }
+      }
+      throw new JsonParseException(readJson.getParser(), "No migration path from " + beanType.getName() + "(v=" + version+")");
+    }
+
+    /**
+     * Retuns the value of the "_v" property, which must be the first one in the JSON stream.
+     * It is written by the {@link TestJsonVersionWriter}.
+     */
+    private int getVersion(ReadJson readJson) throws JsonParseException, IOException {
+      JsonParser parser = readJson.getParser();
+
+      if (parser.nextToken() != JsonToken.FIELD_NAME) {
+        throw new JsonParseException(parser, "Error reading dataversion - expected [v] but no json key?",
+            parser.getCurrentLocation());
+      }
+
+      if (!"_v".equals(parser.getCurrentName())) {
+        throw new JsonParseException(parser, "Error reading dataversion - expected [_v] but got ["
+            + parser.getCurrentName() + "] ?", parser.getCurrentLocation());
+      }
+      return parser.nextIntValue(-1);
+    }
+
+    /**
+     * This is a utility method that convert the readJson to an other one.
+     */
+    private ReadJson update(ReadJson readJson, Consumer<ObjectNode> migration) throws JsonProcessingException, IOException {
+      readJson.nextToken();
+      ObjectNode node = readJson.getObjectMapper().readTree(readJson.getParser());
+      migration.accept(node);
+      JsonParser newParser = node.traverse();
+      if (newParser.nextToken() != JsonToken.START_OBJECT) {
+        throw new IllegalStateException("Could not read START_OBJECT from " + node);
+      }
+      return readJson.forJson(newParser, false);
+    }
+
+  }
+
+  @Test
+  public void testWriteVersion() throws IOException {
+
+    Order o = Ebean.find(Order.class).setId(1).fetch("shipments").findOne();
+
+    JsonWriteOptions jsonOpts = new JsonWriteOptions();
+    jsonOpts.setVersionWrite(new TestJsonVersionWriter());
+    String s = Ebean.json().toJson(o, jsonOpts);
+
+    s = s.replaceAll("\\d{5,}", "XXXX"); // replaces all timestamps
+    assertThat(s).isEqualTo("{\"_v\":23,\"id\":1,\"status\":\"NEW\",\"orderDate\":XXXX,\"shipDate\":null,"
+        + "\"customer\":{\"_v\":1,\"id\":1},\"customerName\":\"Rob\","
+        + "\"shipments\":[{\"_v\":17,\"id\":1,\"shipTime\":XXXX,\"cretime\":XXXX,\"updtime\":XXXX,\"version\":1}],"
+        + "\"cretime\":XXXX,\"updtime\":XXXX,\"totalAmount\":null,\"totalItems\":null}");
+
+  }
+
+
+  @Test
+  public void testMigrateVersion22_15() throws IOException {
+
+    String s = "{\"_v\":22,\"id\":101,\"status\":\"NEW\",\"orderDate\":1519772400000,\"shipDate\":null,"
+        + "\"customer\":{\"_v\":1,\"id\":101},\"customerName\":\"Roland\","
+        + "\"shipmetns\":[{\"_v\":15,\"id\":101,\"shipTime\":1519772400000,\"createdtime\":1519012300,\"updatedtime\":1519012400,\"version\":1}],"
+        + "\"cretime\":1519772400000,\"updtime\":1519772400000,\"totalAmount\":null,\"totalItems\":null}";
+
+    JsonReadOptions options = new JsonReadOptions();
+    options.setVersionMigrationHandler(new TestJsonVersionMigrationHandler());
+    Order o = Ebean.json().toBean(Order.class, s, options);
+    assertThat(o.getCustomerName()).isEqualTo("Roland");
+    assertThat(o.getShipments()).hasSize(1);
+    assertThat(o.getShipments().get(0).getCretime().getTime()).isEqualTo(1519012300000L);
+    assertThat(o.getShipments().get(0).getUpdtime().getTime()).isEqualTo(1519012400000L);
+
+  }
+
+  @Test
+  public void testMigrateVersion23_15() throws IOException {
+
+    String s = "{\"_v\":23,\"id\":101,\"status\":\"NEW\",\"orderDate\":1519772400000,\"shipDate\":null,"
+        + "\"customer\":{\"_v\":1,\"id\":101},\"customerName\":\"Roland\","
+        + "\"shipments\":[{\"_v\":15,\"id\":101,\"shipTime\":1519772400000,\"createdtime\":1519012300,\"updatedtime\":1519012400,\"version\":1}],"
+        + "\"cretime\":1519772400000,\"updtime\":1519772400000,\"totalAmount\":null,\"totalItems\":null}";
+
+    JsonReadOptions options = new JsonReadOptions();
+    options.setVersionMigrationHandler(new TestJsonVersionMigrationHandler());
+    Order o = Ebean.json().toBean(Order.class, s, options);
+    assertThat(o.getCustomerName()).isEqualTo("Roland");
+    assertThat(o.getShipments()).hasSize(1);
+    assertThat(o.getShipments().get(0).getCretime().getTime()).isEqualTo(1519012300000L);
+    assertThat(o.getShipments().get(0).getUpdtime().getTime()).isEqualTo(1519012400000L);
+
+  }
+
+  @Test
+  public void testMigrateVersion23_16() throws IOException {
+
+    String s = "{\"_v\":23,\"id\":101,\"status\":\"NEW\",\"orderDate\":1519772400000,\"shipDate\":null,"
+        + "\"customer\":{\"_v\":1,\"id\":101},\"customerName\":\"Roland\","
+        + "\"shipments\":[{\"_v\":16,\"id\":101,\"shipTime\":1519772400000,\"createdtime\":1519012300000,\"updtime\":1519012400000,\"version\":1}],"
+        + "\"cretime\":1519772400000,\"updtime\":1519772400000,\"totalAmount\":null,\"totalItems\":null}";
+
+    JsonReadOptions options = new JsonReadOptions();
+    options.setVersionMigrationHandler(new TestJsonVersionMigrationHandler());
+    Order o = Ebean.json().toBean(Order.class, s, options);
+    assertThat(o.getCustomerName()).isEqualTo("Roland");
+    assertThat(o.getShipments()).hasSize(1);
+    assertThat(o.getShipments().get(0).getCretime().getTime()).isEqualTo(1519012300000L);
+    assertThat(o.getShipments().get(0).getUpdtime().getTime()).isEqualTo(1519012400000L);
+
+  }
+
+  @Test
+  public void testMigrateVersion23_17() throws IOException {
+
+    String s = "{\"_v\":23,\"id\":101,\"status\":\"NEW\",\"orderDate\":1519772400000,\"shipDate\":null,"
+        + "\"customer\":{\"_v\":1,\"id\":101},\"customerName\":\"Roland\","
+        + "\"shipments\":[{\"_v\":17,\"id\":101,\"shipTime\":1519772400000,\"cretime\":1519012300000,\"updtime\":1519012400000,\"version\":1}],"
+        + "\"cretime\":1519772400000,\"updtime\":1519772400000,\"totalAmount\":null,\"totalItems\":null}";
+
+    JsonReadOptions options = new JsonReadOptions();
+    options.setVersionMigrationHandler(new TestJsonVersionMigrationHandler());
+    Order o = Ebean.json().toBean(Order.class, s, options);
+    assertThat(o.getCustomerName()).isEqualTo("Roland");
+    assertThat(o.getShipments()).hasSize(1);
+    assertThat(o.getShipments().get(0).getCretime().getTime()).isEqualTo(1519012300000L);
+    assertThat(o.getShipments().get(0).getUpdtime().getTime()).isEqualTo(1519012400000L);
+
+  }
+
+  @Test(expected = JsonIOException.class)
+  public void testMigrateVersion23_18() throws IOException {
+
+    String s = "{\"_v\":23,\"id\":101,\"status\":\"NEW\",\"orderDate\":1519772400000,\"shipDate\":null,"
+        + "\"customer\":{\"_v\":1,\"id\":101},\"customerName\":\"Roland\","
+        + "\"shipments\":[{\"_v\":18,\"id\":101,\"shipTime\":1519772400000,\"cretime\":1519772400000,\"updtime\":1519772400000,\"version\":1}],"
+        + "\"cretime\":1519772400000,\"updtime\":1519772400000,\"totalAmount\":null,\"totalItems\":null}";
+
+    JsonReadOptions options = new JsonReadOptions();
+    options.setVersionMigrationHandler(new TestJsonVersionMigrationHandler());
+    Ebean.json().toBean(Order.class, s, options);
+
+  }
+}

--- a/src/test/java/org/tests/text/json/TestJsonWriteOptions.java
+++ b/src/test/java/org/tests/text/json/TestJsonWriteOptions.java
@@ -1,0 +1,89 @@
+package org.tests.text.json;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import io.ebean.config.JsonConfig.Include;
+import io.ebean.text.json.JsonWriteOptions;
+import org.tests.model.basic.Order;
+import org.tests.model.basic.ResetBasicData;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+public class TestJsonWriteOptions extends BaseTestCase {
+
+  @Before
+  public void prepare() {
+    ResetBasicData.reset();
+    Ebean.getServerCacheManager().getBeanCache(Order.class).clear();
+  }
+
+  @Test
+  public void testNoOpts() throws IOException {
+
+    Order o = Ebean.find(Order.class).setId(1).fetch("shipments").findOne();
+
+    JsonWriteOptions jsonOpts = new JsonWriteOptions();
+    String s = Ebean.json().toJson(o, jsonOpts);
+
+    s = s.replaceAll("\\d{5,}", "XXXX"); // replaces all timestamps
+    assertThat(s).isEqualTo("{\"id\":1,\"status\":\"NEW\",\"orderDate\":XXXX,\"shipDate\":null,"
+        + "\"customer\":{\"id\":1},\"customerName\":\"Rob\","
+        + "\"shipments\":[{\"id\":1,\"shipTime\":XXXX,\"cretime\":XXXX,\"updtime\":XXXX,\"version\":1}],"
+        + "\"cretime\":XXXX,\"updtime\":XXXX,\"totalAmount\":null,\"totalItems\":null}");
+
+  }
+
+  @Test
+  public void testIncludeNonEmpty() throws IOException {
+
+    Order o = Ebean.find(Order.class).setId(1).fetch("shipments").findOne();
+
+    JsonWriteOptions jsonOpts = new JsonWriteOptions();
+    jsonOpts.setInclude(Include.NON_EMPTY);
+    String s = Ebean.json().toJson(o, jsonOpts);
+
+    s = s.replaceAll("\\d{5,}", "XXXX");
+    assertThat(s).isEqualTo("{\"id\":1,\"status\":\"NEW\",\"orderDate\":XXXX,"
+        + "\"customer\":{\"id\":1},\"customerName\":\"Rob\","
+        + "\"shipments\":[{\"id\":1,\"shipTime\":XXXX,\"cretime\":XXXX,\"updtime\":XXXX,\"version\":1}],"
+        + "\"cretime\":XXXX,\"updtime\":XXXX}");
+
+  }
+
+  @Test
+  public void testIncludeForceReference() throws IOException {
+
+    Order o = Ebean.find(Order.class).setId(1).fetch("shipments").findOne();
+
+    JsonWriteOptions jsonOpts = new JsonWriteOptions();
+    jsonOpts.setForceReference(true);
+    String s = Ebean.json().toJson(o, jsonOpts);
+
+    s = s.replaceAll("\\d{5,}", "XXXX");
+    assertThat(s).isEqualTo("{\"id\":1,\"status\":\"NEW\",\"orderDate\":XXXX,\"shipDate\":null,"
+        + "\"customer\":{\"id\":1},\"customerName\":\"Rob\","
+        + "\"shipments\":[{\"id\":1}],"
+        + "\"cretime\":XXXX,\"updtime\":XXXX,\"totalAmount\":null,\"totalItems\":null}");
+  }
+
+  @Test
+  public void testIncludeForceReferenceNonEmpty() throws IOException {
+
+    Order o = Ebean.find(Order.class).setId(1).fetch("shipments").findOne();
+
+    JsonWriteOptions jsonOpts = new JsonWriteOptions();
+    jsonOpts.setForceReference(true);
+    jsonOpts.setInclude(Include.NON_EMPTY);
+    String s = Ebean.json().toJson(o, jsonOpts);
+
+    s = s.replaceAll("\\d{5,}", "XXXX");
+    assertThat(s).isEqualTo("{\"id\":1,\"status\":\"NEW\",\"orderDate\":XXXX,"
+        + "\"customer\":{\"id\":1},\"customerName\":\"Rob\","
+        + "\"shipments\":[{\"id\":1}],"
+        + "\"cretime\":XXXX,\"updtime\":XXXX}");
+  }
+}


### PR DESCRIPTION
**Use Case**
What do you do, if dataModel of a @DbJson model changes? e.g. jon the fields firstname + lastname to name. 
Do you write migration scripts in SQL that will handle the update.

So this PR adds version information in the json and also adds functionality, that you can migrate from an older json structure in database to a newer one
