### PR TITLE
Refactor rename method ProfileLocation.shortDescription() to location()

### DIFF
--- a/src/main/java/io/ebean/ProfileLocation.java
+++ b/src/main/java/io/ebean/ProfileLocation.java
@@ -38,7 +38,7 @@ public interface ProfileLocation {
   /**
    * Return a short version of the location description.
    */
-  String shortDescription();
+  String location();
 
   /**
    * Return the short label.

--- a/src/main/java/io/ebeaninternal/server/profile/BasicProfileLocation.java
+++ b/src/main/java/io/ebeaninternal/server/profile/BasicProfileLocation.java
@@ -7,19 +7,19 @@ import io.ebean.ProfileLocation;
  */
 final class BasicProfileLocation implements ProfileLocation {
 
+  private final String fullLocation;
   private final String location;
-  private final String shortDescription;
   private final String label;
 
-  BasicProfileLocation(String location) {
-    this.location = location;
-    this.shortDescription = shortDesc(location);
-    this.label = UtilLocation.label(shortDescription);
+  BasicProfileLocation(String fullLocation) {
+    this.fullLocation = fullLocation;
+    this.location = shortDesc(fullLocation);
+    this.label = UtilLocation.label(location);
   }
 
   @Override
   public String toString() {
-    return shortDescription;
+    return location;
   }
 
   @Override
@@ -29,7 +29,7 @@ final class BasicProfileLocation implements ProfileLocation {
 
   @Override
   public String obtain() {
-    return location;
+    return fullLocation;
   }
 
   @Override
@@ -38,8 +38,8 @@ final class BasicProfileLocation implements ProfileLocation {
   }
 
   @Override
-  public String shortDescription() {
-    return shortDescription;
+  public String location() {
+    return location;
   }
 
   private String shortDesc(String location) {

--- a/src/main/java/io/ebeaninternal/server/profile/DProfileLocation.java
+++ b/src/main/java/io/ebeaninternal/server/profile/DProfileLocation.java
@@ -11,9 +11,9 @@ class DProfileLocation implements ProfileLocation {
 
   private static final String UNKNOWN = "unknown";
 
-  private String location;
+  private String fullLocation;
 
-  private String shortDescription;
+  private String location;
 
   private String label;
 
@@ -43,15 +43,15 @@ class DProfileLocation implements ProfileLocation {
   @Override
   public String obtain() {
     // atomic assignments so happy enough with this (racing but atomic)
-    if (location == null) {
+    if (fullLocation == null) {
       final String loc = create();
       final String shortDesc = shortDesc(loc);
       label = UtilLocation.label(shortDesc);
-      shortDescription = shortDesc;
-      location = loc;
+      location = shortDesc;
+      fullLocation = loc;
       initWith(label);
     }
-    return location;
+    return fullLocation;
   }
 
   protected void initWith(String label) {
@@ -64,8 +64,8 @@ class DProfileLocation implements ProfileLocation {
   }
 
   @Override
-  public String shortDescription() {
-    return shortDescription;
+  public String location() {
+    return location;
   }
 
   private String create() {

--- a/src/main/java/io/ebeaninternal/server/profile/DQueryPlanMeta.java
+++ b/src/main/java/io/ebeaninternal/server/profile/DQueryPlanMeta.java
@@ -39,7 +39,7 @@ class DQueryPlanMeta {
   }
 
   public String getLocation() {
-    return (profileLocation == null) ? null : profileLocation.shortDescription();
+    return (profileLocation == null) ? null : profileLocation.location();
   }
 
   public String getSql() {

--- a/src/main/java/io/ebeaninternal/server/profile/DTimedProfileLocation.java
+++ b/src/main/java/io/ebeaninternal/server/profile/DTimedProfileLocation.java
@@ -53,7 +53,7 @@ class DTimedProfileLocation extends DProfileLocation implements TimedProfileLoca
       if (overrideMetricName) {
         collect.setName(fullName);
       }
-      collect.setLocation(shortDescription());
+      collect.setLocation(location());
       visitor.visitTimed(collect);
     }
   }

--- a/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
+++ b/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
@@ -176,7 +176,7 @@ public class CQueryPlan {
   }
 
   private String location() {
-    return (profileLocation == null) ? null : profileLocation.shortDescription();
+    return (profileLocation == null) ? null : profileLocation.location();
   }
 
   private CQueryPlanKey buildPlanKey(String sql, boolean rowNumberIncluded, String logWhereSql) {

--- a/src/test/java/io/ebean/DtoQueryFromOrmTest.java
+++ b/src/test/java/io/ebean/DtoQueryFromOrmTest.java
@@ -63,7 +63,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
     for (MetaQueryMetric stat : stats) {
       long meanMicros = stat.getMean();
       assertThat(meanMicros).isLessThan(900_000);
-      assertThat(stat.getLocation()).isSameAs(loc0.shortDescription());
+      assertThat(stat.getLocation()).isSameAs(loc0.location());
     }
 
     assertThat(stats).hasSize(1);

--- a/src/test/java/io/ebeaninternal/server/profile/BasicProfileLocationTest.java
+++ b/src/test/java/io/ebeaninternal/server/profile/BasicProfileLocationTest.java
@@ -14,7 +14,7 @@ public class BasicProfileLocationTest {
     DProfileLocation loc = new DTimedProfileLocation(12, "foo", MetricFactory.get().createTimedMetric(MetricType.TXN, "junk"));
 
     assertThat(loc.obtain()).endsWith(":12)");
-    assertThat(loc.shortDescription()).isEqualTo("NativeMethodAccessorImpl.invoke0(Native Method:12)");
+    assertThat(loc.location()).isEqualTo("NativeMethodAccessorImpl.invoke0(Native Method:12)");
     assertThat(loc.label()).isEqualTo("NativeMethodAccessorImpl.invoke0");
 
   }
@@ -24,7 +24,7 @@ public class BasicProfileLocationTest {
 
     BasicProfileLocation loc = new BasicProfileLocation("com.foo.Bar.all");
     assertThat(loc.obtain()).isEqualTo("com.foo.Bar.all");
-    assertThat(loc.shortDescription()).isEqualTo("Bar.all");
+    assertThat(loc.location()).isEqualTo("Bar.all");
     assertThat(loc.label()).isEqualTo("Bar.all");
   }
 
@@ -33,7 +33,7 @@ public class BasicProfileLocationTest {
 
     BasicProfileLocation loc = new BasicProfileLocation("foo.Bar.all");
     assertThat(loc.obtain()).isEqualTo("foo.Bar.all");
-    assertThat(loc.shortDescription()).isEqualTo("Bar.all");
+    assertThat(loc.location()).isEqualTo("Bar.all");
     assertThat(loc.label()).isEqualTo("Bar.all");
   }
 }

--- a/src/test/java/org/tests/profile/ProfileLocationTest.java
+++ b/src/test/java/org/tests/profile/ProfileLocationTest.java
@@ -19,7 +19,7 @@ public class ProfileLocationTest {
   public void test_obtain() {
 
     assertThat(doIt()).isEqualTo("org.tests.profile.ProfileLocationTest.doIt(ProfileLocationTest.java:15)");
-    assertThat(loc.shortDescription()).isEqualTo("ProfileLocationTest.doIt(ProfileLocationTest.java:15)");
+    assertThat(loc.location()).isEqualTo("ProfileLocationTest.doIt(ProfileLocationTest.java:15)");
     assertThat(loc.label()).isEqualTo("ProfileLocationTest.doIt");
   }
 
@@ -35,7 +35,7 @@ public class ProfileLocationTest {
     other.hashCode();
 
     assertThat(loc2.label()).isEqualTo("ProfileLocationTest$Other.init");
-    assertThat(loc2.shortDescription()).isEqualTo("ProfileLocationTest$Other.<init>(ProfileLocationTest.java:44)");
+    assertThat(loc2.location()).isEqualTo("ProfileLocationTest$Other.<init>(ProfileLocationTest.java:44)");
   }
 
   static class Other {


### PR DESCRIPTION
location is strictly speaking the shortened version of the full location but it is the most useful and currently we don't use full location.

Renaming to `location()` makes sense.