### PR TITLE
FIX: load all props from cache when inheritance is involved

### DIFF
--- a/src/main/java/io/ebeaninternal/server/cache/CachedBeanDataToBean.java
+++ b/src/main/java/io/ebeaninternal/server/cache/CachedBeanDataToBean.java
@@ -15,6 +15,10 @@ public class CachedBeanDataToBean {
     EntityBeanIntercept ebi = bean._ebean_getIntercept();
 
     BeanProperty idProperty = desc.getIdProperty();
+    if (desc.getInheritInfo() != null) {
+        desc = desc.getInheritInfo().readType(bean.getClass()).desc();
+    }
+
     if (idProperty != null) {
       // load the id property
       loadProperty(bean, cacheBeanData, ebi, idProperty, context);

--- a/src/test/java/org/tests/cache/TestCacheManyToOne.java
+++ b/src/test/java/org/tests/cache/TestCacheManyToOne.java
@@ -1,0 +1,39 @@
+package org.tests.cache;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import org.tests.model.basic.OCachedInhChildA;
+import org.tests.model.basic.OCachedInhRoot;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test class testing deleting/invalidating of cached beans
+ */
+public class TestCacheManyToOne extends BaseTestCase {
+
+  @Test
+  public void crudInvoice() {
+
+    OCachedInhChildA bean = new OCachedInhChildA();
+    bean.setName("Roland");
+    bean.setChildAData("ChildData");
+    Ebean.save(bean);
+
+    Ebean.find(OCachedInhRoot.class).select("id").where().idIn(bean.getId()).findEach(bean0 -> {
+      assertNotNull(bean0);
+      assertThat(bean0.getName()).isEqualTo("Roland");
+      assertThat(((OCachedInhChildA)bean0).getChildAData()).isEqualTo("ChildData");
+    });
+
+    Ebean.find(OCachedInhRoot.class).select("id").where().idIn(bean.getId()).findEach(bean1 -> {
+      assertNotNull(bean1);
+      assertThat(bean1.getName()).isEqualTo("Roland");
+      // this will fail if the bean is loaded from cache and the wrong discriminator is used.
+      assertThat(((OCachedInhChildA)bean1).getChildAData()).isEqualTo("ChildData");
+    });
+
+  }
+}

--- a/src/test/java/org/tests/model/basic/OCachedInhChildA.java
+++ b/src/test/java/org/tests/model/basic/OCachedInhChildA.java
@@ -1,0 +1,30 @@
+package org.tests.model.basic;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+
+/**
+ * Child bean A
+ */
+@Entity
+@DiscriminatorValue("childA")
+public class OCachedInhChildA extends OCachedInhRoot {
+
+  String childAData;
+
+  /**
+   * @return the childAData
+   */
+  public String getChildAData() {
+    return childAData;
+  }
+
+  /**
+   * @param childAData
+   *          the childAData to set
+   */
+  public void setChildAData(String childAData) {
+    this.childAData = childAData;
+  }
+}

--- a/src/test/java/org/tests/model/basic/OCachedInhChildB.java
+++ b/src/test/java/org/tests/model/basic/OCachedInhChildB.java
@@ -1,0 +1,29 @@
+package org.tests.model.basic;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+
+/**
+ * Child bean B
+ */
+@Entity
+@DiscriminatorValue("childB")
+public class OCachedInhChildB extends OCachedInhRoot {
+  String childBData;
+
+  /**
+   * @return the childBData
+   */
+  public String getChildBData() {
+    return childBData;
+  }
+
+  /**
+   * @param childBData
+   *          the childBData to set
+   */
+  public void setChildBData(String childBData) {
+    this.childBData = childBData;
+  }
+}

--- a/src/test/java/org/tests/model/basic/OCachedInhRoot.java
+++ b/src/test/java/org/tests/model/basic/OCachedInhRoot.java
@@ -1,0 +1,44 @@
+package org.tests.model.basic;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.Table;
+
+import io.ebean.annotation.Cache;
+
+/**
+ * Cached entity for inheritance.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+@Entity
+@Table(name = "o_cached_inherit")
+@Inheritance
+@Cache
+public abstract class OCachedInhRoot {
+
+  @Id
+  Long id;
+
+  String name;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+
+
+}


### PR DESCRIPTION
Hello Rob, this fixes an issue where a bean is not properly restored from the cache, when inheritance is involved.