### PR TITLE
Potential resource leaks, as reported by Infer.

### DIFF
--- a/src/main/java/io/ebean/config/properties/Loader.java
+++ b/src/main/java/io/ebean/config/properties/Loader.java
@@ -117,8 +117,8 @@ class Loader {
 
 	void loadYaml(String resourcePath, Source source) {
 		if (yamlLoader != null) {
-		  try {
-			  yamlLoader.load(resource(resourcePath, source));
+		  try (InputStream is = resource(resourcePath, source)) {
+			  yamlLoader.load(is);
       } catch (Exception e) {
         log.warn("Failed to read yml from:" + resourcePath, e);
       }

--- a/src/main/java/io/ebean/config/properties/YamlLoader.java
+++ b/src/main/java/io/ebean/config/properties/YamlLoader.java
@@ -2,6 +2,7 @@ package io.ebean.config.properties;
 
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 

--- a/src/main/java/io/ebeaninternal/dbmigration/DdlGenerator.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/DdlGenerator.java
@@ -173,10 +173,13 @@ public class DdlGenerator {
   protected void runResourceScript(String sqlScript) throws IOException {
 
     if (sqlScript != null) {
-      InputStream is = getClassLoader().getResourceAsStream(sqlScript);
-      if (is != null) {
-        String content = readContent(new InputStreamReader(is));
-        runScript(false, content, sqlScript);
+      try (InputStream is = getClassLoader().getResourceAsStream(sqlScript)) {
+        if (is != null) {
+          String content = readContent(new InputStreamReader(is));
+          runScript(false, content, sqlScript);
+        }
+      } catch (IOException ioe) {
+        // Nothing, because that's how it was before.
       }
     }
   }
@@ -273,7 +276,6 @@ public class DdlGenerator {
         buf.append(s).append("\n");
       }
       return buf.toString();
-
     }
   }
 


### PR DESCRIPTION
Infer: https://github.com/facebook/infer

Infer is a static analysis tool that's a bit different. It goes very specifically into resource leaks, null dereference and thread safety violations.

Example: `infer -- mvn clean compile` and it will do the analysis on the code.

Afterwards a report is generated. Then you can use the command `infer-explore`, which will let you select a report and it will generate the code path through which it detected the potential problem.

Report for ebean was:
```
  THREAD_SAFETY_VIOLATION: 38
         NULL_DEREFERENCE: 23
            RESOURCE_LEAK: 6
```

I focussed on resource leaks as other subjects require a deeper knowledge of the code, which I don't have.

Fixed as best as possible. Comments added. Not all reported leaks are guaranteed to be leaks, as the algorithm seems to be very conservative in determining this.

Comments left in the code in places of uncertainty, will remove after getting comments about them.

That being said, I can't recall if PR's on this repo trigger Travis builds or something similar. Having all the tests run on these change would be nice and I just don't have the various databases installed for it.


There were more reports than the ones I put in this PR, but those seemed to be new instances that have to be passed along and kept in memory. I feel Infer reports resource leaks when it sees that the scope is being exited and the Closable that was created at some point in the scope hasn't been closed. Ignored that maybe that's intended.

That last part is something to keep in mind: the analysis is very conservative and you may spend a lot of time researching the code, to come to the conclusion that it's almost all false positives.