### PR TITLE
FIX: tableName detection for native statements on SQLServer

### DIFF
--- a/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -417,7 +417,9 @@ class CQueryBuilder {
 
     BeanDescriptor<?> desc = request.getBeanDescriptor();
     try {
-      PreparedStatement statement = connection.prepareStatement(sql);
+      // For SqlServer we need either "selectMethod=cursor" in the connection string or fetch explicitly a cursorable
+      // statement here by specifying ResultSet.CONCUR_UPDATABLE
+      PreparedStatement statement = connection.prepareStatement(sql,ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
       predicates.bind(statement, connection);
 
       ResultSet resultSet = statement.executeQuery();

--- a/src/test/java/org/tests/rawsql/nativesql/TestNativeSqlBasic.java
+++ b/src/test/java/org/tests/rawsql/nativesql/TestNativeSqlBasic.java
@@ -139,7 +139,7 @@ public class TestNativeSqlBasic extends BaseTestCase {
    * Oracle does not support getTableName() via JDBC resultSet meta data
    */
   @Test
-  @IgnorePlatform({Platform.SQLSERVER, Platform.ORACLE}) // does only work in 'cursor' mode!
+  @IgnorePlatform({Platform.ORACLE})
   public void partialAssoc() {
 
     ResetBasicData.reset();


### PR DESCRIPTION
This fixes the problem that metaData.getTableName is always null on SqlServer
