### PR TITLE
Bugfix/create entity bean unload

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1915,17 +1915,18 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
         beanPostConstructListener.autowire(bean); // calls all registered listeners
         beanPostConstructListener.postConstruct(bean); // calls first the @PostConstruct method and then the listeners
       }
-
-      if (unloadProperties.length > 0) {
+      if (isNew) {
+        if (beanPostConstructListener != null) {
+          beanPostConstructListener.postCreate(bean);
+          // if bean is not new, postLoad will be executed later in the bean's lifecycle
+        }
+        // do not unload properties for new beans!
+      } else if (unloadProperties.length > 0) {
         // 'unload' any properties initialised in the default constructor
         EntityBeanIntercept ebi = bean._ebean_getIntercept();
         for (int unloadProperty : unloadProperties) {
           ebi.setPropertyUnloaded(unloadProperty);
         }
-      }
-      if (beanPostConstructListener != null && isNew) {
-        beanPostConstructListener.postCreate(bean);
-        // if bean is not new, postLoad will be executed later in the bean's lifecycle
       }
       return bean;
 

--- a/src/test/java/org/tests/basic/TestCreateEntityBean.java
+++ b/src/test/java/org/tests/basic/TestCreateEntityBean.java
@@ -1,0 +1,36 @@
+package org.tests.basic;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.Ebean;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tests.model.basic.EDefaultProp;
+
+public class TestCreateEntityBean extends BaseTestCase {
+
+  @Test
+  public void testDefaultRelation() {
+    // Use `new` to construct EntityBean
+    final EDefaultProp beanNew = new EDefaultProp();
+    Ebean.save(beanNew);
+
+    final EDefaultProp beanNewDb = Ebean.find(EDefaultProp.class, beanNew.getId());
+    Assert.assertNotNull(beanNewDb);
+    Assert.assertEquals("defaultName", beanNew.getName());
+    Assert.assertNotNull(beanNewDb.geteSimple());
+    Assert.assertEquals("Default prop eSimple", beanNewDb.geteSimple().getName());
+
+    // Use `createEntityBean` to construct EntityBean and check if it behaves the same as `new`
+    final EDefaultProp beanCreateEntityBean = DB.getDefault().createEntityBean(EDefaultProp.class);
+    Ebean.save(beanCreateEntityBean);
+
+    final EDefaultProp beanCreateEntityBeanDb = Ebean.find(EDefaultProp.class, beanCreateEntityBean.getId());
+    Assert.assertNotNull(beanCreateEntityBeanDb);
+    Assert.assertEquals("defaultName", beanCreateEntityBeanDb.getName());
+    Assert.assertNotNull(beanCreateEntityBeanDb.geteSimple());
+    Assert.assertEquals("Default prop eSimple", beanCreateEntityBeanDb.geteSimple().getName());
+
+  }
+
+}

--- a/src/test/java/org/tests/model/basic/EDefaultProp.java
+++ b/src/test/java/org/tests/model/basic/EDefaultProp.java
@@ -1,0 +1,48 @@
+package org.tests.model.basic;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+@Entity
+public class EDefaultProp {
+
+  @Id
+  Integer id;
+
+  @OneToOne(cascade = CascadeType.ALL)
+  ESimple eSimple;
+
+  String name;
+
+  public EDefaultProp() {
+    eSimple = new ESimple();
+    eSimple.setName("Default prop eSimple");
+    name = "defaultName";
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public ESimple geteSimple() {
+    return eSimple;
+  }
+
+  public void seteSimple(final ESimple eSimple) {
+    this.eSimple = eSimple;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+}


### PR DESCRIPTION
This PR fixes the unexpected behaviour of `createEntityBean` described in issue #1726.