### PR TITLE
ENH: native UUID-support for SqlServer

### DIFF
--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
@@ -31,6 +31,7 @@ public class SqlServerPlatform extends DatabasePlatform {
     this.sqlLimiter = new SqlServerSqlLimiter();
     this.basicSqlLimiter = new SqlServerBasicSqlLimiter();
     this.historySupport = new SqlServerHistorySupport();
+    this.nativeUuidType = true;
     this.dbIdentity.setIdType(IdType.IDENTITY);
     this.dbIdentity.setSupportsGetGeneratedKeys(true);
     this.dbIdentity.setSupportsIdentity(true);
@@ -82,6 +83,9 @@ public class SqlServerPlatform extends DatabasePlatform {
     super.configure(config);
     if (dbIdentity.getIdType() == IdType.SEQUENCE) {
       this.persistBatchOnCascade = PersistBatch.ALL;
+    }
+    if (nativeUuidType && config.getDbTypeConfig().getDbUuid().useNativeType()) {
+      dbTypeMap.put(DbType.UUID, new DbPlatformType("uniqueidentifier", false));
     }
   }
 

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeUUIDNative.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeUUIDNative.java
@@ -20,6 +20,9 @@ public class ScalarTypeUUIDNative extends ScalarTypeUUIDBase {
     if (value == null) {
       return null;
     }
+    if (value instanceof String) {
+      return UUID.fromString((String) value);
+    }
     return (UUID) value;
   }
 


### PR DESCRIPTION
This adds UUID support for SqlServer.
This may break things, if UUIDs were already used and migrating to this ebean version (May require to set dbuuid=VARCHAR explicitly)