### PR TITLE
Fixed tests that modify BasicData

### DIFF
--- a/src/test/java/io/ebean/plugin/ExpressionPathTest.java
+++ b/src/test/java/io/ebean/plugin/ExpressionPathTest.java
@@ -4,6 +4,7 @@ import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
+import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,6 +81,8 @@ public class ExpressionPathTest {
   @Test
   public void test_dirty() throws Exception {
 
+    ResetBasicData.reset();
+
     BeanType<Customer> customerBeanType = beanType(Customer.class);
     BeanType<Order> orderBeanType = beanType(Order.class);
 
@@ -113,6 +116,10 @@ public class ExpressionPathTest {
 
     order = server.find(Order.class, order.getId());
     assertThat(order.getCustomer().getName()).isEqualTo("baz");
+
+    // cleanup
+    server.delete(Order.class, order.getId());
+    server.delete(Customer.class, customer.getId());
   }
 
 }

--- a/src/test/java/org/tests/autofetch/TunedQueryWithNullFetchedBeanTest.java
+++ b/src/test/java/org/tests/autofetch/TunedQueryWithNullFetchedBeanTest.java
@@ -63,5 +63,7 @@ public class TunedQueryWithNullFetchedBeanTest extends BaseTestCase {
     // assert only one query executed
     List<String> loggedSql = LoggedSqlCollector.stop();
     Assert.assertEquals(1, loggedSql.size());
+
+    Ebean.delete(newCustomer);
   }
 }

--- a/src/test/java/org/tests/basic/TestLazyLoadEmptyOneToMany.java
+++ b/src/test/java/org/tests/basic/TestLazyLoadEmptyOneToMany.java
@@ -33,5 +33,8 @@ public class TestLazyLoadEmptyOneToMany extends BaseTestCase {
     int sz = contacts.size();
 
     Assert.assertTrue(sz == 0);
+
+    // cleanup
+    Ebean.delete(c1);
   }
 }

--- a/src/test/java/org/tests/basic/TestTransient.java
+++ b/src/test/java/org/tests/basic/TestTransient.java
@@ -4,6 +4,7 @@ import io.ebean.BaseTestCase;
 import io.ebean.BeanState;
 import io.ebean.Ebean;
 import org.tests.model.basic.Customer;
+import org.tests.model.basic.ResetBasicData;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,6 +12,8 @@ public class TestTransient extends BaseTestCase {
 
   @Test
   public void testTransient() {
+
+    ResetBasicData.reset();
 
     Customer cnew = new Customer();
     cnew.setName("testTrans");
@@ -58,5 +61,8 @@ public class TestTransient extends BaseTestCase {
     int rows = Ebean.createUpdate(Customer.class, updateStmt).set("id", custId).execute();
 
     Assert.assertTrue("changed name back", 1 == rows);
+
+    // cleanup
+    Ebean.delete(Customer.class, custId);
   }
 }

--- a/src/test/java/org/tests/batchinsert/TestBatchSaveWithGetBeanId.java
+++ b/src/test/java/org/tests/batchinsert/TestBatchSaveWithGetBeanId.java
@@ -33,5 +33,7 @@ public class TestBatchSaveWithGetBeanId extends BaseTestCase {
     // insert occurs and the bean has an Id value
     Object beanId = server.getBeanId(model);
     assertNotNull(beanId);
+
+    Ebean.delete(Customer.class, beanId);
   }
 }

--- a/src/test/java/org/tests/batchload/TestBasicNavOnEmpty.java
+++ b/src/test/java/org/tests/batchload/TestBasicNavOnEmpty.java
@@ -4,6 +4,7 @@ import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
+import org.tests.model.basic.ResetBasicData;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -14,6 +15,8 @@ public class TestBasicNavOnEmpty extends BaseTestCase {
   @Test
   public void test() {
 
+    ResetBasicData.reset();
+
     Customer c = new Customer();
     c.setName("HelloRob");
 
@@ -23,6 +26,9 @@ public class TestBasicNavOnEmpty extends BaseTestCase {
 
     List<Contact> contacts = c.getContacts();
     Assert.assertEquals(0, contacts.size());
+
+    // cleanup
+    Ebean.delete(c);
   }
 
 }

--- a/src/test/java/org/tests/batchload/TestEmptyManyLazyLoad.java
+++ b/src/test/java/org/tests/batchload/TestEmptyManyLazyLoad.java
@@ -26,5 +26,8 @@ public class TestEmptyManyLazyLoad extends BaseTestCase {
     Order o2 = Ebean.find(Order.class, o.getId());
     o2.getDetails().size();
 
+    // cleanup
+    Ebean.delete(o2);
+
   }
 }

--- a/src/test/java/org/tests/batchload/TestSecondQueryNoRows.java
+++ b/src/test/java/org/tests/batchload/TestSecondQueryNoRows.java
@@ -4,6 +4,7 @@ import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.FetchConfig;
 import org.tests.model.basic.Customer;
+import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -13,6 +14,8 @@ public class TestSecondQueryNoRows extends BaseTestCase {
 
   @Test
   public void test() {
+
+    ResetBasicData.reset();
 
     Customer cnew = new Customer();
     cnew.setName("testSecQueryNoRows");
@@ -27,5 +30,7 @@ public class TestSecondQueryNoRows extends BaseTestCase {
 
     assertNotNull(c);
     assertEquals(0, c.getContacts().size());
+
+    Ebean.delete(c);
   }
 }

--- a/src/test/java/org/tests/cache/TestCacheInterceptSaveWhenLazyLoaded.java
+++ b/src/test/java/org/tests/cache/TestCacheInterceptSaveWhenLazyLoaded.java
@@ -4,6 +4,7 @@ import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
+import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
 import static org.junit.Assert.assertSame;
@@ -13,6 +14,8 @@ public class TestCacheInterceptSaveWhenLazyLoaded extends BaseTestCase {
 
   @Test
   public void test() {
+
+    ResetBasicData.reset();
 
     Customer customer = new Customer();
     customer.setName("daCustomer");
@@ -45,12 +48,12 @@ public class TestCacheInterceptSaveWhenLazyLoaded extends BaseTestCase {
       assertSame(foundOrder, order1);
       assertTrue(Ebean.getBeanState(foundOrder).isDirty());
 
-      Ebean.delete(order1);
-      Ebean.delete(customer);
-
     } finally {
       Ebean.endTransaction();
     }
 
+    // cleanup
+    Ebean.delete(order);
+    Ebean.delete(customer);
   }
 }

--- a/src/test/java/org/tests/delete/TestDeleteByIdWithPersistenceContext.java
+++ b/src/test/java/org/tests/delete/TestDeleteByIdWithPersistenceContext.java
@@ -43,6 +43,9 @@ public class TestDeleteByIdWithPersistenceContext extends BaseTestCase {
 
     }
 
+    // cleanup
+    Ebean.delete(Product.class, 100);
+    Ebean.delete(Product.class, 101);
   }
 
   private Product createProduct(Integer id, String name) {

--- a/src/test/java/org/tests/model/basic/ResetBasicData.java
+++ b/src/test/java/org/tests/model/basic/ResetBasicData.java
@@ -4,6 +4,8 @@ import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import org.tests.model.basic.Order.Status;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +19,25 @@ public class ResetBasicData {
   public static synchronized void reset() {
 
     if (runOnce) {
+      int cnt1 = server.find(Customer.class).findCount();
+      int cnt2 = server.find(Order.class).findCount();
+      int cnt3 = server.find(Country.class).findCount();
+      int cnt4 = server.find(Product.class).findCount();
+      if (cnt1 == 4 && cnt2 == 5 && cnt3 == 2 && cnt4 == 4) {
+        // OK, test data not modified
+      } else {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Customers:");
+        server.find(Customer.class).findEach(c -> sb.append(' ').append(c.getId()));
+        sb.append(", Orders:");
+        server.find(Order.class).findEach(c -> sb.append(' ').append(c.getId()));
+        sb.append(", Countries:");
+        server.find(Country.class).findEach(c -> sb.append(' ').append(c.getCode()));
+        sb.append(", Products:");
+        server.find(Product.class).findEach(c -> sb.append(' ').append(c.getId()));
+        System.err.println("WARNING: basic test data was modified. Current content:");
+        System.err.println(sb.toString());
+      }
       return;
     }
 

--- a/src/test/java/org/tests/query/TestQueryFindPagedList.java
+++ b/src/test/java/org/tests/query/TestQueryFindPagedList.java
@@ -194,7 +194,7 @@ public class TestQueryFindPagedList extends BaseTestCase {
 
     ResetBasicData.reset();
 
-    PagedList<Order> pagedList = Ebean.find(Order.class).setMaxRows(6).findPagedList();
+    PagedList<Order> pagedList = Ebean.find(Order.class).setMaxRows(3).findPagedList();
 
     LoggedSqlCollector.start();
 

--- a/src/test/java/org/tests/repository/TestBeanRepository.java
+++ b/src/test/java/org/tests/repository/TestBeanRepository.java
@@ -3,6 +3,7 @@ package org.tests.repository;
 import io.ebean.BaseTestCase;
 import org.junit.Test;
 import org.tests.model.basic.Customer;
+import org.tests.model.basic.ResetBasicData;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +15,8 @@ public class TestBeanRepository extends BaseTestCase {
 
   @Test
   public void test() {
+
+    ResetBasicData.reset();
 
     CustomerRepository repository = new CustomerRepository(server());
 
@@ -47,6 +50,8 @@ public class TestBeanRepository extends BaseTestCase {
 
   @Test
   public void findByName() {
+
+    ResetBasicData.reset();
 
     CustomerRepository repository = new CustomerRepository(server());
 

--- a/src/test/java/org/tests/text/csv/TestCsvReader.java
+++ b/src/test/java/org/tests/text/csv/TestCsvReader.java
@@ -1,7 +1,7 @@
 package org.tests.text.csv;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.TransactionalTestCase;
 import io.ebean.text.csv.CsvReader;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
@@ -12,7 +12,7 @@ import java.io.FileReader;
 import java.net.URL;
 import java.util.Locale;
 
-public class TestCsvReader extends BaseTestCase {
+public class TestCsvReader extends TransactionalTestCase {
 
   @Test
   public void test() {

--- a/src/test/java/org/tests/text/csv/TestCsvReaderWithCallback.java
+++ b/src/test/java/org/tests/text/csv/TestCsvReaderWithCallback.java
@@ -1,25 +1,25 @@
 package org.tests.text.csv;
 
-import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
+import io.ebean.TransactionalTestCase;
 import io.ebean.text.csv.CsvReader;
 import io.ebean.text.csv.DefaultCsvCallback;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
 import java.util.Locale;
 
-public class TestCsvReaderWithCallback extends BaseTestCase {
+public class TestCsvReaderWithCallback extends TransactionalTestCase {
 
   @Test
   public void test() throws Throwable {
-
-    ResetBasicData.reset();
 
     URL resource = TestCsvReaderWithCallback.class.getResource("/test1.csv");
     File f = new File(resource.getFile());
@@ -43,6 +43,8 @@ public class TestCsvReaderWithCallback extends BaseTestCase {
     // processor.addReference("billingAddress.country.code");
     csvReader.addProperty("billingAddress.country.code");
 
+    int before = Ebean.find(Customer.class).findCount();
+
     csvReader.process(reader, new DefaultCsvCallback<Customer>() {
 
       @Override
@@ -50,9 +52,13 @@ public class TestCsvReaderWithCallback extends BaseTestCase {
 
         server.save(cust.getBillingAddress(), transaction);
         server.save(cust, transaction);
+
       }
 
     });
+
+    int after = Ebean.find(Customer.class).findCount();
+    assertThat(after).isEqualTo(before + 9);
 
   }
 

--- a/src/test/java/org/tests/text/json/TestTextJsonInsertUpdate.java
+++ b/src/test/java/org/tests/text/json/TestTextJsonInsertUpdate.java
@@ -36,5 +36,8 @@ public class TestTextJsonInsertUpdate extends BaseTestCase {
     Customer c2 = jsonContext.toBean(Customer.class, j2);
     Ebean.update(c2);
 
+    // cleanup
+    Ebean.delete(Customer.class, c0.getId());
+
   }
 }

--- a/src/test/java/org/tests/update/TestUpdatePartial.java
+++ b/src/test/java/org/tests/update/TestUpdatePartial.java
@@ -46,6 +46,9 @@ public class TestUpdatePartial extends BaseTestCase {
 
     Ebean.save(c3);
     checkDbStatusValue(c.getId(), "N");
+
+    // cleanup
+    Ebean.delete(Customer.class, c.getId());
   }
 
   private void checkDbStatusValue(Integer custId, String dbStatus) {
@@ -71,5 +74,9 @@ public class TestUpdatePartial extends BaseTestCase {
     Ebean.save(customerWithoutChanges);
 
     assertThat(customerWithoutChanges.getUpdtime()).isEqualToIgnoringMillis(customer.getUpdtime());
+
+    // cleanup
+    Ebean.delete(customerWithoutChanges);
+
   }
 }


### PR DESCRIPTION
## Expected behavior

- Tests should not interfere each other, so a test should ideally not modify the database (especially the basic dataset like Customer, Order, ...)
- Test order should not matter (Eclipse and maven run tests in a different order, it seems that maven may change the test order completely, as it probably use a hash map internally)
- The dataReset that ResetBasicData.reset() creates should NOT be modified

## Actual behavior

A lot of tests will create additional customers, orders etc and this may interfere other tests.
Especially if one test creates a customer before ResetBasicData.reset(), this will interfere a lot of other tests, as they rely, that the first customer has orders etc.

### Steps to reproduce

for example, run `TestQueryFindPagedList.java` alone and it will fail.
It requries at least 7 in the database, but the basic test dataset contains only 5.


This PR fixes most (maybe all) of these tests and add a check method to `ResetBasicData.reset()`

