### PR TITLE
FIX: using nvarchar, etc to support UTF8 on SqlServer

### DIFF
--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -2725,6 +2725,7 @@ public class ServerConfig {
    */
   protected void loadDataSourceSettings(PropertiesWrapper p) {
     dataSourceConfig.loadSettings(p.properties, name);
+    readOnlyDataSourceConfig.loadSettings(p.properties, name);
   }
 
   /**

--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -2725,7 +2725,6 @@ public class ServerConfig {
    */
   protected void loadDataSourceSettings(PropertiesWrapper p) {
     dataSourceConfig.loadSettings(p.properties, name);
-    readOnlyDataSourceConfig.loadSettings(p.properties, name);
   }
 
   /**

--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerPlatform.java
@@ -54,6 +54,7 @@ public class SqlServerPlatform extends DatabasePlatform {
     this.dbDefaultValue.setFalse("0");
     this.dbDefaultValue.setTrue("1");
     this.dbDefaultValue.setNow("SYSUTCDATETIME()");
+
     dbTypeMap.put(DbType.BOOLEAN, new DbPlatformType("bit"));
 
     dbTypeMap.put(DbType.INTEGER, new DbPlatformType("integer", false));
@@ -64,9 +65,11 @@ public class SqlServerPlatform extends DatabasePlatform {
     dbTypeMap.put(DbType.DECIMAL, new DbPlatformType("numeric", 28));
 
     dbTypeMap.put(DbType.BLOB, new DbPlatformType("image"));
-    dbTypeMap.put(DbType.CLOB, new DbPlatformType("text"));
+    dbTypeMap.put(DbType.CLOB, new DbPlatformType("nvarchar", Integer.MAX_VALUE));
+    dbTypeMap.put(DbType.VARCHAR, new DbPlatformType("nvarchar", 255)); // UTF8 aware!
+    dbTypeMap.put(DbType.CHAR, new DbPlatformType("nchar", 1));
     dbTypeMap.put(DbType.LONGVARBINARY, new DbPlatformType("image"));
-    dbTypeMap.put(DbType.LONGVARCHAR, new DbPlatformType("text"));
+    dbTypeMap.put(DbType.LONGVARCHAR, new DbPlatformType("nvarchar", Integer.MAX_VALUE));
 
     dbTypeMap.put(DbType.DATE, new DbPlatformType("date"));
     dbTypeMap.put(DbType.TIME, new DbPlatformType("time"));

--- a/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/BaseDdlHandlerTest.java
+++ b/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/BaseDdlHandlerTest.java
@@ -46,7 +46,7 @@ public class BaseDdlHandlerTest extends BaseTestCase {
 
     write = new DdlWrite();
     sqlserverHandler().generate(write, Helper.getAddColumn());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add added_to_foo varchar(20);\n\n");
+    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add added_to_foo nvarchar(20);\n\n");
   }
 
   @Test

--- a/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl_AlterColumnTest.java
+++ b/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl_AlterColumnTest.java
@@ -76,7 +76,7 @@ public class PlatformDdl_AlterColumnTest {
     assertEquals("alter table mytab modify acol varchar(5) not null", sql);
 
     sql = sqlServerDdl.alterColumnBaseAttributes(alterColumn);
-    assertEquals("alter table mytab alter column acol varchar(5) not null", sql);
+    assertEquals("alter table mytab alter column acol nvarchar(5) not null", sql);
 
     alterColumn.setNotnull(Boolean.FALSE);
     sql = mysqlDdl.alterColumnBaseAttributes(alterColumn);

--- a/src/test/java/org/tests/basic/TestEncoding.java
+++ b/src/test/java/org/tests/basic/TestEncoding.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed Materials - Property of FOCONIS AG
+ * (C) Copyright FOCONIS AG.
+ */
+
+package org.tests.basic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.tests.model.basic.ESimple;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+
+/**
+ * Tests various encoding issues with different platforms
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class TestEncoding extends BaseTestCase {
+
+  /**
+   * Checks, if the search works exactly. It must be case sensitive and
+   * distinguish between Umlauts and their paraphrase ( ä!=ae, ß!=ss ).
+   * @throws SQLException
+   */
+  @Test
+  public void testStringFind() throws SQLException {
+    Ebean.find(ESimple.class).delete();
+
+    // prepare tests
+    Collection<String> testData = Arrays.asList("Übel", "Uebel", "übel", "uebel", "Weiss", "Weiß", "Bär", "Baer", "A",
+        "a", "Ä", "ä", "€µè§²³áàâ", // special chars
+        "ÄÖÜäöüß", // Umlauts
+        "АБВ", // Cyrillic
+        "\uD800\uDF00\uD800\uDF01\uD800\uDF02", // old italic
+        "ÄB̈C̈", // Diacritic
+        "\uD83D\uDE08\uD83D\uDCA9", // Emoticons
+
+        // 2 byte unicode
+        "ÉÊËÌÍÎÏÐÑÒÓ ŰÝÞßàáâãäå ăæçèéêëìíî ðñòóôõöőøș αβγδθικλμν ΓΔΕΖΗΘΙΚΛΜ ΝΞΟΠΡΣΤΥΦΧ ظ ع غ ف ق ك ل م ن ه",
+
+        // 3 byte unicode https://gist.github.com/jimjam88/cce5b57c50c973c313de
+        "ルビンツアウェブふべ|からずセシリテどトモ|デプロファイとマィッ|めよう内准剛んを始コ|展久スド情報して使|にほるレでのすソた「",
+
+        // 4 byte unicode
+        "𠜎𠜱𠝹𠱓𠱸𠲖𠳏𠳕𠴕𠵼 𠵿𠸎𠸏𠹷𠺝𠺢𠻗𠻹𠻺𠼭 𠼮𠽌𠾴𠾼𠿪𡁜𡁯𡁵𡁶𡁻𡃁 𡃉𡇙𢃇𢞵𢫕𢭃𢯊𢱑𢱕𢳂𢴈");
+
+    List<Integer> ids = new ArrayList<>();
+    // create test entries
+    for (String entry : testData) {
+      System.out.println("Inserting: " + entry);
+      ESimple entity = new ESimple();
+      entity.setName(entry);
+      Ebean.save(entity);
+    }
+
+
+    for (String entry : testData) {
+      System.out.println("Searching: " + entry);
+      //try (Transaction txn = Ebean.beginTransaction()) {
+//        Statement stmt = txn.getConnection().createStatement();
+//        ResultSet rset = stmt.executeQuery("show variables WHERE variable_name like \"col%\" ");
+//        while (rset.next()) {
+//          System.out.println(rset.getString(1)+": " + rset.getString(2));
+//        }
+      ESimple current = Ebean.find(ESimple.class).where().eq("name", entry).findOne();
+      assertThat(current.getName()).isEqualTo(entry);
+
+      current = Ebean.find(ESimple.class).where().in("name", entry).findOne();
+      assertThat(current.getName()).isEqualTo(entry);
+
+
+      current = Ebean.find(ESimple.class).where().in("name", entry, "gibtsned").findOne();
+      assertThat(current.getName()).isEqualTo(entry);
+      //}
+    }
+
+    // For MySQL to debug:
+    //    try (Transaction txn = Ebean.beginTransaction()) {
+    //      Statement stmt = txn.getConnection().createStatement();
+    //      ResultSet rset = stmt.executeQuery("show variables WHERE variable_name like \"col%\" ");
+    //      while (rset.next()) {
+    //        System.out.println(rset.getString(1)+": " + rset.getString(2));
+    //      }
+    //    }
+
+    List<ESimple> list = Ebean.find(ESimple.class).where().in("name", testData).findList();
+    assertThat(list.size()).isEqualTo(testData.size());
+    for (ESimple current : list) {
+      assertThat(testData).contains(current.getName());
+    }
+  }
+
+}

--- a/src/test/resources/dbmigration/migrationtest/sqlserver/1.0__initial.sql
+++ b/src/test/resources/dbmigration/migrationtest/sqlserver/1.0__initial.sql
@@ -2,22 +2,22 @@
 -- apply changes
 create table migtest_ckey_assoc (
   id                            integer not null,
-  assoc_one                     varchar(255),
+  assoc_one                     nvarchar(255),
   constraint pk_migtest_ckey_assoc primary key (id)
 );
 create sequence migtest_ckey_assoc_seq as bigint  start with 1 ;
 
 create table migtest_ckey_detail (
   id                            integer not null,
-  something                     varchar(255),
+  something                     nvarchar(255),
   constraint pk_migtest_ckey_detail primary key (id)
 );
 create sequence migtest_ckey_detail_seq as bigint  start with 1 ;
 
 create table migtest_ckey_parent (
   one_key                       integer not null,
-  two_key                       varchar(127) not null,
-  name                          varchar(255),
+  two_key                       nvarchar(127) not null,
+  name                          nvarchar(255),
   version                       integer not null,
   constraint pk_migtest_ckey_parent primary key (one_key,two_key)
 );
@@ -64,19 +64,19 @@ create sequence migtest_fk_set_null_seq as bigint  start with 1 ;
 
 create table migtest_e_basic (
   id                            integer not null,
-  status                        varchar(1),
-  name                          varchar(127),
-  description                   varchar(127),
+  status                        nvarchar(1),
+  name                          nvarchar(127),
+  description                   nvarchar(127),
   some_date                     datetime2,
   old_boolean                   bit default 0 not null,
   old_boolean2                  bit,
   eref_id                       integer,
-  indextest1                    varchar(127),
-  indextest2                    varchar(127),
-  indextest3                    varchar(127),
-  indextest4                    varchar(127),
-  indextest5                    varchar(127),
-  indextest6                    varchar(127),
+  indextest1                    nvarchar(127),
+  indextest2                    nvarchar(127),
+  indextest3                    nvarchar(127),
+  indextest4                    nvarchar(127),
+  indextest5                    nvarchar(127),
+  indextest6                    nvarchar(127),
   user_id                       integer not null,
   constraint ck_migtest_e_basic_status check ( status in ('N','A','I')),
   constraint pk_migtest_e_basic primary key (id)
@@ -87,21 +87,21 @@ create sequence migtest_e_basic_seq as bigint  start with 1 ;
 
 create table migtest_e_history (
   id                            integer not null,
-  test_string                   varchar(255),
+  test_string                   nvarchar(255),
   constraint pk_migtest_e_history primary key (id)
 );
 create sequence migtest_e_history_seq as bigint  start with 1 ;
 
 create table migtest_e_history2 (
   id                            integer not null,
-  test_string                   varchar(255),
+  test_string                   nvarchar(255),
   constraint pk_migtest_e_history2 primary key (id)
 );
 create sequence migtest_e_history2_seq as bigint  start with 1 ;
 
 create table migtest_e_ref (
   id                            integer not null,
-  name                          varchar(127) not null,
+  name                          nvarchar(127) not null,
   constraint pk_migtest_e_ref primary key (id)
 );
 alter table migtest_e_ref add constraint uq_migtest_e_ref_name unique  (name);
@@ -109,35 +109,35 @@ create sequence migtest_e_ref_seq as bigint  start with 1 ;
 
 create table migtest_e_softdelete (
   id                            integer not null,
-  test_string                   varchar(255),
+  test_string                   nvarchar(255),
   constraint pk_migtest_e_softdelete primary key (id)
 );
 create sequence migtest_e_softdelete_seq as bigint  start with 1 ;
 
 create table migtest_mtm_c (
   id                            integer not null,
-  name                          varchar(255),
+  name                          nvarchar(255),
   constraint pk_migtest_mtm_c primary key (id)
 );
 create sequence migtest_mtm_c_seq as bigint  start with 1 ;
 
 create table migtest_mtm_m (
   id                            numeric(19) not null,
-  name                          varchar(255),
+  name                          nvarchar(255),
   constraint pk_migtest_mtm_m primary key (id)
 );
 create sequence migtest_mtm_m_seq as bigint  start with 1 ;
 
 create table migtest_oto_child (
   id                            integer not null,
-  name                          varchar(255),
+  name                          nvarchar(255),
   constraint pk_migtest_oto_child primary key (id)
 );
 create sequence migtest_oto_child_seq as bigint  start with 1 ;
 
 create table migtest_oto_master (
   id                            numeric(19) not null,
-  name                          varchar(255),
+  name                          nvarchar(255),
   constraint pk_migtest_oto_master primary key (id)
 );
 create sequence migtest_oto_master_seq as bigint  start with 1 ;

--- a/src/test/resources/dbmigration/migrationtest/sqlserver/1.1.sql
+++ b/src/test/resources/dbmigration/migrationtest/sqlserver/1.1.sql
@@ -19,7 +19,7 @@ create table migtest_mtm_m_migtest_mtm_c (
 );
 
 alter table migtest_ckey_detail add one_key integer;
-alter table migtest_ckey_detail add two_key varchar(127);
+alter table migtest_ckey_detail add two_key nvarchar(127);
 
 alter table migtest_ckey_detail add constraint fk_migtest_ckey_detail_parent foreign key (one_key,two_key) references migtest_ckey_parent (one_key,two_key);
 alter table migtest_ckey_parent add assoc_id integer;
@@ -34,7 +34,7 @@ alter table migtest_fk_set_null add constraint fk_migtest_fk_set_null_one_id for
 update migtest_e_basic set status = 'A' where status is null;
 IF (OBJECT_ID('ck_migtest_e_basic_status', 'C') IS NOT NULL) alter table migtest_e_basic drop constraint ck_migtest_e_basic_status;
 alter table migtest_e_basic add default 'A' for status;
-alter table migtest_e_basic alter column status varchar(1) not null;
+alter table migtest_e_basic alter column status nvarchar(1) not null;
 alter table migtest_e_basic add constraint ck_migtest_e_basic_status check ( status in ('N','A','I','?'));
 
 -- rename all collisions;
@@ -47,7 +47,7 @@ alter table migtest_e_basic alter column some_date datetime2 not null;
 insert into migtest_e_user (id) select distinct user_id from migtest_e_basic;
 alter table migtest_e_basic add constraint fk_migtest_e_basic_user_id foreign key (user_id) references migtest_e_user (id);
 alter table migtest_e_basic alter column user_id integer;
-alter table migtest_e_basic add new_string_field varchar(255) default 'foo''bar' not null;
+alter table migtest_e_basic add new_string_field nvarchar(255) default 'foo''bar' not null;
 alter table migtest_e_basic add new_boolean_field bit default 1 not null;
 update migtest_e_basic set new_boolean_field = old_boolean;
 
@@ -68,9 +68,9 @@ alter table migtest_e_history alter column test_string numeric(19);
 
 update migtest_e_history2 set test_string = 'unknown' where test_string is null;
 alter table migtest_e_history2 add default 'unknown' for test_string;
-alter table migtest_e_history2 alter column test_string varchar(255) not null;
-alter table migtest_e_history2 add test_string2 varchar(255);
-alter table migtest_e_history2 add test_string3 varchar(255) default 'unknown' not null;
+alter table migtest_e_history2 alter column test_string nvarchar(255) not null;
+alter table migtest_e_history2 add test_string2 nvarchar(255);
+alter table migtest_e_history2 add test_string3 nvarchar(255) default 'unknown' not null;
 
 alter table migtest_e_softdelete add deleted bit default 0 not null;
 

--- a/src/test/resources/dbmigration/migrationtest/sqlserver/1.3.sql
+++ b/src/test/resources/dbmigration/migrationtest/sqlserver/1.3.sql
@@ -2,7 +2,7 @@
 -- apply changes
 create table migtest_e_ref (
   id                            integer not null,
-  name                          varchar(127) not null,
+  name                          nvarchar(127) not null,
   constraint pk_migtest_e_ref primary key (id)
 );
 alter table migtest_e_ref add constraint uq_migtest_e_ref_name unique  (name);


### PR DESCRIPTION
This PR changes the datatype to nvarchar, so that you can use UTF8 characters in SqlServer