### PR TITLE
Fix Transaction Flushing when ID Property is Loaded

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
+++ b/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
@@ -356,7 +356,15 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
 
   private boolean flushBatchOnGetter(int propertyIndex) {
     // propertyIndex of -1 the Id property, no flush for get Id on UPDATE
-    return propertyIndex == -1 ? type == Type.INSERT : beanDescriptor.isGeneratedProperty(propertyIndex);
+    if (propertyIndex == -1) {
+      if (beanDescriptor.isIdLoaded(intercept)) {
+        return false;
+      } else {
+        return type == Type.INSERT;
+      }
+    } else {
+      return beanDescriptor.isGeneratedProperty(propertyIndex);
+    }
   }
 
   public void setSkipBatchForTopLevel() {

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -3160,6 +3160,10 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
   public boolean hasIdPropertyOnly(EntityBeanIntercept ebi) {
     return ebi.hasIdOnly(idPropertyIndex);
   }
+  
+  public boolean isIdLoaded(EntityBeanIntercept ebi) {
+    return ebi.isLoadedProperty(idPropertyIndex);
+  }
 
   public boolean hasIdValue(EntityBean bean) {
     return (idProperty != null && !DmlUtil.isNullOrZero(idProperty.getValue(bean)));

--- a/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
+++ b/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
@@ -122,15 +122,20 @@ public class TestBatchInsertFlush extends BaseTestCase {
   public void transactional_flushOnGetId() {
 
     EbeanServer server = Ebean.getDefaultServer();
-
+    LoggedSqlCollector.start();
+    
     EBasicVer b1 = new EBasicVer("b1");
     server.save(b1);
 
     EBasicVer b2 = new EBasicVer("b2");
     server.save(b2);
 
+    //flush here
+    assertThat(LoggedSqlCollector.current()).isEmpty();
     Integer id = b1.getId();
     assertNotNull(id);
+    assertThat(LoggedSqlCollector.current()).hasSize(2);
+    
     EBasicVer b3 = new EBasicVer("b3");
     server.save(b3);
   }
@@ -141,7 +146,8 @@ public class TestBatchInsertFlush extends BaseTestCase {
     EbeanServer server = Ebean.getDefaultServer();
     Transaction txn = server.beginTransaction();
     try {
-      txn.setBatch(PersistBatch.ALL);
+      LoggedSqlCollector.start();
+      txn.setBatchMode(true);
 
       EBasicVer b1 = new EBasicVer("b1");
       server.save(b1, txn);
@@ -149,13 +155,76 @@ public class TestBatchInsertFlush extends BaseTestCase {
       EBasicVer b2 = new EBasicVer("b2");
       server.save(b2, txn);
 
+      //flush here
+      assertThat(LoggedSqlCollector.current()).isEmpty();
       Integer id = b1.getId();
       assertNotNull(id);
+      assertThat(LoggedSqlCollector.current()).hasSize(2);
 
       EBasicVer b3 = new EBasicVer("b3");
       server.save(b3, txn);
 
       txn.commit();
+
+    } finally {
+      txn.end();
+    }
+  }
+  
+  @Test
+  @Transactional(batch = PersistBatch.ALL)
+  public void transactional_noflushWhenIdIsLoaded() {
+
+    EbeanServer server = Ebean.getDefaultServer();
+    LoggedSqlCollector.start();
+
+    EBasicVer b1 = new EBasicVer("b1");
+    b1.setId(12);
+    server.save(b1);
+
+    EBasicVer b2 = new EBasicVer("b2");
+    b2.setId(20);
+    server.save(b2);
+
+    assertThat(LoggedSqlCollector.current()).isEmpty();
+    // dont flush here
+    Integer id = b1.getId();
+    assertNotNull(id);
+    assertThat(LoggedSqlCollector.current()).isEmpty();
+    
+    EBasicVer b3 = new EBasicVer("b3");
+    server.save(b3);
+  }
+
+  @Test
+  public void noflushWhenIdIsLoaded() {
+
+    EbeanServer server = Ebean.getDefaultServer();
+    Transaction txn = server.beginTransaction();
+    try {
+      
+      LoggedSqlCollector.start();
+      txn.setBatchMode(true);
+
+      EBasicVer b1 = new EBasicVer("b1");
+      b1.setId(12);
+      server.save(b1, txn);
+
+      EBasicVer b2 = new EBasicVer("b2");
+      b2.setId(20);
+      server.save(b2, txn);
+
+      assertThat(LoggedSqlCollector.current()).isEmpty();
+      //dont flush here
+      Integer id = b1.getId();
+      assertNotNull(id);
+      assertThat(LoggedSqlCollector.current()).isEmpty();
+
+      EBasicVer b3 = new EBasicVer("b3");
+      server.save(b3, txn);
+
+      txn.commit();
+      assertThat(LoggedSqlCollector.current()).hasSize(3);
 
     } finally {
       txn.end();

--- a/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
+++ b/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
@@ -179,11 +179,11 @@ public class TestBatchInsertFlush extends BaseTestCase {
     LoggedSqlCollector.start();
 
     EBasicVer b1 = new EBasicVer("b1");
-    b1.setId(12);
+    b1.setId(100);
     server.save(b1);
 
     EBasicVer b2 = new EBasicVer("b2");
-    b2.setId(20);
+    b2.setId(200);
     server.save(b2);
 
     assertThat(LoggedSqlCollector.current()).isEmpty();

--- a/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
+++ b/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
@@ -176,14 +176,15 @@ public class TestBatchInsertFlush extends BaseTestCase {
   public void transactional_noflushWhenIdIsLoaded() {
 
     EbeanServer server = Ebean.getDefaultServer();
+      
     LoggedSqlCollector.start();
 
     EBasicVer b1 = new EBasicVer("b1");
-    b1.setId(100);
+    b1.setId(78965);
     server.save(b1);
 
     EBasicVer b2 = new EBasicVer("b2");
-    b2.setId(200);
+    b2.setId(78645);
     server.save(b2);
 
     assertThat(LoggedSqlCollector.current()).isEmpty();
@@ -194,6 +195,7 @@ public class TestBatchInsertFlush extends BaseTestCase {
     
     EBasicVer b3 = new EBasicVer("b3");
     server.save(b3);
+    
   }
 
   @Test
@@ -202,16 +204,15 @@ public class TestBatchInsertFlush extends BaseTestCase {
     EbeanServer server = Ebean.getDefaultServer();
     Transaction txn = server.beginTransaction();
     try {
-      
       LoggedSqlCollector.start();
       txn.setBatchMode(true);
 
       EBasicVer b1 = new EBasicVer("b1");
-      b1.setId(12);
+      b1.setId(546864);
       server.save(b1, txn);
 
       EBasicVer b2 = new EBasicVer("b2");
-      b2.setId(20);
+      b2.setId(21354);
       server.save(b2, txn);
 
       assertThat(LoggedSqlCollector.current()).isEmpty();


### PR DESCRIPTION
Hi Rob,

I have an import-routine that inserts/updates model in a certain order via batchmode. To do that,  I have to check the ID-property (not generated) of the model prior in the batch. Although the id-property is set in the previous model, the bean getter will call "flushBatch", so that the pervious model ist saved to the database, which is not necessary. This results in flushing the batch before every insert.

My testcase is similar to the existing test case "testFlushOnGetId"  and has the logging output:

![ebean test log](https://user-images.githubusercontent.com/28051929/42578925-84fcf100-8527-11e8-8d57-cf1b92756aa1.png)

