### PR TITLE
ENH: Use java.time.Clock for @WhenModified and @WhenCreated and allow it to be Replaceable for testing

### DIFF
--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -33,6 +33,7 @@ import io.ebean.util.StringHelper;
 import org.avaje.datasource.DataSourceConfig;
 
 import javax.sql.DataSource;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -362,6 +363,11 @@ public class ServerConfig {
    */
   private String uuidStateFile = "ebean-uuid.state";
 
+  /**
+   * The clock used for setting the timestamps (e.g. @UpdatedTimestamp) on objects.
+   */
+  private Clock clock = Clock.systemUTC();
+
   private List<IdGenerator> idGenerators = new ArrayList<>();
   private List<BeanFindController> findControllers = new ArrayList<>();
   private List<BeanPersistController> persistControllers = new ArrayList<>();
@@ -505,6 +511,20 @@ public class ServerConfig {
    */
   public ServerConfig() {
 
+  }
+
+  /**
+   * Get the clock used for setting the timestamps (e.g. @UpdatedTimestamp) on objects.
+   */
+  public Clock getClock() {
+    return clock;
+  }
+
+  /**
+   * Set the clock used for setting the timestamps (e.g. @UpdatedTimestamp) on objects.
+   */
+  public void setClock(final Clock clock) {
+    this.clock = clock;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
+++ b/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
@@ -1275,7 +1275,7 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
    */
   public long now() {
     if (now == 0) {
-      now = System.currentTimeMillis();
+      now = ebeanServer.getServerConfig().getClock().millis();
     }
     return now;
   }

--- a/src/test/java/io/ebean/ExtendedServerTest.java
+++ b/src/test/java/io/ebean/ExtendedServerTest.java
@@ -1,14 +1,26 @@
 package io.ebean;
 
+import io.ebeaninternal.api.SpiEbeanServer;
+import org.junit.After;
 import org.junit.Test;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExtendedServerTest extends BaseTestCase {
+
+  @After
+  public void cleanup() {
+    ((SpiEbeanServer) Ebean.getDefaultServer())
+      .getServerConfig()
+      .setClock(Clock.systemUTC());
+  }
 
   @Test
   public void findList() {
@@ -36,6 +48,47 @@ public class ExtendedServerTest extends BaseTestCase {
       assertThat(customers).isNotEmpty();
       transaction.commit();
     }
+  }
+
+  @Test
+  public void mockClock() {
+    SpiEbeanServer server = (SpiEbeanServer) Ebean.getDefaultServer();
+    final Instant snapshot = Instant.now();
+    Instant backedSnapshot = snapshot.minus(1, ChronoUnit.DAYS);
+    Clock snapshotClock = Clock.fixed(backedSnapshot, Clock.systemUTC().getZone());
+    server.getServerConfig().setClock(snapshotClock);
+
+    ResetBasicData.reset();
+
+    int count = server
+      .find(Customer.class)
+      .where()
+      .gt("cretime", snapshot)
+      .findCount();
+    assertThat(count).isEqualTo(0);
+
+    int count2 = server
+      .find(Customer.class)
+      .where()
+      .ge("cretime", backedSnapshot)
+      .findCount();
+    assertThat(count2).isGreaterThan(0);
+
+    int count3 = server
+      .find(Customer.class)
+      .where()
+      .gt("updtime", snapshot)
+      .findCount();
+    assertThat(count3).isEqualTo(0);
+
+    int count4 = server
+      .find(Customer.class)
+      .where()
+      .ge("updtime", backedSnapshot)
+      .findCount();
+    assertThat(count4).isGreaterThan(0);
+
+
   }
 
 }


### PR DESCRIPTION
As per discussion https://groups.google.com/forum/#!topic/ebean/cvy6MDhji3U a simple way to replace the clock used for setting @UpdatedTimestamp and
@CreatedTimestamp. 

I'm pretty new to hacking in the Ebean source, but this solves the problem for us.