### PR TITLE
Fix for error with multiple uses of enum with integer storage type

### DIFF
--- a/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -351,7 +351,7 @@ public final class DefaultTypeManager implements TypeManager {
     if (type.equals(List.class)) {
       if (arrayTypeListFactory != null) {
         if (isEnumType(valueType)) {
-          return arrayTypeListFactory.typeForEnum(createEnumScalarType(asEnumClass(valueType), EnumType.STRING));
+          return arrayTypeListFactory.typeForEnum(createEnumScalarType(asEnumClass(valueType), null));
         }
         return arrayTypeListFactory.typeFor(valueType);
       }
@@ -360,7 +360,7 @@ public final class DefaultTypeManager implements TypeManager {
     } else if (type.equals(Set.class)) {
       if (arrayTypeSetFactory != null) {
         if (isEnumType(valueType)) {
-          return arrayTypeSetFactory.typeForEnum(createEnumScalarType(asEnumClass(valueType), EnumType.STRING));
+          return arrayTypeSetFactory.typeForEnum(createEnumScalarType(asEnumClass(valueType), null));
         }
         return arrayTypeSetFactory.typeFor(valueType);
       }

--- a/src/test/java/org/tests/model/array/EArrayBean.java
+++ b/src/test/java/org/tests/model/array/EArrayBean.java
@@ -18,6 +18,8 @@ public class EArrayBean {
     ONE, TWO, THREE
   }
 
+  IntEnum foo;
+
   @Id
   Long id;
 
@@ -49,6 +51,14 @@ public class EArrayBean {
 
   @Version
   Long version;
+
+  public IntEnum getFoo() {
+    return foo;
+  }
+
+  public void setFoo(final IntEnum foo) {
+    this.foo = foo;
+  }
 
   public Long getId() {
     return id;


### PR DESCRIPTION
When an enum is exists in the type cache and isn't String, @DbArray
fails. This includes a test that should fail everywhere (order of
reading fields isn't guaranteed afaik and the column needs to be read
before the @DbArray for the test to fail).

I'm VERY uncertain if just changing `EnumType.STRING` into `null` is good, but from what I understand of `io.ebeaninternal.server.deploy.parse.DeployUtil#setEnumScalarType` it should be ok?