### PR TITLE
Fix memory leak in threadLocal on implicit transactions

### DIFF
--- a/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionScopeManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionScopeManager.java
@@ -42,5 +42,9 @@ public class DefaultTransactionScopeManager extends TransactionScopeManager {
     DefaultTransactionThreadLocal.set(serverName, trans);
   }
 
+  @Override
+  public void clear(SpiTransaction trans) {
+    DefaultTransactionThreadLocal.clear(serverName, trans);
+  }
 
 }

--- a/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionThreadLocal.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionThreadLocal.java
@@ -41,6 +41,17 @@ public final class DefaultTransactionThreadLocal {
   }
 
   /**
+   * Clears a transaction from the ThreadLocal to prevent memory leaks.
+   * Will only clear, if trans == currentTransaction
+   */
+  public static void clear(String serverName, SpiTransaction trans) {
+    Map<String, SpiTransaction> map = local.get();
+    if (map.get(serverName) == trans) {
+      map.remove(serverName);
+    }
+  }
+
+  /**
    * A mechanism to get the transaction out of the thread local by replacing it
    * with a 'proxy'.
    * <p>

--- a/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -920,6 +920,9 @@ public class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
     }
     connection = null;
     active = false;
+    if (manager != null) {
+      manager.scope().clear(this);
+    }
     profileEnd();
   }
 

--- a/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
@@ -102,7 +102,7 @@ public class JtaTransactionManager implements ExternalTransactionManager {
     }
 
     // check current Ebean transaction
-    SpiTransaction currentEbeanTransaction = transactionManager.getInScope();
+    SpiTransaction currentEbeanTransaction = DefaultTransactionThreadLocal.get(serverName);
     if (currentEbeanTransaction != null) {
       // NOT expecting this so log WARNING
       String msg = "JTA Transaction - no current txn BUT using current Ebean one " + currentEbeanTransaction.getId();
@@ -116,7 +116,6 @@ public class JtaTransactionManager implements ExternalTransactionManager {
       if (logger.isDebugEnabled()) {
         logger.debug("JTA Transaction - no current txn");
       }
-      transactionManager.set(null);
       return null;
     }
 
@@ -133,7 +132,7 @@ public class JtaTransactionManager implements ExternalTransactionManager {
     syncRegistry.registerInterposedSynchronization(txnListener);
 
     // also put in Ebean ThreadLocal
-    transactionManager.set(newTrans);
+    DefaultTransactionThreadLocal.set(serverName, newTrans);
     return newTrans;
   }
 
@@ -193,10 +192,12 @@ public class JtaTransactionManager implements ExternalTransactionManager {
 
     private final SpiTransaction transaction;
 
+    private final String serverName;
 
     private JtaTxnListener(TransactionManager transactionManager, SpiTransaction t) {
       this.transactionManager = transactionManager;
       this.transaction = t;
+      this.serverName = transactionManager.getServerName();
     }
 
     @Override
@@ -214,6 +215,8 @@ public class JtaTransactionManager implements ExternalTransactionManager {
             logger.debug("Jta Txn [" + transaction.getId() + "] committed");
           }
           transactionManager.notifyOfCommit(transaction);
+          // Remove this transaction object as it is completed
+          DefaultTransactionThreadLocal.replace(serverName, null);
           break;
 
         case Status.STATUS_ROLLEDBACK:
@@ -221,6 +224,8 @@ public class JtaTransactionManager implements ExternalTransactionManager {
             logger.debug("Jta Txn [" + transaction.getId() + "] rollback");
           }
           transactionManager.notifyOfRollback(transaction, null);
+          // Remove this transaction object as it is completed
+          DefaultTransactionThreadLocal.replace(serverName, null);
           break;
 
         default:
@@ -231,8 +236,6 @@ public class JtaTransactionManager implements ExternalTransactionManager {
 
       // No matter the completion status of the transaction, we release the connection we got from the pool.
       JdbcClose.close(transaction.getInternalConnection());
-      // And we remove this transaction object as it is completed
-      transactionManager.scope().clear(transaction);
     }
   }
 

--- a/src/main/java/io/ebeaninternal/server/transaction/TransactionScopeManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/TransactionScopeManager.java
@@ -35,6 +35,11 @@ public abstract class TransactionScopeManager implements SpiTransactionScopeMana
   public abstract void set(SpiTransaction trans);
 
   /**
+   * Clears the given Transaction for this serverName and Thread.
+   */
+  public abstract void clear(SpiTransaction trans);
+
+  /**
    * Replace the current transaction with this one.
    * <p>
    * Used for Background fetching and Nested transaction scopes.

--- a/src/test/java/org/tests/transaction/TestExecuteComplete.java
+++ b/src/test/java/org/tests/transaction/TestExecuteComplete.java
@@ -1,8 +1,8 @@
 package org.tests.transaction;
 
 import io.ebean.BaseTestCase;
+import io.ebean.DB;
 import io.ebean.DataIntegrityException;
-import io.ebean.Ebean;
 import io.ebean.Transaction;
 import io.ebean.TxScope;
 import io.ebean.annotation.ForPlatform;
@@ -16,7 +16,7 @@ import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
 
 import static org.assertj.core.api.StrictAssertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestExecuteComplete extends BaseTestCase {
 
@@ -26,15 +26,15 @@ public class TestExecuteComplete extends BaseTestCase {
   public void execute_when_errorOnCommit_threadLocalIsCleared() {
 
     try {
-      Ebean.execute(TxScope.required().setBatch(PersistBatch.ALL), () -> {
+      DB.execute(TxScope.required().setBatch(PersistBatch.ALL), () -> {
 
-        Customer customer = Ebean.getReference(Customer.class, 42424242L);
+        Customer customer = DB.getReference(Customer.class, 42424242L);
         Order order = new Order();
         order.setCustomer(customer);
 
-        Ebean.save(order);
+        DB.save(order);
       });
-      assertTrue(false);
+      fail();
     } catch (DataIntegrityException e) {
       // assert the thread local has been cleaned up
       SpiTransaction txn = DefaultTransactionThreadLocal.get("h2");
@@ -47,15 +47,16 @@ public class TestExecuteComplete extends BaseTestCase {
   public void nestedExecute_when_errorOnCommit_threadLocalIsCleared() {
 
     try {
-      Ebean.execute(TxScope.required().setBatch(PersistBatch.ALL), () ->
-        Ebean.execute(() -> {
+      DB.execute(TxScope.required().setBatch(PersistBatch.ALL), () ->
+      DB.execute(() -> {
 
-          Customer customer = Ebean.getReference(Customer.class, 42424242L);
+          Customer customer = DB.getReference(Customer.class, 42424242L);
           Order order = new Order();
           order.setCustomer(customer);
 
-          Ebean.save(order);
+          DB.save(order);
         }));
+      fail();
     } catch (DataIntegrityException e) {
       // assert the thread local has been cleaned up
       SpiTransaction txn = DefaultTransactionThreadLocal.get("h2");
@@ -69,6 +70,7 @@ public class TestExecuteComplete extends BaseTestCase {
 
     try {
       errorOnCommit();
+      fail();
     } catch (DataIntegrityException e) {
       SpiTransaction txn = DefaultTransactionThreadLocal.get("h2");
       assertThat(txn).isNull();
@@ -77,11 +79,11 @@ public class TestExecuteComplete extends BaseTestCase {
 
   @Transactional(batchSize = 10)
   private void errorOnCommit() {
-    Customer customer = Ebean.getReference(Customer.class, 42424242L);
+    Customer customer = DB.getReference(Customer.class, 42424242L);
     Order order = new Order();
     order.setCustomer(customer);
 
-    Ebean.save(order);
+    DB.save(order);
   }
 
   @ForPlatform(Platform.H2)

--- a/src/test/java/org/tests/transaction/TestExecuteComplete.java
+++ b/src/test/java/org/tests/transaction/TestExecuteComplete.java
@@ -133,4 +133,42 @@ public class TestExecuteComplete extends BaseTestCase {
     assertThat(txn2).isNull();
   }
 
+  @ForPlatform(Platform.H2)
+  @Test
+  public void implicit_query_expect_threadScopeCleanup() {
+
+    DB.find(Customer.class).findList();
+
+    SpiTransaction txn = DefaultTransactionThreadLocal.get("h2");
+    assertThat(txn).isNull();
+  }
+
+  @ForPlatform(Platform.H2)
+  @Test
+  public void implicit_save_expect_threadScopeCleanup() {
+
+    Customer cust = new Customer();
+    cust.setName("Roland");
+    DB.save(cust);
+
+    SpiTransaction txn = DefaultTransactionThreadLocal.get("h2");
+    assertThat(txn).isNull();
+  }
+
+  @ForPlatform(Platform.H2)
+  @Test
+  public void no_transaction_expect_threadScopeCleanup() {
+
+    try (Transaction txn = DB.beginTransaction(TxScope.notSupported())) {
+      SpiTransaction txn2 = DefaultTransactionThreadLocal.get("h2");
+      // The NoTransaction placeholder can normally only occur inside
+      // a scopedTrans. (Class is package private, so check
+      assertThat(txn2.toString()).contains("NoTransaction");
+      assertThat(txn2.toString()).contains("NoTransaction");
+    }
+
+    SpiTransaction txn = DefaultTransactionThreadLocal.get("h2");
+    assertThat(txn).isNull();
+  }
+
 }


### PR DESCRIPTION
In continuation to #1704:
When an implicit transaction is used, the transaction will not be removed from the threadLocal.

So the JDBC (and JTA) transaction have to be removed from the ThreadLocal, when they are complete.

/edit: reverted the JTA part, as I cannot test it.

@rbygrave I tried to keep the changes as mininal now ;)
Can you take a look at this commit: https://github.com/ebean-orm/ebean/commit/c36e65e645cc56a17e3f5793e975ec10fe1a8229 - do you think it is good to check if there are leaked transactions after each test?
