### PR TITLE
Add support for Postgres range partition DDL plus refactor xsd definitions that had got out of sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>io.ebean</groupId>
   <artifactId>ebean</artifactId>
-  <version>11.19.3-SNAPSHOT</version>
+  <version>11.19.3</version>
   <packaging>jar</packaging>
 
   <name>ebean</name>
@@ -22,7 +22,7 @@
 
   <scm>
     <developerConnection>scm:git:git@github.com:ebean-orm/ebean.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>ebean-11.19.3</tag>
   </scm>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>io.ebean</groupId>
   <artifactId>ebean</artifactId>
-  <version>11.19.4-SNAPSHOT</version>
+  <version>11.20.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>ebean</name>
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-migration</artifactId>
-      <version>11.7.1</version>
+      <version>11.8.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>io.ebean</groupId>
   <artifactId>ebean</artifactId>
-  <version>11.19.3</version>
+  <version>11.19.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>ebean</name>
@@ -22,7 +22,7 @@
 
   <scm>
     <developerConnection>scm:git:git@github.com:ebean-orm/ebean.git</developerConnection>
-    <tag>ebean-11.19.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-annotation</artifactId>
-      <version>4.1</version>
+      <version>4.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
@@ -662,4 +662,12 @@ public class PlatformDdl {
   public void unlockTables(DdlBuffer buffer, Collection<String> tables) throws IOException {
 
   }
+
+  public boolean suppressPrimaryKeyOnPartition() {
+    return false;
+  }
+
+  public void addTablePartition(DdlBuffer apply, String partitionMode, String partitionColumn) throws IOException {
+    // only supported by postgres initially
+  }
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresDdl.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresDdl.java
@@ -1,6 +1,9 @@
 package io.ebeaninternal.dbmigration.ddlgeneration.platform;
 
 import io.ebean.config.dbplatform.DatabasePlatform;
+import io.ebeaninternal.dbmigration.ddlgeneration.DdlBuffer;
+
+import java.io.IOException;
 
 /**
  * Postgres specific DDL.
@@ -14,6 +17,11 @@ public class PostgresDdl extends PlatformDdl {
     this.columnSetType = "type ";
     this.alterTableIfExists = "if exists ";
     this.columnSetNull = "drop not null";
+  }
+
+  @Override
+  public boolean suppressPrimaryKeyOnPartition() {
+    return true;
   }
 
   @Override
@@ -37,5 +45,10 @@ public class PostgresDdl extends PlatformDdl {
       return "smallserial";
     }
     return columnDefn;
+  }
+
+  @Override
+  public void addTablePartition(DdlBuffer apply, String partitionMode, String partitionColumn) throws IOException {
+    apply.append(" partition by range (").append(partitionColumn).append(")");
   }
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AddColumn.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AddColumn.java
@@ -12,9 +12,9 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
@@ -45,20 +45,20 @@ public class AddColumn {
 
   /**
    * Gets the value of the column property.
-   * <p>
+   *
    * <p>
    * This accessor method returns a reference to the live list,
    * not a snapshot. Therefore any modification you make to the
    * returned list will be present inside the JAXB object.
    * This is why there is not a <CODE>set</CODE> method for the column property.
-   * <p>
+   *
    * <p>
    * For example, to add a new item, do as follows:
    * <pre>
    *    getColumn().add(newItem);
    * </pre>
-   * <p>
-   * <p>
+   *
+   *
    * <p>
    * Objects of the following type(s) are allowed in the list
    * {@link Column }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AddHistoryTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AddHistoryTable.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AddTableComment.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AddTableComment.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AddUniqueConstraint.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AddUniqueConstraint.java
@@ -32,7 +32,7 @@ public class AddUniqueConstraint {
 
   @XmlAttribute(name = "nullableColumns", required = true)
   protected String nullableColumns;
-    
+
   @XmlAttribute(name = "oneToOne", required = false)
   protected Boolean oneToOne;
 
@@ -55,7 +55,7 @@ public class AddUniqueConstraint {
   public void setConstraintName(String value) {
     this.constraintName = value;
   }
-  
+
   /**
    * Gets the value of the tableName property.
    *
@@ -65,7 +65,7 @@ public class AddUniqueConstraint {
   public String getTableName() {
     return tableName;
   }
-  
+
   /**
    * Sets the value of the tableName property.
    *
@@ -115,7 +115,7 @@ public class AddUniqueConstraint {
   public void setNullableColumns(String value) {
     this.nullableColumns = value;
   }
-  
+
   /**
    * Gets the value of the oneToOne property.
    *

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AddUniqueConstraint.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AddUniqueConstraint.java
@@ -9,11 +9,21 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
- * TODO
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;attribute name="constraintName" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="tableName" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="columnNames" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="oneToOne" type="{http://www.w3.org/2001/XMLSchema}boolean" />
+ *       &lt;attribute name="nullableColumns" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -23,18 +33,14 @@ public class AddUniqueConstraint {
 
   @XmlAttribute(name = "constraintName", required = true)
   protected String constraintName;
-
   @XmlAttribute(name = "tableName", required = true)
   protected String tableName;
-
   @XmlAttribute(name = "columnNames", required = true)
   protected String columnNames;
-
-  @XmlAttribute(name = "nullableColumns", required = true)
-  protected String nullableColumns;
-
-  @XmlAttribute(name = "oneToOne", required = false)
+  @XmlAttribute(name = "oneToOne")
   protected Boolean oneToOne;
+  @XmlAttribute(name = "nullableColumns")
+  protected String nullableColumns;
 
   /**
    * Gets the value of the constraintName property.
@@ -72,8 +78,8 @@ public class AddUniqueConstraint {
    * @param value allowed object is
    *              {@link String }
    */
-  public void setTableName(String tableName) {
-    this.tableName = tableName;
+  public void setTableName(String value) {
+    this.tableName = value;
   }
 
   /**
@@ -97,6 +103,26 @@ public class AddUniqueConstraint {
   }
 
   /**
+   * Gets the value of the oneToOne property.
+   *
+   * @return possible object is
+   * {@link Boolean }
+   */
+  public Boolean isOneToOne() {
+    return oneToOne;
+  }
+
+  /**
+   * Sets the value of the oneToOne property.
+   *
+   * @param value allowed object is
+   *              {@link Boolean }
+   */
+  public void setOneToOne(Boolean value) {
+    this.oneToOne = value;
+  }
+
+  /**
    * Gets the value of the nullableColumns property.
    *
    * @return possible object is
@@ -114,24 +140,6 @@ public class AddUniqueConstraint {
    */
   public void setNullableColumns(String value) {
     this.nullableColumns = value;
-  }
-
-  /**
-   * Gets the value of the oneToOne property.
-   *
-   * @return true if oneToOne was set
-   */
-  public boolean isOneToOne() {
-    return Boolean.TRUE.equals(oneToOne);
-  }
-
-  /**
-   * Sets the value of the oneToOne property.
-   *
-   * @param value boolean
-   */
-  public void setOneToOne(boolean oneToOne) {
-    this.oneToOne = oneToOne;
   }
 
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AlterColumn.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AlterColumn.java
@@ -3,7 +3,6 @@ package io.ebeaninternal.dbmigration.migration;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
@@ -12,13 +11,17 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
  *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="before" type="{http://ebean-orm.github.io/xml/ns/dbmigration}ddl-script" maxOccurs="unbounded" minOccurs="0"/>
+ *         &lt;element name="after" type="{http://ebean-orm.github.io/xml/ns/dbmigration}ddl-script" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
  *       &lt;attribute name="columnName" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="tableName" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="withHistory" type="{http://www.w3.org/2001/XMLSchema}boolean" />
@@ -50,16 +53,14 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {
-    "before", "after"
+  "before",
+  "after"
 })
 @XmlRootElement(name = "alterColumn")
 public class AlterColumn {
 
-  @XmlElement(required = false)
   protected List<DdlScript> before;
-  @XmlElement(required = false)
   protected List<DdlScript> after;
-
   @XmlAttribute(name = "columnName", required = true)
   protected String columnName;
   @XmlAttribute(name = "tableName", required = true)
@@ -108,6 +109,60 @@ public class AlterColumn {
   protected String dropForeignKey;
   @XmlAttribute(name = "dropForeignKeyIndex")
   protected String dropForeignKeyIndex;
+
+  /**
+   * Gets the value of the before property.
+   *
+   * <p>
+   * This accessor method returns a reference to the live list,
+   * not a snapshot. Therefore any modification you make to the
+   * returned list will be present inside the JAXB object.
+   * This is why there is not a <CODE>set</CODE> method for the before property.
+   *
+   * <p>
+   * For example, to add a new item, do as follows:
+   * <pre>
+   *    getBefore().add(newItem);
+   * </pre>
+   *
+   *
+   * <p>
+   * Objects of the following type(s) are allowed in the list
+   * {@link DdlScript }
+   */
+  public List<DdlScript> getBefore() {
+    if (before == null) {
+      before = new ArrayList<>();
+    }
+    return this.before;
+  }
+
+  /**
+   * Gets the value of the after property.
+   *
+   * <p>
+   * This accessor method returns a reference to the live list,
+   * not a snapshot. Therefore any modification you make to the
+   * returned list will be present inside the JAXB object.
+   * This is why there is not a <CODE>set</CODE> method for the after property.
+   *
+   * <p>
+   * For example, to add a new item, do as follows:
+   * <pre>
+   *    getAfter().add(newItem);
+   * </pre>
+   *
+   *
+   * <p>
+   * Objects of the following type(s) are allowed in the list
+   * {@link DdlScript }
+   */
+  public List<DdlScript> getAfter() {
+    if (after == null) {
+      after = new ArrayList<>();
+    }
+    return this.after;
+  }
 
   /**
    * Gets the value of the columnName property.
@@ -589,17 +644,4 @@ public class AlterColumn {
     this.dropForeignKeyIndex = value;
   }
 
-  public List<DdlScript> getBefore() {
-    if (before == null) {
-      before = new ArrayList<>();
-    }
-    return before;
-  }
-
-  public List<DdlScript> getAfter() {
-    if (after == null) {
-      after = new ArrayList<>();
-    }
-    return after;
-  }
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AlterForeignKey.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AlterForeignKey.java
@@ -9,21 +9,34 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
- * TODO
+ * &lt;complexType>
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="columnNames" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="refColumnNames" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="refTableName" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="indexName" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="tableName" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="onDelete" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="onUpdate" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "")
-@XmlRootElement(name = "foreignKey")
+@XmlRootElement(name = "alterForeignKey")
 public class AlterForeignKey {
 
   @XmlAttribute(name = "name", required = true)
   protected String name;
-  @XmlAttribute(name = "columnNames", required = true)
+  @XmlAttribute(name = "columnNames")
   protected String columnNames;
   @XmlAttribute(name = "refColumnNames")
   protected String refColumnNames;
@@ -37,6 +50,7 @@ public class AlterForeignKey {
   protected String onDelete;
   @XmlAttribute(name = "onUpdate")
   protected String onUpdate;
+
   /**
    * Gets the value of the name property.
    *
@@ -196,4 +210,5 @@ public class AlterForeignKey {
   public void setOnUpdate(String value) {
     this.onUpdate = value;
   }
+
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/AlterHistoryTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/AlterHistoryTable.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/Apply.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/Apply.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlValue;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;simpleContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSet.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSet.java
@@ -13,9 +13,9 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
@@ -50,16 +50,16 @@ public class ChangeSet {
     @XmlElement(name = "dropTable", type = DropTable.class),
     @XmlElement(name = "renameTable", type = RenameTable.class),
     @XmlElement(name = "addTableComment", type = AddTableComment.class),
+    @XmlElement(name = "addUniqueConstraint", type = AddUniqueConstraint.class),
     @XmlElement(name = "addHistoryTable", type = AddHistoryTable.class),
     @XmlElement(name = "dropHistoryTable", type = DropHistoryTable.class),
+    @XmlElement(name = "alterForeignKey", type = AlterForeignKey.class),
     @XmlElement(name = "addColumn", type = AddColumn.class),
     @XmlElement(name = "dropColumn", type = DropColumn.class),
     @XmlElement(name = "alterColumn", type = AlterColumn.class),
     @XmlElement(name = "renameColumn", type = RenameColumn.class),
     @XmlElement(name = "createIndex", type = CreateIndex.class),
-    @XmlElement(name = "dropIndex", type = DropIndex.class),
-    @XmlElement(name = "addUniqueConstraint", type = AddUniqueConstraint.class),
-    @XmlElement(name = "alterForeignKey", type = AlterForeignKey.class),
+    @XmlElement(name = "dropIndex", type = DropIndex.class)
   })
   protected List<Object> changeSetChildren;
   @XmlAttribute(name = "type", required = true)
@@ -77,20 +77,20 @@ public class ChangeSet {
 
   /**
    * Gets the value of the changeSetChildren property.
-   * <p>
+   *
    * <p>
    * This accessor method returns a reference to the live list,
    * not a snapshot. Therefore any modification you make to the
    * returned list will be present inside the JAXB object.
    * This is why there is not a <CODE>set</CODE> method for the changeSetChildren property.
-   * <p>
+   *
    * <p>
    * For example, to add a new item, do as follows:
    * <pre>
    *    getChangeSetChildren().add(newItem);
    * </pre>
-   * <p>
-   * <p>
+   *
+   *
    * <p>
    * Objects of the following type(s) are allowed in the list
    * {@link Configuration }
@@ -99,8 +99,10 @@ public class ChangeSet {
    * {@link DropTable }
    * {@link RenameTable }
    * {@link AddTableComment }
+   * {@link AddUniqueConstraint }
    * {@link AddHistoryTable }
    * {@link DropHistoryTable }
+   * {@link AlterForeignKey }
    * {@link AddColumn }
    * {@link DropColumn }
    * {@link AlterColumn }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSetType.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSetType.java
@@ -7,7 +7,7 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for changeSetType.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
  * <p>
  * <pre>
@@ -16,6 +16,7 @@ import javax.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="apply"/>
  *     &lt;enumeration value="pendingDrops"/>
  *     &lt;enumeration value="baseline"/>
+ *     &lt;enumeration value="drop"/>
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
@@ -29,7 +30,9 @@ public enum ChangeSetType {
   @XmlEnumValue("pendingDrops")
   PENDING_DROPS("pendingDrops"),
   @XmlEnumValue("baseline")
-  BASELINE("baseline");
+  BASELINE("baseline"),
+  @XmlEnumValue("drop")
+  DROP("drop");
   private final String value;
 
   ChangeSetType(String v) {

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/Column.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/Column.java
@@ -3,7 +3,6 @@ package io.ebeaninternal.dbmigration.migration;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
@@ -12,13 +11,17 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
  *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="before" type="{http://ebean-orm.github.io/xml/ns/dbmigration}ddl-script" maxOccurs="unbounded" minOccurs="0"/>
+ *         &lt;element name="after" type="{http://ebean-orm.github.io/xml/ns/dbmigration}ddl-script" maxOccurs="unbounded" minOccurs="0"/>
+ *       &lt;/sequence>
  *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="type" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="defaultValue" type="{http://www.w3.org/2001/XMLSchema}string" />
@@ -43,16 +46,14 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = {
-  "before", "after"
+  "before",
+  "after"
 })
 @XmlRootElement(name = "column")
 public class Column {
 
-  @XmlElement(required = false)
   protected List<DdlScript> before;
-  @XmlElement(required = false)
   protected List<DdlScript> after;
-
   @XmlAttribute(name = "name", required = true)
   protected String name;
   @XmlAttribute(name = "type", required = true)
@@ -88,19 +89,58 @@ public class Column {
   @XmlAttribute(name = "comment")
   protected String comment;
 
-
+  /**
+   * Gets the value of the before property.
+   *
+   * <p>
+   * This accessor method returns a reference to the live list,
+   * not a snapshot. Therefore any modification you make to the
+   * returned list will be present inside the JAXB object.
+   * This is why there is not a <CODE>set</CODE> method for the before property.
+   *
+   * <p>
+   * For example, to add a new item, do as follows:
+   * <pre>
+   *    getBefore().add(newItem);
+   * </pre>
+   *
+   *
+   * <p>
+   * Objects of the following type(s) are allowed in the list
+   * {@link DdlScript }
+   */
   public List<DdlScript> getBefore() {
     if (before == null) {
       before = new ArrayList<>();
     }
-    return before;
+    return this.before;
   }
 
+  /**
+   * Gets the value of the after property.
+   *
+   * <p>
+   * This accessor method returns a reference to the live list,
+   * not a snapshot. Therefore any modification you make to the
+   * returned list will be present inside the JAXB object.
+   * This is why there is not a <CODE>set</CODE> method for the after property.
+   *
+   * <p>
+   * For example, to add a new item, do as follows:
+   * <pre>
+   *    getAfter().add(newItem);
+   * </pre>
+   *
+   *
+   * <p>
+   * Objects of the following type(s) are allowed in the list
+   * {@link DdlScript }
+   */
   public List<DdlScript> getAfter() {
     if (after == null) {
       after = new ArrayList<>();
     }
-    return after;
+    return this.after;
   }
 
   /**
@@ -384,7 +424,7 @@ public class Column {
   }
 
   /**
-   * Gets the value of the foreignOnDelete property.
+   * Gets the value of the foreignKeyOnDelete property.
    *
    * @return possible object is
    * {@link String }
@@ -404,7 +444,7 @@ public class Column {
   }
 
   /**
-   * Gets the value of the foreignOnUpdate property.
+   * Gets the value of the foreignKeyOnUpdate property.
    *
    * @return possible object is
    * {@link String }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/Configuration.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/Configuration.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/CreateIndex.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/CreateIndex.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/CreateTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/CreateTable.java
@@ -14,9 +14,9 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
@@ -28,6 +28,8 @@ import java.util.List;
  *       &lt;/sequence>
  *       &lt;attGroup ref="{http://ebean-orm.github.io/xml/ns/dbmigration}tablespaceAttributes"/>
  *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="partitionMode" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="partitionColumn" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="withHistory" type="{http://www.w3.org/2001/XMLSchema}boolean" />
  *       &lt;attribute name="draft" type="{http://www.w3.org/2001/XMLSchema}boolean" />
  *       &lt;attribute name="identityType" type="{http://ebean-orm.github.io/xml/ns/dbmigration}identityType" />
@@ -55,6 +57,10 @@ public class CreateTable {
   protected List<ForeignKey> foreignKey;
   @XmlAttribute(name = "name", required = true)
   protected String name;
+  @XmlAttribute(name = "partitionMode")
+  protected String partitionMode;
+  @XmlAttribute(name = "partitionColumn")
+  protected String partitionColumn;
   @XmlAttribute(name = "withHistory")
   protected Boolean withHistory;
   @XmlAttribute(name = "draft")
@@ -80,20 +86,20 @@ public class CreateTable {
 
   /**
    * Gets the value of the column property.
-   * <p>
+   *
    * <p>
    * This accessor method returns a reference to the live list,
    * not a snapshot. Therefore any modification you make to the
    * returned list will be present inside the JAXB object.
    * This is why there is not a <CODE>set</CODE> method for the column property.
-   * <p>
+   *
    * <p>
    * For example, to add a new item, do as follows:
    * <pre>
    *    getColumn().add(newItem);
    * </pre>
-   * <p>
-   * <p>
+   *
+   *
    * <p>
    * Objects of the following type(s) are allowed in the list
    * {@link Column }
@@ -107,20 +113,20 @@ public class CreateTable {
 
   /**
    * Gets the value of the uniqueConstraint property.
-   * <p>
+   *
    * <p>
    * This accessor method returns a reference to the live list,
    * not a snapshot. Therefore any modification you make to the
    * returned list will be present inside the JAXB object.
    * This is why there is not a <CODE>set</CODE> method for the uniqueConstraint property.
-   * <p>
+   *
    * <p>
    * For example, to add a new item, do as follows:
    * <pre>
    *    getUniqueConstraint().add(newItem);
    * </pre>
-   * <p>
-   * <p>
+   *
+   *
    * <p>
    * Objects of the following type(s) are allowed in the list
    * {@link UniqueConstraint }
@@ -134,20 +140,20 @@ public class CreateTable {
 
   /**
    * Gets the value of the foreignKey property.
-   * <p>
+   *
    * <p>
    * This accessor method returns a reference to the live list,
    * not a snapshot. Therefore any modification you make to the
    * returned list will be present inside the JAXB object.
    * This is why there is not a <CODE>set</CODE> method for the foreignKey property.
-   * <p>
+   *
    * <p>
    * For example, to add a new item, do as follows:
    * <pre>
    *    getForeignKey().add(newItem);
    * </pre>
-   * <p>
-   * <p>
+   *
+   *
    * <p>
    * Objects of the following type(s) are allowed in the list
    * {@link ForeignKey }
@@ -177,6 +183,46 @@ public class CreateTable {
    */
   public void setName(String value) {
     this.name = value;
+  }
+
+  /**
+   * Gets the value of the partitionMode property.
+   *
+   * @return possible object is
+   * {@link String }
+   */
+  public String getPartitionMode() {
+    return partitionMode;
+  }
+
+  /**
+   * Sets the value of the partitionMode property.
+   *
+   * @param value allowed object is
+   *              {@link String }
+   */
+  public void setPartitionMode(String value) {
+    this.partitionMode = value;
+  }
+
+  /**
+   * Gets the value of the partitionColumn property.
+   *
+   * @return possible object is
+   * {@link String }
+   */
+  public String getPartitionColumn() {
+    return partitionColumn;
+  }
+
+  /**
+   * Sets the value of the partitionColumn property.
+   *
+   * @param value allowed object is
+   *              {@link String }
+   */
+  public void setPartitionColumn(String value) {
+    this.partitionColumn = value;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/DdlScript.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/DdlScript.java
@@ -1,42 +1,61 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
- * <p>Java class for anonymous complex type.
- * <p>
+ * <p>Java class for ddl-script complex type.
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
- * TODO @Rob: Can this generated automatically?
+ * &lt;complexType name="ddl-script">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="ddl" type="{http://www.w3.org/2001/XMLSchema}string" maxOccurs="unbounded"/>
+ *       &lt;/sequence>
+ *       &lt;attribute name="platforms" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "", propOrder = {
+@XmlType(name = "ddl-script", propOrder = {
   "ddl"
 })
-@XmlRootElement(name = "ddl-script")
 public class DdlScript {
 
-  @XmlValue
+  @XmlElement(required = true)
   protected List<String> ddl;
-
   @XmlAttribute(name = "platforms")
   protected String platforms;
 
   /**
-   * Gets the value of the value property.
+   * Gets the value of the ddl property.
    *
-   * @return possible object is
+   * <p>
+   * This accessor method returns a reference to the live list,
+   * not a snapshot. Therefore any modification you make to the
+   * returned list will be present inside the JAXB object.
+   * This is why there is not a <CODE>set</CODE> method for the ddl property.
+   *
+   * <p>
+   * For example, to add a new item, do as follows:
+   * <pre>
+   *    getDdl().add(newItem);
+   * </pre>
+   *
+   *
+   * <p>
+   * Objects of the following type(s) are allowed in the list
    * {@link String }
    */
   public List<String> getDdl() {

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/DefaultTablespace.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/DefaultTablespace.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/DropColumn.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/DropColumn.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/DropHistoryTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/DropHistoryTable.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/DropIndex.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/DropIndex.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/DropTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/DropTable.java
@@ -9,14 +9,16 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
  *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
  *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="sequenceCol" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="sequenceName" type="{http://www.w3.org/2001/XMLSchema}string" />
  *     &lt;/restriction>
  *   &lt;/complexContent>
  * &lt;/complexType>
@@ -65,16 +67,6 @@ public class DropTable {
   }
 
   /**
-   * Gets the value of the sequenceName property.
-   *
-   * @return possible object is
-   * {@link String }
-   */
-  public String getSequenceName() {
-    return sequenceName;
-  }
-
-  /**
    * Sets the value of the sequenceCol property.
    *
    * @param value allowed object is
@@ -82,6 +74,16 @@ public class DropTable {
    */
   public void setSequenceCol(String value) {
     this.sequenceCol = value;
+  }
+
+  /**
+   * Gets the value of the sequenceName property.
+   *
+   * @return possible object is
+   * {@link String }
+   */
+  public String getSequenceName() {
+    return sequenceName;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/ForeignKey.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/ForeignKey.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
@@ -47,6 +47,7 @@ public class ForeignKey {
   protected String onDelete;
   @XmlAttribute(name = "onUpdate")
   protected String onUpdate;
+
   /**
    * Gets the value of the name property.
    *

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/IdentityType.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/IdentityType.java
@@ -7,7 +7,7 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for identityType.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
  * <p>
  * <pre>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/Migration.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/Migration.java
@@ -11,9 +11,9 @@ import java.util.List;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
@@ -38,20 +38,20 @@ public class Migration {
 
   /**
    * Gets the value of the changeSet property.
-   * <p>
+   *
    * <p>
    * This accessor method returns a reference to the live list,
    * not a snapshot. Therefore any modification you make to the
    * returned list will be present inside the JAXB object.
    * This is why there is not a <CODE>set</CODE> method for the changeSet property.
-   * <p>
+   *
    * <p>
    * For example, to add a new item, do as follows:
    * <pre>
    *    getChangeSet().add(newItem);
    * </pre>
-   * <p>
-   * <p>
+   *
+   *
    * <p>
    * Objects of the following type(s) are allowed in the list
    * {@link ChangeSet }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/ObjectFactory.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/ObjectFactory.java
@@ -6,7 +6,7 @@ import javax.xml.bind.annotation.XmlRegistry;
 /**
  * This object contains factory methods for each
  * Java content interface and Java element interface
- * generated in the io.ebean.dbmigration.migration package.
+ * generated in the io.ebeaninternal.dbmigration.migration package.
  * <p>An ObjectFactory allows you to programatically
  * construct new instances of the Java representation
  * for XML content. The Java representation of XML
@@ -21,23 +21,23 @@ public class ObjectFactory {
 
 
   /**
-   * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: io.ebean.dbmigration.migration
+   * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: io.ebeaninternal.dbmigration.migration
    */
   public ObjectFactory() {
   }
 
   /**
-   * Create an instance of {@link Rollback }
+   * Create an instance of {@link AddUniqueConstraint }
    */
-  public Rollback createRollback() {
-    return new Rollback();
+  public AddUniqueConstraint createAddUniqueConstraint() {
+    return new AddUniqueConstraint();
   }
 
   /**
-   * Create an instance of {@link AddColumn }
+   * Create an instance of {@link CreateTable }
    */
-  public AddColumn createAddColumn() {
-    return new AddColumn();
+  public CreateTable createCreateTable() {
+    return new CreateTable();
   }
 
   /**
@@ -48,10 +48,10 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link CreateTable }
+   * Create an instance of {@link DdlScript }
    */
-  public CreateTable createCreateTable() {
-    return new CreateTable();
+  public DdlScript createDdlScript() {
+    return new DdlScript();
   }
 
   /**
@@ -69,13 +69,6 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link Apply }
-   */
-  public Apply createApply() {
-    return new Apply();
-  }
-
-  /**
    * Create an instance of {@link Configuration }
    */
   public Configuration createConfiguration() {
@@ -87,13 +80,6 @@ public class ObjectFactory {
    */
   public DefaultTablespace createDefaultTablespace() {
     return new DefaultTablespace();
-  }
-
-  /**
-   * Create an instance of {@link AddTableComment }
-   */
-  public AddTableComment createAddTableComment() {
-    return new AddTableComment();
   }
 
   /**
@@ -111,10 +97,10 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link AlterColumn }
+   * Create an instance of {@link AlterForeignKey }
    */
-  public AlterColumn createAlterColumn() {
-    return new AlterColumn();
+  public AlterForeignKey createAlterForeignKey() {
+    return new AlterForeignKey();
   }
 
   /**
@@ -122,6 +108,69 @@ public class ObjectFactory {
    */
   public DropColumn createDropColumn() {
     return new DropColumn();
+  }
+
+  /**
+   * Create an instance of {@link Sql }
+   */
+  public Sql createSql() {
+    return new Sql();
+  }
+
+  /**
+   * Create an instance of {@link Apply }
+   */
+  public Apply createApply() {
+    return new Apply();
+  }
+
+  /**
+   * Create an instance of {@link Rollback }
+   */
+  public Rollback createRollback() {
+    return new Rollback();
+  }
+
+  /**
+   * Create an instance of {@link DropIndex }
+   */
+  public DropIndex createDropIndex() {
+    return new DropIndex();
+  }
+
+  /**
+   * Create an instance of {@link RenameColumn }
+   */
+  public RenameColumn createRenameColumn() {
+    return new RenameColumn();
+  }
+
+  /**
+   * Create an instance of {@link DropTable }
+   */
+  public DropTable createDropTable() {
+    return new DropTable();
+  }
+
+  /**
+   * Create an instance of {@link AddColumn }
+   */
+  public AddColumn createAddColumn() {
+    return new AddColumn();
+  }
+
+  /**
+   * Create an instance of {@link AddTableComment }
+   */
+  public AddTableComment createAddTableComment() {
+    return new AddTableComment();
+  }
+
+  /**
+   * Create an instance of {@link AlterColumn }
+   */
+  public AlterColumn createAlterColumn() {
+    return new AlterColumn();
   }
 
   /**
@@ -139,38 +188,10 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link Sql }
-   */
-  public Sql createSql() {
-    return new Sql();
-  }
-
-  /**
-   * Create an instance of {@link DropTable }
-   */
-  public DropTable createDropTable() {
-    return new DropTable();
-  }
-
-  /**
    * Create an instance of {@link AddHistoryTable }
    */
   public AddHistoryTable createAddHistoryTable() {
     return new AddHistoryTable();
-  }
-
-  /**
-   * Create an instance of {@link RenameColumn }
-   */
-  public RenameColumn createRenameColumn() {
-    return new RenameColumn();
-  }
-
-  /**
-   * Create an instance of {@link DropIndex }
-   */
-  public DropIndex createDropIndex() {
-    return new DropIndex();
   }
 
   /**
@@ -187,24 +208,4 @@ public class ObjectFactory {
     return new Migration();
   }
 
-  /**
-   * Create an instance of {@link DdlScript }
-   */
-  public DdlScript createDdlScript() {
-    return new DdlScript();
-  }
-
-  /**
-   * Create an instance of {@link AddUniqueConstraint }
-   */
-  public AddUniqueConstraint createAddUniqueConstraint() {
-    return new AddUniqueConstraint();
-  }
-
-  /**
-   * Create an instance of {@link AddUniqueConstraint }
-   */
-  public AlterForeignKey createAlterForeignKey() {
-    return new AlterForeignKey();
-  }
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/RenameColumn.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/RenameColumn.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/RenameTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/RenameTable.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/Rollback.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/Rollback.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlValue;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;simpleContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/Sql.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/Sql.java
@@ -9,9 +9,9 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>

--- a/src/main/java/io/ebeaninternal/dbmigration/migration/UniqueConstraint.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/migration/UniqueConstraint.java
@@ -9,15 +9,17 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.
- * <p>
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
+ *
  * <pre>
  * &lt;complexType>
  *   &lt;complexContent>
  *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
  *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="columnNames" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="oneToOne" type="{http://www.w3.org/2001/XMLSchema}boolean" />
+ *       &lt;attribute name="nullableColumns" type="{http://www.w3.org/2001/XMLSchema}string" />
  *     &lt;/restriction>
  *   &lt;/complexContent>
  * &lt;/complexType>
@@ -30,16 +32,13 @@ public class UniqueConstraint {
 
   @XmlAttribute(name = "name", required = true)
   protected String name;
-
   @XmlAttribute(name = "columnNames", required = true)
   protected String columnNames;
-
-  @XmlAttribute(name = "oneToOne", required = false)
+  @XmlAttribute(name = "oneToOne")
   protected Boolean oneToOne;
-
-  @XmlAttribute(name = "nullableColumns", required = true)
+  @XmlAttribute(name = "nullableColumns")
   protected String nullableColumns;
-  
+
   /**
    * Gets the value of the name property.
    *
@@ -79,23 +78,25 @@ public class UniqueConstraint {
   public void setColumnNames(String value) {
     this.columnNames = value;
   }
-  
+
   /**
    * Gets the value of the oneToOne property.
    *
-   * @return true if oneToOne was set
+   * @return possible object is
+   * {@link Boolean }
    */
-  public boolean isOneToOne() {
-    return Boolean.TRUE.equals(oneToOne);
+  public Boolean isOneToOne() {
+    return oneToOne;
   }
-  
+
   /**
    * Sets the value of the oneToOne property.
    *
-   * @param value boolean
+   * @param value allowed object is
+   *              {@link Boolean }
    */
-  public void setOneToOne(boolean oneToOne) {
-    this.oneToOne = oneToOne;
+  public void setOneToOne(Boolean value) {
+    this.oneToOne = value;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/dbmigration/model/MCompoundUniqueConstraint.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/model/MCompoundUniqueConstraint.java
@@ -1,11 +1,12 @@
 package io.ebeaninternal.dbmigration.model;
 
-import java.util.Arrays;
-import java.util.Objects;
-
 import io.ebeaninternal.dbmigration.ddlgeneration.platform.DdlHelp;
 import io.ebeaninternal.dbmigration.migration.AddUniqueConstraint;
 import io.ebeaninternal.dbmigration.migration.UniqueConstraint;
+
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * A unique constraint for multiple columns.
  * <p>
@@ -26,13 +27,13 @@ public class MCompoundUniqueConstraint {
    * The columns combined to be unique.
    */
   private final String[] columns;
-  
+
   private String[] nullableColumns;
 
-  public MCompoundUniqueConstraint(String[] columns, boolean oneToOne, String name) {
+  public MCompoundUniqueConstraint(String[] columns, Boolean oneToOne, String name) {
     this.name = name;
     this.columns = columns;
-    this.oneToOne = oneToOne;
+    this.oneToOne = Boolean.TRUE.equals(oneToOne);
   }
 
   /**
@@ -55,6 +56,7 @@ public class MCompoundUniqueConstraint {
   public String getName() {
     return name;
   }
+
   public UniqueConstraint getUniqueConstraint() {
     UniqueConstraint uq = new UniqueConstraint();
     uq.setName(getName());
@@ -63,6 +65,7 @@ public class MCompoundUniqueConstraint {
     uq.setOneToOne(isOneToOne());
     return uq;
   }
+
   /**
    * Return a AddUniqueConstraint migration for this constraint.
    */
@@ -87,7 +90,7 @@ public class MCompoundUniqueConstraint {
     dropUniqueConstraint.setNullableColumns(join(nullableColumns));
     return dropUniqueConstraint;
   }
-  
+
   public void setNullableColumns(String[] nullableColumns) {
     if (nullableColumns != null && nullableColumns.length == 0) {
       this.nullableColumns = null;
@@ -109,12 +112,12 @@ public class MCompoundUniqueConstraint {
     }
     return sb.toString();
   }
-  
+
   @Override
   public int hashCode() {
     return Arrays.hashCode(columns) + 31 * Objects.hash(name, oneToOne);
   }
-  
+
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
@@ -125,8 +128,8 @@ public class MCompoundUniqueConstraint {
     }
     MCompoundUniqueConstraint other = (MCompoundUniqueConstraint) obj;
     return Arrays.equals(columns, other.columns)
-        && Arrays.equals(nullableColumns, other.nullableColumns)
-        && Objects.equals(name, other.name)
-        && oneToOne == other.oneToOne;
+      && Arrays.equals(nullableColumns, other.nullableColumns)
+      && Objects.equals(name, other.name)
+      && oneToOne == other.oneToOne;
   }
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/model/MTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/model/MTable.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.dbmigration.model;
 
+import io.ebean.annotation.PartitionMode;
 import io.ebeaninternal.dbmigration.ddlgeneration.platform.DdlHelp;
 import io.ebeaninternal.dbmigration.ddlgeneration.platform.SplitColumns;
 import io.ebeaninternal.dbmigration.migration.AddColumn;
@@ -14,6 +15,7 @@ import io.ebeaninternal.dbmigration.migration.DropTable;
 import io.ebeaninternal.dbmigration.migration.ForeignKey;
 import io.ebeaninternal.dbmigration.migration.IdentityType;
 import io.ebeaninternal.dbmigration.migration.UniqueConstraint;
+import io.ebeaninternal.server.deploy.PartitionMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +62,8 @@ public class MTable {
    * after all the draft tables have been identified.
    */
   private boolean draft;
+
+  private PartitionMeta partitionMeta;
 
   /**
    * Primary key name.
@@ -237,6 +241,10 @@ public class MTable {
     createTable.setName(name);
     createTable.setPkName(pkName);
     createTable.setComment(comment);
+    if (partitionMeta != null) {
+      createTable.setPartitionMode(partitionMeta.getMode().name());
+      createTable.setPartitionColumn(partitionMeta.getProperty());
+    }
     createTable.setTablespace(tablespace);
     createTable.setIndexTablespace(indexTablespace);
     createTable.setSequenceName(sequenceName);
@@ -744,5 +752,9 @@ public class MTable {
     for (MCompoundForeignKey compoundKey : compoundKeys) {
       compoundKey.setIndexName(null);
     }
+  }
+
+  public void setPartitionMeta(PartitionMeta partitionMeta) {
+    this.partitionMeta = partitionMeta;
   }
 }

--- a/src/main/java/io/ebeaninternal/dbmigration/model/MTable.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/model/MTable.java
@@ -427,6 +427,13 @@ public class MTable {
     return draft;
   }
 
+  /**
+   * Return true if this table is partitioned.
+   */
+  public boolean isPartitioned() {
+    return partitionMeta != null;
+  }
+
   public void setPkName(String pkName) {
     this.pkName = pkName;
   }

--- a/src/main/java/io/ebeaninternal/dbmigration/model/build/ModelBuildBeanVisitor.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/model/build/ModelBuildBeanVisitor.java
@@ -36,6 +36,7 @@ public class ModelBuildBeanVisitor implements BeanVisitor {
     }
 
     MTable table = new MTable(descriptor.getBaseTable());
+    table.setPartitionMeta(descriptor.getPartitionMeta());
     table.setComment(descriptor.getDbComment());
     if (descriptor.isHistorySupport()) {
       table.setWithHistory(true);

--- a/src/main/java/io/ebeaninternal/dbmigration/model/build/ModelBuildPropertyVisitor.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/model/build/ModelBuildPropertyVisitor.java
@@ -192,7 +192,7 @@ public class ModelBuildPropertyVisitor extends BaseTablePropertyVisitor {
       col.setDbMigrationInfos(p.getDbMigrationInfos());
       col.setDefaultValue(p.getDbColumnDefault());
       if (columns.length == 1) {
-        if (p.hasForeignKey()) {
+        if (p.hasForeignKey() && !importedProperty.getBeanDescriptor().suppressForeignKey()) {
           // single references column (put it on the column)
           String refTable = importedProperty.getBeanDescriptor().getBaseTable();
           if (refTable == null) {
@@ -251,7 +251,7 @@ public class ModelBuildPropertyVisitor extends BaseTablePropertyVisitor {
         col.setIdentity(true);
       }
       TableJoin primaryKeyJoin = p.getBeanDescriptor().getPrimaryKeyJoin();
-      if (primaryKeyJoin != null) {
+      if (primaryKeyJoin != null && !table.isPartitioned()) {
         TableJoinColumn[] columns = primaryKeyJoin.columns();
         col.setReferences(primaryKeyJoin.getTable() + "." + columns[0].getForeignDbColumn());
         col.setForeignKeyName(determineForeignKeyConstraintName(col.getName()));

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -7,6 +7,7 @@ import io.ebean.SqlUpdate;
 import io.ebean.Transaction;
 import io.ebean.ValuePair;
 import io.ebean.annotation.DocStoreMode;
+import io.ebean.annotation.PartitionMode;
 import io.ebean.bean.BeanCollection;
 import io.ebean.bean.EntityBean;
 import io.ebean.bean.EntityBeanIntercept;
@@ -203,6 +204,8 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
   private final boolean softDelete;
 
   private final String draftTable;
+
+  private final PartitionMeta partitionMeta;
 
   /**
    * DB table comment.
@@ -482,6 +485,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
     this.baseTableVersionsBetween = deploy.getBaseTableVersionsBetween();
     this.dependentTables = deploy.getDependentTables();
     this.dbComment = deploy.getDbComment();
+    this.partitionMeta = deploy.getPartitionMeta();
     this.autoTunable = EntityType.ORM == entityType && (beanFinder == null);
 
     // helper object used to derive lists of properties
@@ -2817,6 +2821,13 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
   }
 
   /**
+   * Return the partition details of the bean.
+   */
+  public PartitionMeta getPartitionMeta() {
+    return partitionMeta;
+  }
+
+  /**
    * Return the dependent tables for a view based entity.
    * <p>
    * These tables
@@ -3160,7 +3171,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
   public boolean hasIdPropertyOnly(EntityBeanIntercept ebi) {
     return ebi.hasIdOnly(idPropertyIndex);
   }
-  
+
   public boolean isIdLoaded(EntityBeanIntercept ebi) {
     return ebi.isLoadedProperty(idPropertyIndex);
   }

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -2821,6 +2821,13 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
   }
 
   /**
+   * Return true if foreign keys to the base table should be suppressed.
+   */
+  public boolean suppressForeignKey() {
+    return partitionMeta != null;
+  }
+
+  /**
    * Return the partition details of the bean.
    */
   public PartitionMeta getPartitionMeta() {

--- a/src/main/java/io/ebeaninternal/server/deploy/PartitionMeta.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/PartitionMeta.java
@@ -1,0 +1,23 @@
+package io.ebeaninternal.server.deploy;
+
+import io.ebean.annotation.PartitionMode;
+
+public class PartitionMeta {
+
+  private final PartitionMode mode;
+
+  private final String property;
+
+  public PartitionMeta(PartitionMode mode, String property) {
+    this.mode = mode;
+    this.property = property;
+  }
+
+  public PartitionMode getMode() {
+    return mode;
+  }
+
+  public String getProperty() {
+    return property;
+  }
+}

--- a/src/main/java/io/ebeaninternal/server/deploy/PartitionMeta.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/PartitionMeta.java
@@ -6,7 +6,7 @@ public class PartitionMeta {
 
   private final PartitionMode mode;
 
-  private final String property;
+  private String property;
 
   public PartitionMeta(PartitionMode mode, String property) {
     this.mode = mode;
@@ -19,5 +19,9 @@ public class PartitionMeta {
 
   public String getProperty() {
     return property;
+  }
+
+  public void setProperty(String dbColumn) {
+    this.property = dbColumn;
   }
 }

--- a/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -3,6 +3,7 @@ package io.ebeaninternal.server.deploy.meta;
 import io.ebean.annotation.Cache;
 import io.ebean.annotation.DocStore;
 import io.ebean.annotation.DocStoreMode;
+import io.ebean.annotation.PartitionMode;
 import io.ebean.config.ServerConfig;
 import io.ebean.config.TableName;
 import io.ebean.config.dbplatform.IdType;
@@ -27,6 +28,7 @@ import io.ebeaninternal.server.deploy.ChainedBeanQueryAdapter;
 import io.ebeaninternal.server.deploy.DeployPropertyParserMap;
 import io.ebeaninternal.server.deploy.IndexDefinition;
 import io.ebeaninternal.server.deploy.InheritInfo;
+import io.ebeaninternal.server.deploy.PartitionMeta;
 import io.ebeaninternal.server.deploy.TableJoin;
 import io.ebeaninternal.server.deploy.parse.DeployBeanInfo;
 import io.ebeaninternal.server.idgen.UuidV1IdGenerator;
@@ -193,6 +195,8 @@ public class DeployBeanDescriptor<T> {
 
   private String dbComment;
 
+  private PartitionMeta partitionMeta;
+
   /**
    * One of NONE, INDEX or EMBEDDED.
    */
@@ -303,6 +307,14 @@ public class DeployBeanDescriptor<T> {
 
   public String getDbComment() {
     return dbComment;
+  }
+
+  public void setPartitionMeta(PartitionMeta partitionMeta) {
+    this.partitionMeta = partitionMeta;
+  }
+
+  public PartitionMeta  getPartitionMeta() {
+    return partitionMeta;
   }
 
   public void setDraftable() {

--- a/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -314,6 +314,12 @@ public class DeployBeanDescriptor<T> {
   }
 
   public PartitionMeta  getPartitionMeta() {
+    if (partitionMeta != null) {
+      DeployBeanProperty beanProperty = getBeanProperty(partitionMeta.getProperty());
+      if (beanProperty != null) {
+        partitionMeta.setProperty(beanProperty.getDbColumn());
+      }
+    }
     return partitionMeta;
   }
 

--- a/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationClass.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationClass.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.deploy.parse;
 
 import io.ebean.annotation.Cache;
 import io.ebean.annotation.DbComment;
+import io.ebean.annotation.DbPartition;
 import io.ebean.annotation.DocStore;
 import io.ebean.annotation.Draftable;
 import io.ebean.annotation.DraftableElement;
@@ -16,6 +17,7 @@ import io.ebean.util.AnnotationUtil;
 import io.ebeaninternal.server.deploy.BeanDescriptor.EntityType;
 import io.ebeaninternal.server.deploy.IndexDefinition;
 import io.ebeaninternal.server.deploy.InheritInfo;
+import io.ebeaninternal.server.deploy.PartitionMeta;
 import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,6 +152,11 @@ public class AnnotationClass extends AnnotationParser {
       for (UniqueConstraint c : uniqueConstraints) {
         descriptor.addIndex(new IndexDefinition(c.columnNames()));
       }
+    }
+
+    DbPartition partition = AnnotationUtil.findAnnotationRecursive(cls, DbPartition.class);
+    if (partition != null) {
+      descriptor.setPartitionMeta(new PartitionMeta(partition.mode(), partition.property()));
     }
 
     Draftable draftable = AnnotationUtil.findAnnotationRecursive(cls, Draftable.class);

--- a/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -412,7 +412,13 @@ public final class SqlTreeBuilder {
       if (!selectProps.containsProperty(baseName)) {
         STreeProperty p = desc.findPropertyWithDynamic(baseName);
         if (p == null) {
-          logger.error("property [" + propName + "] not found on " + desc + " for query - excluding it.");
+          // maybe dynamic formula with schema prefix
+          p = desc.findPropertyWithDynamic(propName);
+          if (p != null) {
+            selectProps.add(p);
+          } else {
+            logger.error("property [" + propName + "] not found on " + desc + " for query - excluding it.");
+          }
 
         } else if (p.isEmbedded()) {
           // add the embedded bean (and effectively

--- a/src/main/resources/ebean-dbmigration-1.0.xsd
+++ b/src/main/resources/ebean-dbmigration-1.0.xsd
@@ -37,8 +37,16 @@
       <xsd:enumeration value="apply"/>
       <xsd:enumeration value="pendingDrops"/>
       <xsd:enumeration value="baseline"/>
+      <xsd:enumeration value="drop"/>
     </xsd:restriction>
   </xsd:simpleType>
+
+  <xsd:complexType name="ddl-script">
+      <xsd:sequence>
+        <xsd:element name="ddl" type="xsd:string" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="platforms" type="xsd:string"/>
+  </xsd:complexType>
 
   <!-- =========================================================== -->
   <!-- CHANGE SET CHILDREN                                         -->
@@ -99,6 +107,8 @@
         <xsd:element ref="foreignKey" minOccurs="0" maxOccurs="unbounded"/>
       </xsd:sequence>
       <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="partitionMode" type="xsd:string"/>
+      <xsd:attribute name="partitionColumn" type="xsd:string"/>
       <xsd:attribute name="withHistory" type="xsd:boolean"/>
       <xsd:attribute name="draft" type="xsd:boolean"/>
       <xsd:attribute name="identityType" type="identityType"/>
@@ -125,6 +135,18 @@
     <xsd:complexType>
       <xsd:attribute name="name" type="xsd:string" use="required"/>
       <xsd:attribute name="columnNames" type="xsd:string" use="required"/>
+      <xsd:attribute name="oneToOne" type="xsd:boolean"/>
+      <xsd:attribute name="nullableColumns" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="addUniqueConstraint">
+    <xsd:complexType>
+      <xsd:attribute name="constraintName" type="xsd:string" use="required"/>
+      <xsd:attribute name="tableName" type="xsd:string" use="required"/>
+      <xsd:attribute name="columnNames" type="xsd:string" use="required"/>
+      <xsd:attribute name="oneToOne" type="xsd:boolean"/>
+      <xsd:attribute name="nullableColumns" type="xsd:string"/>
     </xsd:complexType>
   </xsd:element>
 
@@ -157,6 +179,8 @@
   <xsd:element name="dropTable">
     <xsd:complexType>
       <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="sequenceCol" type="xsd:string"/>
+      <xsd:attribute name="sequenceName" type="xsd:string"/>
     </xsd:complexType>
   </xsd:element>
 
@@ -216,6 +240,10 @@
 
   <xsd:element name="alterColumn">
     <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="before" minOccurs="0" maxOccurs="unbounded" type="ddl-script"/>
+        <xsd:element name="after" minOccurs="0" maxOccurs="unbounded" type="ddl-script"/>
+      </xsd:sequence>
       <xsd:attribute name="columnName" type="xsd:string" use="required"/>
       <xsd:attribute name="tableName" type="xsd:string" use="required"/>
       <xsd:attribute name="withHistory" type="xsd:boolean"/>
@@ -236,8 +264,8 @@
       <xsd:attribute name="references" type="xsd:string"/>
       <xsd:attribute name="foreignKeyName" type="xsd:string"/>
       <xsd:attribute name="foreignKeyIndex" type="xsd:string"/>
-      <xsd:attribute name="foreignOnDelete" type="xsd:string"/>
-      <xsd:attribute name="foreignOnUpdate" type="xsd:string"/>
+      <xsd:attribute name="foreignKeyOnDelete" type="xsd:string"/>
+      <xsd:attribute name="foreignKeyOnUpdate" type="xsd:string"/>
       <xsd:attribute name="dropForeignKey" type="xsd:string"/>
       <xsd:attribute name="dropForeignKeyIndex" type="xsd:string"/>
     </xsd:complexType>
@@ -269,11 +297,14 @@
     </xsd:complexType>
   </xsd:element>
 
-
   <!-- ============================================ -->
 
   <xsd:element name="column">
-    <xsd:complexType mixed="true">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="before" minOccurs="0" maxOccurs="unbounded" type="ddl-script"/>
+        <xsd:element name="after" minOccurs="0" maxOccurs="unbounded" type="ddl-script"/>
+      </xsd:sequence>
       <xsd:attribute name="name" type="xsd:string" use="required"/>
       <xsd:attribute name="type" type="xsd:string" use="required"/>
       <xsd:attribute name="defaultValue" type="xsd:string"/>
@@ -310,6 +341,7 @@
       <xsd:element ref="dropTable" maxOccurs="unbounded"/>
       <xsd:element ref="renameTable" maxOccurs="unbounded"/>
       <xsd:element ref="addTableComment" maxOccurs="unbounded"/>
+      <xsd:element ref="addUniqueConstraint" maxOccurs="unbounded"/>
 
       <xsd:element ref="addHistoryTable" maxOccurs="unbounded"/>
       <xsd:element ref="dropHistoryTable" maxOccurs="unbounded"/>

--- a/src/main/resources/ebean-extraddl-1.0.xsd
+++ b/src/main/resources/ebean-extraddl-1.0.xsd
@@ -18,6 +18,7 @@
         <xsd:extension base="xsd:string">
           <xsd:attribute name="name" type="xsd:string" use="required"/>
           <xsd:attribute name="platforms" type="xsd:string"/>
+          <xsd:attribute name="init" type="xsd:boolean"/>
         </xsd:extension>
       </xsd:simpleContent>
     </xsd:complexType>

--- a/src/main/resources/ebean-extraddl-1.0.xsd
+++ b/src/main/resources/ebean-extraddl-1.0.xsd
@@ -19,6 +19,7 @@
           <xsd:attribute name="name" type="xsd:string" use="required"/>
           <xsd:attribute name="platforms" type="xsd:string"/>
           <xsd:attribute name="init" type="xsd:boolean"/>
+          <xsd:attribute name="drop" type="xsd:boolean"/>
         </xsd:extension>
       </xsd:simpleContent>
     </xsd:complexType>

--- a/src/test/resources/dbmigration/migrationtest/model/1.1.model.xml
+++ b/src/test/resources/dbmigration/migrationtest/model/1.1.model.xml
@@ -15,15 +15,21 @@
         <alterColumn columnName="one_id" tableName="migtest_fk_set_null" references="migtest_fk_one.id" foreignKeyName="fk_migtest_fk_set_null_one_id" foreignKeyIndex="ix_migtest_fk_set_null_one_id" foreignKeyOnDelete="RESTRICT" foreignKeyOnUpdate="RESTRICT" dropForeignKey="fk_migtest_fk_set_null_one_id" dropForeignKeyIndex="ix_migtest_fk_set_null_one_id"/>
         <alterColumn columnName="status" tableName="migtest_e_basic" currentType="varchar(1)" defaultValue="'A'" notnull="true" currentNotnull="false" checkConstraint="check ( status in ('N','A','I','?'))" checkConstraintName="ck_migtest_e_basic_status"/>
         <alterColumn columnName="description" tableName="migtest_e_basic" unique="uq_migtest_e_basic_description">
-            <before>-- rename all collisions</before>
+            <before>
+                <ddl>-- rename all collisions</ddl>
+            </before>
         </alterColumn>
         <alterColumn columnName="user_id" tableName="migtest_e_basic" currentType="integer" notnull="false" currentNotnull="true" references="migtest_e_user.id" foreignKeyName="fk_migtest_e_basic_user_id" foreignKeyIndex="ix_migtest_e_basic_user_id">
-            <before>insert into migtest_e_user (id) select distinct user_id from migtest_e_basic</before>
+            <before>
+                <ddl>insert into migtest_e_user (id) select distinct user_id from migtest_e_basic</ddl>
+            </before>
         </alterColumn>
         <addColumn tableName="migtest_e_basic">
             <column name="new_string_field" type="varchar" defaultValue="'foo''bar'" notnull="true"/>
             <column name="new_boolean_field" type="boolean" defaultValue="true" notnull="true">
-                <after>update ${table} set ${column} = old_boolean</after>
+                <after>
+                    <ddl>update ${table} set ${column} = old_boolean</ddl>
+                </after>
             </column>
             <column name="new_boolean_field2" type="boolean" defaultValue="true" notnull="true"/>
             <column name="progress" type="integer" defaultValue="0" notnull="true" checkConstraint="check ( progress in (0,1,2))" checkConstraintName="ck_migtest_e_basic_progress"/>
@@ -31,14 +37,16 @@
         </addColumn>
         <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest2" tableName="migtest_e_basic" columnNames="DROP CONSTRAINT" nullableColumns="indextest2"/>
         <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest6" tableName="migtest_e_basic" columnNames="DROP CONSTRAINT" nullableColumns="indextest6"/>
-        <addUniqueConstraint constraintName="uq_migtest_e_basic_status_indextest1" tableName="migtest_e_basic" columnNames="status,indextest1" nullableColumns="indextest1" oneToOne="false"/>
-        <addUniqueConstraint constraintName="uq_migtest_e_basic_name" tableName="migtest_e_basic" columnNames="name" nullableColumns="name" oneToOne="false"/>
-        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest4" tableName="migtest_e_basic" columnNames="indextest4" nullableColumns="indextest4" oneToOne="false"/>
-        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest5" tableName="migtest_e_basic" columnNames="indextest5" nullableColumns="indextest5" oneToOne="false"/>
+        <addUniqueConstraint constraintName="uq_migtest_e_basic_status_indextest1" tableName="migtest_e_basic" columnNames="status,indextest1" oneToOne="false" nullableColumns="indextest1"/>
+        <addUniqueConstraint constraintName="uq_migtest_e_basic_name" tableName="migtest_e_basic" columnNames="name" oneToOne="false" nullableColumns="name"/>
+        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest4" tableName="migtest_e_basic" columnNames="indextest4" oneToOne="false" nullableColumns="indextest4"/>
+        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest5" tableName="migtest_e_basic" columnNames="indextest5" oneToOne="false" nullableColumns="indextest5"/>
         <alterColumn columnName="test_status" tableName="migtest_e_enum" dropCheckConstraint="ck_migtest_e_enum_test_status"/>
         <addHistoryTable baseTable="migtest_e_history"/>
         <alterColumn columnName="test_string" tableName="migtest_e_history" type="bigint" currentType="varchar" currentNotnull="false" comment="Column altered to long now">
-            <before platforms="postgres">alter table ${table} alter column ${column} TYPE bigint USING (${column}::integer)</before>
+            <before platforms="postgres">
+                <ddl>alter table ${table} alter column ${column} TYPE bigint USING (${column}::integer)</ddl>
+            </before>
         </alterColumn>
         <addTableComment name="migtest_e_history" comment="We have history now"/>
         <alterColumn columnName="test_string" tableName="migtest_e_history2" withHistory="true" currentType="varchar" defaultValue="'unknown'" notnull="true" currentNotnull="false"/>

--- a/src/test/resources/dbmigration/migrationtest/model/1.3.model.xml
+++ b/src/test/resources/dbmigration/migrationtest/model/1.3.model.xml
@@ -18,8 +18,8 @@
         <addUniqueConstraint constraintName="uq_migtest_e_basic_name" tableName="migtest_e_basic" columnNames="DROP CONSTRAINT" nullableColumns="name"/>
         <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest4" tableName="migtest_e_basic" columnNames="DROP CONSTRAINT" nullableColumns="indextest4"/>
         <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest5" tableName="migtest_e_basic" columnNames="DROP CONSTRAINT" nullableColumns="indextest5"/>
-        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest2" tableName="migtest_e_basic" columnNames="indextest2" nullableColumns="indextest2" oneToOne="false"/>
-        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest6" tableName="migtest_e_basic" columnNames="indextest6" nullableColumns="indextest6" oneToOne="false"/>
+        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest2" tableName="migtest_e_basic" columnNames="indextest2" oneToOne="false" nullableColumns="indextest2"/>
+        <addUniqueConstraint constraintName="uq_migtest_e_basic_indextest6" tableName="migtest_e_basic" columnNames="indextest6" oneToOne="false" nullableColumns="indextest6"/>
         <alterColumn columnName="test_status" tableName="migtest_e_enum" checkConstraint="check ( test_status in ('N','A','I'))" checkConstraintName="ck_migtest_e_enum_test_status"/>
         <alterColumn columnName="test_string" tableName="migtest_e_history" withHistory="true" comment="DROP COMMENT"/>
         <addTableComment name="migtest_e_history" comment="DROP COMMENT"/>


### PR DESCRIPTION
- The xsd schema for ebean-dbmigration-1.0.xsd and ebean-extraddl-1.0.xsd had got out of sync with the generated.  This includes the changes to bring that back in line.

- Additionally this has initial support for Postgres range partitioning DDL