### PR TITLE
FIX: null handling in ScalarType.toBeanType

### DIFF
--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeChar.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeChar.java
@@ -51,6 +51,7 @@ public class ScalarTypeChar extends ScalarTypeBaseVarchar<Character> {
 
   @Override
   public Character toBeanType(Object value) {
+    if (value == null) return null;
     String s = BasicTypeConverter.toString(value);
     return s.charAt(0);
   }

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeCharArray.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeCharArray.java
@@ -54,6 +54,7 @@ public class ScalarTypeCharArray extends ScalarTypeBaseVarchar<char[]> {
 
   @Override
   public char[] toBeanType(Object value) {
+    if (value == null) return null;
     String s = BasicTypeConverter.toString(value);
     return s.toCharArray();
   }

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeDuration.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeDuration.java
@@ -59,6 +59,7 @@ public class ScalarTypeDuration extends ScalarTypeBase<Duration> {
   @Override
   public Duration toBeanType(Object value) {
     if (value instanceof Duration) return (Duration) value;
+    if (value == null) return null;
     return Duration.ofSeconds(BasicTypeConverter.toLong(value));
   }
 

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeDurationWithNanos.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeDurationWithNanos.java
@@ -42,6 +42,7 @@ public class ScalarTypeDurationWithNanos extends ScalarTypeDuration {
   @Override
   public Duration toBeanType(Object value) {
     if (value instanceof Duration) return (Duration) value;
+    if (value == null) return null;
     return convertFromBigDecimal(BasicTypeConverter.toBigDecimal(value));
   }
 

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeInstant.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeInstant.java
@@ -53,7 +53,7 @@ public class ScalarTypeInstant extends ScalarTypeBaseDateTime<Instant> {
 
   @Override
   public Instant toBeanType(Object value) {
-    if (value instanceof Instant) return (Instant) value;
-    return convertFromTimestamp((Timestamp) value);
+    if (value instanceof Timestamp) return convertFromTimestamp((Timestamp) value);
+    return (Instant) value;
   }
 }

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
@@ -54,7 +54,7 @@ public class ScalarTypeLocalDateTime extends ScalarTypeBaseDateTime<LocalDateTim
 
   @Override
   public LocalDateTime toBeanType(Object value) {
-    if (value instanceof LocalDateTime) return (LocalDateTime) value;
-    return convertFromTimestamp((Timestamp) value);
+    if (value instanceof Timestamp) return convertFromTimestamp((Timestamp) value);
+    return (LocalDateTime) value;
   }
 }

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTime.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTime.java
@@ -55,7 +55,7 @@ public class ScalarTypeOffsetDateTime extends ScalarTypeBaseDateTime<OffsetDateT
 
   @Override
   public OffsetDateTime toBeanType(Object value) {
-    if (value instanceof OffsetDateTime) return (OffsetDateTime) value;
-    return convertFromTimestamp((Timestamp) value);
+    if (value instanceof Timestamp) return convertFromTimestamp((Timestamp) value);
+    return (OffsetDateTime) value;
   }
 }

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeYear.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeYear.java
@@ -65,6 +65,7 @@ public class ScalarTypeYear extends ScalarTypeBase<Year> {
   @Override
   public Year toBeanType(Object value) {
     if (value instanceof Year) return (Year) value;
+    if (value == null) return null;
     return Year.of(BasicTypeConverter.toInteger(value));
   }
 

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeYearMonthDate.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeYearMonthDate.java
@@ -61,6 +61,7 @@ public class ScalarTypeYearMonthDate extends ScalarTypeBaseDate<YearMonth> {
   public YearMonth toBeanType(Object value) {
     if (value instanceof YearMonth) return (YearMonth) value;
     if (value instanceof LocalDate) return fromLocalDate((LocalDate) value);
+    if (value == null) return null;
     return fromLocalDate(BasicTypeConverter.toDate(value).toLocalDate());
   }
 

--- a/src/main/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTime.java
+++ b/src/main/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTime.java
@@ -55,7 +55,7 @@ public class ScalarTypeZonedDateTime extends ScalarTypeBaseDateTime<ZonedDateTim
 
   @Override
   public ZonedDateTime toBeanType(Object value) {
-    if (value instanceof ZonedDateTime) return (ZonedDateTime) value;
-    return convertFromTimestamp((Timestamp) value);
+    if (value instanceof Timestamp) return convertFromTimestamp((Timestamp) value);
+    return (ZonedDateTime) value;
   }
 }

--- a/src/test/java/org/tests/types/TestNewTypes.java
+++ b/src/test/java/org/tests/types/TestNewTypes.java
@@ -2,6 +2,9 @@ package org.tests.types;
 
 import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.plugin.BeanType;
+import io.ebean.plugin.ExpressionPath;
+
 import org.junit.Test;
 import org.tests.model.types.SomeNewTypesBean;
 
@@ -21,9 +24,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class TestNewTypes extends BaseTestCase {
 
@@ -145,4 +146,90 @@ public class TestNewTypes extends BaseTestCase {
     assertNull(fetched.getPath());
     assertNull(fetched.getPeriod());
   }
+
+  @Test
+  public void testSetGetPathNonNull() throws Exception {
+    SomeNewTypesBean refBean = new SomeNewTypesBean();
+    refBean.setLocalDate(LocalDate.now());
+    refBean.setLocalDateTime(LocalDateTime.now());
+    refBean.setOffsetDateTime(OffsetDateTime.now());
+    refBean.setZonedDateTime(ZonedDateTime.now());
+    refBean.setInstant(Instant.now());
+    refBean.setYear(Year.now());
+    refBean.setMonth(Month.APRIL);
+    refBean.setDayOfWeek(DayOfWeek.WEDNESDAY);
+    refBean.setZoneId(ZoneId.systemDefault());
+    refBean.setZoneOffset(ZonedDateTime.now().getOffset());
+    refBean.setYearMonth(YearMonth.of(2014, 9));
+    refBean.setPath(Paths.get(TEMP_PATH));
+    refBean.setPeriod(Period.of(4,3,2));
+
+    testSetGetPath(refBean);
+  }
+
+  @Test
+  public void testSetGetPathNull() throws Exception {
+    SomeNewTypesBean refBean = new SomeNewTypesBean();
+    testSetGetPath(refBean);
+  }
+  private void testSetGetPath(SomeNewTypesBean refBean) {
+    SomeNewTypesBean testBean = new SomeNewTypesBean();
+    BeanType<SomeNewTypesBean> beanType = Ebean.getDefaultServer().getPluginApi().getBeanType(SomeNewTypesBean.class);
+    ExpressionPath localDate = beanType.getExpressionPath("localDate");
+    ExpressionPath localDateTime = beanType.getExpressionPath("localDateTime");
+    ExpressionPath offsetDateTime = beanType.getExpressionPath("offsetDateTime");
+    ExpressionPath zonedDateTime = beanType.getExpressionPath("zonedDateTime");
+    ExpressionPath instant = beanType.getExpressionPath("instant");
+    ExpressionPath year = beanType.getExpressionPath("year");
+    ExpressionPath month = beanType.getExpressionPath("month");
+    ExpressionPath dayOfWeek = beanType.getExpressionPath("dayOfWeek");
+    ExpressionPath zoneId = beanType.getExpressionPath("zoneId");
+    ExpressionPath zoneOffset = beanType.getExpressionPath("zoneOffset");
+    ExpressionPath yearMonth = beanType.getExpressionPath("yearMonth");
+    ExpressionPath path = beanType.getExpressionPath("path");
+    ExpressionPath period = beanType.getExpressionPath("period");
+
+    localDate.pathSet(testBean, refBean.getLocalDate());
+    assertThat(localDate.pathGet(testBean)).isEqualTo(refBean.getLocalDate());
+
+    localDateTime.pathSet(testBean, refBean.getLocalDateTime());
+    assertThat(localDateTime.pathGet(testBean)).isEqualTo(refBean.getLocalDateTime());
+
+    offsetDateTime.pathSet(testBean, refBean.getOffsetDateTime());
+    assertThat(offsetDateTime.pathGet(testBean)).isEqualTo(refBean.getOffsetDateTime());
+
+    zonedDateTime.pathSet(testBean, refBean.getZonedDateTime());
+    assertThat(zonedDateTime.pathGet(testBean)).isEqualTo(refBean.getZonedDateTime());
+
+    instant.pathSet(testBean, refBean.getInstant());
+    assertThat(instant.pathGet(testBean)).isEqualTo(refBean.getInstant());
+
+    year.pathSet(testBean, refBean.getYear());
+    assertThat(year.pathGet(testBean)).isEqualTo(refBean.getYear());
+
+    month.pathSet(testBean, refBean.getMonth());
+    assertThat(month.pathGet(testBean)).isEqualTo(refBean.getMonth());
+
+    dayOfWeek.pathSet(testBean, refBean.getDayOfWeek());
+    assertThat(dayOfWeek.pathGet(testBean)).isEqualTo(refBean.getDayOfWeek());
+
+    zoneId.pathSet(testBean, refBean.getZoneId());
+    assertThat(zoneId.pathGet(testBean)).isEqualTo(refBean.getZoneId());
+
+    zoneOffset.pathSet(testBean, refBean.getZoneOffset());
+    assertThat(zoneOffset.pathGet(testBean)).isEqualTo(refBean.getZoneOffset());
+
+    yearMonth.pathSet(testBean, refBean.getYearMonth());
+    assertThat(yearMonth.pathGet(testBean)).isEqualTo(refBean.getYearMonth());
+
+    path.pathSet(testBean, refBean.getPath());
+    assertThat(path.pathGet(testBean)).isEqualTo(refBean.getPath());
+
+    period.pathSet(testBean, refBean.getPeriod());
+    assertThat(period.pathGet(testBean)).isEqualTo(refBean.getPeriod());
+
+    Ebean.save(refBean);
+    Ebean.save(testBean);
+  }
+
 }


### PR DESCRIPTION
**Bug:** When setting java 8 time API values to null with `pathSet(bean, null)`, you'll get a NPE.

This PR tries to fix this bug. I've also checked all other toBeanType methods, if they can handle `null`