### PR TITLE
Deleting a bean does not invalidate the bean cache (Regression from 11.18.1 - introduced by #1427)

### DIFF
--- a/src/test/java/org/tests/delete/TestDeleteByQuery.java
+++ b/src/test/java/org/tests/delete/TestDeleteByQuery.java
@@ -9,6 +9,7 @@ import io.ebean.annotation.Platform;
 
 import org.tests.model.basic.BBookmarkUser;
 import org.tests.model.basic.Contact;
+import org.tests.model.basic.Country;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
 import org.ebeantest.LoggedSqlCollector;
@@ -169,5 +170,23 @@ public class TestDeleteByQuery extends BaseTestCase {
 
     Contact contactFind = Ebean.find(Contact.class, contact.getId());
     assertThat(contactFind).isNull();
+  }
+
+  @Test
+  public void deleteByPredicateCached() {
+
+    Country country = new Country();
+    country.setCode("XX");
+    country.setName("SecretName");
+    Ebean.save(country);
+    Query<Country> query = Ebean.find(Country.class).where().eq("name", "SecretName").setUseQueryCache(true);
+
+    assertThat(query.findList()).hasSize(1);
+    assertThat(query.findCount()).isEqualTo(1);
+
+    Ebean.find(Country.class).where().eq("name", "SecretName").delete();
+    //Ebean.getDefaultServer().getPluginApi().getBeanType(Country.class).clearQueryCache();
+    assertThat(query.findList()).hasSize(0);
+    assertThat(query.findCount()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
Hello Rob,

unfortunately the change #1447 causes a caching issue as you see in the test case.
Do you have time to take a look at this or should I try to provide a fix?

**Expected behaviour:**
Caches of all involved beans have to be invalidated


