### PR TITLE
Wrong behaviour in BeanMap.put/putAll

### DIFF
--- a/src/main/java/io/ebean/common/BeanMap.java
+++ b/src/main/java/io/ebean/common/BeanMap.java
@@ -273,14 +273,16 @@ public final class BeanMap<K, E> extends AbstractBeanCollection<E> implements Ma
     checkReadOnly();
     init();
     if (modifyListening) {
-      Object oldBean = map.put(key, value);
+      E oldBean = map.put(key, value);
       if (value != oldBean) {
         // register the add of the new and the removal of the old
         modifyAddition(value);
         modifyRemoval(oldBean);
       }
+      return oldBean;
+    } else {
+      return map.put(key, value);
     }
-    return map.put(key, value);
   }
 
   @Override
@@ -295,8 +297,9 @@ public final class BeanMap<K, E> extends AbstractBeanCollection<E> implements Ma
           modifyRemoval(oldBean);
         }
       }
+    } else {
+      map.putAll(puts);
     }
-    map.putAll(puts);
   }
 
   @Override


### PR DESCRIPTION
I think I have spotted out 2 issues in BeanMap

- put does not return old value if modifyListening
- putAll calls unneccessary putAll method 