### PR TITLE
FIX: withQuote_when_match for different platforms

### DIFF
--- a/src/test/java/io/ebeaninternal/server/deploy/DeployPropertyParserTest.java
+++ b/src/test/java/io/ebeaninternal/server/deploy/DeployPropertyParserTest.java
@@ -1,6 +1,9 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.BaseTestCase;
+import io.ebean.annotation.ForPlatform;
+import io.ebean.annotation.Platform;
+
 import org.junit.Test;
 import org.tests.model.basic.Address;
 import org.tests.model.basic.BWithQIdent;
@@ -53,9 +56,24 @@ public class DeployPropertyParserTest extends BaseTestCase {
   }
 
   @Test
-  public void withQuote_when_match() {
+  @ForPlatform(value = {Platform.H2, Platform.POSTGRES})
+  public void withQuote_when_match_h2() {
     assertThat(withQuoteParser().parse("name like ?")).isEqualTo("${}\"Name\" like ?");
     assertThat(withQuoteParser().parse("t0.\"CODE\" like ?")).isEqualTo("t0.\"CODE\" like ?");
+  }
+
+  @Test
+  @ForPlatform(value = Platform.SQLSERVER)
+  public void withQuote_when_match_sqlserver() {
+    assertThat(withQuoteParser().parse("name like ?")).isEqualTo("${}[Name] like ?");
+    assertThat(withQuoteParser().parse("t0.[CODE] like ?")).isEqualTo("t0.[CODE] like ?");
+  }
+
+  @Test
+  @ForPlatform(value = Platform.MYSQL)
+  public void withQuote_when_match_mysql() {
+    assertThat(withQuoteParser().parse("name like ?")).isEqualTo("${}`Name` like ?");
+    assertThat(withQuoteParser().parse("t0.`CODE` like ?")).isEqualTo("t0.`CODE` like ?");
   }
 
   @Test


### PR DESCRIPTION
the withQuote_when_match fails on sqlserver and mysql.

There is still one issue, you shold investigate on the "CODE" tests, because I do not know what is here expected.
Should all quotes get converted to the platform one, so `t0."CODE"` becomes `t0.[CODE]` (does not work) or shouldn't it modify the statement. At least I can say that this fails on MySQL
```
assertThat(withQuoteParser().parse("t0.`CODE` like ?")).isEqualTo("t0.`CODE` like ?");
```
because it returns
```
t0.`[${}`CODE`]` like ?
```
