### PR TITLE
When an application is redeployed on tomcat, DtoQueries may fail with wrong MethodLookup

### DIFF
--- a/src/main/java/io/ebeaninternal/server/dto/DtoMetaConstructor.java
+++ b/src/main/java/io/ebeaninternal/server/dto/DtoMetaConstructor.java
@@ -12,11 +12,13 @@ import java.sql.SQLException;
 
 class DtoMetaConstructor {
 
-	private final Class<?>[] types;
-	private final MethodHandle handle;
+  private final Class<?>[] types;
+  private final MethodHandle handle;
+
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
   private final ScalarType<?>[] scalarTypes;
 
-	DtoMetaConstructor(TypeManager typeManager, Constructor<?> constructor, Class<?> someClass) throws NoSuchMethodException, IllegalAccessException {
+  DtoMetaConstructor(TypeManager typeManager, Constructor<?> constructor, Class<?> someClass) throws NoSuchMethodException, IllegalAccessException {
 
     this.types = constructor.getParameterTypes();
     this.scalarTypes = new ScalarType[types.length];
@@ -24,13 +26,12 @@ class DtoMetaConstructor {
       scalarTypes[i] = typeManager.getScalarType(types[i]);
     }
 
-    MethodHandles.Lookup lookup = MethodHandles.publicLookup();
-		this.handle = lookup.findConstructor(someClass, typeFor(types));
-	}
+    this.handle = LOOKUP.findConstructor(someClass, typeFor(types));
+  }
 
-	private MethodType typeFor(Class<?>[] types) {
-		return MethodType.methodType(void.class, types);
-	}
+  private MethodType typeFor(Class<?>[] types) {
+    return MethodType.methodType(void.class, types);
+  }
 
   Class<?>[] getTypes() {
     return types;
@@ -48,7 +49,7 @@ class DtoMetaConstructor {
     }
   }
 
-	public Object process(DataReader dataReader) throws SQLException {
+  public Object process(DataReader dataReader) throws SQLException {
     Object[] values = new Object[scalarTypes.length];
     for (int i = 0; i < scalarTypes.length; i++) {
       values[i] = scalarTypes[i].read(dataReader);
@@ -56,12 +57,12 @@ class DtoMetaConstructor {
     return invoke(values);
   }
 
-	private Object invoke(Object... args) {
-	  try {
-	    return handle.invokeWithArguments(args);
+  private Object invoke(Object... args) {
+    try {
+      return handle.invokeWithArguments(args);
     } catch (Throwable e) {
-	    throw new RuntimeException("Unexpected error invoking constructor", e);
+      throw new RuntimeException("Unexpected error invoking constructor", e);
     }
-	}
+  }
 
 }

--- a/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
+++ b/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
@@ -13,6 +13,8 @@ import java.sql.SQLException;
 
 class DtoMetaProperty implements DtoReadSet {
 
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
   private final Class<?> dtoType;
   private final String name;
   private final MethodHandle setter;
@@ -28,8 +30,7 @@ class DtoMetaProperty implements DtoReadSet {
 
       Class<?> propertyType = descriptor.getPropertyType();
 
-      MethodHandles.Lookup lookup = MethodHandles.publicLookup();
-      this.setter = lookup.findVirtual(dtoType, writeMethod.getName(), MethodType.methodType(void.class, propertyType));
+      this.setter = LOOKUP.findVirtual(dtoType, writeMethod.getName(), MethodType.methodType(void.class, propertyType));
       this.scalarType = typeManager.getScalarType(propertyType);
 
     } else {


### PR DESCRIPTION
We have a web application where we have the following DTO bean
```java
@Data // from lombok, generates getter + setters
public static final class MigQueryDto {
	private UUID id;
	private String sqlQuery;
	private JsonNode paramProperties; // jackson is part of the WAR file
}
```
After a redeploy, the DTO stops working with an `IllegalAccessException: no such method: setParamProperties(JsonNode)void/invokeVirtual` caused by `java.lang.LinkageError: loader constraint violation` (see full stack below)

The issue here is, that the "JsonNode" class is part of the WAR file (respectively loaded by tomcat's WebAppClassLoader). On the first deploy, `MethodHandles.publicLookup().findVirtual` has no problem, to find the method handle, after a redeploy, it fails with the stack trace below.

So, I changed the publicLookup to `MethodHandles.lookup()` which is caller sensitive (and also class loader sensitive) - so this solves my problem. Unfortunately, it would not be easy to write a test for this.

```
java.lang.IllegalAccessException: no such method: de.foconis.core.domain.dbconnection.MigrateParametersJdbcMigration$MigQueryDto.setParamProperties(JsonNode)void/invokeVirtual
        at java.lang.invoke.MemberName.makeAccessException(MemberName.java:867)
        at java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1003)
        at java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:1386)
        at java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:861)
        at io.ebeaninternal.server.dto.DtoMetaProperty.<init>(DtoMetaProperty.java:32)
        at io.ebeaninternal.server.dto.DtoMetaBuilder.readProperties(DtoMetaBuilder.java:51)
        at io.ebeaninternal.server.dto.DtoMetaBuilder.build(DtoMetaBuilder.java:40)
        at io.ebeaninternal.server.dto.DtoBeanManager.createDescriptor(DtoBeanManager.java:40)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
        at io.ebeaninternal.server.dto.DtoBeanManager.getDescriptor(DtoBeanManager.java:34)
        at io.ebeaninternal.server.core.DefaultServer.findDto(DefaultServer.java:1006)
        at io.ebean.Ebean.findDto(Ebean.java:1074)
        at de.foconis.core.domain.dbconnection.MigrateParametersJdbcMigration.migrateDbQueries(MigrateParametersJdbcMigration.java:61)
        at de.foconis.core.domain.dbconnection.MigrateParametersJdbcMigration.migrate(MigrateParametersJdbcMigration.java:55)
        at de.foconis.core.api.migration.AbstractJdbcMigration.migrate(AbstractJdbcMigration.java:59)
        at dbmigration.sqlserver17.V1_152_1__MigrateParameters.migrate(V1_152_1__MigrateParameters.java:22)
        at io.ebean.migration.runner.MigrationTable.executeMigration(MigrationTable.java:367)
        at io.ebean.migration.runner.MigrationTable.runMigration(MigrationTable.java:286)
        at io.ebean.migration.runner.MigrationTable.shouldRun(MigrationTable.java:253)
        at io.ebean.migration.runner.MigrationTable.runAll(MigrationTable.java:455)
        at io.ebean.migration.MigrationRunner.runMigrations(MigrationRunner.java:149)
        at io.ebean.migration.MigrationRunner.run(MigrationRunner.java:109)
        at io.ebean.migration.MigrationRunner.run(MigrationRunner.java:89)
        at io.ebean.migration.MigrationRunner.run(MigrationRunner.java:67)
        at io.ebean.config.ServerConfig.runDbMigration(ServerConfig.java:3297)
        at io.ebeaninternal.server.core.DefaultServer.initDatabase(DefaultServer.java:341)
        at de.foconis.core.app.DoRegisterTenants.createOrUpdateDatabase(DoRegisterTenants.java:245)
        at de.foconis.core.app.DoRegisterTenants.registerRoot(DoRegisterTenants.java:219)
        at de.foconis.core.app.FocApplication.startServer(FocApplication.java:315)
        at de.foconis.core.app.FocApplication.boot(FocApplication.java:272)
        at de.foconis.core.app.FocApplication.onApplicationEvent(FocApplication.java:230)
        at de.foconis.core.app.FocApplication.onApplicationEvent(FocApplication.java:1)
        at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172)
        at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165)
        at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139)
        at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:402)
        at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:359)
        at org.springframework.boot.context.event.EventPublishingRunListener.running(EventPublishingRunListener.java:102)
        at org.springframework.boot.SpringApplicationRunListeners.running(SpringApplicationRunListeners.java:77)
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:326)
        at org.springframework.boot.web.servlet.support.SpringBootServletInitializer.run(SpringBootServletInitializer.java:151)
        at org.springframework.boot.web.servlet.support.SpringBootServletInitializer.createRootApplicationContext(SpringBootServletInitializer.java:131)
        at org.springframework.boot.web.servlet.support.SpringBootServletInitializer.onStartup(SpringBootServletInitializer.java:91)
        at org.springframework.web.SpringServletContainerInitializer.onStartup(SpringServletContainerInitializer.java:171)
        at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5225)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
        at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:754)
        at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:730)
        at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:744)
        at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:980)
        at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1851)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method "de.foconis.core.domain.dbconnection.MigrateParametersJdbcMigration$MigQueryDto.setParamProperties(Lcom/fasterxml/jackson/databind                     /JsonNode;)V" the class loader (instance of <bootloader>) of the current class, java/lang/Object, and the class loader (instance of org/apache/catalina/loader/ParallelWebappClassLoader) for the method's defining clas                     s, de/foconis/core/domain/dbconnection/MigrateParametersJdbcMigration$MigQueryDto, have different Class objects for the type com/fasterxml/jackson/databind/JsonNode used in the signature
        at java.lang.invoke.MethodHandleNatives.resolve(Native Method)
        at java.lang.invoke.MemberName$Factory.resolve(MemberName.java:975)
        at java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1000)
        ... 54 more
```