### PR TITLE
Fix implicit conversion from array to string

### DIFF
--- a/src/main/java/io/ebeaninternal/server/type/bindcapture/BindCaptureTypes.java
+++ b/src/main/java/io/ebeaninternal/server/type/bindcapture/BindCaptureTypes.java
@@ -95,7 +95,7 @@ class BindCaptureTypes {
 
     @Override
     public String toString() {
-      return String.valueOf(x);
+      return Arrays.toString(x);
     }
   }
 


### PR DESCRIPTION
According to other object implementing `BindCaptureEntry`. Don't use a simple `String.valueOf()` for one-dimension array. When converting an array to a readable string, use Arrays.toString for one-dimensional arrays. This function iterate over the contents of the array and produce human-readable output.
