### PR TITLE
FIX: check platform on multiple annotations

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationBase.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationBase.java
@@ -82,12 +82,12 @@ public abstract class AnnotationBase {
     T a = null;
     Field field = prop.getField();
     if (field != null) {
-      a = AnnotationUtil.findAnnotation(field, annClass);
+      a = AnnotationUtil.findAnnotation(field, annClass, platform);
     }
     if (a == null) {
       Method method = prop.getReadMethod();
       if (method != null) {
-        a = AnnotationUtil.findAnnotation(method, annClass);
+        a = AnnotationUtil.findAnnotation(method, annClass, platform);
       }
     }
     return a;


### PR DESCRIPTION
this fixes a bug so that the right annotation is taken like in this example:

```java
@Formula(platform= Platform.MYSQL, select = "mysql-specific select")
@Formula(platform= Platform.H2, , select = "h2-specific select")
private String computedString
```