### PR TITLE
Fix create reference bean on abstract class

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1923,6 +1923,17 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
   }
 
   /**
+   * We actually need to do a query because we don't know the type without the discriminator
+   * value, just select the id property and discriminator column (auto added)
+   */
+  private T findReferenceBean(Object id) {
+      DefaultOrmQuery<T> query = new DefaultOrmQuery<>(this, ebeanServer, ebeanServer.getExpressionFactory());
+      return query
+    		  //.select(getIdProperty().getName()) we do not select the id because we probably have to load the entire bean
+    		  .setId(id).findOne();
+  }
+  
+  /**
    * Create a reference bean based on the id.
    */
   @SuppressWarnings("unchecked")
@@ -1941,6 +1952,10 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
       }
     }
     try {
+     if (inheritInfo != null && !inheritInfo.isConcrete()) {
+    	return findReferenceBean(id);
+      }
+      
       EntityBean eb = createEntityBean();
       id = convertSetId(id, eb);
 
@@ -1974,10 +1989,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
 
     try {
       if (inheritInfo != null && !inheritInfo.isConcrete()) {
-        // we actually need to do a query because we don't know the type without the discriminator
-        // value, just select the id property and discriminator column (auto added)
-        DefaultOrmQuery<T> query = new DefaultOrmQuery<>(this, ebeanServer, ebeanServer.getExpressionFactory());
-        return query.select(getIdProperty().getName()).setId(id).findOne();
+      	return findReferenceBean(id);
       }
 
       EntityBean eb = createEntityBean();

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1926,11 +1926,14 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
    * We actually need to do a query because we don't know the type without the discriminator
    * value, just select the id property and discriminator column (auto added)
    */
-  private T findReferenceBean(Object id) {
-      DefaultOrmQuery<T> query = new DefaultOrmQuery<>(this, ebeanServer, ebeanServer.getExpressionFactory());
-      return query
-    		  //.select(getIdProperty().getName()) we do not select the id because we probably have to load the entire bean
-    		  .setId(id).findOne();
+  private T findReferenceBean(Object id, PersistenceContext pc) {
+    DefaultOrmQuery<T> query = new DefaultOrmQuery<>(this, ebeanServer, ebeanServer.getExpressionFactory());
+    query.setPersistenceContext(pc);
+    return query
+        // .select(getIdProperty().getName())
+        // we do not select the id because we
+        // probably have to load the entire bean
+        .setId(id).findOne();
   }
   
   /**
@@ -1952,10 +1955,10 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
       }
     }
     try {
-     if (inheritInfo != null && !inheritInfo.isConcrete()) {
-    	return findReferenceBean(id);
+      if (inheritInfo != null && !inheritInfo.isConcrete()) {
+        return findReferenceBean(id, pc);
       }
-      
+
       EntityBean eb = createEntityBean();
       id = convertSetId(id, eb);
 
@@ -1989,7 +1992,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
 
     try {
       if (inheritInfo != null && !inheritInfo.isConcrete()) {
-      	return findReferenceBean(id);
+        return findReferenceBean(id, pc);
       }
 
       EntityBean eb = createEntityBean();

--- a/src/test/java/io/ebeaninternal/server/deploy/BeanDescriptorTest.java
+++ b/src/test/java/io/ebeaninternal/server/deploy/BeanDescriptorTest.java
@@ -1,10 +1,15 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
 import io.ebean.bean.EntityBean;
 import io.ebean.plugin.Property;
 import org.junit.Test;
+import org.tests.model.basic.Animal;
+import org.tests.model.basic.AnimalShelter;
+import org.tests.model.basic.Cat;
 import org.tests.model.basic.Customer;
+import org.tests.model.basic.Dog;
 import org.tests.model.basic.Order;
 
 import java.util.Collection;
@@ -45,6 +50,29 @@ public class BeanDescriptorTest extends BaseTestCase {
 
     Customer bean = customerDesc.createReference(Boolean.FALSE, true, 42, null);
     assertThat(server().getBeanState(bean).isDisableLazyLoad()).isTrue();
+  }
+  
+  @Test
+  public void createReference_with_inheritance() {
+    Cat cat = new Cat();
+    cat.setName("Puss");
+    Ebean.save(cat);
+
+    Dog dog = new Dog();
+    dog.setRegistrationNumber("DOGGIE");
+    Ebean.save(dog);
+
+    AnimalShelter shelter = new AnimalShelter();
+    shelter.setName("My Animal Shelter");
+    shelter.getAnimals().add(cat);
+    shelter.getAnimals().add(dog);
+
+    Ebean.save(shelter);
+
+    BeanDescriptor<Animal> animalDesc = spiEbeanServer().getBeanDescriptor(Animal.class);
+
+    Animal bean = animalDesc.createReference(Boolean.FALSE, false, dog.getId(), null);
+    assertThat(bean.getId()).isEqualTo(dog.getId());
   }
 
   @Test

--- a/src/test/java/org/tests/inheritance/OrganizationNode.java
+++ b/src/test/java/org/tests/inheritance/OrganizationNode.java
@@ -1,0 +1,49 @@
+package org.tests.inheritance;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToOne;
+import javax.validation.constraints.NotNull;
+
+import io.ebean.annotation.Index;
+
+/**
+ * Model class to reference an organization node.
+ *
+ * @author Christian Hartl, FOCONIS AG
+ */
+@Entity
+@MappedSuperclass
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "kind")
+@Index(unique = false, columnNames = "kind")
+public abstract class OrganizationNode {
+
+	@Id
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@OneToOne(cascade = {})
+	@NotNull
+	private OrganizationTreeNode parentTreeNode;
+
+	public OrganizationTreeNode getParentTreeNode() {
+		return parentTreeNode;
+	}
+
+	public void setParentTreeNode(OrganizationTreeNode parentTreeNode) {
+		this.parentTreeNode = parentTreeNode;
+	}
+
+}

--- a/src/test/java/org/tests/inheritance/OrganizationTreeNode.java
+++ b/src/test/java/org/tests/inheritance/OrganizationTreeNode.java
@@ -1,0 +1,45 @@
+package org.tests.inheritance;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.validation.constraints.NotNull;
+
+import io.ebean.annotation.PrivateOwned;
+
+/**
+ * Model class to reference an organization tree node.
+ *
+ * @author Christian Hartl, FOCONIS AG
+ */
+@Entity
+public class OrganizationTreeNode {
+
+	@Id
+	private Long id;
+
+	@OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "parentTreeNode")
+	@NotNull
+	@PrivateOwned
+	private OrganizationNode organizationNode;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public OrganizationNode getOrganizationNode() {
+		return organizationNode;
+	}
+
+	public void setOrganizationNode(OrganizationNode organizationNode) {
+		this.organizationNode = organizationNode;
+	}
+
+
+}

--- a/src/test/java/org/tests/inheritance/OrganizationUnit.java
+++ b/src/test/java/org/tests/inheritance/OrganizationUnit.java
@@ -1,0 +1,20 @@
+package org.tests.inheritance;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("Unit")
+public class OrganizationUnit extends OrganizationNode {
+	
+	private String title;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+}

--- a/src/test/java/org/tests/inheritance/TestTreeOrganisations.java
+++ b/src/test/java/org/tests/inheritance/TestTreeOrganisations.java
@@ -1,0 +1,25 @@
+package org.tests.inheritance;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TestTreeOrganisations extends BaseTestCase {
+
+  @Test
+  public void test() {
+
+    OrganizationTreeNode treeNode = new  OrganizationTreeNode();
+    OrganizationNode node = new OrganizationUnit();
+    
+    treeNode.setOrganizationNode(node);
+    Ebean.save(treeNode);
+
+    treeNode = Ebean.find(OrganizationTreeNode.class, treeNode.getId());
+    assertEquals(node, treeNode.getOrganizationNode());
+
+  }
+}


### PR DESCRIPTION
Found an other issue, where the wrong descriptor was used to create a reference bean of an abstract class 