### PR TITLE
FIX: Proper sort of migration versions (possible regression due #1577)

### DIFF
--- a/src/main/java/io/ebeaninternal/dbmigration/LastMigration.java
+++ b/src/main/java/io/ebeaninternal/dbmigration/LastMigration.java
@@ -33,12 +33,12 @@ class LastMigration {
    */
   static String lastVersion(File migDirectory, File modelDir) {
 
-    List<String> fileNames = new ArrayList<>();
+    List<MigrationVersion> versions = new ArrayList<>();
 
     File[] sqlFiles = migDirectory.listFiles(pathname -> includeSqlFile(pathname.getName().toLowerCase()));
     if (sqlFiles != null) {
       for (File file : sqlFiles) {
-        fileNames.add(trim(file.getName()));
+        versions.add(trimAndParse(file.getName()));
       }
     }
 
@@ -46,14 +46,14 @@ class LastMigration {
       File[] xmlFiles = modelDir.listFiles(pathname -> includeModelFile(pathname.getName().toLowerCase()));
       if (xmlFiles != null) {
         for (File file : xmlFiles) {
-          fileNames.add(trim(file.getName()));
+          versions.add(trimAndParse(file.getName()));
         }
       }
     }
 
-    Collections.sort(fileNames);
-    if (!fileNames.isEmpty()) {
-      return fileNames.get(fileNames.size() - 1);
+    Collections.sort(versions);
+    if (!versions.isEmpty()) {
+      return versions.get(versions.size() - 1).asString();
     }
     return null;
   }
@@ -69,23 +69,14 @@ class LastMigration {
     return lowerFileName.endsWith(MODEL_XML);
   }
 
-  private static String trim(String name) {
-    name = name.toLowerCase();
-    char c = name.charAt(0);
-    if (c == 'v') {
-      name = name.substring(1);
-    }
-    int p = name.indexOf("__");
-    if (p > -1) {
-      name = name.substring(0, p);
-    }
+  private static MigrationVersion trimAndParse(String name) {
     if (name.endsWith(SQL)) {
       name = name.substring(0, name.length() - 4);
     }
     if (name.endsWith(MODEL_XML)) {
       name = name.substring(0, name.length() - 10);
     }
-    return name;
+    return MigrationVersion.parse(name);
   }
 
 }


### PR DESCRIPTION
Hello Rob,

this fixes a bug when you have several migration scripts. e.g. V1.1, V1.2 ... V1.9, V1.10, V1.11
They were sorted alphanumerically V1.1, V1.10, V1.11, V1.2 ... V1.9 and LastMigration.nextVersion returend V1.10 instead of V1.12

Cheers Roland