### PR TITLE
Test usingDatabase with a non default db

### DIFF
--- a/src/test/java/org/tests/basic/TestQueryUsingConnection.java
+++ b/src/test/java/org/tests/basic/TestQueryUsingConnection.java
@@ -20,21 +20,6 @@ import static org.junit.Assert.assertEquals;
 public class TestQueryUsingConnection extends BaseTestCase {
 
   @Test
-  public void usingDatabase() {
-
-    ResetBasicData.reset();
-
-    final Database database = DB.getDefault();
-
-    int count =
-      DB.find(Country.class)
-        .usingDatabase(database)
-        .findCount();
-
-    assertThat(count).isGreaterThan(0);
-  }
-
-  @Test
   public void usingConnection() throws SQLException {
 
     ResetBasicData.reset();

--- a/src/test/java/org/tests/basic/TestQueryUsingDatabase.java
+++ b/src/test/java/org/tests/basic/TestQueryUsingDatabase.java
@@ -1,0 +1,36 @@
+package org.tests.basic;
+
+import io.ebean.DB;
+import io.ebean.Database;
+import org.junit.Before;
+import org.junit.Test;
+import org.tests.model.basic.ESimple;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestQueryUsingDatabase {
+
+  private static final String SOME_OTHER_DB_NAME = "someotherdb";
+  public static final ESimple RECORD1 = new ESimple();
+  public static final ESimple RECORD2 = new ESimple();
+
+  @Before
+  public void setupNonDefaultDatabase() {
+    DB.byName(SOME_OTHER_DB_NAME).insert(RECORD1);
+    DB.byName(SOME_OTHER_DB_NAME).insert(RECORD2);
+  }
+
+  @Test
+  public void usingNonDefaultDatabase() {
+    final Database nonDefaultDb = DB.byName(SOME_OTHER_DB_NAME);
+
+    List<ESimple> orderList = DB.find(ESimple.class)
+      .usingDatabase(nonDefaultDb)
+      .findList();
+
+    assertThat(orderList).size().isEqualTo(2);
+    assertThat(orderList).containsExactlyInAnyOrder(RECORD1, RECORD2);
+  }
+}

--- a/src/test/resources/test-ebean.properties
+++ b/src/test/resources/test-ebean.properties
@@ -6,3 +6,7 @@ ebean.jodaLocalTimeMode=normal
 
 #ebean.skipCacheAfterWrite=false
 
+datasource.someotherdb.username=sa
+datasource.someotherdb.password=
+datasource.someotherdb.databaseUrl=jdbc:h2:mem:someotherdb
+datasource.someotherdb.databaseDriver=org.h2.Driver


### PR DESCRIPTION
Move the test to separate class with a better name.
I did not think the test was sufficiently testing the purpose of this method, which I assume was provided to be able to use a different, non-default DB, when querying.
Commenting out the 
```
this.server = (SpiEbeanServer) database; 
```
assignment in io.ebeaninternal.server.querydefn.DefaultOrmQuery#usingDatabase did not make the original test fail.
