### PR TITLE
Transform extra-ddl.xml files when running in ddl mode (no migration)

### DIFF
--- a/src/main/java/io/ebeaninternal/dbmigration/PlaceholderBuilder.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/PlaceholderBuilder.java
@@ -1,0 +1,53 @@
+package io.ebeaninternal.dbmigration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Joins placeholder map and comma/equals delimited string.
+ */
+class PlaceholderBuilder {
+
+  private final Map<String,String> map = new HashMap<>();
+
+  /**
+   * Create with raw comma and equals delimited pairs plus map of key value pairs.
+   */
+  static Map<String,String> build(String commaDelimited, Map<String,String> placeholders) {
+
+    PlaceholderBuilder builder = new PlaceholderBuilder();
+    builder.add(commaDelimited);
+    builder.add(placeholders);
+
+    return builder.map;
+  }
+
+  private PlaceholderBuilder() {
+
+  }
+
+  /**
+   * Add a comma and equals delimited string to parse for key value pairs.
+   */
+  private void add(String commaDelimited) {
+
+    if (commaDelimited != null) {
+      String[] split = commaDelimited.split("[,;]");
+      for (String keyValue : split) {
+        String[] pair = keyValue.split("=");
+        if (pair.length == 2) {
+          map.put(pair[0].trim(), pair[1].trim());
+        }
+      }
+    }
+  }
+
+  /**
+   * Add a map of key value placeholder pairs.
+   */
+  private void add(Map<String,String> placeholders) {
+    if (placeholders != null) {
+      map.putAll(placeholders);
+    }
+  }
+}

--- a/src/main/java/io/ebeaninternal/dbmigration/ScriptTransform.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/ScriptTransform.java
@@ -1,0 +1,40 @@
+package io.ebeaninternal.dbmigration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Transforms a SQL script given a map of key/value substitutions.
+ */
+class ScriptTransform {
+
+  /**
+   * Transform just ${table} with the table name.
+   */
+  static String replace(String key, String value, String script) {
+    return script.replace(key, value);
+  }
+
+  private final Map<String,String> placeholders = new HashMap<>();
+
+  ScriptTransform(Map<String,String> map) {
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      placeholders.put(wrapKey(entry.getKey()), entry.getValue());
+    }
+  }
+
+  private String wrapKey(String key) {
+    return "${"+key+"}";
+  }
+
+  /**
+   * Transform the script replacing placeholders in the form <code>${key}</code> with <code>value</code>.
+   */
+  String transform(String source) {
+
+    for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+      source = source.replace(entry.getKey(), entry.getValue());
+    }
+    return source;
+  }
+}


### PR DESCRIPTION
Hi Rob,

during our junit tests we faced a problem that ebean does not substitute variables (${...}) in extra-ddl.xml files when ebean is not running in migration mode (our junit tests run in ddl creation mode only). We fixed the problem temporarily by copying PlaceholderBuilder and ScriptTransform from the io.ebean.migration.runner package and integrating them into DdlGenerator.

Could you please take a look at the PR? Maybe you have an idea for a better solution (e.g., make the classes/methods in io.ebean.migration.runner public so that they can be used from other packages as well). With the changes in this PR, our junit tests succeed in ddl mode.

Best regards,

Manuel