### PR TITLE
FIX: ReadOnlyDatasource must also be configured

### DIFF
--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -2725,6 +2725,7 @@ public class ServerConfig {
    */
   protected void loadDataSourceSettings(PropertiesWrapper p) {
     dataSourceConfig.loadSettings(p.properties, name);
+    readOnlyDataSourceConfig.loadSettings(p.properties, name);
   }
 
   /**


### PR DESCRIPTION
The read only datasource was not configured. It should get the same properties as the main datasource.
maybe we need something like this;
```
 dataSourceConfig.loadSettings(p.properties, name);
 readOnlyDataSourceConfig.loadSettings(p.properties, name);

 dataSourceConfig.loadSettings(p.properties, name+"-rw");
 readOnlyDataSourceConfig.loadSettings(p.properties, name+"-ro");
```
so that we can explicitly set options