### PR TITLE
TempFiles will be deleted automatically if the reference is gc'ed

### DIFF
--- a/src/main/java/io/ebean/config/DeleteOnShutdownTempFileProvider.java
+++ b/src/main/java/io/ebean/config/DeleteOnShutdownTempFileProvider.java
@@ -1,0 +1,68 @@
+package io.ebean.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TempFileProvider implementation, which deletes all temp files on shutdown.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class DeleteOnShutdownTempFileProvider implements TempFileProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(DeleteOnShutdownTempFileProvider.class);
+
+  List<String> tempFiles = new ArrayList<>();
+  private final String prefix;
+  private final String suffix;
+  private final File directory;
+
+  /**
+   * Creates the TempFileProvider with default prefix "db-".
+   */
+  public DeleteOnShutdownTempFileProvider() {
+    this("db-", null, null);
+  }
+
+  /**
+   * Creates the TempFileProvider.
+   */
+  public DeleteOnShutdownTempFileProvider(String prefix, String suffix, File directory) {
+    this.prefix = prefix;
+    this.suffix = suffix;
+    this.directory = directory;
+  }
+
+  @Override
+  public File createTempFile() throws IOException {
+    File file = File.createTempFile(prefix, suffix, directory);
+    synchronized (tempFiles) {
+      tempFiles.add(file.getAbsolutePath());
+    }
+    return file;
+  }
+
+  /**
+   * Deletes all created files on shutdown.
+   */
+  @Override
+  public void shutdown() {
+    synchronized (tempFiles) {
+      for (String path : tempFiles) {
+        if (new File(path).delete()) {
+          logger.trace("deleted {}", path);
+        } else {
+          logger.warn("could not delete {}", path);
+        }
+      }
+      tempFiles.clear();
+    }
+  }
+
+}

--- a/src/main/java/io/ebean/config/ServerConfig.java
+++ b/src/main/java/io/ebean/config/ServerConfig.java
@@ -375,6 +375,8 @@ public class ServerConfig {
    */
   private Clock clock = Clock.systemUTC();
 
+  private TempFileProvider tempFileProvider = new WeakRefTempFileProvider();
+
   private List<IdGenerator> idGenerators = new ArrayList<>();
   private List<BeanFindController> findControllers = new ArrayList<>();
   private List<BeanPersistController> persistControllers = new ArrayList<>();
@@ -538,6 +540,20 @@ public class ServerConfig {
   public void setClock(final Clock clock) {
     this.clock = clock;
   }
+  /**
+   * Get the tempFileProvider to handle file attachments.
+   */
+  public TempFileProvider getTempFileProvider() {
+    return tempFileProvider;
+  }
+
+  /**
+   * Sets an alternative tempFileProvider, that may delete the temp files earlier (default implementation deletes on exit).
+   */
+  public void setTempFileProvider(TempFileProvider tempFileProvider) {
+    this.tempFileProvider = tempFileProvider;
+  }
+
 
   /**
    * Return the slow query time in millis.

--- a/src/main/java/io/ebean/config/TempFileProvider.java
+++ b/src/main/java/io/ebean/config/TempFileProvider.java
@@ -1,0 +1,23 @@
+package io.ebean.config;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Creates a temp file for the ScalarTypeFile datatype.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public interface TempFileProvider {
+
+  /**
+   * Creates a tempFile.
+   */
+  File createTempFile() throws IOException;
+
+  /**
+   * Shutdown the tempFileProvider.
+   */
+  void shutdown();
+}

--- a/src/main/java/io/ebean/config/WeakRefTempFileProvider.java
+++ b/src/main/java/io/ebean/config/WeakRefTempFileProvider.java
@@ -1,0 +1,141 @@
+package io.ebean.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * WeakRefTempFileProvider will delete the tempFile if all references to the returned File
+ * object are collected by the garbage collection.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class WeakRefTempFileProvider implements TempFileProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(WeakRefTempFileProvider.class);
+
+  private final ReferenceQueue<File> tempFiles = new ReferenceQueue<>();
+
+  private WeakFileReference root;
+
+  private final String prefix;
+  private final String suffix;
+  private final File directory;
+
+  /**
+   * We hold a linkedList of weak references. So we can remove stale files in O(1)
+   *
+   * @author Roland Praml, FOCONIS AG
+   */
+  private static class WeakFileReference extends WeakReference<File> {
+
+    String path;
+    WeakFileReference prev;
+    WeakFileReference next;
+
+    WeakFileReference(File referent, ReferenceQueue<? super File> q) {
+      super(referent, q);
+      path = referent.getAbsolutePath();
+    }
+
+    boolean delete(boolean shutdown) {
+      if (new File(path).delete()) {
+        logger.trace("deleted {}", path);
+        return true;
+      } else {
+        if (shutdown) {
+          logger.warn("could not delete {}", path);
+        } else {
+          logger.info("could not delete {} - will delete on shutdown", path);
+        }
+        return false;
+      }
+    }
+  }
+
+
+  /**
+   * Creates the TempFileProvider with default prefix "db-".
+   */
+  public WeakRefTempFileProvider() {
+    this("db-", null, null);
+  }
+
+  /**
+   * Creates the TempFileProvider.
+   */
+  public WeakRefTempFileProvider(String prefix, String suffix, File directory) {
+    this.prefix = prefix;
+    this.suffix = suffix;
+    this.directory = directory;
+  }
+
+  @Override
+  public File createTempFile() throws IOException {
+    File tempFile = File.createTempFile(prefix, suffix, directory);
+    logger.trace("createTempFile: {}", tempFile);
+    synchronized (this) {
+      add(new WeakFileReference(tempFile, tempFiles));
+    }
+    return tempFile;
+  }
+
+  /**
+   * Will delete stale files.
+   * This is public to use in tests.
+   */
+  public void deleteStaleTempFiles() {
+    synchronized (this) {
+      deleteStaleTempFilesInternal();
+    }
+  }
+
+  private void deleteStaleTempFilesInternal() {
+    WeakFileReference ref;
+    while ((ref = (WeakFileReference) tempFiles.poll()) != null) {
+      if (ref.delete(false)) {
+        remove(ref); // remove from linkedList only, if delete was successful.
+      }
+    }
+  }
+
+  private void add(WeakFileReference ref) {
+    deleteStaleTempFilesInternal();
+
+    if (root == null) {
+      root = ref;
+    } else {
+      ref.next = root;
+      root.prev = ref;
+      root = ref;
+    }
+  }
+
+  private void remove(WeakFileReference ref) {
+    if (ref.next != null) {
+      ref.next.prev = ref.prev;
+    }
+    if (ref.prev != null) {
+      ref.prev.next = ref.next;
+    } else {
+      root = ref.next;
+    }
+  }
+
+  /**
+   * Deletes all created files on shutdown.
+   */
+  @Override
+  public void shutdown() {
+    while (root != null) {
+      root.delete(true);
+      root = root.next;
+    }
+  }
+
+}

--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -48,6 +48,7 @@ import io.ebean.config.EncryptKeyManager;
 import io.ebean.config.ServerConfig;
 import io.ebean.config.SlowQueryEvent;
 import io.ebean.config.SlowQueryListener;
+import io.ebean.config.TempFileProvider;
 import io.ebean.config.TenantMode;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.event.BeanPersistController;
@@ -154,6 +155,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   private final DatabasePlatform databasePlatform;
 
   private final TransactionManager transactionManager;
+
+  private final TempFileProvider tempFileProvider;
 
   private final DataTimeZone dataTimeZone;
 
@@ -298,6 +301,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     this.documentStore = docStoreComponents.documentStore();
 
     this.serverPlugins = config.getPlugins();
+    this.tempFileProvider = config.getTempFileProvider();
     this.ddlGenerator = new DdlGenerator(this, serverConfig);
     this.scriptRunner = new DScriptRunner(this);
 
@@ -496,6 +500,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     backgroundExecutor.shutdown();
     // shutdown DataSource (if its an Ebean one)
     transactionManager.shutdown(shutdownDataSource, deregisterDriver);
+
+    tempFileProvider.shutdown();
     shutdown = true;
     if (shutdownDataSource) {
       // deregister the DataSource in case ServerConfig is re-used

--- a/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
+++ b/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
@@ -13,6 +13,7 @@ import io.ebean.config.ExternalTransactionManager;
 import io.ebean.config.ProfilingConfig;
 import io.ebean.config.ServerConfig;
 import io.ebean.config.SlowQueryListener;
+import io.ebean.config.TempFileProvider;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbHistorySupport;
 import io.ebean.datasource.DataSourcePool;
@@ -120,6 +121,8 @@ public class InternalConfiguration {
 
   private final TypeManager typeManager;
 
+  private final TempFileProvider tempFileProvider;
+
   private final DtoBeanManager dtoBeanManager;
 
   private final ClockService clockService;
@@ -179,6 +182,7 @@ public class InternalConfiguration {
 
     this.databasePlatform = serverConfig.getDatabasePlatform();
     this.expressionFactory = initExpressionFactory(serverConfig);
+    this.tempFileProvider = serverConfig.getTempFileProvider();
     this.typeManager = new DefaultTypeManager(serverConfig, bootupClasses);
 
     this.multiValueBind = createMultiValueBind(databasePlatform.getPlatform());
@@ -567,6 +571,10 @@ public class InternalConfiguration {
 
   public SpiLogManager getLogManager() {
     return logManager;
+  }
+
+  public TempFileProvider getTempFileProvider() {
+    return tempFileProvider;
   }
 
   private ServerCachePlugin initServerCachePlugin() {

--- a/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -92,7 +92,7 @@ public final class DefaultTypeManager implements TypeManager {
 
   private final ScalarType<?> hstoreType = new ScalarTypePostgresHstore();
 
-  private final ScalarTypeFile fileType = new ScalarTypeFile();
+  private final ScalarTypeFile fileType;
 
   private final ScalarType<?> charType = new ScalarTypeChar();
 
@@ -197,6 +197,7 @@ public final class DefaultTypeManager implements TypeManager {
     this.arrayTypeSetFactory = arrayTypeSetFactory(config.getDatabasePlatform());
 
     this.offlineMigrationGeneration = DbOffline.isGenerateMigration();
+    this.fileType = new ScalarTypeFile(config.getTempFileProvider());
 
     initialiseStandard(jsonDateTime, config);
     initialiseJavaTimeTypes(jsonDateTime, config);

--- a/src/test/java/io/ebean/config/TestWeakRefTempFileProvider.java
+++ b/src/test/java/io/ebean/config/TestWeakRefTempFileProvider.java
@@ -1,0 +1,171 @@
+package io.ebean.config;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.channels.FileLock;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test for the WeakRefTempFileProvider. (Note: this test relies on an aggressive garbage collection.
+ * if GC implementation will change, the test may fail)
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class TestWeakRefTempFileProvider {
+
+  WeakRefTempFileProvider prov = new WeakRefTempFileProvider();
+
+  @After
+  public void shutdown() {
+    prov.shutdown();
+  }
+
+  /**
+   * Run the garbage collection and delete stale files.
+   */
+  private void gc() throws InterruptedException {
+    System.gc();
+    Thread.sleep(100);
+    prov.deleteStaleTempFiles();
+  }
+
+  @Test
+  public void testStaleEntries() throws Exception {
+    File tempFile = prov.createTempFile();
+    String fileName =  tempFile.getAbsolutePath();
+
+    gc();
+
+    assertThat(new File(fileName)).exists();
+
+    tempFile = null; // give up reference
+
+    gc();
+
+    assertThat(new File(fileName)).doesNotExist();
+
+
+  }
+
+  @Test
+  public void testLinkedListForward() throws Exception {
+    File tempFile1 = prov.createTempFile();
+    String fileName1 = tempFile1.getAbsolutePath();
+    File tempFile2 = prov.createTempFile();
+    String fileName2 = tempFile2.getAbsolutePath();
+    File tempFile3 = prov.createTempFile();
+    String fileName3 = tempFile3.getAbsolutePath();
+
+    assertThat(new File(fileName1)).exists();
+    assertThat(new File(fileName2)).exists();
+    assertThat(new File(fileName3)).exists();
+
+    gc();
+
+    // give up first ref
+    tempFile1 = null;
+
+    gc();
+
+    assertThat(new File(fileName1)).doesNotExist();
+    assertThat(new File(fileName2)).exists();
+    assertThat(new File(fileName3)).exists();
+
+    // give up second ref
+    tempFile2 = null;
+
+    gc();
+
+    assertThat(new File(fileName1)).doesNotExist();
+    assertThat(new File(fileName2)).doesNotExist();
+    assertThat(new File(fileName3)).exists();
+
+    // give up third ref
+    tempFile3 = null;
+
+    gc();
+
+    assertThat(new File(fileName1)).doesNotExist();
+    assertThat(new File(fileName2)).doesNotExist();
+    assertThat(new File(fileName3)).doesNotExist();
+
+  }
+
+
+  @Test
+  public void testLinkedListReverse() throws Exception {
+    File tempFile1 = prov.createTempFile();
+    String fileName1 = tempFile1.getAbsolutePath();
+    File tempFile2 = prov.createTempFile();
+    String fileName2 = tempFile2.getAbsolutePath();
+    File tempFile3 = prov.createTempFile();
+    String fileName3 = tempFile3.getAbsolutePath();
+
+    assertThat(new File(fileName1)).exists();
+    assertThat(new File(fileName2)).exists();
+    assertThat(new File(fileName3)).exists();
+
+    gc();
+
+    // give up third ref
+    tempFile3 = null;
+
+    gc();
+
+    assertThat(new File(fileName1)).exists();
+    assertThat(new File(fileName2)).exists();
+    assertThat(new File(fileName3)).doesNotExist();
+
+    // give up second ref
+    tempFile2 = null;
+
+    gc();
+
+    assertThat(new File(fileName1)).exists();
+    assertThat(new File(fileName2)).doesNotExist();
+    assertThat(new File(fileName3)).doesNotExist();
+
+    // give up first ref
+    tempFile1 = null;
+
+    gc();
+
+    assertThat(new File(fileName1)).doesNotExist();
+    assertThat(new File(fileName2)).doesNotExist();
+    assertThat(new File(fileName3)).doesNotExist();
+
+  }
+
+  @Test
+  @Ignore("Runs on Windows only")
+  public void testFileLocked() throws Exception {
+    File tempFile = prov.createTempFile();
+    String fileName = tempFile.getAbsolutePath();
+
+    try (FileOutputStream os = new FileOutputStream(fileName)) {
+      FileLock lock = os.getChannel().lock();
+      try {
+        os.write(42);
+
+        tempFile = null;
+        gc();
+      } finally {
+        lock.release();
+      }
+
+    }
+
+    assertThat(new File(fileName)).exists();
+
+    prov.shutdown();
+
+    assertThat(new File(fileName)).doesNotExist();
+  }
+}

--- a/src/test/java/io/ebean/json/EJsonTests.java
+++ b/src/test/java/io/ebean/json/EJsonTests.java
@@ -51,6 +51,7 @@ public class EJsonTests {
   public void write_withWriter_expect_writerNotClosed() throws IOException {
 
     File temp = Files.createTempFile("some", ".json").toFile();
+    temp.deleteOnExit();
     FileWriter writer = new FileWriter(temp);
     Map<String,Object> map = new LinkedHashMap<>();
     map.put("foo", "bar");

--- a/src/test/java/io/ebeaninternal/dbmigration/migrationreader/MigrationXmlWriterTest.java
+++ b/src/test/java/io/ebeaninternal/dbmigration/migrationreader/MigrationXmlWriterTest.java
@@ -17,6 +17,7 @@ public class MigrationXmlWriterTest {
     assertThat(migration.getChangeSet().get(0).getChangeSetChildren()).hasSize(3);
 
     File temp = File.createTempFile("migrationWrite", ".xml");
+    temp.deleteOnExit();
     new MigrationXmlWriter("THIS IS A GENERATED FILE - DO NOT MODIFY").write(migration, temp);
 
     Migration migrationRead = MigrationXmlReader.read(temp);
@@ -24,6 +25,7 @@ public class MigrationXmlWriterTest {
     assertThat(migrationRead.getChangeSet().get(0).getChangeSetChildren()).hasSize(3);
 
     temp = File.createTempFile("migrationWrite", ".xml");
+    temp.deleteOnExit();
     new MigrationXmlWriter(null).write(migration, temp);
 
     Migration migrationRead2 = MigrationXmlReader.read(temp);

--- a/src/test/java/org/tests/types/TestFileType.java
+++ b/src/test/java/org/tests/types/TestFileType.java
@@ -23,6 +23,7 @@ public class TestFileType extends BaseTestCase {
 
   private File newTempFile() throws IOException {
     File tempFile = File.createTempFile("testfile", "txt");
+    tempFile.deleteOnExit();
     try (PrintStream ps = new PrintStream(tempFile)) {
       ps.println("Hello World!");
     }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -92,6 +92,7 @@
   <logger name="io.ebean.cache.BEAN" level="TRACE"/>
   <logger name="io.ebean.cache.NATKEY" level="TRACE"/>
   <logger name="io.ebean.cache.COLL" level="TRACE"/>
+  <logger name="io.ebean.config.WeakRefTempFileProvider" level="TRACE"/>
 
   <!--<logger name="io.ebeaninternal.server.deploy" level="TRACE"/>-->
 


### PR DESCRIPTION
This feature enhances the ScalarTypeFile, so that temp files are deleted if the file is no longer referenced.

**Old behaviour**
TempFiles created by ScalarTypeFile were never deleted by java code (relies on the OS, that the temp dir will be cleared). 
Reading a lot of entities, that contains files could cause an out-of-disk space

**New behaviour**
There are two tempFileProviders:

_1. DeleteOnShutdownTempFileProvider_
This one will delete all created temp files on Ebean.shutdown().

Note 1: Ebean.shutdown normally occurs earlier than File.deleteOnExit()
Note 2: In a long running web application, microservice etc, Ebean.shutdown occurs rarely (=nearly never)

_2. WeakRefTempFileProvider_
This provider tracks a weak reference to the _File_ object, that is returned by ScalarTypeFile. 

As long as this file object is NOT gc'ed, the according temp file will NOT be deleted.
As the File object is referenced by the entity, it is ensured, that the temp-file will not be deleted, as long as you have a reference to the entiy. (which is sufficient for most cases)

Note: If you convert the _File_ to a _Path_ or a _String_, (although if you convert it back to _File_) you will give up the reference to the original _File_ object. So the WeakFileReference will be queued by the next gc run and the file may be deleted, so that your _Path_ or _String_ will point to a non existent file.
This is a bit non-deterministic, so if there are too many problems with the WeakRefTempFileProvider (which is the current default), you probably should use the DeleteOnShutdownTempFileProvider or implement your own provider.
