### PR TITLE
FIX: correct caching when collection with different inherited beans is put to the cache

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
@@ -447,7 +447,21 @@ final class BeanDescriptorCacheHelp<T> {
   void beanPutAll(Collection<EntityBean> beans) {
     if (desc.inheritInfo != null) {
       Class<?> aClass = theClassOf(beans);
-      desc.descOf(aClass).cacheBeanPutAllDirect(beans);
+      // check if all beans have the same class
+      for (EntityBean bean : beans) {
+        if (!bean.getClass().equals(aClass)) {
+          aClass = null;
+          break;
+        }
+      }
+      if (aClass == null) {
+        // there are different bean types in the collection, so we add one by one to the cache
+        for (EntityBean bean : beans) {
+          desc.descOf(bean.getClass()).cacheBeanPutDirect(bean);
+        }
+      } else {
+        desc.descOf(aClass).cacheBeanPutAllDirect(beans);
+      }
     } else {
       beanCachePutAllDirect(beans);
     }

--- a/src/test/java/org/tests/inheritance/cache/TestInheritanceRefCache.java
+++ b/src/test/java/org/tests/inheritance/cache/TestInheritanceRefCache.java
@@ -4,10 +4,14 @@ import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import org.tests.model.basic.cache.CInhOne;
 import org.tests.model.basic.cache.CInhRef;
+import org.tests.model.basic.cache.CInhRoot;
+import org.tests.model.basic.cache.CInhTwo;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.ebeantest.LoggedSqlCollector;
@@ -61,4 +65,49 @@ public class TestInheritanceRefCache extends BaseTestCase {
     assertThat(sql).hasSize(0);
 
   }
+
+  @Test
+  public void testMap() {
+
+    List<Integer> ids = new ArrayList<>();
+
+    CInhOne one = new CInhOne();
+    one.setLicenseNumber("O19");
+    one.setDriver("Foo");
+    one.setNotes("Hello");
+    Ebean.save(one);
+
+    ids.add(one.getId());
+
+    CInhTwo two = new CInhTwo();
+    two.setLicenseNumber("T23");
+    two.setAction("Test");
+    Ebean.save(two);
+
+    ids.add(two.getId());
+
+
+    LoggedSqlCollector.start();
+
+    Ebean.find(CInhRoot.class).setUseQueryCache(true).where().idIn(ids).setMapKey("licenseNumber").findMap();
+
+    List<String> sql = LoggedSqlCollector.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("from cinh_root");
+
+    System.out.println("===1");
+    Ebean.find(CInhRoot.class).setUseQueryCache(true).findList();//setUseCache(true).where().idIn(ids).setMapKey("licenseNumber").findMap();
+    Ebean.find(CInhRoot.class).setUseQueryCache(true).findList();
+    Ebean.find(CInhRoot.class).setUseQueryCache(true).findList();
+    System.out.println("===2");
+
+    LoggedSqlCollector.start();
+
+    Ebean.find(CInhRoot.class).setUseQueryCache(true).where().idIn(ids).setMapKey("licenseNumber").findMap();
+    System.out.println("===3");
+
+    sql = LoggedSqlCollector.stop();
+    assertThat(sql).hasSize(0);
+  }
+
 }

--- a/src/test/java/org/tests/inheritance/cache/TestInheritanceRefCache.java
+++ b/src/test/java/org/tests/inheritance/cache/TestInheritanceRefCache.java
@@ -95,16 +95,14 @@ public class TestInheritanceRefCache extends BaseTestCase {
     assertThat(sql).hasSize(1);
     assertThat(sql.get(0)).contains("from cinh_root");
 
-    System.out.println("===1");
-    Ebean.find(CInhRoot.class).setUseQueryCache(true).findList();//setUseCache(true).where().idIn(ids).setMapKey("licenseNumber").findMap();
+    // try some cache finds
     Ebean.find(CInhRoot.class).setUseQueryCache(true).findList();
     Ebean.find(CInhRoot.class).setUseQueryCache(true).findList();
-    System.out.println("===2");
+    Ebean.find(CInhRoot.class).setUseQueryCache(true).findList();
 
     LoggedSqlCollector.start();
 
     Ebean.find(CInhRoot.class).setUseQueryCache(true).where().idIn(ids).setMapKey("licenseNumber").findMap();
-    System.out.println("===3");
 
     sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(0);

--- a/src/test/java/org/tests/model/basic/cache/CInhRoot.java
+++ b/src/test/java/org/tests/model/basic/cache/CInhRoot.java
@@ -7,7 +7,7 @@ import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 
-@Cache
+@Cache(enableQueryCache = true)
 @Entity
 @Inheritance
 @DiscriminatorColumn(length = 3)


### PR DESCRIPTION
When you have a collection<CInhRoot> that contains two beans: CInhOne and CInhTwo, the second bean was added with the wrong descriptor to the cache.