### PR TITLE
removed the concat-operator "||" and replaced with "concat()"

### DIFF
--- a/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -64,8 +64,6 @@ public class DatabasePlatform {
    */
   protected String closeQuote = "\"";
 
-  protected String concatOperator = "||";
-
   /**
    * When set to true all db column names and table names use quoted identifiers.
    */
@@ -453,13 +451,6 @@ public class DatabasePlatform {
    */
   public String getOpenQuote() {
     return openQuote;
-  }
-
-  /**
-   * Return the DB concat operator.
-   */
-  public String getConcatOperator() {
-    return concatOperator;
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/expression/InPairsExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/InPairsExpression.java
@@ -95,13 +95,9 @@ class InPairsExpression extends AbstractExpression {
 
     StringBuilder sb = new StringBuilder();
 
-    sb.append("CONCAT(").append(property0).append(",'").append(separator).append("',").append(property1);
+    request.getDbPlatformHandler().concat(property0, separator, property1, suffix);
 
-    if (suffix != null && !suffix.isEmpty()) {
-      sb.append(",'").append(suffix).append('\'');
-    }
-    sb.append(')');
-    request.append(sb.toString());
+    request.append(request.getDbPlatformHandler().concat(property0, separator, property1, suffix));
     request.appendInExpression(not, concatBindValues);
   }
 

--- a/src/main/java/io/ebeaninternal/server/expression/InPairsExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/InPairsExpression.java
@@ -92,14 +92,16 @@ class InPairsExpression extends AbstractExpression {
       return;
     }
 
-    String concat = request.getDbPlatformHandler().getConcatOperator();
 
-    String concatFormula = "(" + property0 + concat + "'" + separator + "'" + concat + property1;
+    StringBuilder sb = new StringBuilder();
+
+    sb.append("CONCAT(").append(property0).append(",'").append(separator).append("',").append(property1);
+
     if (suffix != null && !suffix.isEmpty()) {
-      concatFormula += concat + "'" + suffix + "'";
+      sb.append(",'").append(suffix).append('\'');
     }
-    concatFormula += ")";
-    request.append(concatFormula);
+    sb.append(')');
+    request.append(sb.toString());
     request.appendInExpression(not, concatBindValues);
   }
 

--- a/src/main/java/io/ebeaninternal/server/expression/platform/BaseDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/BaseDbExpression.java
@@ -46,4 +46,15 @@ abstract class BaseDbExpression implements DbExpressionHandler {
     }
   }
 
+  @Override
+  public String concat(String property0, String separator, String property1, String suffix) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("CONCAT(").append(property0).append(",'").append(separator).append("',").append(property1);
+
+    if (suffix != null && !suffix.isEmpty()) {
+      sb.append(",'").append(suffix).append('\'');
+    }
+    sb.append(')');
+    return sb.toString();
+  }
 }

--- a/src/main/java/io/ebeaninternal/server/expression/platform/BaseDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/BaseDbExpression.java
@@ -8,17 +8,6 @@ import io.ebeaninternal.server.expression.BitwiseOp;
  */
 abstract class BaseDbExpression implements DbExpressionHandler {
 
-  private final String concatOperator;
-
-  BaseDbExpression(String concatOperator) {
-    this.concatOperator = concatOperator;
-  }
-
-  @Override
-  public String getConcatOperator() {
-    return concatOperator;
-  }
-
   @Override
   public void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
 

--- a/src/main/java/io/ebeaninternal/server/expression/platform/BasicDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/BasicDbExpression.java
@@ -8,10 +8,6 @@ import io.ebeaninternal.server.expression.Op;
  */
 public class BasicDbExpression extends BaseDbExpression {
 
-  BasicDbExpression(String concatOperator) {
-    super(concatOperator);
-  }
-
   @Override
   public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
     throw new RuntimeException("JSON expressions only supported on Postgres and Oracle");

--- a/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandler.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandler.java
@@ -10,11 +10,6 @@ import io.ebeaninternal.server.expression.Op;
 public interface DbExpressionHandler {
 
   /**
-   * Return the DB concat operator (Usually SQL standard "||").
-   */
-  String getConcatOperator();
-
-  /**
    * Write the db platform specific json expression.
    */
   void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value);

--- a/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandler.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandler.java
@@ -28,4 +28,9 @@ public interface DbExpressionHandler {
    * Add the bitwise expression.
    */
   void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match);
+
+  /**
+   * Performs a "CONCAT" operation for that platform.
+   */
+  String concat(String property0, String separator, String property1, String suffix);
 }

--- a/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandlerFactory.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandlerFactory.java
@@ -12,20 +12,21 @@ public class DbExpressionHandlerFactory {
   public static DbExpressionHandler from(DatabasePlatform databasePlatform) {
 
     Platform platform = databasePlatform.getPlatform();
-    String concatOperator = databasePlatform.getConcatOperator();
     switch (platform) {
       case H2:
-        return new H2DbExpression(concatOperator);
+        return new H2DbExpression();
       case POSTGRES:
-        return new PostgresDbExpression(concatOperator);
+        return new PostgresDbExpression();
       case MYSQL:
-        return new MySqlDbExpression(concatOperator);
+        return new MySqlDbExpression();
       case ORACLE:
-        return new OracleDbExpression(concatOperator);
+        return new OracleDbExpression();
+      case SQLSERVER16:
+      case SQLSERVER17:
       case SQLSERVER:
-        return new SqlServerDbExpression(concatOperator);
+        return new SqlServerDbExpression();
       default:
-        return new BasicDbExpression(concatOperator);
+        return new BasicDbExpression();
     }
   }
 }

--- a/src/main/java/io/ebeaninternal/server/expression/platform/H2DbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/H2DbExpression.java
@@ -8,10 +8,6 @@ import io.ebeaninternal.server.expression.BitwiseOp;
  */
 class H2DbExpression extends BasicDbExpression {
 
-  H2DbExpression(String concatOperator) {
-    super(concatOperator);
-  }
-
   @Override
   public void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
 

--- a/src/main/java/io/ebeaninternal/server/expression/platform/MySqlDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/MySqlDbExpression.java
@@ -5,8 +5,4 @@ package io.ebeaninternal.server.expression.platform;
  */
 class MySqlDbExpression extends BasicDbExpression {
 
-  MySqlDbExpression(String concatOperator) {
-    super(concatOperator);
-  }
-
 }

--- a/src/main/java/io/ebeaninternal/server/expression/platform/OracleDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/OracleDbExpression.java
@@ -9,10 +9,6 @@ import io.ebeaninternal.server.expression.Op;
  */
 public class OracleDbExpression extends BaseDbExpression {
 
-  OracleDbExpression(String concatOperator) {
-    super(concatOperator);
-  }
-
   @Override
   public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
 

--- a/src/main/java/io/ebeaninternal/server/expression/platform/PostgresDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/PostgresDbExpression.java
@@ -8,10 +8,6 @@ import io.ebeaninternal.server.expression.Op;
  */
 public class PostgresDbExpression extends BaseDbExpression {
 
-  PostgresDbExpression(String concatOperator) {
-    super(concatOperator);
-  }
-
   @Override
   public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
 

--- a/src/main/java/io/ebeaninternal/server/expression/platform/PostgresDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/PostgresDbExpression.java
@@ -61,4 +61,16 @@ public class PostgresDbExpression extends BaseDbExpression {
       request.append(" <> 0");
     }
   }
+
+  @Override
+  public String concat(String property0, String separator, String property1, String suffix) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("(").append(property0).append("||'").append(separator).append("'||").append(property1);
+
+    if (suffix != null && !suffix.isEmpty()) {
+      sb.append("||'").append(suffix).append('\'');
+    }
+    sb.append(')');
+    return sb.toString();
+  }
 }

--- a/src/main/java/io/ebeaninternal/server/expression/platform/SqlServerDbExpression.java
+++ b/src/main/java/io/ebeaninternal/server/expression/platform/SqlServerDbExpression.java
@@ -8,10 +8,6 @@ import io.ebeaninternal.server.expression.Op;
  */
 public class SqlServerDbExpression extends BaseDbExpression {
 
-  SqlServerDbExpression(String concatOperator) {
-    super(concatOperator);
-  }
-
   @Override
   public void json(final SpiExpressionRequest request, final String propName,
                    final String path, final Op operator, final Object value) {

--- a/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
+++ b/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
@@ -278,6 +278,8 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
 
     if (isH2()) {
       assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,'-',t0.code) in (?, ? )  order by t0.sku desc; --bind(def,Array[2]={2-1000,3-1000})");
+    } else if (isPostgres()) {
+      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and (t0.sku||'-'||t0.code)");
     } else {
       assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,'-',t0.code)");
     }
@@ -315,6 +317,8 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
 
     if (isH2()) {
       assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo') in (?, ? )  order by t0.sku desc; --bind(def,Array[2]={2:1000-foo,3:1000-foo})");
+    } else if (isPostgres()){
+      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo')");
     } else {
       assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo')");
     }

--- a/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
+++ b/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
@@ -318,7 +318,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
     if (isH2()) {
       assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo') in (?, ? )  order by t0.sku desc; --bind(def,Array[2]={2:1000-foo,3:1000-foo})");
     } else if (isPostgres()){
-      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo')");
+      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and (t0.sku||':'||t0.code||'-foo')");
     } else {
       assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo')");
     }

--- a/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
+++ b/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
@@ -4,8 +4,6 @@ import io.ebean.BaseTestCase;
 import io.ebean.CacheMode;
 import io.ebean.Ebean;
 import io.ebean.Pairs;
-import io.ebean.annotation.IgnorePlatform;
-import io.ebean.annotation.Platform;
 import io.ebean.cache.ServerCache;
 import io.ebean.cache.ServerCacheManager;
 import io.ebean.cache.ServerCacheStatistics;
@@ -251,7 +249,6 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
     assertBeanCacheHitMiss(0, 0);
   }
 
-  @IgnorePlatform({Platform.MYSQL, Platform.SQLSERVER})
   @Test
   public void findList_inPairs_standardConcat() {
 
@@ -280,14 +277,13 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
     assertBeanCacheHitMiss(1, 0);
 
     if (isH2()) {
-      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and (t0.sku||'-'||t0.code) in (?, ? )  order by t0.sku desc; --bind(def,Array[2]={2-1000,3-1000})");
+      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,'-',t0.code) in (?, ? )  order by t0.sku desc; --bind(def,Array[2]={2-1000,3-1000})");
     } else {
-      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and (t0.sku||'-'||t0.code)");
+      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,'-',t0.code)");
     }
 
   }
 
-  @IgnorePlatform({Platform.MYSQL, Platform.SQLSERVER})
   @Test
   public void findList_inPairs_userConcat() {
 
@@ -318,9 +314,9 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
     assertBeanCacheHitMiss(1, 0);
 
     if (isH2()) {
-      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and (t0.sku||':'||t0.code||'-foo') in (?, ? )  order by t0.sku desc; --bind(def,Array[2]={2:1000-foo,3:1000-foo})");
+      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo') in (?, ? )  order by t0.sku desc; --bind(def,Array[2]={2:1000-foo,3:1000-foo})");
     } else {
-      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and (t0.sku||':'||t0.code||'-foo')");
+      assertThat(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ?  and CONCAT(t0.sku,':',t0.code,'-foo')");
     }
 
   }


### PR DESCRIPTION
Hi Rob,

this PR removes the concat operator "||" and replaces it with "concat()", because there is no working "+" or "||" operator in SqlServer for different datatypes and it does not work on MySql/MariaDb, too.

Note that SqlServer and MariaDb have also a different handling with null values.

*SqlServer*
`SELECT 'a' + null` = `null`
`SELECT 'a' + 'b'` = `ab`
`SELECT 'a' + 1` = `Conversion failed when converting the varchar value 'a' to data type int.`
`SELECT concat('a',null,'b')` = `ab`
`SELECT concat('a',1)` = `a1`

*MariaDb*
`SELECT 'a' || 'a' ` = `0`
`SELECT 'a' + 'a' ` = `0`
`SELECT 126 || 5` = `4` (logical OR)
`SELECT concat('a',null,'b')` = `null` **Returns null! - Maybe coalesce also needed**

*Postgres*
To be done (concat available since 9.1)


