### PR TITLE
FIX: insert in batch OneToOne relationship

### DIFF
--- a/src/main/java/io/ebeaninternal/server/persist/BatchControl.java
+++ b/src/main/java/io/ebeaninternal/server/persist/BatchControl.java
@@ -327,14 +327,16 @@ public final class BatchControl {
       return maxDepth + 1;
     }
 
+    int parentMaxDepth = -1;
+
     for (BeanPropertyAssocOne<?> parent : imported) {
       BatchedBeanHolder parentBatch = beanHoldMap.get(parent.getTargetDescriptor().rootName());
       if (parentBatch != null) {
         // deeper that the parent
-        return parentBatch.getOrder() + 1;
+        parentMaxDepth = Math.max(parentMaxDepth, parentBatch.getOrder() + 1);
       }
     }
-    return -1;
+    return parentMaxDepth;
   }
 
   /**

--- a/src/test/java/org/tests/batchinsert/TestBatchInsertOneToOne.java
+++ b/src/test/java/org/tests/batchinsert/TestBatchInsertOneToOne.java
@@ -1,0 +1,40 @@
+package org.tests.batchinsert;
+
+import io.ebean.Ebean;
+import io.ebean.annotation.PersistBatch;
+import io.ebean.annotation.Transactional;
+import org.junit.Test;
+import org.tests.batchinsert.o2o.MeterAddressData;
+import org.tests.batchinsert.o2o.MeterContractData;
+import org.tests.batchinsert.o2o.MeterSpecialNeedsClient;
+import org.tests.batchinsert.o2o.MeterSpecialNeedsContact;
+import org.tests.batchinsert.o2o.MeterVersion;
+
+public class TestBatchInsertOneToOne {
+  private MeterVersion build(){
+    MeterAddressData addressData = new MeterAddressData();
+    addressData.setStreet("street");
+    MeterContractData contractData = new MeterContractData();
+
+    MeterSpecialNeedsClient specialNeedsClient = new MeterSpecialNeedsClient();
+    contractData.setSpecialNeedsClient(specialNeedsClient);
+
+    MeterSpecialNeedsContact contact1 = new MeterSpecialNeedsContact();
+
+    specialNeedsClient.setPrimary(contact1);
+
+    MeterVersion meterVersion = new MeterVersion();
+    meterVersion.setAddressData(addressData);
+    meterVersion.setContractData(contractData);
+
+    return meterVersion;
+  }
+
+  @Transactional(batch = PersistBatch.ALL, batchOnCascade = PersistBatch.ALL, batchSize = 10)
+  @Test
+  public void test() {
+    MeterVersion meterVersion = build();
+
+    Ebean.save(meterVersion);
+  }
+}

--- a/src/test/java/org/tests/batchinsert/o2o/MeterAddressData.java
+++ b/src/test/java/org/tests/batchinsert/o2o/MeterAddressData.java
@@ -1,0 +1,23 @@
+package org.tests.batchinsert.o2o;
+
+import io.ebean.annotation.NotNull;
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class MeterAddressData {
+  @Id
+  private UUID id;
+
+  @NotNull
+  private String street;
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(String street) {
+    this.street = street;
+  }
+}

--- a/src/test/java/org/tests/batchinsert/o2o/MeterContractData.java
+++ b/src/test/java/org/tests/batchinsert/o2o/MeterContractData.java
@@ -1,0 +1,26 @@
+package org.tests.batchinsert.o2o;
+
+import io.ebean.annotation.NotNull;
+import java.util.UUID;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+@Entity
+public class MeterContractData {
+  @Id
+  private UUID id;
+
+  @NotNull
+  @OneToOne(cascade = CascadeType.ALL)
+  private MeterSpecialNeedsClient specialNeedsClient;
+
+  public MeterSpecialNeedsClient getSpecialNeedsClient() {
+    return specialNeedsClient;
+  }
+
+  public void setSpecialNeedsClient(MeterSpecialNeedsClient specialNeedsClient) {
+    this.specialNeedsClient = specialNeedsClient;
+  }
+}

--- a/src/test/java/org/tests/batchinsert/o2o/MeterSpecialNeedsClient.java
+++ b/src/test/java/org/tests/batchinsert/o2o/MeterSpecialNeedsClient.java
@@ -1,0 +1,34 @@
+package org.tests.batchinsert.o2o;
+
+import java.util.UUID;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+@Entity
+public class MeterSpecialNeedsClient {
+  @Id
+  private UUID id;
+
+  private String name;
+
+  @OneToOne(cascade = CascadeType.ALL)
+  private MeterSpecialNeedsContact primary;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public MeterSpecialNeedsContact getPrimary() {
+    return primary;
+  }
+
+  public void setPrimary(MeterSpecialNeedsContact primary) {
+    this.primary = primary;
+  }
+}

--- a/src/test/java/org/tests/batchinsert/o2o/MeterSpecialNeedsContact.java
+++ b/src/test/java/org/tests/batchinsert/o2o/MeterSpecialNeedsContact.java
@@ -1,0 +1,21 @@
+package org.tests.batchinsert.o2o;
+
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class MeterSpecialNeedsContact {
+  @Id
+  private UUID id;
+
+  private String name;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/tests/batchinsert/o2o/MeterVersion.java
+++ b/src/test/java/org/tests/batchinsert/o2o/MeterVersion.java
@@ -1,0 +1,38 @@
+package org.tests.batchinsert.o2o;
+
+import io.ebean.annotation.NotNull;
+import java.util.UUID;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+@Entity
+public class MeterVersion {
+  @Id
+  private UUID id;
+
+  //@NotNull
+  @OneToOne(cascade = CascadeType.ALL)
+  private MeterAddressData addressData;
+
+  @NotNull
+  @OneToOne(cascade = CascadeType.ALL)
+  private MeterContractData contractData;
+
+  public MeterAddressData getAddressData() {
+    return addressData;
+  }
+
+  public void setAddressData(MeterAddressData addressData) {
+    this.addressData = addressData;
+  }
+
+  public MeterContractData getContractData() {
+    return contractData;
+  }
+
+  public void setContractData(MeterContractData contractData) {
+    this.contractData = contractData;
+  }
+}


### PR DESCRIPTION
When we have multiple `@OneToOne` relationships with `Cascade.PERSIST` in one entity, the `BatchControl` would simple look to the depth of the first relation, which in some cases would make the inserts out of order, and cause constraint violations.

The fix will make the entity have the maximum depth of all the `@OneToOne` relationships plus 1.

This also includes a test case for this: `TestBatchInsertOneToOne`