### PR TITLE
When deleting complex object graphs, entities are deleted multiple times

### DIFF
--- a/src/test/java/org/tests/cascade/RelDetail.java
+++ b/src/test/java/org/tests/cascade/RelDetail.java
@@ -1,0 +1,44 @@
+package org.tests.cascade;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Version;
+
+@Entity
+public class RelDetail {
+
+  @Id
+  Long id;
+
+  String name;
+
+  @Version
+  int version;
+
+  @OneToMany(cascade = CascadeType.ALL, mappedBy = "detail")
+  private List<RelMaster> masterRel;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<RelMaster> getMasterRel() {
+    return masterRel;
+  }
+}

--- a/src/test/java/org/tests/cascade/RelMaster.java
+++ b/src/test/java/org/tests/cascade/RelMaster.java
@@ -1,0 +1,48 @@
+package org.tests.cascade;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Version;
+
+@Entity
+public class RelMaster {
+
+  @Id
+  Long id;
+
+  String name;
+
+  @Version
+  int version;
+
+  @ManyToOne(cascade = CascadeType.REMOVE)
+  private RelDetail detail;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public RelDetail getDetail() {
+    return detail;
+  }
+
+  public void setDetail(RelDetail detail) {
+    this.detail = detail;
+  }
+
+
+}

--- a/src/test/java/org/tests/cascade/TestMasterDetailDelete.java
+++ b/src/test/java/org/tests/cascade/TestMasterDetailDelete.java
@@ -1,0 +1,83 @@
+package org.tests.cascade;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class TestMasterDetailDelete extends BaseTestCase {
+
+  @Test
+  public void testDeleteOneMasterTxn() {
+    try (Transaction txn = server().beginTransaction()) {
+      RelDetail rd = new RelDetail();
+      rd.setName("test1");
+      server().save(rd);
+
+      RelMaster rm = new RelMaster();
+      rm.setDetail(rd);
+      server().save(rm);
+
+      List<RelDetail> lst = server().find(RelDetail.class).where().eq("name", "test1").findList();
+      assertThat(lst).hasSize(1);
+
+      server().find(RelMaster.class).delete();
+
+      lst = server().find(RelDetail.class).where().eq("name", "test1").findList();
+      assertThat(lst).isEmpty();
+    } // no commit
+  }
+
+
+  @Test
+  public void testDeleteMultiMasterTxn() {
+    try (Transaction txn = server().beginTransaction()) {
+      RelDetail rd = new RelDetail();
+      rd.setName("test2");
+      server().save(rd);
+
+      RelMaster rm1 = new RelMaster();
+      rm1.setDetail(rd);
+      server().save(rm1);
+
+      RelMaster rm2 = new RelMaster();
+      rm2.setDetail(rd);
+      server().save(rm2);
+
+      List<RelDetail> lst = server().find(RelDetail.class).where().eq("name", "test2").findList();
+      assertThat(lst).hasSize(1);
+
+      server().find(RelMaster.class).delete();
+
+      lst = server().find(RelDetail.class).where().eq("name", "test2").findList();
+      assertThat(lst).isEmpty();
+    } // no commit
+  }
+
+  @Test
+  public void testDeleteMultiMasterPlain() {
+    RelDetail rd = new RelDetail();
+    rd.setName("test3");
+    server().save(rd);
+
+    RelMaster rm1 = new RelMaster();
+    rm1.setDetail(rd);
+    server().save(rm1);
+
+    RelMaster rm2 = new RelMaster();
+    rm2.setDetail(rd);
+    server().save(rm2);
+
+    List<RelDetail> lst = server().find(RelDetail.class).where().eq("name", "test3").findList();
+    assertThat(lst).hasSize(1);
+
+    server().find(RelMaster.class).delete();
+
+    lst = server().find(RelDetail.class).where().eq("name", "test3").findList();
+    assertThat(lst).isEmpty();
+  }
+}


### PR DESCRIPTION
When you have a complex object graph, with one2many relations and cascade=REMOVE on both sides, you cannot delete the graph, if you have more than one relation
 
The test `testDeleteMultiMasterTxn()` shows this issue. It fails with an OptimisticLockException in https://github.com/ebean-orm/ebean/blob/f928923b5b380c1dafd261fac7c7cfaef2387f31/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java#L876

Note: 
- you need at least two master beans
- It does only happen in a transaction.
- It only happens, when a version-property is in the entity

So in the test, there are two RelMaster pointing to one RelDetail.
When deleteing all RelMaster, it deletes the dependent RelDetail, which deletes all RelMasters, which deletes all RelDetails...
In the SQLLog, it seems that the RelDetail (1,1) is deleted two times
```java
-- DeleteById of RelMaster ids[[1, 2]] requires fetch of foreign key values
select t0.id, t0.detail_id from rel_master t0 where t0.id in (?, ? ) ; --bind(Array[2]={1,2})
FindMany type[RelMaster] origin[Cjorkz.A.A] exeMicros[3359] rows[2] predicates[t0.id in (?, ? ) ] bind[Array[2]={1,2}]
delete from rel_master where id=?; -- bind(1)
Deleted [RelMaster] [1]
select t0.id from rel_master t0 where detail_id=? ; --bind(1)
FindAttr exeMicros[313] rows[1] type[RelMaster] predicates[detail_id=? ] bind[1]
-- DeleteById of RelMaster ids[[2]] requires fetch of foreign key values
select t0.id, t0.detail_id from rel_master t0 where t0.id in (? ) ; --bind(Array[1]={2})
FindMany type[RelMaster] origin[Cjorkz.A.A] exeMicros[260] rows[1] predicates[t0.id in (? ) ] bind[Array[1]={2}]
BatchControl flush [RelMaster:100 d:1, RelDetail:101 d:1]
delete from rel_master where id=?
 -- bind(2)
Deleted [RelMaster] [2]
delete from rel_detail where id=? and version=?
 -- bind(1,1)
Deleted [RelDetail] [1]
delete from rel_master where id=?; -- bind(2)
Deleted [RelMaster] [2]
select t0.id from rel_master t0 where detail_id=? ; --bind(1)
FindAttr exeMicros[181] rows[0] type[RelMaster] predicates[] bind[1]
BatchControl flush [RelDetail:100 d:1]
delete from rel_detail where id=? and version=?
 -- bind(1,1)
---> OptimisticLockException
```

It seems that the behaviour has changed with #1447 - before, no OptimisticLockException was thrown (but dependent entities were also not deleted) 
