### PR TITLE
Add testcase for wrong batch sorting

### DIFF
--- a/src/test/java/org/tests/cascade/TestMultiCascadeBatch.java
+++ b/src/test/java/org/tests/cascade/TestMultiCascadeBatch.java
@@ -1,0 +1,55 @@
+package org.tests.cascade;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import io.ebean.Transaction;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.tests.model.site.DataContainer;
+import org.tests.model.site.Site;
+import org.tests.model.site.SiteAddress;
+
+public class TestMultiCascadeBatch extends BaseTestCase {
+
+  private Transaction txn;
+
+  @Before
+  public void before() {
+    txn = Ebean.beginTransaction();
+  }
+
+  @After
+  public void after() {
+    if (txn != null) {
+      txn.end();
+    }
+  }
+
+  @Test
+  public void testMultipleCascadeInsideTransaction() {
+    final Site mainSite = new Site();
+    mainSite.setName("mainSite");
+    Ebean.save(mainSite);
+
+    // create child including data
+    final Site childSite = new Site();
+    childSite.setName("childSite");
+
+    final SiteAddress childAddress = new SiteAddress();
+    childAddress.setCity("Some city");
+    childAddress.setStreet("some street");
+    childAddress.setZipCode("12345");
+    childSite.setSiteAddress(childAddress);
+
+    final DataContainer dataContainer = new DataContainer();
+    dataContainer.setContent("container content");
+    childSite.setDataContainer(dataContainer);
+
+    mainSite.getChildren().add(childSite);
+    mainSite.setName("a different name");
+
+    Ebean.save(mainSite);
+  }
+
+}

--- a/src/test/java/org/tests/model/site/DataContainer.java
+++ b/src/test/java/org/tests/model/site/DataContainer.java
@@ -1,0 +1,31 @@
+package org.tests.model.site;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.UUID;
+
+@Entity
+public class DataContainer {
+
+  @Id
+  private UUID id;
+
+  private String content;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(final UUID id) {
+    this.id = id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(final String content) {
+    this.content = content;
+  }
+
+}

--- a/src/test/java/org/tests/model/site/Site.java
+++ b/src/test/java/org/tests/model/site/Site.java
@@ -1,0 +1,80 @@
+package org.tests.model.site;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+public class Site {
+
+  @Id
+  private UUID id;
+
+  private String name;
+
+  @OneToMany(cascade = CascadeType.ALL, mappedBy = "parent")
+  private List<Site> children = new ArrayList<>();
+
+  @ManyToOne(cascade = {})
+  private Site parent;
+
+  @OneToOne(cascade = CascadeType.ALL)
+  private DataContainer dataContainer;
+
+  @OneToOne(cascade = CascadeType.ALL)
+  private SiteAddress siteAddress;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(final UUID id) {
+    this.id = id;
+  }
+
+  public List<Site> getChildren() {
+    return children;
+  }
+
+  public void setChildren(final List<Site> children) {
+    this.children = children;
+  }
+
+  public Site getParent() {
+    return parent;
+  }
+
+  public void setParent(final Site parent) {
+    this.parent = parent;
+  }
+
+  public SiteAddress getSiteAddress() {
+    return siteAddress;
+  }
+
+  public void setSiteAddress(final SiteAddress siteAddress) {
+    this.siteAddress = siteAddress;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public DataContainer getDataContainer() {
+    return dataContainer;
+  }
+
+  public void setDataContainer(final DataContainer dataContainer) {
+    this.dataContainer = dataContainer;
+  }
+}

--- a/src/test/java/org/tests/model/site/SiteAddress.java
+++ b/src/test/java/org/tests/model/site/SiteAddress.java
@@ -1,0 +1,50 @@
+package org.tests.model.site;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.UUID;
+
+@Entity
+public class SiteAddress {
+
+  @Id
+  private UUID id;
+
+  private String street;
+
+  private String city;
+
+  private String zipCode;
+
+  public String getStreet() {
+    return street;
+  }
+
+  public void setStreet(final String street) {
+    this.street = street;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(final String city) {
+    this.city = city;
+  }
+
+  public String getZipCode() {
+    return zipCode;
+  }
+
+  public void setZipCode(final String zipCode) {
+    this.zipCode = zipCode;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(final UUID id) {
+    this.id = id;
+  }
+}


### PR DESCRIPTION
This PR adds a testcase for a problem that showed up after a fix in c66e954. This test shows that the order of statements in a batch can be wrong when first having a *ToMany reference and then from there two or more *ToOne reference, when using UUID as identity type.