### PR TITLE
Adjustment on #1711, more explicit clearing of inactive transactions from thread local

### DIFF
--- a/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
+++ b/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
@@ -134,6 +134,11 @@ public interface SpiEbeanServer extends ExtendedServer, EbeanServer, BeanLoader,
   void externalModification(TransactionEventTable event);
 
   /**
+   * Clear an implicit transaction from the scope.
+   */
+  void clearServerTransaction();
+
+  /**
    * Begin a managed transaction (Uses scope manager / ThreadLocal).
    */
   SpiTransaction beginServerTransaction();

--- a/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
+++ b/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
@@ -79,6 +79,15 @@ public abstract class BeanRequest {
   }
 
   /**
+   * Clear the transaction from the thread local for implicit transactions.
+   */
+  public void clearTransIfRequired() {
+    if (createdTransaction) {
+      ebeanServer.clearServerTransaction();
+    }
+  }
+
+  /**
    * Return the server processing the request. Made available for
    * BeanController and BeanFinder.
    */

--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -2255,6 +2255,11 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
+  public void clearServerTransaction() {
+    transactionManager.clearServerTransaction();
+  }
+
+  @Override
   public SpiTransaction beginServerTransaction() {
     return transactionManager.beginServerTransaction();
   }

--- a/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -123,6 +123,8 @@ public final class DefaultPersister implements Persister {
     } catch (RuntimeException e) {
       request.rollbackTransIfRequired();
       throw e;
+    } finally {
+      request.clearTransIfRequired();
     }
   }
 
@@ -435,6 +437,8 @@ public final class DefaultPersister implements Persister {
     } catch (RuntimeException ex) {
       req.rollbackTransIfRequired();
       throw ex;
+    } finally {
+      req.clearTransIfRequired();
     }
   }
 
@@ -471,6 +475,8 @@ public final class DefaultPersister implements Persister {
     } catch (RuntimeException ex) {
       req.rollbackTransIfRequired();
       throw ex;
+    } finally {
+      req.clearTransIfRequired();
     }
   }
 
@@ -623,6 +629,8 @@ public final class DefaultPersister implements Persister {
     } catch (RuntimeException ex) {
       req.rollbackTransIfRequired();
       throw ex;
+    } finally {
+      req.clearTransIfRequired();
     }
   }
 

--- a/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionScopeManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionScopeManager.java
@@ -43,8 +43,8 @@ public class DefaultTransactionScopeManager extends TransactionScopeManager {
   }
 
   @Override
-  public void clear(SpiTransaction trans) {
-    DefaultTransactionThreadLocal.clear(serverName, trans);
+  public void clear() {
+    DefaultTransactionThreadLocal.clear(serverName);
   }
 
 }

--- a/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionThreadLocal.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/DefaultTransactionThreadLocal.java
@@ -41,13 +41,12 @@ public final class DefaultTransactionThreadLocal {
   }
 
   /**
-   * Clears a transaction from the ThreadLocal to prevent memory leaks.
-   * Will only clear, if trans == currentTransaction
+   * Clear a transaction. It should be inactive.
    */
-  public static void clear(String serverName, SpiTransaction trans) {
-    Map<String, SpiTransaction> map = local.get();
-    if (map.get(serverName) == trans) {
-      map.remove(serverName);
+  public static void clear(String serverName) {
+    SpiTransaction transaction = local.get().remove(serverName);
+    if (transaction != null && transaction.isActive()) {
+      throw new IllegalStateException("Clearing an ACTIVE transaction " + transaction);
     }
   }
 

--- a/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -920,9 +920,6 @@ public class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
     }
     connection = null;
     active = false;
-    if (manager != null) {
-      manager.scope().clear(this);
-    }
     profileEnd();
   }
 

--- a/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -568,6 +568,13 @@ public class TransactionManager implements SpiTransactionManager {
   }
 
   /**
+   * Clear an implicit transaction from thread local scope.
+   */
+  public void clearServerTransaction() {
+    scopeManager.clear();
+  }
+
+  /**
    * Begin an implicit transaction.
    */
   public SpiTransaction beginServerTransaction() {

--- a/src/main/java/io/ebeaninternal/server/transaction/TransactionScopeManager.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/TransactionScopeManager.java
@@ -35,9 +35,9 @@ public abstract class TransactionScopeManager implements SpiTransactionScopeMana
   public abstract void set(SpiTransaction trans);
 
   /**
-   * Clears the given Transaction for this serverName and Thread.
+   * Clears the current Transaction from thread local scope (for implicit transactions).
    */
-  public abstract void clear(SpiTransaction trans);
+  public abstract void clear();
 
   /**
    * Replace the current transaction with this one.

--- a/src/test/java/io/ebeaninternal/api/TDSpiEbeanServer.java
+++ b/src/test/java/io/ebeaninternal/api/TDSpiEbeanServer.java
@@ -228,6 +228,11 @@ public class TDSpiEbeanServer implements SpiEbeanServer {
   }
 
   @Override
+  public void clearServerTransaction() {
+    
+  }
+
+  @Override
   public SpiTransaction beginServerTransaction() {
     return null;
   }


### PR DESCRIPTION
Hi @rPraml , this is an adjustment that I think gives us more explicit clearing of the inactive implicit transactions.

The specific case is implicit persistence transactions (insert, update, delete etc) and note that these are always JdbcTransactions or more specifically NOT ScopedTransactions (as there is no possibility of nested transactions for this case).
