### PR TITLE
NEW: collation support for orderBy

### DIFF
--- a/src/test/java/org/tests/unitinternal/TestOrderByParse.java
+++ b/src/test/java/org/tests/unitinternal/TestOrderByParse.java
@@ -153,4 +153,51 @@ public class TestOrderByParse extends BaseTestCase {
     assertEquals("id, name", copy.toStringFormat());
 
   }
+
+  @Test
+  public void testParsingWithCollation() {
+
+    OrderBy<Object> o1 = new OrderBy<>();
+    o1.asc("id", "latin_1");
+    assertTrue(o1.getProperties().size() == 1);
+    assertTrue(o1.getProperties().get(0).getProperty().equals("id"));
+    assertTrue(o1.getProperties().get(0).isAscending());
+    assertEquals("id COLLATE latin_1", o1.toStringFormat());
+
+    o1 = new OrderBy<>();
+    o1.desc("id", "latin_1");
+    assertTrue(o1.getProperties().size() == 1);
+    assertTrue(o1.getProperties().get(0).getProperty().equals("id"));
+    assertTrue(!o1.getProperties().get(0).isAscending());
+    assertEquals("id COLLATE latin_1 desc", o1.toStringFormat());
+
+    o1 = new OrderBy<>();
+    o1.desc("id", "latin_1");
+    o1.asc("date");
+    assertTrue(o1.getProperties().size() == 2);
+    assertTrue(o1.getProperties().get(0).getProperty().equals("id"));
+    assertTrue(o1.getProperties().get(1).getProperty().equals("date"));
+    assertTrue(!o1.getProperties().get(0).isAscending());
+    assertTrue(o1.getProperties().get(1).isAscending());
+    assertEquals("id COLLATE latin_1 desc, date", o1.toStringFormat());
+
+    o1 = new OrderBy<>();
+    o1.desc("id", "latin_1");
+    o1.asc("name", "latin_2");
+    assertTrue(o1.getProperties().size() == 2);
+    assertTrue(o1.getProperties().get(0).getProperty().equals("id"));
+    assertTrue(o1.getProperties().get(1).getProperty().equals("name"));
+    assertTrue(!o1.getProperties().get(0).isAscending());
+    assertTrue(o1.getProperties().get(1).isAscending());
+    assertEquals("id COLLATE latin_1 desc, name COLLATE latin_2", o1.toStringFormat());
+
+    // functional (DB2) syntax
+    o1 = new OrderBy<>();
+    o1.desc("id", "COLLATION_KEY(${}, 'latin_1')");
+    assertTrue(o1.getProperties().size() == 1);
+    assertTrue(o1.getProperties().get(0).getProperty().equals("id"));
+    assertTrue(!o1.getProperties().get(0).isAscending());
+    assertEquals("COLLATION_KEY(id, 'latin_1') desc", o1.toStringFormat());
+
+  }
 }


### PR DESCRIPTION
this adds collation (and functional) support for orderBy. 
You can specify a collation like `latin_1` which results in an `ORDER BY name COLLATE latin_1`
If the string contains the placeholder `${}`, the argument is considered as function which is required for DB2 or for complex orderings

DB2 example: `o1.desc("name", "COLLATION_KEY(${}, 'latin_1')");`
Complex ordering example: `o1.desc("name", "SOUNDEX(${})");`