### PR TITLE
When using @DbForeignKey(noconstraint = true) in views, you may not access the ID of a 'deleted' entity

### DIFF
--- a/src/test/java/org/tests/lazyforeignkeys/MainEntity.java
+++ b/src/test/java/org/tests/lazyforeignkeys/MainEntity.java
@@ -1,0 +1,41 @@
+package org.tests.lazyforeignkeys;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "main_entity")
+public class MainEntity {
+
+  @Id
+  private String id;
+
+  private String attr1;
+  
+  private String attr2;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getAttr1() {
+    return attr1;
+  }
+
+  public void setAttr1(String attr1) {
+    this.attr1 = attr1;
+  }
+
+  public String getAttr2() {
+    return attr2;
+  }
+
+  public void setAttr2(String attr2) {
+    this.attr2 = attr2;
+  }
+}

--- a/src/test/java/org/tests/lazyforeignkeys/MainEntityRelation.java
+++ b/src/test/java/org/tests/lazyforeignkeys/MainEntityRelation.java
@@ -1,0 +1,46 @@
+package org.tests.lazyforeignkeys;
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+
+@Entity
+@Table(name = "main_entity_relation")
+public class MainEntityRelation {
+
+  @Id
+  private UUID id;
+
+  private String id1;
+  
+  private String id2;
+  
+  private String attr1;
+
+  public String getId1() {
+    return id1;
+  }
+
+  public void setId1(String id1) {
+    this.id1 = id1;
+  }
+
+  public String getId2() {
+    return id2;
+  }
+
+  public void setId2(String id2) {
+    this.id2 = id2;
+  }
+  
+  public String getAttr1() {
+    return attr1;
+  }
+
+  public void setAttr1(String attr1) {
+    this.attr1 = attr1;
+  }
+}

--- a/src/test/java/org/tests/lazyforeignkeys/TestLazyForeignKeys.java
+++ b/src/test/java/org/tests/lazyforeignkeys/TestLazyForeignKeys.java
@@ -1,0 +1,53 @@
+package org.tests.lazyforeignkeys;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.Ebean;
+import io.ebean.Query;
+import io.ebean.text.PathProperties;
+
+public class TestLazyForeignKeys extends BaseTestCase {
+
+  @Test
+  public void test() {
+    MainEntity ent1 = new MainEntity();
+    ent1.setId("ent1");
+    ent1.setAttr1("attr1");
+    DB.save(ent1);
+    
+    MainEntityRelation rel1 = new MainEntityRelation();
+    rel1.setId1("ent1");
+    rel1.setId2("ent2");
+    DB.save(rel1);
+    
+    ViewMainEntityRelation vwRel1 = DB.find(ViewMainEntityRelation.class).findOne();
+    
+    assertEquals("ent1", vwRel1.getEntity1().getId());
+    assertEquals("ent2", vwRel1.getEntity2().getId());
+    
+    assertEquals("attr1", vwRel1.getEntity1().getAttr1());
+    //assertNull(vwRel1.getEntity2().getAttr1());
+    
+    PathProperties pathProp = new PathProperties();
+    pathProp.addToPath(null, "attr1");
+    pathProp.addToPath("entity1", "id");
+    pathProp.addToPath("entity2", "id");
+    
+    Query<ViewMainEntityRelation> query = Ebean.find(ViewMainEntityRelation.class).apply(pathProp);
+    List<ViewMainEntityRelation> list = query.findList();
+    assertEquals(1, list.size());
+    
+    assertEquals("ent1", list.get(0).getEntity1().getId());
+    assertEquals("ent2", list.get(0).getEntity2().getId());
+    
+    assertEquals("select t0.id, t0.attr1, t0.id1, t0.id2 from vw_main_entity_relation t0",
+        query.getGeneratedSql());
+  }
+}

--- a/src/test/java/org/tests/lazyforeignkeys/ViewMainEntity.java
+++ b/src/test/java/org/tests/lazyforeignkeys/ViewMainEntity.java
@@ -1,0 +1,42 @@
+package org.tests.lazyforeignkeys;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import io.ebean.annotation.View;
+
+@View(name = "vw_main_entity")
+@Entity
+public class ViewMainEntity {
+
+  @Id
+  private String id;
+
+  private String attr1;
+  
+  private String attr2;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getAttr1() {
+    return attr1;
+  }
+
+  public void setAttr1(String attr1) {
+    this.attr1 = attr1;
+  }
+
+  public String getAttr2() {
+    return attr2;
+  }
+
+  public void setAttr2(String attr2) {
+    this.attr2 = attr2;
+  }
+}

--- a/src/test/java/org/tests/lazyforeignkeys/ViewMainEntityRelation.java
+++ b/src/test/java/org/tests/lazyforeignkeys/ViewMainEntityRelation.java
@@ -1,0 +1,47 @@
+package org.tests.lazyforeignkeys;
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import io.ebean.annotation.DbForeignKey;
+import io.ebean.annotation.View;
+
+@View(name = "vw_main_entity_relation")
+@Entity
+public class ViewMainEntityRelation {
+
+  @Id
+  private UUID id;
+
+  @ManyToOne
+  @JoinColumn(name = "id1")
+  @DbForeignKey(noConstraint = true)
+  private MainEntity entity1;
+  
+  @ManyToOne
+  @JoinColumn(name = "id2")
+  @DbForeignKey(noConstraint = true)
+  private MainEntity entity2;
+  
+  private String attr1;
+
+  public String getAttr1() {
+    return attr1;
+  }
+
+  public void setAttr1(String attr1) {
+    this.attr1 = attr1;
+  }
+
+  public MainEntity getEntity1() {
+    return entity1;
+  }
+
+  public MainEntity getEntity2() {
+    return entity2;
+  }
+}

--- a/src/test/resources/dbmigration/migrationtest/h2/R__main_entity_views.sql
+++ b/src/test/resources/dbmigration/migrationtest/h2/R__main_entity_views.sql
@@ -1,0 +1,8 @@
+
+
+    create or replace view vw_main_entity as
+    select * from main_entity;
+    
+    create or replace view vw_main_entity_relation as
+    select * from main_entity_relation;
+  

--- a/src/test/resources/extra-ddl.xml
+++ b/src/test/resources/extra-ddl.xml
@@ -4,8 +4,12 @@
   <ddl-script name="order views" platforms="h2" drop="true">
       drop view order_agg_vw if exists;
   </ddl-script>
+  <ddl-script name="main entity views" platforms="h2" drop="true">
+      drop view vw_main_entity if exists;
+      drop view vw_main_entity_relation if exists;
+  </ddl-script>
+  
   <ddl-script name="order views" platforms="db2,h2,postgres,oracle,mysql">
-
     create or replace view order_agg_vw as
     select d.order_id, sum(d.order_qty * d.unit_price) as order_total,
            sum(d.ship_qty * d.unit_price) as ship_total
@@ -13,6 +17,14 @@
     group by d.order_id
   </ddl-script>
 
+  <ddl-script name="main entity views" platforms="db2,h2,postgres,oracle,mysql">
+    create or replace view vw_main_entity as
+    select * from main_entity;
+    
+    create or replace view vw_main_entity_relation as
+    select * from main_entity_relation;
+  </ddl-script>
+  
   <ddl-script name="order views hsqldb" platforms="hsqldb">
     drop view order_agg_vw if exists ;
     create view order_agg_vw as


### PR DESCRIPTION
When you explicitly select properties, you may not access to the origin id of a deleted reference