### PR TITLE
Refactor Tests: Check idType instead of assuming idType for a platform

### DIFF
--- a/src/test/java/io/ebean/BaseTestCase.java
+++ b/src/test/java/io/ebean/BaseTestCase.java
@@ -2,6 +2,7 @@ package io.ebean;
 
 import io.ebean.annotation.PersistBatch;
 import io.ebean.annotation.Platform;
+import io.ebean.config.dbplatform.IdType;
 import io.ebean.meta.MetaTimedMetric;
 import io.ebean.meta.MetricType;
 import io.ebean.meta.ServerMetrics;
@@ -195,6 +196,10 @@ public abstract class BaseTestCase {
 
   protected Platform platform() {
     return spiEbeanServer().getDatabasePlatform().getPlatform();
+  }
+
+  protected IdType idType() {
+    return spiEbeanServer().getDatabasePlatform().getDbIdentity().getIdType();
   }
 
   protected SpiEbeanServer spiEbeanServer() {

--- a/src/test/java/org/tests/genkey/TestSeqBatch.java
+++ b/src/test/java/org/tests/genkey/TestSeqBatch.java
@@ -1,10 +1,7 @@
 package org.tests.genkey;
 
 import io.ebean.BaseTestCase;
-import io.ebean.Ebean;
-import io.ebean.EbeanServer;
 import io.ebean.config.dbplatform.IdType;
-import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import org.tests.model.basic.TOne;
 import org.junit.Assert;
@@ -14,24 +11,20 @@ public class TestSeqBatch extends BaseTestCase {
 
   @Test
   public void test() {
+    if (idType() != IdType.SEQUENCE) {
+      return;
+    }
 
-    EbeanServer server = Ebean.getServer(null);
-    SpiEbeanServer spiServer = (SpiEbeanServer) server;
+    BeanDescriptor<TOne> d = spiEbeanServer().getBeanDescriptor(TOne.class);
 
-    IdType idType = spiServer.getDatabasePlatform().getDbIdentity().getIdType();
+    Object id = d.nextId(null);
+    Assert.assertNotNull(id);
+    // System.out.println(id);
 
-    if (IdType.SEQUENCE == idType) {
-      BeanDescriptor<TOne> d = spiServer.getBeanDescriptor(TOne.class);
-
-      Object id = d.nextId(null);
-      Assert.assertNotNull(id);
-      //System.out.println(id);
-
-      for (int i = 0; i < 16; i++) {
-        Object id2 = d.nextId(null);
-        Assert.assertNotNull(id2);
-        //System.out.println(id2);
-      }
+    for (int i = 0; i < 16; i++) {
+      Object id2 = d.nextId(null);
+      Assert.assertNotNull(id2);
+      // System.out.println(id2);
     }
   }
 

--- a/src/test/java/org/tests/idkeys/TestGeneratedKeys.java
+++ b/src/test/java/org/tests/idkeys/TestGeneratedKeys.java
@@ -24,8 +24,8 @@ public class TestGeneratedKeys extends BaseTestCase {
   @ForPlatform(Platform.H2) // readSequenceValue is H2 specific
   public void testSequence() throws SQLException {
     SpiEbeanServer server = spiEbeanServer();
-    IdType idType = server.getDatabasePlatform().getDbIdentity().getIdType();
-    if (!IdType.SEQUENCE.equals(idType)) {
+
+    if (idType() != IdType.SEQUENCE) {
       // only run this test when SEQUENCE is being used
       return;
     }
@@ -69,19 +69,16 @@ public class TestGeneratedKeys extends BaseTestCase {
   @Test
   public void testIdentity() throws SQLException {
 
-    SpiEbeanServer server = spiEbeanServer();
-    IdType idType = server.getDatabasePlatform().getDbIdentity().getIdType();
-
-    if (!IdType.IDENTITY.equals(idType)) {
+    if (idType() != IdType.IDENTITY) {
       // only run this test when SEQUENCE is being used
       return;
     }
 
-    try (Transaction tx = server.beginTransaction()) {
+    try (Transaction tx = server().beginTransaction()) {
 
       GenKeyIdentity al = new GenKeyIdentity();
       al.setDescription("my description");
-      server.save(al);
+      server().save(al);
 
       // For JDBC batching we won't get the id until after
       // the batch has been flushed explicitly or via commit

--- a/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableInheritance.java
+++ b/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableInheritance.java
@@ -2,6 +2,8 @@ package org.tests.o2m.jointable;
 
 import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
+import io.ebean.config.dbplatform.IdType;
+
 import org.ebeantest.LoggedSqlCollector;
 import org.junit.Test;
 import org.tests.o2m.jointable.inheritance.ClassA;
@@ -34,15 +36,14 @@ public class TestOneToManyJoinTableInheritance extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.current();
 
-    boolean hasSequence = isSqlServer(); // uses sequence
     assertThat(sql).hasSize(11);
     assertThat(sql.get(0)).contains("insert into class_super ");
-    if (!hasSequence) {
+    if (idType() == IdType.IDENTITY) {
       assertThat(sql.get(1)).contains("-- bind(ClassA)");
       assertThat(sql.get(2)).contains("-- bind(ClassB)");
     }
     assertThat(sql.get(3)).contains("insert into monkey ");
-    if (!hasSequence) {
+    if (idType() == IdType.IDENTITY) {
       assertThat(sql.get(4)).contains("-- bind(Sim");
       assertThat(sql.get(5)).contains("-- bind(Tim");
       assertThat(sql.get(6)).contains("-- bind(Uim");

--- a/src/test/java/org/tests/transaction/TestBatchModelFlush.java
+++ b/src/test/java/org/tests/transaction/TestBatchModelFlush.java
@@ -5,6 +5,8 @@ import io.ebean.DB;
 import io.ebean.Ebean;
 import io.ebean.Transaction;
 import io.ebean.annotation.Transactional;
+import io.ebean.config.dbplatform.IdType;
+
 import org.ebeantest.LoggedSqlCollector;
 import org.junit.Test;
 import org.tests.model.m2m.MnyB;
@@ -75,9 +77,8 @@ public class TestBatchModelFlush extends BaseTestCase {
     assertThat(sql).hasSize(9);
 
     // first saved to batch - (depth 100)
-    boolean hasSequence = isSqlServer();
     assertThat(sql.get(0)).contains("insert into mny_b");
-    if (!hasSequence) {
+    if (idType() == IdType.IDENTITY) {
       assertThat(sql.get(1)).contains(" -- bind(BatchMultipleTop_0");
       assertThat(sql.get(2)).contains(" -- bind(BatchMultipleTop_1");
     }
@@ -87,7 +88,7 @@ public class TestBatchModelFlush extends BaseTestCase {
     assertThat(sql.get(5)).contains(" -- bind(");
     // third saved to batch - (depth 102)
     assertThat(sql.get(6)).contains("insert into mny_topic");
-    if (!hasSequence) {
+    if (idType() == IdType.IDENTITY) {
       assertThat(sql.get(7)).contains(" -- bind(MnyTopic_0");
       assertThat(sql.get(8)).contains(" -- bind(MnyTopic_1");
     }


### PR DESCRIPTION
This PR checks against the IdType and not against the platform.
It simplifies the code a bit, but should not change any functionality