### PR TITLE
FIX: use LinkedHashMap in enum types to get deterministic ordering

### DIFF
--- a/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -58,9 +58,9 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Currency;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -564,7 +564,7 @@ public final class DefaultTypeManager implements TypeManager {
 
     boolean integerType = true;
 
-    Map<String, String> nameValueMap = new HashMap<>();
+    Map<String, String> nameValueMap = new LinkedHashMap<>();
 
     Field[] fields = enumType.getDeclaredFields();
     for (Field field : fields) {
@@ -657,7 +657,7 @@ public final class DefaultTypeManager implements TypeManager {
    */
   private ScalarTypeEnum<?> createEnumScalarTypeDbValue(Class<? extends Enum<?>> enumType, Method method, boolean integerType) {
 
-    Map<String, String> nameValueMap = new HashMap<>();
+    Map<String, String> nameValueMap = new LinkedHashMap<>();
 
     Enum<?>[] enumConstants = enumType.getEnumConstants();
     for (Enum<?> enumConstant : enumConstants) {


### PR DESCRIPTION
This PR uses a LinkedHashMap to preserve the order of the constraints added for enum columns

If I have a Enum
```
enum Priority{
  @EnumValue("0") LOW,
  @EnumValue("1") MID,
  @EnumValue("2") MID,
} 
```
I expect the constraint `alter table my_table add constraint ck_ my_table_prio check ( prio in (0,1,2));` and not `... in (2,0,1)` or an other non predictable order.

Technically, it does not matter, how the ordering is, but ordering is not guaranteed by the HashMap. See API:
> This class makes no guarantees as to the order of the map; in particular,
> it does not guarantee that the order will remain constant over time. 

So it could happen, that DbMigration-generate thinks the datamodel has changed, because the underlying code produces a different check constraing on different JVMs

(Unfortunately, the DbMigration-generate will create migration scripts now, it drops every constraint and re-adds it in the correct order)