### PR TITLE
exists() limits the max rows on the query, this should be done on a copy

### DIFF
--- a/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1351,8 +1351,9 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   public <T> boolean exists(SpiQuery<?> ormQuery, SpiTransaction transaction) {
 
-    ormQuery.setMaxRows(1);
-    SpiOrmQueryRequest<?> request = createQueryRequest(Type.ID_LIST, ormQuery, transaction);
+    Query<?> ormQueryCopy = ormQuery.copy();
+    ormQueryCopy.setMaxRows(1);
+    SpiOrmQueryRequest<?> request = createQueryRequest(Type.ID_LIST, ormQueryCopy, transaction);
     try {
       request.initTransIfRequired();
       List<Object> ids = request.findIds();

--- a/src/test/java/org/tests/query/TestQueryExists.java
+++ b/src/test/java/org/tests/query/TestQueryExists.java
@@ -3,6 +3,8 @@ package org.tests.query;
 import io.ebean.BaseTestCase;
 import io.ebean.Ebean;
 import io.ebean.Query;
+import io.ebeantest.LoggedSql;
+
 import org.junit.Test;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
@@ -23,10 +25,11 @@ public class TestQueryExists extends BaseTestCase {
       .where().gt("id", 1)
       .query();
 
+    LoggedSql.start();
     boolean check = query.exists();
+    String sql = LoggedSql.stop().get(0);
     assertThat(check).isTrue();
 
-    String sql = sqlOf(query);
     if (isH2() || isPostgres()) {
       assertThat(sql).contains("select t0.id from o_order t0 where t0.id > ? limit 1");
     }


### PR DESCRIPTION
Hi Rob,

When I began to replace all the 'query.findCount() > 1' code with 'query.exists()', I realized that exists() modifies the query (sets the max rows size to 1). This should be done on a copy of the query so that the original query can be re-used after calling exists().

I simply changed the code so that exists() calls copy() before query modifications.

Best regards,
Manuel