### PR TITLE
backdoor to disable @Transactional during unit testing

### DIFF
--- a/src/main/java/io/ebeaninternal/api/HelpScopeTrans.java
+++ b/src/main/java/io/ebeaninternal/api/HelpScopeTrans.java
@@ -7,22 +7,37 @@ import io.ebean.TxScope;
  * Helper object to make AOP generated code simpler.
  */
 public class HelpScopeTrans {
+  private static boolean enabled = true;
 
   /**
    * Entering an enhanced transactional method.
    */
   public static void enter(TxScope txScope) {
-    server().scopedTransactionEnter(txScope);
+    if (enabled) {
+      server().scopedTransactionEnter(txScope);
+    }
   }
 
   /**
    * Exiting an enhanced transactional method.
    */
   public static void exit(Object returnOrThrowable, int opCode) {
-    server().scopedTransactionExit(returnOrThrowable, opCode);
+    if (enabled) {
+      server().scopedTransactionExit(returnOrThrowable, opCode);
+    }
   }
 
   private static SpiEbeanServer server() {
     return (SpiEbeanServer) Ebean.getDefaultServer();
+  }
+
+  /**
+   * Defines if the @Transactional does what is supposed to do or is disabled
+   * (useful only unit testing)
+   *
+   * @param enabled if set to false, @Transactional will not create a transaction
+   */
+  public static void setEnabled(boolean enabled) {
+    HelpScopeTrans.enabled = enabled;
   }
 }

--- a/src/test/java/io/ebeaninternal/api/HelpScopeTransTest.java
+++ b/src/test/java/io/ebeaninternal/api/HelpScopeTransTest.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.api;
 
 import io.ebean.Ebean;
 import io.ebean.TxScope;
+import org.junit.Assert;
 import org.junit.Test;
 import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
@@ -31,6 +32,19 @@ public class HelpScopeTransTest {
 
     HelpScopeTrans.exit(null, 1);
     HelpScopeTrans.exit(null, 1);
+  }
+
+  @Test
+  public void disableTransaction() {
+    HelpScopeTrans.setEnabled(false);
+
+    try {
+      HelpScopeTrans.enter(TxScope.required());
+      Assert.assertNull(Ebean.getDefaultServer().currentTransaction());
+      HelpScopeTrans.exit(null, 1);
+    } finally {
+      HelpScopeTrans.setEnabled(true);
+    }
   }
 
 }


### PR DESCRIPTION
```
HelpScopeTrans.setEnabled(false)
```

disables the creation of transactions.

I'm open to changes with the way to do this.