### PR TITLE
Remove useless comparison test

### DIFF
--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServer2005SqlLimiter.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServer2005SqlLimiter.java
@@ -65,13 +65,9 @@ public class SqlServer2005SqlLimiter implements SqlLimiter {
     sb.append(NEW_LINE).append(") ");
     sb.append(rowNumberWindowAlias);
     sb.append(" where ");
-    if (firstRow > 0) {
-      sb.append(" rn > ").append(firstRow);
-      if (lastRow > 0) {
-        sb.append(" and ");
-      }
-    }
+    sb.append(" rn > ").append(firstRow);
     if (lastRow > 0) {
+      sb.append(" and ");
       sb.append(" rn <= ").append(lastRow);
     }
 

--- a/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerSqlLimiter.java
+++ b/src/main/java/io/ebean/config/dbplatform/sqlserver/SqlServerSqlLimiter.java
@@ -38,10 +38,8 @@ public class SqlServerSqlLimiter implements SqlLimiter {
     }
 
     sb.append(dbSql);
-    if (firstRow > 0) {
-      sb.append(" ").append("offset");
-      sb.append(" ").append(firstRow).append(" rows");
-    }
+    sb.append(" ").append("offset");
+    sb.append(" ").append(firstRow).append(" rows");
     if (maxRows > 0) {
       sb.append(" fetch next ").append(maxRows).append(" rows only");
     }

--- a/src/main/java/io/ebeaninternal/server/query/CQueryPlanRawSql.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryPlanRawSql.java
@@ -48,10 +48,8 @@ class CQueryPlanRawSql extends CQueryPlan {
     // an associated bean is in the raw SQL but is mapped columnIgnore
     for (int i = 0; i < indexPositions.length; i++) {
       if (indexPositions[i] == 0) {
-        if (i < indexPositions.length) {
-          // expect discriminator column to immediately proceed id column
-          indexPositions[i] = indexPositions[i + 1] - 1;
-        }
+        // expect discriminator column to immediately proceed id column
+        indexPositions[i] = indexPositions[i + 1] - 1;
       }
     }
 


### PR DESCRIPTION
The result of certain comparison tests can sometimes be inferred from their context and the results of other comparisons. Inspect the code to check whether the logic is correct, and consider simplifying the logical expression.
