### PR TITLE
refresh does not work on oneToMany if property was not yet accessed

### DIFF
--- a/src/test/java/io/ebean/EbeanServer_refresh.java
+++ b/src/test/java/io/ebean/EbeanServer_refresh.java
@@ -3,12 +3,14 @@ package io.ebean;
 import org.junit.Test;
 import org.tests.model.basic.EBasic;
 import org.tests.model.basic.Order;
+import org.tests.model.basic.OrderDetail;
 import org.tests.model.basic.ResetBasicData;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class EbeanServer_refresh {
@@ -77,4 +79,77 @@ public class EbeanServer_refresh {
     Ebean.refresh(order);
   }
 
+
+
+  @Test
+  public void refresh_on_details_new() {
+
+    ResetBasicData.reset();
+
+    Order order = Ebean.find(Order.class, 1);
+
+    DB.refresh(order); // call refresh BEFORE first access on "getDetail";
+
+    assertThat(order.getDetails()).hasSize(3);
+
+    OrderDetail detail = new OrderDetail();
+    detail.setOrder(order);
+    DB.save(detail);
+
+    try {
+
+      assertThat(order.getDetails()).hasSize(3);
+
+      DB.refresh(order);
+
+      assertThat(order.getDetails()).hasSize(4);
+
+    } finally {
+      DB.delete(detail); // restore old state
+    }
+
+    DB.refresh(order);
+
+    assertThat(order.getDetails()).hasSize(3);
+  }
+
+
+
+  @Test
+  public void refresh_on_details_changed() {
+
+    ResetBasicData.reset();
+
+    Order order = Ebean.find(Order.class, 1);
+
+    DB.refresh(order); // call refresh BEFORE first access on "getDetail"
+    // this changes the loader of the details-bean collection from DefaultServer to DLoadManyContext$LoadBuffer
+    // if this refresh is commented out, the test will pass
+
+    assertThat(order.getDetails().get(0).getOrderQty()).isEqualTo(5);
+
+    // search the detail in the DB and change qty to 42
+    OrderDetail detail = DB.find(OrderDetail.class, order.getDetails().get(0).getId());
+    assertThat(order.getDetails().get(0)).isEqualTo(detail).isNotSameAs(detail);
+    detail.setOrderQty(42);
+    DB.save(detail);
+
+    try {
+      assertThat(order.getDetails().get(0).getOrderQty()).isEqualTo(5);
+
+      DB.refresh(order);
+
+      assertThat(order.getDetails().get(0).getOrderQty()).isEqualTo(42);
+
+    } finally {
+      // restore old value
+      detail.setOrderQty(5);
+      DB.save(detail);
+    }
+
+    DB.refresh(order);
+
+    assertThat(order.getDetails().get(0).getOrderQty()).isEqualTo(5);
+
+  }
 }


### PR DESCRIPTION
This shows an issue in DB.refresh

**Actual behaviour**

If the code is in this order 
```java
Order order = Ebean.find(Order.class, 1);
DB.refresh(order); // call refresh, before "details" were accessed
order.getDetails();
... change details
DB.refresh(order);
order.getDetails();
```
the refresh will not work properly.

Calling `order.getDetails();` before `DB.refresh(order);` will work.
The issue is probably, that the BeanCollectionLoaderis changed by refresh from DefaultServer to DLoadManyContext which holds a PersistenceContext, where the "old" bean is stored.

So, I do not get the values stored in DB (adding new entries works)
see provided test cases

**Expected behaviour**
Calling DB.refresh should always return the current values stored in the database

**How to reproduce**
```
mvn clean verify -Dtest="EbeanServer_refresh"
[ERROR] Failures:
[ERROR]   EbeanServer_refresh.refresh_on_details_changed:142 expected:<[42]> but was:<[5]>
```
NOTE: test will only fail if executed separately 