### PR TITLE
Fix: equals() and hashCode() in ModifyAwareXXX

### DIFF
--- a/src/main/java/io/ebeaninternal/json/ModifyAwareList.java
+++ b/src/main/java/io/ebeaninternal/json/ModifyAwareList.java
@@ -36,9 +36,13 @@ public class ModifyAwareList<E> implements List<E>, ModifyAwareOwner {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ModifyAwareList)) return false;
-    ModifyAwareList<?> that = (ModifyAwareList<?>) o;
-    return Objects.equals(list, that.list);
+    if (o instanceof ModifyAwareList) {
+      ModifyAwareList<?> that = (ModifyAwareList<?>) o;
+      return Objects.equals(list, that.list);
+    }
+    if (!(o instanceof List)) return false;
+    List<?> that = (List<?>) o;
+    return Objects.equals(list, that);
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/json/ModifyAwareList.java
+++ b/src/main/java/io/ebeaninternal/json/ModifyAwareList.java
@@ -47,7 +47,7 @@ public class ModifyAwareList<E> implements List<E>, ModifyAwareOwner {
 
   @Override
   public int hashCode() {
-    return Objects.hash(list);
+    return list.hashCode();
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/json/ModifyAwareMap.java
+++ b/src/main/java/io/ebeaninternal/json/ModifyAwareMap.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.json;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -38,9 +39,13 @@ public class ModifyAwareMap<K, V> implements Map<K, V>, ModifyAwareOwner {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ModifyAwareMap)) return false;
-    ModifyAwareMap<?, ?> that = (ModifyAwareMap<?, ?>) o;
-    return Objects.equals(map, that.map);
+    if (o instanceof ModifyAwareMap) {
+      ModifyAwareMap<?,?> that = (ModifyAwareMap<?,?>) o;
+      return Objects.equals(map, that.map);
+    }
+    if (!(o instanceof Map)) return false;
+    Map<?,?> that = (Map<?,?>) o;
+    return Objects.equals(map, that);
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/json/ModifyAwareMap.java
+++ b/src/main/java/io/ebeaninternal/json/ModifyAwareMap.java
@@ -2,7 +2,6 @@ package io.ebeaninternal.json;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class ModifyAwareMap<K, V> implements Map<K, V>, ModifyAwareOwner {
 
   @Override
   public int hashCode() {
-    return Objects.hash(map);
+    return map.hashCode();
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/json/ModifyAwareSet.java
+++ b/src/main/java/io/ebeaninternal/json/ModifyAwareSet.java
@@ -66,7 +66,7 @@ public class ModifyAwareSet<E> implements Set<E>, ModifyAwareOwner {
 
   @Override
   public int hashCode() {
-    return Objects.hash(set);
+    return set.hashCode();
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/json/ModifyAwareSet.java
+++ b/src/main/java/io/ebeaninternal/json/ModifyAwareSet.java
@@ -55,9 +55,13 @@ public class ModifyAwareSet<E> implements Set<E>, ModifyAwareOwner {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ModifyAwareSet)) return false;
-    ModifyAwareSet<?> that = (ModifyAwareSet<?>) o;
-    return Objects.equals(set, that.set);
+    if (o instanceof ModifyAwareSet) {
+      ModifyAwareSet<?> that = (ModifyAwareSet<?>) o;
+      return Objects.equals(set, that.set);
+    }
+    if (!(o instanceof Set)) return false;
+    Set<?> that = (Set<?>) o;
+    return Objects.equals(set, that);
   }
 
   @Override

--- a/src/test/java/io/ebeaninternal/server/type/ModifyAwareListTest.java
+++ b/src/test/java/io/ebeaninternal/server/type/ModifyAwareListTest.java
@@ -16,9 +16,7 @@ import java.util.List;
 import java.util.ListIterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 public class ModifyAwareListTest {
@@ -289,5 +287,22 @@ public class ModifyAwareListTest {
 
     assertThat(listA).isNotEqualTo(listB);
     assertThat(listA.hashCode()).isNotEqualTo(listB.hashCode());
+  }
+
+  @Test
+  public void testEqualsAndHashCode() throws Exception {
+    ModifyAwareList<String> listA = createEmptyList();
+    ArrayList<String> listB = new ArrayList<>();
+
+    assertThat(listA).isEqualTo(listB);
+    assertThat(listA.hashCode()).isEqualTo(listB.hashCode());
+
+    listA.add("foo");
+    assertThat(listA).isNotEqualTo(listB);
+    assertThat(listA.hashCode()).isNotEqualTo(listB.hashCode());
+
+    listB.add("foo");
+    assertThat(listA).isEqualTo(listB);
+    assertThat(listA.hashCode()).isEqualTo(listB.hashCode());
   }
 }

--- a/src/test/java/io/ebeaninternal/server/type/ModifyAwareMapTest.java
+++ b/src/test/java/io/ebeaninternal/server/type/ModifyAwareMapTest.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.server.type;
 
-import io.ebeaninternal.json.ModifyAwareSet;
+import io.ebeaninternal.json.ModifyAwareMap;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -8,23 +8,26 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.StrictAssertions.assertThat;
 
-public class ModifyAwareSetTest {
+public class ModifyAwareMapTest {
 
-  private ModifyAwareSet<String> createSet() {
-    HashSet<String> set = new HashSet<>();
-    set.addAll(Arrays.asList("A", "B", "C", "D", "E"));
-    return new ModifyAwareSet<>(set);
+  private ModifyAwareMap<String, Integer> createMap() {
+    HashMap<String, Integer> set = new HashMap<>();
+    set.put("A", 1);
+    set.put("B", 2);
+    set.put("C", 3);
+    set.put("D", 4);
+    set.put("E", 5);
+    return new ModifyAwareMap<>(set);
   }
 
-  private ModifyAwareSet<String> createEmptySet() {
-    HashSet<String> set = new HashSet<>();
-    return new ModifyAwareSet<>(set);
+  private ModifyAwareMap<String, Integer> createEmptyMap() {
+    HashMap<String, Integer> set = new HashMap<>();
+    return new ModifyAwareMap<>(set);
   }
 
   @Test
@@ -33,7 +36,7 @@ public class ModifyAwareSetTest {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     ObjectOutputStream oos = new ObjectOutputStream(os);
 
-    oos.writeObject(createSet());
+    oos.writeObject(createMap());
     oos.flush();
     oos.close();
 
@@ -41,15 +44,15 @@ public class ModifyAwareSetTest {
     ObjectInputStream ois = new ObjectInputStream(is);
 
     @SuppressWarnings("unchecked")
-    ModifyAwareSet<String> read = (ModifyAwareSet<String>)ois.readObject();
-    assertThat(read).contains("A", "B", "C", "D", "E");
+    ModifyAwareMap<String, Integer> read = (ModifyAwareMap<String, Integer>) ois.readObject();
+    assertThat(read).containsKeys("A", "B", "C", "D", "E").containsValues(1, 2, 3, 4, 5);
   }
 
   @Test
   public void equalsWhenEqual() {
 
-    ModifyAwareSet<String> setA = createSet();
-    ModifyAwareSet<String> setB = createSet();
+    ModifyAwareMap<String, Integer> setA = createMap();
+    ModifyAwareMap<String, Integer> setB = createMap();
 
     assertThat(setA).isEqualTo(setB);
     assertThat(setA.hashCode()).isEqualTo(setB.hashCode());
@@ -58,9 +61,9 @@ public class ModifyAwareSetTest {
   @Test
   public void equalsWhenNotEqual() {
 
-    ModifyAwareSet<String> setA = createSet();
-    ModifyAwareSet<String> setB = createSet();
-    setB.add("F");
+    ModifyAwareMap<String, Integer> setA = createMap();
+    ModifyAwareMap<String, Integer> setB = createMap();
+    setB.put("F", 6);
 
     assertThat(setA).isNotEqualTo(setB);
     assertThat(setA.hashCode()).isNotEqualTo(setB.hashCode());
@@ -68,17 +71,17 @@ public class ModifyAwareSetTest {
 
   @Test
   public void testEqualsAndHashCode() throws Exception {
-    ModifyAwareSet<String> setA = createEmptySet();
-    HashSet<String> setB = new HashSet<>();
+    ModifyAwareMap<String, Integer> setA = createEmptyMap();
+    HashMap<String, Integer> setB = new HashMap<>();
 
     assertThat(setA).isEqualTo(setB);
     assertThat(setA.hashCode()).isEqualTo(setB.hashCode());
 
-    setA.add("foo");
+    setA.put("foo", 42);
     assertThat(setA).isNotEqualTo(setB);
     assertThat(setA.hashCode()).isNotEqualTo(setB.hashCode());
 
-    setB.add("foo");
+    setB.put("foo", 42);
     assertThat(setA).isEqualTo(setB);
     assertThat(setA.hashCode()).isEqualTo(setB.hashCode());
   }


### PR DESCRIPTION
This adds equals (and correct) hashCode to ModifyAwareList/Set/Map, so that they are equals with an other collection, that contains the same elements
