### PR TITLE
FIX: NPE when fetching inherited beans from cache

### DIFF
--- a/src/test/java/org/tests/inheritance/cache/TestInheritanceRefCache.java
+++ b/src/test/java/org/tests/inheritance/cache/TestInheritanceRefCache.java
@@ -1,0 +1,64 @@
+package org.tests.inheritance.cache;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import org.tests.model.basic.cache.CInhOne;
+import org.tests.model.basic.cache.CInhRef;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.ebeantest.LoggedSqlCollector;
+
+public class TestInheritanceRefCache extends BaseTestCase {
+
+  @Test
+  public void test() {
+
+    CInhOne one = new CInhOne();
+    one.setLicenseNumber("O12");
+    one.setDriver("Jimmy");
+    one.setNotes("Hello");
+
+    Ebean.save(one);
+
+    CInhRef ref = new CInhRef();
+    ref.setRef(one);
+
+    Ebean.save(ref);
+
+    Integer id = ref.getId();
+
+    LoggedSqlCollector.start();
+    CInhRef gotRef = Ebean.find(CInhRef.class).setId(id).findOne();
+
+    assertThat(gotRef).isInstanceOf(CInhRef.class);
+    assertThat(gotRef.getRef()).isInstanceOf(CInhOne.class);
+    List<String> sql = LoggedSqlCollector.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("from cinh_ref").contains("left join cinh_root");
+
+    // fetch again - from cache (but fetch second bean from cache)
+    LoggedSqlCollector.start();
+    gotRef = Ebean.find(CInhRef.class).setId(id).findOne();
+
+    assertThat(gotRef).isInstanceOf(CInhRef.class);
+    assertThat(gotRef.getRef()).isInstanceOf(CInhOne.class);
+    sql = LoggedSqlCollector.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("from cinh_root");
+
+
+    // fetch again - both from cache
+    LoggedSqlCollector.start();
+    gotRef = Ebean.find(CInhRef.class).setId(id).findOne();
+
+    assertThat(gotRef).isInstanceOf(CInhRef.class);
+    assertThat(gotRef.getRef()).isInstanceOf(CInhOne.class);
+    sql = LoggedSqlCollector.stop();
+    assertThat(sql).hasSize(0);
+
+  }
+}

--- a/src/test/java/org/tests/model/basic/cache/CInhRef.java
+++ b/src/test/java/org/tests/model/basic/cache/CInhRef.java
@@ -1,0 +1,25 @@
+package org.tests.model.basic.cache;
+
+import org.tests.model.basic.BasicDomain;
+
+import io.ebean.annotation.Cache;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Cache(enableQueryCache = true)
+public class CInhRef extends BasicDomain {
+  private static final long serialVersionUID = -4673953370819311120L;
+
+  @ManyToOne(cascade = {})
+  private CInhRoot ref;
+
+  public CInhRoot getRef() {
+    return ref;
+  }
+
+  public void setRef(CInhRoot ref) {
+    this.ref = ref;
+  }
+}


### PR DESCRIPTION
**Steps to reproduce**
You need a base entity that references an inherited entity. (CInhRef -> CInhRoot)

Alt least CInhRef must be cacheable. When hitting the cache, the code tries to create a reference to CInhRoot, which is abstract and cannot be instantiated.

This fix hits the database (or cache) to get the concrete entity.