### PR TITLE
FIX: jsonRead of transient maps - to skip the read of start_array - Avoid error "Unexpected token start_object - expecting start_array "

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManyJsonHelp.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManyJsonHelp.java
@@ -46,13 +46,14 @@ class BeanPropertyAssocManyJsonHelp {
     if (JsonToken.VALUE_NULL == event) {
       return;
     }
-    if (JsonToken.START_ARRAY != event) {
-      throw new JsonParseException(parser, "Unexpected token " + event + " - expecting start_array ");
-    }
 
     if (many.isTransient()) {
       jsonReadTransientUsingObjectMapper(readJson, parentBean);
       return;
+    }
+
+    if (JsonToken.START_ARRAY != event) {
+      throw new JsonParseException(parser, "Unexpected token " + event + " - expecting start_array");
     }
 
     many.setValue(parentBean, many.jsonReadCollection(readJson, parentBean));

--- a/src/test/java/org/tests/model/elementcollection/EcmPerson.java
+++ b/src/test/java/org/tests/model/elementcollection/EcmPerson.java
@@ -7,7 +7,9 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.MapKeyColumn;
+import javax.persistence.Transient;
 import javax.persistence.Version;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -24,6 +26,9 @@ public class EcmPerson {
   @MapKeyColumn(name = "type", length = 4)
   @Column(name = "number", length = 10)
   Map<String, String> phoneNumbers = new LinkedHashMap<>();
+
+  @Transient
+  Map<String, String> transientPhoneNumbers;
 
   @Version
   long version;

--- a/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMap.java
+++ b/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMap.java
@@ -5,6 +5,7 @@ import io.ebean.Ebean;
 import org.ebeantest.LoggedSqlCollector;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -137,6 +138,7 @@ public class TestElementCollectionBasicMap extends BaseTestCase {
   }
 
   private void jsonToFrom(EcmPerson foundFirst) {
+    foundFirst.transientPhoneNumbers = new HashMap<>();
     String asJson = Ebean.json().toJson(foundFirst);
     EcmPerson fromJson = Ebean.json().toBean(EcmPerson.class, asJson);
 


### PR DESCRIPTION
Nontransient and transient maps are written in a different way.

Nontransient is written with BeanDescriptorElementScalarType and produces this json: `[{"key":"key1", "value":"value1"}, {"key":"key2", "value":"value2"}]`

Transient maps are wrtitten with the ObjectMapper and produce this json: `{"key1":"value1", "key2":"value2"}`

When trying to read a transient map, it fails with "Unexpected token start_object - expecting start_array "

This PR does not test the token, if it is transient.