### PR TITLE
FIX: update extra ddl also, if no migration was written

### DIFF
--- a/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
@@ -289,6 +289,12 @@ public class DefaultDbMigration implements DbMigration {
       Request request = createRequest();
       if (platforms.isEmpty()) {
         generateExtraDdl(request.migrationDir, databasePlatform, request.isTablePartitioning());
+      } else {
+        for (Pair pair : platforms) {
+          PlatformDdlWriter platformWriter = createDdlWriter(pair.platform);
+          File subPath = platformWriter.subPath(request.migrationDir, pair.prefix);
+          generateExtraDdl(subPath, pair.platform, request.isTablePartitioning());
+        }
       }
 
       String pendingVersion = generatePendingDrop();
@@ -560,8 +566,6 @@ public class DefaultDbMigration implements DbMigration {
       PlatformDdlWriter platformWriter = createDdlWriter(pair.platform);
       File subPath = platformWriter.subPath(writePath, pair.prefix);
       platformWriter.processMigration(dbMigration, platformBuffer, subPath, fullVersion);
-
-      generateExtraDdl(subPath, pair.platform, currentModel.isTablePartitioning());
     }
   }
 


### PR DESCRIPTION
## Expected behavior

- generateMigration should update extra DDL independently of model changes.

## Actual behavior 

- Add at least one platform with `migration.addPlatform(Platform.DB2, "db2");` (NOTE: If `platform.isEmpty()` it will work)
- Generate all migration scripts, so migration is up to date
- Modify the extra-ddl.xml
- Generate all migration scripts again - you will get `no changes detected - no migration written` on the console
- Ebean does not update the extra DDL in the R_xxxxx files in the platform directory


## Steps to reproduce

(sorry no automatic test case provided)

- open `DbMigrationGenerateTest`
- comment out line 72/73 where the ouput directory is cleaned up
- run the test at least twice, until it will return null in `migration.generateMigration()` (Test wil fail, and will generate 1.5 migration scripts, but that does not matter)
- modify extra-ddl.xml
- Run the test again (it will return null again, and will print, that no migration is written)
- **Actual**: R__xxxxx files stay untouched
- **Expected**: You should see your extra-ddl changes in the R__xxxxx files
