### PR TITLE
Original Value and bean change was not computed correctly in changelog

### DIFF
--- a/src/test/java/org/tests/changelog/TestChangeLog.java
+++ b/src/test/java/org/tests/changelog/TestChangeLog.java
@@ -5,11 +5,13 @@ import io.ebean.EbeanServerFactory;
 import io.ebean.annotation.ChangeLog;
 import io.ebean.config.ServerConfig;
 import io.ebean.event.BeanPersistRequest;
+import io.ebean.event.changelog.BeanChange;
 import io.ebean.event.changelog.ChangeLogFilter;
 import io.ebean.event.changelog.ChangeLogListener;
 import io.ebean.event.changelog.ChangeLogPrepare;
 import io.ebean.event.changelog.ChangeLogRegister;
 import io.ebean.event.changelog.ChangeSet;
+import io.ebean.event.changelog.ChangeType;
 import io.ebeaninternal.api.SpiEbeanServer;
 import org.tests.model.basic.EBasicChangeLog;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -18,7 +20,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class TestChangeLog extends BaseTestCase {
 
@@ -47,13 +53,76 @@ public class TestChangeLog extends BaseTestCase {
     bean.setName("logBean");
     bean.setShortDescription("hello");
     server.save(bean);
+    BeanChange change = changeLogListener.changes.getChanges().get(0);
+
+    assertThat(change.getEvent()).isEqualTo(ChangeType.INSERT);
+    assertThat(change.getData())
+      .contains("\"name\":\"logBean\"")
+      .contains("\"shortDescription\":\"hello\"");
+
 
     bean.setName("ChangedName");
     server.save(bean);
 
+    change = changeLogListener.changes.getChanges().get(0);
+
+    assertThat(change.getEvent()).isEqualTo(ChangeType.UPDATE);
+    assertThat(change.getOldData()).contains("\"name\":\"logBean\"");
+    assertThat(change.getData())   .contains("\"name\":\"ChangedName\"");
+
+
     server.delete(bean);
 
+    change = changeLogListener.changes.getChanges().get(0);
+
+    assertThat(change.getEvent()).isEqualTo(ChangeType.DELETE);
+    assertThat(change.getData()).isNull();
+
   }
+
+
+  @Test
+  public void testWithNull() {
+
+    EBasicChangeLog bean = new EBasicChangeLog();
+    bean.setName(null);
+    bean.setShortDescription("hello");
+    server.save(bean);
+    BeanChange change = changeLogListener.changes.getChanges().get(0);
+
+    assertThat(change.getEvent()).isEqualTo(ChangeType.INSERT);
+    assertThat(change.getData())
+      .doesNotContain("\"name\"")
+      .contains("\"shortDescription\":\"hello\"");
+
+
+    bean.setName("log");
+    bean.setName("logBean");
+    bean.setShortDescription("world");
+    bean.setShortDescription("hello");
+    server.save(bean);
+
+    change = changeLogListener.changes.getChanges().get(0);
+
+    assertThat(change.getEvent()).isEqualTo(ChangeType.UPDATE);
+    assertThat(change.getOldData())
+      .doesNotContain("\"name\"") // it was null
+      .doesNotContain("\"shortDescription\""); // it is unchanged
+
+    assertThat(change.getData())
+      .contains("\"name\":\"logBean\"")
+      .doesNotContain("\"shortDescription\""); // it is unchanged
+
+
+    server.delete(bean);
+
+    change = changeLogListener.changes.getChanges().get(0);
+
+    assertThat(change.getEvent()).isEqualTo(ChangeType.DELETE);
+    assertThat(change.getData()).isNull();
+
+  }
+
 
   private SpiEbeanServer getServer() {
 

--- a/src/test/java/org/tests/changelog/TestChangeLog.java
+++ b/src/test/java/org/tests/changelog/TestChangeLog.java
@@ -106,7 +106,7 @@ public class TestChangeLog extends BaseTestCase {
 
     assertThat(change.getEvent()).isEqualTo(ChangeType.UPDATE);
     assertThat(change.getOldData())
-      .doesNotContain("\"name\"") // it was null
+      .contains("\"name\":null") // it was null
       .doesNotContain("\"shortDescription\""); // it is unchanged
 
     assertThat(change.getData())


### PR DESCRIPTION
This fixes 2 issues in changelog:

1. changing a null value to non null in two steps uses the first non null value as oldValue:

```java
Bean bean = new Bean().
bean.setName(null);
bean.save();

bean.setName("Foo"); // this was taken as old value
bean.setName("Bar");
bean.save(); // produced a changelog entry: name was changed from "Foo" to "Bar"
```

The issue here was, that the code that stores the value checks for 'null' and not for a flag. So I introduced a flag "original value set" in the EBI. As there are already 3 boolean arrays, I did not want to introduce a 4th. So I changed this to a byte array and use bit-flags. This should reduce the memory footprint per entity also


2. not really changing a value logs the value

```java
Bean bean = new Bean().
bean.setName("Foo");
bean.save();

bean.setName("Bar"); 
bean.setName("Foo"); // change the name back to "Foo"
bean.save(); // produced a changelog entry: name was changed from "Foo" to "Foo"
```

this case happens through edititing in UI where the user may change a field and decide to change it back. It is a little bit confusing if the "change" apperars in the changelog. I added an 'areEqual' test in the two visitor methods




