### PR TITLE
Testcase for #1902

### DIFF
--- a/src/test/java/org/tests/model/basic/VwCustomer.java
+++ b/src/test/java/org/tests/model/basic/VwCustomer.java
@@ -1,0 +1,228 @@
+package org.tests.model.basic;
+
+import io.ebean.annotation.Cache;
+import io.ebean.annotation.ChangeLog;
+import io.ebean.annotation.ChangeLogInsertMode;
+import io.ebean.annotation.DbComment;
+import io.ebean.annotation.DbEnumValue;
+import io.ebean.annotation.DocEmbedded;
+import io.ebean.annotation.DocStore;
+import io.ebean.annotation.JsonIgnore;
+import io.ebean.annotation.View;
+import io.ebean.annotation.Where;
+import org.tests.model.basic.finder.CustomerFinder;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.OneToMany;
+import javax.persistence.Transient;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Customer entity bean.
+ */
+@NamedQueries(
+  value = {
+    @NamedQuery(name = "name", query = "select(name) order by name"),
+    @NamedQuery(name = "withStatus", query = "select(name,status) order by name")
+  }
+)
+@NamedQuery(name = "withContacts", query = "fetch contacts (firstName, lastName) where id = :id")
+@Cache(enableQueryCache = true)
+@DocStore
+@ChangeLog(inserts = ChangeLogInsertMode.EXCLUDE, updatesThatInclude = {"name", "status"})
+@Entity
+@View(name = "o_customer", // treat table like a view...
+  dependentTables =  "o_customer")
+@DbComment("Holds external customers")
+public class VwCustomer extends BasicDomain {
+
+  private static final long serialVersionUID = 1L;
+
+  public static final CustomerFinder find = new CustomerFinder();
+
+  /**
+   * EnumValue is an Ebean specific mapping for enums.
+   */
+  public enum Status {
+    NEW("N"),
+    ACTIVE("A"),
+    INACTIVE("I");
+
+    String dbValue;
+
+    Status(String dbValue) {
+      this.dbValue = dbValue;
+    }
+
+    @DbEnumValue
+    public String getValue() {
+      return dbValue;
+    }
+  }
+
+  @Transient
+  Boolean selected;
+
+
+  @JsonIgnore
+  //@Expose(deserialize = false, serialize = false)
+  @Transient
+  ReentrantLock lock = new ReentrantLock();
+
+  @DbComment("status of the customer")
+  Status status;
+
+  @NotNull
+  @Size(max = 40)
+  String name;
+
+  @DbComment("Short notes regarding the customer")
+  @Size(max = 100)
+  String smallnote;
+
+  @DbComment("Join date of the customer")
+  @NotNull(groups = {ValidationGroupSomething.class})
+  Date anniversary;
+
+  @DocEmbedded(doc = "*,country(*)")
+  @ManyToOne(cascade = CascadeType.ALL)
+  Address billingAddress;
+
+  @DocEmbedded(doc = "*,country(*)")
+  @ManyToOne(cascade = CascadeType.ALL)
+  Address shippingAddress;
+
+  @OneToMany(mappedBy = "customer")
+  @Where(clause = "${ta}.order_date is not null")
+  List<Order> orders;
+
+  @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL)
+  List<Contact> contacts;
+
+  @Override
+  public String toString() {
+    return id + " " + status + " " + name;
+  }
+
+  /**
+   * Return name.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Set name.
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Return billing address.
+   */
+  public Address getBillingAddress() {
+    return billingAddress;
+  }
+
+  /**
+   * Set billing address.
+   */
+  public void setBillingAddress(Address billingAddress) {
+    this.billingAddress = billingAddress;
+  }
+
+  /**
+   * Return status.
+   */
+  public Status getStatus() {
+    return status;
+  }
+
+  /**
+   * Set status.
+   */
+  public void setStatus(Status status) {
+    this.status = status;
+  }
+
+  /**
+   * Return shipping address.
+   */
+  public Address getShippingAddress() {
+    return shippingAddress;
+  }
+
+  /**
+   * Set shipping address.
+   */
+  public void setShippingAddress(Address shippingAddress) {
+    this.shippingAddress = shippingAddress;
+  }
+
+  /**
+   * Return orders.
+   */
+  public List<Order> getOrders() {
+    return orders;
+  }
+
+  /**
+   * Set orders.
+   */
+  public void setOrders(List<Order> orders) {
+    this.orders = orders;
+  }
+
+  public Boolean getSelected() {
+    return selected;
+  }
+
+  public void setSelected(Boolean selected) {
+    this.selected = selected;
+  }
+
+  public ReentrantLock getLock() {
+    return lock;
+  }
+
+  public String getSmallnote() {
+    return smallnote;
+  }
+
+  public void setSmallnote(String smallnote) {
+    this.smallnote = smallnote;
+  }
+
+  public Date getAnniversary() {
+    return anniversary;
+  }
+
+  public void setAnniversary(Date anniversary) {
+    this.anniversary = anniversary;
+  }
+
+  public List<Contact> getContacts() {
+    return contacts;
+  }
+
+  public void setContacts(List<Contact> contacts) {
+    this.contacts = contacts;
+  }
+
+  public void addContact(Contact contact) {
+    if (contacts == null) {
+      contacts = new ArrayList<>();
+    }
+    contacts.add(contact);
+  }
+}

--- a/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -14,6 +14,7 @@ import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
 import org.tests.model.basic.ResetBasicData;
+import org.tests.model.basic.VwCustomer;
 
 import java.sql.Date;
 import java.time.LocalDate;
@@ -286,6 +287,20 @@ public class TestQuerySingleAttribute extends BaseTestCase {
 
     assertThat(cities).contains("Auckland").containsNull();
     assertThat(sqlOf(query)).contains("select t1.city from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id");
+  }
+
+  @Test
+  public void findSingleWithFetchOnView() {
+
+    ResetBasicData.reset();
+
+    Query<VwCustomer> query = Ebean.find(VwCustomer.class)
+      .fetch("billingAddress", "city");
+
+    List<String> cities = query.findSingleAttributeList();
+
+    assertThat(sqlOf(query)).contains("select t1.city from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id");
+    assertThat(cities).contains("Auckland").containsNull();
   }
 
   @Test


### PR DESCRIPTION
Hello Rob,

I think we need to call `setDefaultSelectClause()` or an other fix.

Take a look at this test case. 
```
    Query<Customer> query = Ebean.find(Customer.class)
      .fetch("billingAddress", "city");
```
vs
```
    Query<VwCustomer> query = Ebean.find(VwCustomer.class)
      .fetch("billingAddress", "city");
```
The `VwCustomer` is a copy of `Customer`, but uses `@View` instead of `@Table` annotation.
(i use no real view here, but this should not matter)

the assertion `assertThat(cities).contains("Auckland").containsNull();` fails with:
```
java.lang.AssertionError: 
Expecting:
 <[NEW, NEW, ACTIVE, ACTIVE]>
to contain:
 <["Auckland"]>
but could not find:
 <["Auckland"]>
```

you see, that the produced query has all root properties selected:
```
java.lang.AssertionError: 
Expecting:
 <"select t0.status, t0.name, t0.smallnote, t0.anniversary, t0.cretime, t0.updtime, t0.version, t0.shipping_address_id, t1.city from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id ">
to contain:
 <"select t1.city from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id"> 
	at org.tests.query.other.TestQuerySingleAttribute.findSingleWithFetchOnView(TestQuerySingleAttribute.java:302)
```	

