### PR TITLE
Fix issue in UUID-v1 generator on AWS Beanstalk

### DIFF
--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -1965,6 +1965,15 @@ public class ServerConfig {
    * Return the UUID state file.
    */
   public String getUuidStateFile() {
+    if (uuidStateFile == null || uuidStateFile.isEmpty()) {
+      // by default, add servername...
+      uuidStateFile = name + "-uuid.state";
+      // and store it in the user's home directory
+      String homeDir = System.getProperty("user.home");
+      if (homeDir != null && homeDir.isEmpty()) {
+        uuidStateFile = homeDir + "/.ebean/" + uuidStateFile;
+      }
+    }
     return uuidStateFile;
   }
 


### PR DESCRIPTION
This issue fixes MAC address detection on AWS and saves the uuid-state file in 
$HOME/.ebean/<ebean-servername>-uuid.state