### PR TITLE
Failing unit test to demonstrate the bug that deleting an entity via …

### DIFF
--- a/src/test/java/org/tests/basic/delete/TestDeleteCascadeByQuery.java
+++ b/src/test/java/org/tests/basic/delete/TestDeleteCascadeByQuery.java
@@ -6,6 +6,8 @@ import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.Query;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.tests.model.onetoone.OtoUser;
@@ -13,8 +15,40 @@ import org.tests.model.onetoone.OtoUserOptional;
 
 public class TestDeleteCascadeByQuery extends BaseTestCase {
   
-  Query<OtoUserOptional> userOptionalQuery = Ebean.find(OtoUserOptional.class);
-  Query<OtoUser> userQuery = Ebean.find(OtoUser.class);
+  private OtoUser testUser;
+  private OtoUserOptional userOptional;
+  private Query<OtoUserOptional> userOptionalQuery = Ebean.find(OtoUserOptional.class);
+  private Query<OtoUser> userQuery = Ebean.find(OtoUser.class);
+  
+  /**
+   * Init each test. Delete all existing beans. Then create OtoUser, add OtoUserOptional and save.
+   */
+  @Before
+  public void init() {
+    Ebean.deleteAll(userQuery.findList());
+    Ebean.deleteAll(userOptionalQuery.findList());
+    
+    userOptional = new OtoUserOptional();
+    Ebean.save(userOptional);
+    testUser = new OtoUser();
+    testUser.setOptional(userOptional);
+    Ebean.save(testUser);
+  }
+  
+  /**
+   * Test that validates deleting a bean using Ebean.delete() respects the CascadeType.DELETE 
+   * setting.
+   */
+  @Test
+  public void testDeleteCascadeByEbeanDelete() {
+
+    assertThat(Ebean.delete(testUser)).isTrue();
+
+    assertThat(userOptionalQuery.findCount())
+      .overridingErrorMessage("Entity OtoUserOptional found. Ebean.delete() on the user "
+          + "did not delete the OneToOne mapped entity as set with CascadeType.ALL")
+      .isEqualTo(0);
+  }
   
   /**
    * Test that validates deleting a bean with OneToOne mapping with a query respects the 
@@ -22,39 +56,21 @@ public class TestDeleteCascadeByQuery extends BaseTestCase {
    */
   @Test
   public void testDeleteCascadeByQuery() {
-
-    // Check that both models do not exist
-    assertNoUserOrOptionalExist();
-
-    // Create OtoUser and assign OtoUserOptional to it then save
-    createUserAndOptional();
     
-    // Deleting the testUser using Ebean.delete() works
-    // Ebean.delete(testUser);
-    
-    // Deleting the testUser using the Ebean query
     assertThat(userQuery.delete()).isEqualTo(1);
-    
-    // Check that both models are deleted (CascadeType.DELETE was respected)
-    assertNoUserOrOptionalExist();
 
-  }
-  
-  private OtoUser createUserAndOptional() {
-    OtoUserOptional userOptional = new OtoUserOptional();
-    OtoUser testUser = new OtoUser();
-    testUser.setOptional(userOptional);
-    Ebean.save(userOptional);
-    Ebean.save(testUser);
-    return testUser;
-  }
-  
-  private void assertNoUserOrOptionalExist() {
     assertThat(userOptionalQuery.findCount())
-      .overridingErrorMessage("Entity OtoUserOptional found.")
+      .overridingErrorMessage("Entity OtoUserOptional found. Ebean query delete() on the user "
+          + "did not delete the OneToOne mapped entity as set with CascadeType.ALL")
       .isEqualTo(0);
-    assertThat(userQuery.findCount())
-      .overridingErrorMessage("Entity OtoUser found.")
-      .isEqualTo(0);
+  }
+  
+  /**
+   * Cleanup - Delete all existing beans for the next test.
+   */
+  @After
+  public void cleanup() {
+    Ebean.deleteAll(userQuery.findList());
+    Ebean.deleteAll(userOptionalQuery.findList());
   }
 }

--- a/src/test/java/org/tests/basic/delete/TestDeleteCascadeByQuery.java
+++ b/src/test/java/org/tests/basic/delete/TestDeleteCascadeByQuery.java
@@ -1,0 +1,60 @@
+package org.tests.basic.delete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import io.ebean.Query;
+
+import org.junit.Test;
+
+import org.tests.model.onetoone.OtoUser;
+import org.tests.model.onetoone.OtoUserOptional;
+
+public class TestDeleteCascadeByQuery extends BaseTestCase {
+  
+  Query<OtoUserOptional> userOptionalQuery = Ebean.find(OtoUserOptional.class);
+  Query<OtoUser> userQuery = Ebean.find(OtoUser.class);
+  
+  /**
+   * Test that validates deleting a bean with OneToOne mapping with a query respects the 
+   * CascadeType.DELETE setting.
+   */
+  @Test
+  public void testDeleteCascadeByQuery() {
+
+    // Check that both models do not exist
+    assertNoUserOrOptionalExist();
+
+    // Create OtoUser and assign OtoUserOptional to it then save
+    createUserAndOptional();
+    
+    // Deleting the testUser using Ebean.delete() works
+    // Ebean.delete(testUser);
+    
+    // Deleting the testUser using the Ebean query
+    assertThat(userQuery.delete()).isEqualTo(1);
+    
+    // Check that both models are deleted (CascadeType.DELETE was respected)
+    assertNoUserOrOptionalExist();
+
+  }
+  
+  private OtoUser createUserAndOptional() {
+    OtoUserOptional userOptional = new OtoUserOptional();
+    OtoUser testUser = new OtoUser();
+    testUser.setOptional(userOptional);
+    Ebean.save(userOptional);
+    Ebean.save(testUser);
+    return testUser;
+  }
+  
+  private void assertNoUserOrOptionalExist() {
+    assertThat(userOptionalQuery.findCount())
+      .overridingErrorMessage("Entity OtoUserOptional found.")
+      .isEqualTo(0);
+    assertThat(userQuery.findCount())
+      .overridingErrorMessage("Entity OtoUser found.")
+      .isEqualTo(0);
+  }
+}

--- a/src/test/java/org/tests/model/onetoone/OtoUser.java
+++ b/src/test/java/org/tests/model/onetoone/OtoUser.java
@@ -1,0 +1,31 @@
+package org.tests.model.onetoone;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.tests.model.BaseModel;
+
+@Entity
+@Table(name = "oto_user_model")
+public class OtoUser extends BaseModel {
+
+  String name;
+  
+  @OneToOne(optional = true, cascade = CascadeType.ALL)
+  OtoUserOptional userOptional;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+  
+  public void setOptional(OtoUserOptional userOptional) {
+    this.userOptional = userOptional;
+  }
+
+}

--- a/src/test/java/org/tests/model/onetoone/OtoUserOptional.java
+++ b/src/test/java/org/tests/model/onetoone/OtoUserOptional.java
@@ -1,0 +1,22 @@
+package org.tests.model.onetoone;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import org.tests.model.BaseModel;
+
+@Entity
+@Table(name = "oto_user_model_optional")
+public class OtoUserOptional extends BaseModel {
+
+  String optional;
+
+  public void setPassword(final String optional) {
+    this.optional = optional;
+  }
+  
+  String getOptional() {
+    return optional;
+  }
+
+}


### PR DESCRIPTION
…an Ebean query does not respect the cascade setting.

(here a mapped optional OneToOne entity is not deleted using an Ebean query even if the CascadeType.ALL was used)

> We have a model A with an optional one-to-one mapped object B which in our case is an encrypted password object for A.
@OneToOne(cascade = CascadeType.ALL, optional = true)
After creating both modelA, assigning modelB and saving those my test deletes model A and checks if modelB was also removed.
Two ways to remove modelA yield different results:
1) deleting the model with modelA.delete() also removes modelB following the persistence option ALL which include CascadeType.DELETE
--> this is okay and works as expected
2) deleting the model using the Query object new QModelA().delete() the persistence option is ignored and modelB is left
--> our expectation was that the CascadeType is considered here as well

Ebean Google Forums Link:
https://groups.google.com/forum/#!topic/ebean/JZeklZ66evc