### PR TITLE
Beautify bindNoLog format

### DIFF
--- a/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
+++ b/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
@@ -187,7 +187,10 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
   @Override
   public void bindNoLog(Object value, int sqlType, String logPlaceHolder) throws SQLException {
     if (logLevelSql) {
-      bindLog.append(logPlaceHolder).append(" ");
+      if (bindLog.length() > 0) {
+        bindLog.append(",");
+      }
+      bindLog.append(logPlaceHolder);
     }
     dataBind.setObject(value, sqlType);
   }


### PR DESCRIPTION
when call method bindNoLog(Object value, int sqlType, String logPlaceHolder)
before:
  sql...; --bind(testmoddescription=**** ,ONE,1)
after:
  sql...; --bind(testmod,description=****,ONE,1)