### PR TITLE
build on jdk11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,22 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Provided scope to compile with java 11 -->
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.4.0-b180830.0438</version>
+      <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    
+
     <!-- Provided scope for Postgres JSON/JSONB support -->
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -222,7 +238,7 @@
     <dependency>
       <groupId>org.avaje</groupId>
       <artifactId>avaje-agentloader</artifactId>
-      <version>2.1.2</version>
+      <version>3.0.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 
@@ -327,9 +343,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.22.1</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
+          <trimStackTrace>false</trimStackTrace>
           <failIfNoTests>false</failIfNoTests>
           <includes>
             <include>**/Test*.java</include>

--- a/src/test/java/io/ebeaninternal/server/type/ScalarTypeInstantTest.java
+++ b/src/test/java/io/ebeaninternal/server/type/ScalarTypeInstantTest.java
@@ -16,13 +16,21 @@ public class ScalarTypeInstantTest {
 
   ScalarTypeInstant type = new ScalarTypeInstant(JsonConfig.DateTime.MILLIS);
 
+  private Instant now() {
+    // in JDK11 Instant.now() returns a nanosecond precise instant.
+    // as ScalarTypeInstant is only milliSecond precise, tests may fail with
+    // expected:<2019-02-10T15:39:36.702700200Z> but was:<2019-02-10T15:39:36.702Z>
+    // if we use Instant.now() - so we use this workaround here.
+    return Instant.ofEpochMilli(System.currentTimeMillis());
+  }
+
   @Test
   public void testReadData() throws Exception {
 
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     ObjectOutputStream out = new ObjectOutputStream(os);
 
-    Instant now = Instant.now();
+    Instant now = now();
     type.writeData(out, now);
     type.writeData(out, null);
     out.flush();
@@ -41,7 +49,7 @@ public class ScalarTypeInstantTest {
   @Test
   public void testToJdbcType() throws Exception {
 
-    Instant now = Instant.now();
+    Instant now = now();
     Timestamp timestamp = Timestamp.from(now);
     Object val1 = type.toJdbcType(now);
     Object val2 = type.toJdbcType(timestamp);
@@ -53,7 +61,7 @@ public class ScalarTypeInstantTest {
   @Test
   public void testToBeanType() throws Exception {
 
-    Instant now = Instant.now();
+    Instant now = now();
     Instant val1 = type.toBeanType(now);
     Instant val2 = type.toBeanType(Timestamp.from(now));
 
@@ -64,7 +72,7 @@ public class ScalarTypeInstantTest {
   @Test
   public void testFormatValue() throws Exception {
 
-    Instant now = Instant.now();
+    Instant now = now();
     Timestamp timestamp = Timestamp.from(now);
     String formatted = type.formatValue(now);
     assertEquals("" + timestamp.getTime(), formatted);
@@ -73,7 +81,7 @@ public class ScalarTypeInstantTest {
   @Test
   public void testParse_when_epochMillis() throws Exception {
 
-    Instant now = Instant.now();
+    Instant now = now();
     Timestamp timestamp = Timestamp.from(now);
     Instant val1 = type.parse("" + timestamp.getTime());
     assertEquals(now, val1);
@@ -82,7 +90,7 @@ public class ScalarTypeInstantTest {
   @Test
   public void testParse_when_timestampForm() throws Exception {
 
-    Instant now = Instant.now();
+    Instant now = now();
     Timestamp timestamp = Timestamp.from(now);
     Instant val1 = type.parse(timestamp.toString());
     assertEquals(now, val1);
@@ -91,7 +99,7 @@ public class ScalarTypeInstantTest {
   @Test
   public void testFormatAndParse() throws Exception {
 
-    Instant now = Instant.now();
+    Instant now = now();
 
     String format = type.format(now);
     Instant val1 = type.parse(format);
@@ -107,7 +115,7 @@ public class ScalarTypeInstantTest {
   @Test
   public void testConvertFromMillis() throws Exception {
 
-    Instant now = Instant.now();
+    Instant now = now();
     Instant val = type.convertFromMillis(now.toEpochMilli());
     assertEquals(now, val);
   }
@@ -116,7 +124,7 @@ public class ScalarTypeInstantTest {
   public void testJsonRead() throws Exception {
 
 
-    Instant now = Instant.now();
+    Instant now = now();
 
     JsonTester<Instant> jsonTester = new JsonTester<>(type);
     jsonTester.test(now);

--- a/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTimeTest.java
+++ b/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTimeTest.java
@@ -28,7 +28,7 @@ public class ScalarTypeLocalDateTimeTest {
   @Test
   public void testConvertToMillis() throws Exception {
 
-    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime now = LocalDateTime.now().withNano(123_000_000); // jdk11 workaround
     long asMillis = type.convertToMillis(now);
     LocalDateTime fromMillis = type.convertFromMillis(asMillis);
 
@@ -74,7 +74,7 @@ public class ScalarTypeLocalDateTimeTest {
   @Test
   public void testJson() throws Exception {
 
-    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime now = LocalDateTime.now().withNano(123_000_000); // jdk11 workaround
 
     JsonTester<LocalDateTime> jsonTester = new JsonTester<>(type);
     jsonTester.test(now);

--- a/src/test/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTimeTest.java
+++ b/src/test/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTimeTest.java
@@ -61,7 +61,7 @@ public class ScalarTypeOffsetDateTimeTest {
   @Test
   public void testJson() throws Exception {
 
-    OffsetDateTime now = OffsetDateTime.now();
+    OffsetDateTime now = OffsetDateTime.now().withNano(123_000_000); // jdk11 workaround
 
     JsonTester<OffsetDateTime> jsonTester = new JsonTester<>(type);
     jsonTester.test(now);

--- a/src/test/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTimeTest.java
+++ b/src/test/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTimeTest.java
@@ -62,7 +62,7 @@ public class ScalarTypeZonedDateTimeTest {
   @Test
   public void testJson() throws Exception {
 
-    ZonedDateTime now = ZonedDateTime.now();
+    ZonedDateTime now = ZonedDateTime.now().withNano(123_000_000); // jdk11 workaround
 
     JsonTester<ZonedDateTime> jsonTester = new JsonTester<>(type);
     jsonTester.test(now);


### PR DESCRIPTION
Hello Rob,

please take a look at these changes, they would add JDK11 build support.
- They require a new agentloader: https://github.com/avaje-common/avaje-agentloader/pull/6
- There is the same bug in javadoc generation, so skip javadoc generation

cheers
Roland