### PR TITLE
Add Java 8 Time API support for BasicTypeConverter

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/BasicTypeConverter.java
+++ b/src/main/java/io/ebeaninternal/server/core/BasicTypeConverter.java
@@ -7,6 +7,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Calendar;
 import java.util.UUID;
 
@@ -341,6 +345,9 @@ public final class BasicTypeConverter implements Serializable {
     } else if (value instanceof String) {
       return Timestamp.valueOf((String) value);
 
+    } else if (value instanceof LocalDateTime) {
+      return Timestamp.valueOf((LocalDateTime) value);
+
     } else if (value instanceof Number) {
       return new Timestamp(((Number) value).longValue());
 
@@ -360,6 +367,9 @@ public final class BasicTypeConverter implements Serializable {
 
     } else if (value instanceof String) {
       return java.sql.Time.valueOf((String) value);
+
+    } else if (value instanceof LocalTime) {
+      return java.sql.Time.valueOf((LocalTime) value);
 
     } else {
       String m = "Unable to convert [" + value.getClass().getName() + "] into a java.sql.Date.";
@@ -389,6 +399,9 @@ public final class BasicTypeConverter implements Serializable {
 
     } else if (value instanceof Number) {
       return new java.sql.Date(((Number) value).longValue());
+
+    } else if (value instanceof LocalDate) {
+      return java.sql.Date.valueOf((LocalDate)value);
 
     } else {
       String m = "Unable to convert [" + value.getClass().getName() + "] into a java.sql.Date.";


### PR DESCRIPTION
Adds some conversion rules. They will be needed when you try to use a filter on a sqlDate property. e.g.
```
Ebean.filter(MyBean).gt("sqlDateProp", LocalDate.of(2018,1,1))
```
