### PR TITLE
Filter and ExpressionList share a common API

### DIFF
--- a/src/main/java/io/ebean/ExpressionList.java
+++ b/src/main/java/io/ebean/ExpressionList.java
@@ -38,7 +38,7 @@ import java.util.function.Predicate;
  *
  * @see Query#where()
  */
-public interface ExpressionList<T> {
+public interface ExpressionList<T> extends QueryDsl<T, ExpressionList<T>> {
 
   /**
    * Return the query that owns this expression list.
@@ -734,61 +734,9 @@ public interface ExpressionList<T> {
   ExpressionList<T> addAll(ExpressionList<T> exprList);
 
   /**
-   * Equal To - property is equal to a given value.
-   */
-  ExpressionList<T> eq(String propertyName, Object value);
-
-  /**
-   * Not Equal To - property not equal to the given value.
-   */
-  ExpressionList<T> ne(String propertyName, Object value);
-
-  /**
-   * Case Insensitive Equal To - property equal to the given value (typically
-   * using a lower() function to make it case insensitive).
-   */
-  ExpressionList<T> ieq(String propertyName, String value);
-
-  /**
-   * Between - property between the two given values.
-   */
-  ExpressionList<T> between(String propertyName, Object value1, Object value2);
-
-  /**
    * Between - value between the two properties.
    */
   ExpressionList<T> betweenProperties(String lowProperty, String highProperty, Object value);
-
-  /**
-   * Greater Than - property greater than the given value.
-   */
-  ExpressionList<T> gt(String propertyName, Object value);
-
-  /**
-   * Greater Than or Equal to - property greater than or equal to the given
-   * value.
-   */
-  ExpressionList<T> ge(String propertyName, Object value);
-
-  /**
-   * Less Than - property less than the given value.
-   */
-  ExpressionList<T> lt(String propertyName, Object value);
-
-  /**
-   * Less Than or Equal to - property less than or equal to the given value.
-   */
-  ExpressionList<T> le(String propertyName, Object value);
-
-  /**
-   * Is Null - property is null.
-   */
-  ExpressionList<T> isNull(String propertyName);
-
-  /**
-   * Is Not Null - property is not null.
-   */
-  ExpressionList<T> isNotNull(String propertyName);
 
   /**
    * A "Query By Example" type of expression.
@@ -844,117 +792,6 @@ public interface ExpressionList<T> {
   ExpressionList<T> iexampleLike(Object example);
 
   /**
-   * Like - property like value where the value contains the SQL wild card
-   * characters % (percentage) and _ (underscore).
-   */
-  ExpressionList<T> like(String propertyName, String value);
-
-  /**
-   * Case insensitive Like - property like value where the value contains the
-   * SQL wild card characters % (percentage) and _ (underscore). Typically uses
-   * a lower() function to make the expression case insensitive.
-   */
-  ExpressionList<T> ilike(String propertyName, String value);
-
-  /**
-   * Starts With - property like value%.
-   */
-  ExpressionList<T> startsWith(String propertyName, String value);
-
-  /**
-   * Case insensitive Starts With - property like value%. Typically uses a
-   * lower() function to make the expression case insensitive.
-   */
-  ExpressionList<T> istartsWith(String propertyName, String value);
-
-  /**
-   * Ends With - property like %value.
-   */
-  ExpressionList<T> endsWith(String propertyName, String value);
-
-  /**
-   * Case insensitive Ends With - property like %value. Typically uses a lower()
-   * function to make the expression case insensitive.
-   */
-  ExpressionList<T> iendsWith(String propertyName, String value);
-
-  /**
-   * Contains - property like %value%.
-   */
-  ExpressionList<T> contains(String propertyName, String value);
-
-  /**
-   * Case insensitive Contains - property like %value%. Typically uses a lower()
-   * function to make the expression case insensitive.
-   */
-  ExpressionList<T> icontains(String propertyName, String value);
-
-  /**
-   * In expression using pairs of value objects.
-   */
-  ExpressionList<T> inPairs(Pairs pairs);
-
-  /**
-   * In - using a subQuery.
-   */
-  ExpressionList<T> in(String propertyName, Query<?> subQuery);
-
-  /**
-   * In - property has a value in the array of values.
-   */
-  ExpressionList<T> in(String propertyName, Object... values);
-
-  /**
-   * In - property has a value in the collection of values.
-   */
-  ExpressionList<T> in(String propertyName, Collection<?> values);
-
-  /**
-   * In - using a subQuery.
-   * <p>
-   * This is exactly the same as in() and provided due to "in" being a Kotlin keyword
-   * (and hence to avoid the slightly ugly escaping when using in() in Kotlin)
-   */
-  default ExpressionList<T> isIn(String propertyName, Query<?> subQuery) {
-    return in(propertyName, subQuery);
-  }
-
-  /**
-   * In - property has a value in the array of values.
-   * <p>
-   * This is exactly the same as in() and provided due to "in" being a Kotlin keyword
-   * (and hence to avoid the slightly ugly escaping when using in() in Kotlin)
-   */
-  default ExpressionList<T> isIn(String propertyName, Object... values) {
-    return in(propertyName, values);
-  }
-
-  /**
-   * In - property has a value in the collection of values.
-   * <p>
-   * This is exactly the same as in() and provided due to "in" being a Kotlin keyword
-   * (and hence to avoid the slightly ugly escaping when using in() in Kotlin)
-   */
-  default ExpressionList<T> isIn(String propertyName, Collection<?> values) {
-    return in(propertyName, values);
-  }
-
-  /**
-   * Not In - property has a value in the array of values.
-   */
-  ExpressionList<T> notIn(String propertyName, Object... values);
-
-  /**
-   * Not In - property has a value in the collection of values.
-   */
-  ExpressionList<T> notIn(String propertyName, Collection<?> values);
-
-  /**
-   * Not In - using a subQuery.
-   */
-  ExpressionList<T> notIn(String propertyName, Query<?> subQuery);
-
-  /**
    * Is empty expression for collection properties.
    */
   ExpressionList<T> isEmpty(String propertyName);
@@ -998,6 +835,7 @@ public interface ExpressionList<T> {
    *
    * @param propertyMap a map keyed by property names.
    */
+  @Override
   ExpressionList<T> allEq(Map<String, Object> propertyMap);
 
   /**
@@ -1028,67 +866,6 @@ public interface ExpressionList<T> {
    * </p>
    */
   ExpressionList<T> arrayIsNotEmpty(String propertyName);
-
-  /**
-   * Add expression for ANY of the given bit flags to be set.
-   * <pre>{@code
-   *
-   * where().bitwiseAny("flags", BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
-   *
-   * }</pre>
-   *
-   * @param propertyName The property that holds the flags value
-   * @param flags        The flags we are looking for
-   */
-  ExpressionList<T> bitwiseAny(String propertyName, long flags);
-
-  /**
-   * Add expression for ALL of the given bit flags to be set.
-   * <p>
-   * <pre>{@code
-   *
-   * where().bitwiseAll("flags", BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
-   *
-   * }</pre>
-   *
-   * @param propertyName The property that holds the flags value
-   * @param flags        The flags we are looking for
-   */
-  ExpressionList<T> bitwiseAll(String propertyName, long flags);
-
-  /**
-   * Add expression for the given bit flags to be NOT set.
-   * <p>
-   * <pre>{@code
-   *
-   * where().bitwiseNot("flags", BwFlags.HAS_COLOUR)
-   *
-   * }</pre>
-   *
-   * @param propertyName The property that holds the flags value
-   * @param flags        The flags we are looking for
-   */
-  ExpressionList<T> bitwiseNot(String propertyName, long flags);
-
-  /**
-   * Add bitwise AND expression of the given bit flags to compare with the match/mask.
-   * <p>
-   * <pre>{@code
-   *
-   * // Flags Bulk + Size = Size
-   * // ... meaning Bulk is not set and Size is set
-   *
-   * long selectedFlags = BwFlags.HAS_BULK + BwFlags.HAS_SIZE;
-   * long mask = BwFlags.HAS_SIZE; // Only Size flag set
-   *
-   * where().bitwiseAnd("flags", selectedFlags, mask)
-   *
-   * }</pre>
-   *
-   * @param propertyName The property that holds the flags value
-   * @param flags        The flags we are looking for
-   */
-  ExpressionList<T> bitwiseAnd(String propertyName, long flags, long match);
 
   /**
    * Add raw expression with a single parameter.
@@ -1198,107 +975,14 @@ public interface ExpressionList<T> {
    */
   ExpressionList<T> not(Expression exp);
 
-  /**
-   * Start a list of expressions that will be joined by AND's
-   * returning the expression list the expressions are added to.
-   * <p>
-   * This is exactly the same as conjunction();
-   * </p>
-   * <p>
-   * Use endAnd() or endJunction() to end the AND junction.
-   * </p>
-   * <p>
-   * Note that a where() clause defaults to an AND junction so
-   * typically you only explicitly need to use the and() junction
-   * when it is nested inside an or() or not() junction.
-   * </p>
-   * <p>
-   * <pre>{@code
-   *
-   *  // Example: Nested and()
-   *
-   *  Ebean.find(Customer.class)
-   *    .where()
-   *    .or()
-   *      .and() // nested and
-   *        .startsWith("name", "r")
-   *        .eq("anniversary", onAfter)
-   *        .endAnd()
-   *      .and()
-   *        .eq("status", Customer.Status.ACTIVE)
-   *        .gt("id", 0)
-   *        .endAnd()
-   *      .orderBy().asc("name")
-   *      .findList();
-   * }</pre>
-   */
+  // overridden to return a junction (for API compatibility!)
+  @Override
   Junction<T> and();
 
-  /**
-   * Return a list of expressions that will be joined by OR's.
-   * This is exactly the same as disjunction();
-   * <p>
-   * <p>
-   * Use endOr() or endJunction() to end the OR junction.
-   * </p>
-   * <p>
-   * <pre>{@code
-   *
-   *  // Example: Use or() to join
-   *  // two nested and() expressions
-   *
-   *  Ebean.find(Customer.class)
-   *    .where()
-   *    .or()
-   *      .and()
-   *        .startsWith("name", "r")
-   *        .eq("anniversary", onAfter)
-   *        .endAnd()
-   *      .and()
-   *        .eq("status", Customer.Status.ACTIVE)
-   *        .gt("id", 0)
-   *        .endAnd()
-   *      .orderBy().asc("name")
-   *      .findList();
-   *
-   * }</pre>
-   */
+  @Override
   Junction<T> or();
 
-  /**
-   * Return a list of expressions that will be wrapped by NOT.
-   * <p>
-   * Use endNot() or endJunction() to end expressions being added to the
-   * NOT expression list.
-   * </p>
-   * <p>
-   * <pre>@{code
-   *
-   *    .where()
-   *      .not()
-   *        .gt("id", 1)
-   *        .eq("anniversary", onAfter)
-   *        .endNot()
-   *
-   * }</pre>
-   * <p>
-   * <pre>@{code
-   *
-   * // Example: nested not()
-   *
-   * Ebean.find(Customer.class)
-   *   .where()
-   *     .eq("status", Customer.Status.ACTIVE)
-   *     .not()
-   *       .gt("id", 1)
-   *       .eq("anniversary", onAfter)
-   *       .endNot()
-   *     .orderBy()
-   *       .asc("name")
-   *     .findList();
-   *
-   * }</pre>
-   */
+  @Override
   Junction<T> not();
 
   /**
@@ -1364,20 +1048,5 @@ public interface ExpressionList<T> {
    * </p>
    */
   ExpressionList<T> endJunction();
-
-  /**
-   * End a AND junction - synonym for endJunction().
-   */
-  ExpressionList<T> endAnd();
-
-  /**
-   * End a AND junction - synonym for endJunction().
-   */
-  ExpressionList<T> endOr();
-
-  /**
-   * End a NOT junction - synonym for endJunction().
-   */
-  ExpressionList<T> endNot();
 
 }

--- a/src/main/java/io/ebean/Filter.java
+++ b/src/main/java/io/ebean/Filter.java
@@ -1,7 +1,6 @@
 package io.ebean;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * Provides support for filtering and sorting lists of entities without going
@@ -77,7 +76,7 @@ import java.util.Set;
  *
  * @param <T> the entity bean type
  */
-public interface Filter<T> {
+public interface Filter<T> extends QueryDsl<T,Filter<T>> {
 
   /**
    * Specify a sortByClause.
@@ -92,95 +91,14 @@ public interface Filter<T> {
   Filter<T> sort(String sortByClause);
 
   /**
+   * Specify the first row to return.
+   */
+  Filter<T> firstRow(int firstRow);
+
+  /**
    * Specify the maximum number of rows/elements to return.
    */
   Filter<T> maxRows(int maxRows);
-
-  /**
-   * Equal To - property equal to the given value.
-   */
-  Filter<T> eq(String prop, Object value);
-
-  /**
-   * Not Equal To - property not equal to the given value.
-   */
-  Filter<T> ne(String propertyName, Object value);
-
-  /**
-   * Case Insensitive Equal To.
-   */
-  Filter<T> ieq(String propertyName, String value);
-
-  /**
-   * Between - property between the two given values.
-   */
-  Filter<T> between(String propertyName, Object value1, Object value2);
-
-  /**
-   * Greater Than - property greater than the given value.
-   */
-  Filter<T> gt(String propertyName, Object value);
-
-  /**
-   * Greater Than or Equal to - property greater than or equal to the given
-   * value.
-   */
-  Filter<T> ge(String propertyName, Object value);
-
-  /**
-   * Less Than - property less than the given value.
-   */
-  Filter<T> lt(String propertyName, Object value);
-
-  /**
-   * Less Than or Equal to - property less than or equal to the given value.
-   */
-  Filter<T> le(String propertyName, Object value);
-
-  /**
-   * Is Null - property is null.
-   */
-  Filter<T> isNull(String propertyName);
-
-  /**
-   * Is Not Null - property is not null.
-   */
-  Filter<T> isNotNull(String propertyName);
-
-  /**
-   * Starts With.
-   */
-  Filter<T> startsWith(String propertyName, String value);
-
-  /**
-   * Case insensitive Starts With.
-   */
-  Filter<T> istartsWith(String propertyName, String value);
-
-  /**
-   * Ends With.
-   */
-  Filter<T> endsWith(String propertyName, String value);
-
-  /**
-   * Case insensitive Ends With.
-   */
-  Filter<T> iendsWith(String propertyName, String value);
-
-  /**
-   * Contains - property contains the string "value".
-   */
-  Filter<T> contains(String propertyName, String value);
-
-  /**
-   * Case insensitive Contains.
-   */
-  Filter<T> icontains(String propertyName, String value);
-
-  /**
-   * In - property has a value contained in the set of values.
-   */
-  Filter<T> in(String propertyName, Set<?> values);
 
   /**
    * Apply the filter to the list returning a new list of the matching elements

--- a/src/main/java/io/ebean/OrderBy.java
+++ b/src/main/java/io/ebean/OrderBy.java
@@ -402,6 +402,20 @@ public final class OrderBy<T> implements Serializable {
       this.ascending = ascending;
     }
 
+    /**
+     * Returns true, if we have a "nulls first" or "nulls last" value.
+     */
+    public boolean hasNulls() {
+      return nulls != null;
+    }
+
+    /**
+     * Returns true, if we have a "nulls first" value.
+     */
+    public boolean nullsFirst() {
+      return "first".equalsIgnoreCase(highLow) || "low".equalsIgnoreCase(highLow);
+    }
+
   }
 
   private void parse(String orderByClause) {

--- a/src/main/java/io/ebean/QueryDsl.java
+++ b/src/main/java/io/ebean/QueryDsl.java
@@ -1,0 +1,431 @@
+package io.ebean;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Common interface for DSL specific objects like {@link ExpressionList} (executed by the DB)
+ * and {@link Filter} (done in memory).
+ *
+ * Please see {@link Query} and {@link Filter} for further documentation.
+ *
+ * @param <T> the bean type
+ * @param <F> the fluent type
+ */
+public interface QueryDsl<T, F extends QueryDsl<T, F>> {
+
+  /**
+   * Equal To - property equal to the given value.
+   */
+  F eq(String propertyName, Object value);
+
+  /**
+   * Not Equal To - property not equal to the given value.
+   */
+  F ne(String propertyName, Object value);
+
+  /**
+   * Case Insensitive Equal To - property equal to the given value (typically
+   * using a lower() function to make it case insensitive).
+   */
+  F ieq(String propertyName, String value);
+
+  /**
+   * Between - property between the two given values.
+   */
+  F between(String propertyName, Object value1, Object value2);
+
+//  CHECKME: can this be implemented in Filter?
+//  /**
+//   * Between - value between the two properties.
+//   */
+//  RET betweenProperties(String lowProperty, String highProperty, Object value);
+
+  /**
+   * Greater Than - property greater than the given value.
+   */
+  F gt(String propertyName, Object value);
+
+  /**
+   * Greater Than or Equal to - property greater than or equal to the given value.
+   */
+  F ge(String propertyName, Object value);
+
+  /**
+   * Less Than - property less than the given value.
+   */
+  F lt(String propertyName, Object value);
+
+  /**
+   * Less Than or Equal to - property less than or equal to the given value.
+   */
+  F le(String propertyName, Object value);
+
+  /**
+   * Is Null - property is null.
+   */
+  F isNull(String propertyName);
+
+  /**
+   * Is Not Null - property is not null.
+   */
+  F isNotNull(String propertyName);
+
+  /**
+   * Starts With - property like value%.
+   */
+  F startsWith(String propertyName, String value);
+
+  /**
+   * Case insensitive Starts With - property like value%. Typically uses a
+   * lower() function to make the expression case insensitive.
+   */
+  F istartsWith(String propertyName, String value);
+
+  /**
+   * Ends With - property like %value.
+   */
+  F endsWith(String propertyName, String value);
+
+  /**
+   * Case insensitive Ends With - property like %value. Typically uses a lower()
+   * function to make the expression case insensitive.
+   */
+  F iendsWith(String propertyName, String value);
+
+  /**
+   * Contains - property contains the string "value".
+   */
+  F contains(String propertyName, String value);
+
+  /**
+   * Case insensitive Contains - property like %value%. Typically uses a lower()
+   * function to make the expression case insensitive.
+   */
+  F icontains(String propertyName, String value);
+
+  /**
+   * Like - property like value where the value contains the SQL wild card
+   * characters % (percentage) and _ (underscore).
+   */
+  F like(String propertyName, String value);
+
+  /**
+   * Case insensitive Like - property like value where the value contains the
+   * SQL wild card characters % (percentage) and _ (underscore). Typically uses
+   * a lower() function to make the expression case insensitive.
+   */
+  F ilike(String propertyName, String value);
+
+  /**
+   * In - using a subQuery.
+   */
+  F in(String propertyName, Query<?> subQuery);
+
+  /**
+   * In - property has a value in the array of values.
+   */
+  F in(String propertyName, Object... values);
+
+  /**
+   * In - property has a value contained in the set of values.
+   */
+  F in(String propertyName, Collection<?> values);
+
+  /**
+   * In - using a subQuery.
+   * <p>
+   * This is exactly the same as in() and provided due to "in" being a Kotlin keyword
+   * (and hence to avoid the slightly ugly escaping when using in() in Kotlin)
+   */
+  default F isIn(String propertyName, Query<?> subQuery) {
+    return in(propertyName, subQuery);
+  }
+
+  /**
+   * In - property has a value in the array of values.
+   * <p>
+   * This is exactly the same as in() and provided due to "in" being a Kotlin keyword
+   * (and hence to avoid the slightly ugly escaping when using in() in Kotlin)
+   */
+  default F isIn(String propertyName, Object... values) {
+    return in(propertyName, values);
+  }
+
+  /**
+   * In - property has a value in the collection of values.
+   * <p>
+   * This is exactly the same as in() and provided due to "in" being a Kotlin keyword
+   * (and hence to avoid the slightly ugly escaping when using in() in Kotlin)
+   */
+  default F isIn(String propertyName, Collection<?> values) {
+    return in(propertyName, values);
+  }
+
+  /**
+   * In expression using pairs of value objects.
+   */
+  F inPairs(Pairs pairs);
+
+  /**
+   * Not In - property has a value in the array of values.
+   */
+  F notIn(String propertyName, Object... values);
+
+  /**
+   * Not In - property has a value in the collection of values.
+   */
+  F notIn(String propertyName, Collection<?> values);
+
+  /**
+   * Not In - using a subQuery.
+   */
+  F notIn(String propertyName, Query<?> subQuery);
+
+//CHECKME: can this be implemented in Filter?
+//  /**
+//   * Is empty expression for collection properties.
+//   */
+//  RET isEmpty(String propertyName);
+//
+//  /**
+//   * Is not empty expression for collection properties.
+//   */
+//  RET isNotEmpty(String propertyName);
+
+//  /**
+//   * Id IN a list of id values.
+//   */
+//  RET idIn(Object... idValues);
+//
+//  /**
+//   * Id IN a collection of id values.
+//   */
+//  RET idIn(Collection<?> idValues);
+//
+//  /**
+//   * Id Equal to - ID property is equal to the value.
+//   */
+//  RET idEq(Object value);
+
+  /**
+   * All Equal - Map containing property names and their values.
+   * <p>
+   * Expression where all the property names in the map are equal to the
+   * corresponding value.
+   * </p>
+   *
+   * @param propertyMap a map keyed by property names.
+   */
+  F allEq(Map<String, Object> propertyMap);
+
+//CHECKME: can this be implemented in Filter?
+//  /**
+//   * Array property contains entries with the given values.
+//   */
+//  RET arrayContains(String propertyName, Object... values);
+//
+//  /**
+//   * Array does not contain the given values.
+//   * <p>
+//   * Array support is effectively limited to Postgres at this time.
+//   * </p>
+//   */
+//  RET arrayNotContains(String propertyName, Object... values);
+//
+//  /**
+//   * Array is empty - for the given array property.
+//   * <p>
+//   * Array support is effectively limited to Postgres at this time.
+//   * </p>
+//   */
+//  RET arrayIsEmpty(String propertyName);
+//
+//  /**
+//   * Array is not empty - for the given array property.
+//   * <p>
+//   * Array support is effectively limited to Postgres at this time.
+//   * </p>
+//   */
+//  RET arrayIsNotEmpty(String propertyName);
+
+  /**
+   * Add expression for ANY of the given bit flags to be set.
+   * <pre>{@code
+   *
+   * where().bitwiseAny("flags", BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param propertyName The property that holds the flags value
+   * @param flags        The flags we are looking for
+   */
+  F bitwiseAny(String propertyName, long flags);
+
+  /**
+   * Add expression for ALL of the given bit flags to be set.
+   * <p>
+   * <pre>{@code
+   *
+   * where().bitwiseAll("flags", BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param propertyName The property that holds the flags value
+   * @param flags        The flags we are looking for
+   */
+  F bitwiseAll(String propertyName, long flags);
+
+  /**
+   * Add expression for the given bit flags to be NOT set.
+   * <p>
+   * <pre>{@code
+   *
+   * where().bitwiseNot("flags", BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param propertyName The property that holds the flags value
+   * @param flags        The flags we are looking for
+   */
+  F bitwiseNot(String propertyName, long flags);
+
+  /**
+   * Add bitwise AND expression of the given bit flags to compare with the match/mask.
+   * <p>
+   * <pre>{@code
+   *
+   * // Flags Bulk + Size = Size
+   * // ... meaning Bulk is not set and Size is set
+   *
+   * long selectedFlags = BwFlags.HAS_BULK + BwFlags.HAS_SIZE;
+   * long mask = BwFlags.HAS_SIZE; // Only Size flag set
+   *
+   * where().bitwiseAnd("flags", selectedFlags, mask)
+   *
+   * }</pre>
+   *
+   * @param propertyName The property that holds the flags value
+   * @param flags        The flags we are looking for
+   */
+  F bitwiseAnd(String propertyName, long flags, long match);
+
+  /**
+   * Start a list of expressions that will be joined by AND's
+   * returning the expression list the expressions are added to.
+   * <p>
+   * This is exactly the same as conjunction();
+   * </p>
+   * <p>
+   * Use endAnd() or endJunction() to end the AND junction.
+   * </p>
+   * <p>
+   * Note that a where() clause defaults to an AND junction so
+   * typically you only explicitly need to use the and() junction
+   * when it is nested inside an or() or not() junction.
+   * </p>
+   * <p>
+   * <pre>{@code
+   *
+   *  // Example: Nested and()
+   *
+   *  Ebean.find(Customer.class)
+   *    .where()
+   *    .or()
+   *      .and() // nested and
+   *        .startsWith("name", "r")
+   *        .eq("anniversary", onAfter)
+   *        .endAnd()
+   *      .and()
+   *        .eq("status", Customer.Status.ACTIVE)
+   *        .gt("id", 0)
+   *        .endAnd()
+   *      .orderBy().asc("name")
+   *      .findList();
+   * }</pre>
+   */
+  F and();
+
+  /**
+   * End an AND junction.
+   */
+  F endAnd();
+
+  /**
+   * Return a list of expressions that will be joined by OR's.
+   * This is exactly the same as disjunction();
+   * <p>
+   * <p>
+   * Use endOr() or endJunction() to end the OR junction.
+   * </p>
+   * <p>
+   * <pre>{@code
+   *
+   *  // Example: Use or() to join
+   *  // two nested and() expressions
+   *
+   *  Ebean.find(Customer.class)
+   *    .where()
+   *    .or()
+   *      .and()
+   *        .startsWith("name", "r")
+   *        .eq("anniversary", onAfter)
+   *        .endAnd()
+   *      .and()
+   *        .eq("status", Customer.Status.ACTIVE)
+   *        .gt("id", 0)
+   *        .endAnd()
+   *      .orderBy().asc("name")
+   *      .findList();
+   *
+   * }</pre>
+   */
+  F or();
+
+  /**
+   * End an OR junction.
+   */
+  F endOr();
+
+  /**
+   * Return a list of expressions that will be wrapped by NOT.
+   * <p>
+   * Use endNot() or endJunction() to end expressions being added to the
+   * NOT expression list.
+   * </p>
+   * <p>
+   * <pre>@{code
+   *
+   *    .where()
+   *      .not()
+   *        .gt("id", 1)
+   *        .eq("anniversary", onAfter)
+   *        .endNot()
+   *
+   * }</pre>
+   * <p>
+   * <pre>@{code
+   *
+   * // Example: nested not()
+   *
+   * Ebean.find(Customer.class)
+   *   .where()
+   *     .eq("status", Customer.Status.ACTIVE)
+   *     .not()
+   *       .gt("id", 1)
+   *       .eq("anniversary", onAfter)
+   *       .endNot()
+   *     .orderBy()
+   *       .asc("name")
+   *     .findList();
+   *
+   * }</pre>
+   */
+  F not();
+
+  /**
+   * End a NOT junction.
+   */
+  F endNot();
+
+}

--- a/src/main/java/io/ebeaninternal/server/el/ElFilter.java
+++ b/src/main/java/io/ebeaninternal/server/el/ElFilter.java
@@ -1,10 +1,14 @@
 package io.ebeaninternal.server.el;
 
 import io.ebean.Filter;
+import io.ebean.Pairs;
+import io.ebean.Query;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -58,7 +62,7 @@ public final class ElFilter<T> implements Filter<T> {
 
 
   @Override
-  public Filter<T> in(String propertyName, Set<?> matchingValues) {
+  public Filter<T> in(String propertyName, Collection<?> matchingValues) {
 
     ElPropertyValue elGetValue = getElGetValue(propertyName);
 
@@ -264,6 +268,108 @@ public final class ElFilter<T> implements Filter<T> {
     }
 
     return filterList;
+  }
+
+
+  // these methods will come soon with next PRs
+  @Override
+  public Filter<T> like(String propertyName, String value) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> ilike(String propertyName, String value) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> in(String propertyName, Query<?> subQuery) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> in(String propertyName, Object... values) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> inPairs(Pairs pairs) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> notIn(String propertyName, Object... values) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> notIn(String propertyName, Collection<?> values) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> notIn(String propertyName, Query<?> subQuery) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> allEq(Map<String, Object> propertyMap) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> bitwiseAny(String propertyName, long flags) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> bitwiseAll(String propertyName, long flags) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> bitwiseNot(String propertyName, long flags) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> bitwiseAnd(String propertyName, long flags, long match) {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> and() {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> endAnd() {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> or() {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> endOr() {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> not() {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> endNot() {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Filter<T> firstRow(int firstRow) {
+    throw new UnsupportedOperationException("not yet implemented");
   }
 
 }

--- a/src/main/java/io/ebeaninternal/server/el/ElMatchBuilder.java
+++ b/src/main/java/io/ebeaninternal/server/el/ElMatchBuilder.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.el;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -176,7 +177,7 @@ class ElMatchBuilder {
     final ElPropertyValue elGetValue;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public InSet(Set<?> set, ElPropertyValue elGetValue) {
+    public InSet(Collection<?> set, ElPropertyValue elGetValue) {
       this.set = new HashSet(set);
       this.elGetValue = elGetValue;
     }


### PR DESCRIPTION
Hello Rob,

this is what I'm currently working on, I've improved the filters, so that you can convert a query to a filter and perform the filtering in-memory.

To keep the PRs small, this PR is the first step, others will follow (if you want one big PR with all changes, I can do this also)

So, the following shoud work for all beans, that are not too complex (no raw sql, temporal, and so on)

```java
List dbResult = anyQuery.findList();

Filter filter = anyQuery.filter();
List allBeans = Ebean.find(anyQuery.getBeanType());
List filteredBeans = filter.filter(allBeans);

assertThat(filteredBeans).isEqalTo(dbResult);
```