### PR TITLE
BeanType, Property and EBI can hold a custom object

### DIFF
--- a/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -104,6 +104,11 @@ public final class EntityBeanIntercept implements Serializable {
   private int sortOrder;
 
   /**
+   * Custom object, to attach any object to a bean.
+   */
+  private Object customObject;
+
+  /**
    * Create a intercept with a given entity.
    * <p>
    * Refer to agent ProxyConstructor.
@@ -1114,5 +1119,19 @@ public final class EntityBeanIntercept implements Serializable {
    */
   public void setSortOrder(int sortOrder) {
     this.sortOrder = sortOrder;
+  }
+
+  /**
+   * Returns the custom object. The custom object is not used by ebean.
+   */
+  Object getCustomObject() {
+    return customObject;
+  }
+
+  /**
+   * Sets the custom object.
+   */
+  void setCustomObject(Object object) {
+    customObject = object;
   }
 }

--- a/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -1124,14 +1124,14 @@ public final class EntityBeanIntercept implements Serializable {
   /**
    * Returns the custom object. The custom object is not used by ebean.
    */
-  Object getCustomObject() {
+  public Object getCustomObject() {
     return customObject;
   }
 
   /**
    * Sets the custom object.
    */
-  void setCustomObject(Object object) {
+  public void setCustomObject(Object object) {
     customObject = object;
   }
 }

--- a/src/main/java/io/ebean/plugin/BeanType.java
+++ b/src/main/java/io/ebean/plugin/BeanType.java
@@ -236,4 +236,14 @@ public interface BeanType<T> {
    * Create a bean given the discriminator value.
    */
   T createBeanUsingDisc(Object discValue);
+
+  /**
+   * Returns the custom object. The custom object is not used by ebean.
+   */
+  Object getCustomObject();
+
+  /**
+   * Sets the custom object.
+   */
+  void setCustomObject(Object object);
 }

--- a/src/main/java/io/ebean/plugin/Property.java
+++ b/src/main/java/io/ebean/plugin/Property.java
@@ -28,4 +28,14 @@ public interface Property {
    * Return true if this is a OneToMany or ManyToMany property.
    */
   boolean isMany();
+
+  /**
+   * Returns the custom object
+   */
+  Object getCustomObject();
+
+  /**
+   * sets the custom object.
+   */
+  void setCustomObject(Object object);
 }

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -141,6 +141,9 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
 
   private final boolean multiValueSupported;
 
+  // customObject, not used by ebean
+  private Object customObject;
+
   public enum EntityType {
     ORM, EMBEDDED, VIEW, SQL, DOC
   }
@@ -3480,6 +3483,16 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
    */
   public BeanProperty[] propertiesGenUpdate() {
     return propertiesGenUpdate;
+  }
+
+  @Override
+  public Object getCustomObject() {
+      return customObject;
+  }
+
+  @Override
+  public void setCustomObject(Object object) {
+    customObject = object;
   }
 
   public void jsonWriteDirty(SpiJsonWriter writeJson, EntityBean bean, boolean[] dirtyProps) throws IOException {

--- a/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -267,6 +267,8 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
 
   final String softDeleteDbPredicate;
 
+  private Object customObject;
+
   public BeanProperty(DeployBeanProperty deploy) {
     this(null, deploy);
   }
@@ -1396,6 +1398,16 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
   @Override
   public String toString() {
     return name;
+  }
+
+  @Override
+  public Object getCustomObject() {
+    return customObject;
+  }
+
+  @Override
+  public void setCustomObject(Object customObject) {
+    this.customObject = customObject;
   }
 
   /**


### PR DESCRIPTION
This feature allows the application to store a customObject on 
- BeanType
- BeanPropery
- EntityBean(Intercept)

This can be used to store additional information per BeanType/Property. e.g. from own annotations.
The customObject in the entity-bean can be used in a similar way, to store meta-information per bean.
