### PR TITLE
Inheritance - Add support for @DiscriminatorValue to be optional

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/InheritInfo.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/InheritInfo.java
@@ -6,6 +6,7 @@ import io.ebeaninternal.server.deploy.id.IdBinder;
 import io.ebeaninternal.server.deploy.parse.DeployInheritInfo;
 import io.ebeaninternal.server.query.SqlTreeProperties;
 
+import java.lang.reflect.Modifier;
 import javax.persistence.PersistenceException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -291,7 +292,7 @@ public class InheritInfo {
    * Return true if this is considered a concrete type in the inheritance hierarchy.
    */
   public boolean isConcrete() {
-    return discriminatorValue != null;
+    return !Modifier.isAbstract(type.getModifiers());
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInherit.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInherit.java
@@ -126,6 +126,8 @@ public class DeployInherit {
     DiscriminatorValue dv = AnnotationUtil.findAnnotation(cls, DiscriminatorValue.class); // do not search recursive
     if (dv != null) {
       info.setDiscriminatorValue(dv.value());
+    } else {
+      info.setDiscriminatorValue(cls.getSimpleName());
     }
 
     return info;

--- a/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.deploy.parse;
 
 import io.ebeaninternal.server.deploy.InheritInfo;
 
+import java.lang.reflect.Modifier;
 import javax.persistence.DiscriminatorType;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -64,7 +65,7 @@ public class DeployInheritInfo {
    * Return true if this is abstract node.
    */
   public boolean isAbstract() {
-    return (discriminatorObjectValue == null);
+    return Modifier.isAbstract(type.getModifiers());
   }
 
   /**
@@ -205,7 +206,7 @@ public class DeployInheritInfo {
   }
 
   private void appendDiscriminator(List<Object> list) {
-    if (discriminatorObjectValue != null) {
+    if (!isAbstract()) {
       list.add(discriminatorObjectValue);
     }
     for (DeployInheritInfo child : children) {


### PR DESCRIPTION
JPA states:

"If the DiscriminatorValue annotation is not specified and a discriminator column is used, a provider-specific function will be used to generate a value representing the entity type. If the DiscriminatorType is STRING, the discriminator value default is the entity name." in https://docs.oracle.com/javaee/7/api/javax/persistence/DiscriminatorValue.html

This change adds support to this by setting the `DiscriminatorValue` to the class name when the annotation is not provided.

But there's a catch, ebean relied on the `DiscriminatorValue` annotation to know if the entity is concrete or not. I changed this behavior to look for the `abstract` modifier in the class.