### PR TITLE
Refactor rename Transaction methods - setBatchGetGeneratedKeys(), setBatchFlushOnMixed() setBatchFlushOnQuery() ... (remove the "batch" part)

### DIFF
--- a/src/main/java/io/ebean/Transaction.java
+++ b/src/main/java/io/ebean/Transaction.java
@@ -313,7 +313,7 @@ public interface Transaction extends AutoCloseable {
    * <h3>getGeneratedKeys</h3>
    * <p>
    * Often with large batch inserts we want to turn off getGeneratedKeys. We do
-   * this via {@link #setBatchGetGeneratedKeys(boolean)}.
+   * this via {@link #setGetGeneratedKeys(boolean)}.
    * Also note that some JDBC drivers do not support getGeneratedKeys in JDBC batch mode.
    * </p>
    * <pre>{@code
@@ -342,7 +342,7 @@ public interface Transaction extends AutoCloseable {
    * </p>
    * <p>
    * We use {@link #flush()} to explicitly flush the batch and we can use
-   * {@link #setBatchFlushOnQuery(boolean)} and {@link #setBatchFlushOnMixed(boolean)}
+   * {@link #setFlushOnQuery(boolean)} and {@link #setFlushOnMixed(boolean)}
    * to control the automatic flushing behaviour.
    * </p>
    * <p>
@@ -432,7 +432,15 @@ public interface Transaction extends AutoCloseable {
    * number of objects and you don't care about getting back the ids.
    * </p>
    */
-  void setBatchGetGeneratedKeys(boolean getGeneratedKeys);
+  void setGetGeneratedKeys(boolean getGeneratedKeys);
+
+  /**
+   * Deprecated renamed to setGetGeneratedKeys().
+   */
+  @Deprecated
+  default void setBatchGetGeneratedKeys(boolean getGeneratedKeys) {
+    setGetGeneratedKeys(getGeneratedKeys);
+  }
 
   /**
    * By default when mixing UpdateSql (or CallableSql) with Beans the batch is
@@ -449,7 +457,15 @@ public interface Transaction extends AutoCloseable {
    * have a 2 step process (delayed binding).
    * </p>
    */
-  void setBatchFlushOnMixed(boolean batchFlushOnMixed);
+  void setFlushOnMixed(boolean batchFlushOnMixed);
+
+  /**
+   * Deprecated renamed to setFlushOnMixed().
+   */
+  @Deprecated
+  default void setBatchFlushOnMixed(boolean batchFlushOnMixed) {
+    setFlushOnMixed(batchFlushOnMixed);
+  }
 
   /**
    * By default executing a query will automatically flush any batched
@@ -459,7 +475,15 @@ public interface Transaction extends AutoCloseable {
    * execute a query and the batch will not be automatically flushed.
    * </p>
    */
-  void setBatchFlushOnQuery(boolean batchFlushOnQuery);
+  void setFlushOnQuery(boolean batchFlushOnQuery);
+
+  /**
+   * Deprecated renamed to setFlushOnQuery().
+   */
+  @Deprecated
+  default void setBatchFlushOnQuery(boolean batchFlushOnQuery) {
+    setFlushOnQuery(batchFlushOnQuery);
+  }
 
   /**
    * Return true if the batch (of persisted beans or executed UpdateSql etc)
@@ -468,7 +492,15 @@ public interface Transaction extends AutoCloseable {
    * The default is for this to be true.
    * </p>
    */
-  boolean isBatchFlushOnQuery();
+  boolean isFlushOnQuery();
+
+  /**
+   * Deprecated renamed to isFlushOnQuery().
+   */
+  @Deprecated
+  default boolean isBatchFlushOnQuery() {
+    return isFlushOnQuery();
+  }
 
   /**
    * The batch will be flushing automatically but you can use this to explicitly

--- a/src/main/java/io/ebean/text/csv/DefaultCsvCallback.java
+++ b/src/main/java/io/ebean/text/csv/DefaultCsvCallback.java
@@ -171,7 +171,7 @@ public class DefaultCsvCallback<T> implements CsvCallback<T> {
         logger.info("Creating transaction, batchSize[" + persistBatchSize + "]");
         transaction.setBatchMode(true);
         transaction.setBatchSize(persistBatchSize);
-        transaction.setBatchGetGeneratedKeys(false);
+        transaction.setGetGeneratedKeys(false);
 
       } else {
         // explicitly turn off JDBC batching in case

--- a/src/main/java/io/ebeaninternal/api/ScopeTrans.java
+++ b/src/main/java/io/ebeaninternal/api/ScopeTrans.java
@@ -71,13 +71,13 @@ public class ScopeTrans {
         restoreBatchOnCascade = transaction.isBatchOnCascade();
         restoreBatchSize = transaction.getBatchSize();
         restoreBatchGeneratedKeys = transaction.getBatchGetGeneratedKeys();
-        restoreBatchFlushOnQuery = transaction.isBatchFlushOnQuery();
+        restoreBatchFlushOnQuery = transaction.isFlushOnQuery();
       }
       if (txScope.isBatchSet()) {
         transaction.setBatchMode(txScope.isBatchMode());
       }
       if (!txScope.isFlushOnQuery()) {
-        transaction.setBatchFlushOnQuery(false);
+        transaction.setFlushOnQuery(false);
       }
       if (txScope.isBatchOnCascadeSet()) {
         transaction.setBatchOnCascade(txScope.isBatchOnCascade());
@@ -86,7 +86,7 @@ public class ScopeTrans {
         transaction.setBatchSize(txScope.getBatchSize());
       }
       if (txScope.isSkipGeneratedKeys()) {
-        transaction.setBatchGetGeneratedKeys(false);
+        transaction.setGetGeneratedKeys(false);
       }
     }
 
@@ -136,7 +136,7 @@ public class ScopeTrans {
       transaction.commit();
     } else {
       nestedCommit = true;
-      transaction.setBatchFlushOnQuery(restoreBatchFlushOnQuery);
+      transaction.setFlushOnQuery(restoreBatchFlushOnQuery);
       if (restoreBatch != null) {
         transaction.setBatchMode(restoreBatch);
       }
@@ -147,7 +147,7 @@ public class ScopeTrans {
         transaction.setBatchSize(restoreBatchSize);
       }
       if (restoreBatchGeneratedKeys != null) {
-        transaction.setBatchGetGeneratedKeys(restoreBatchGeneratedKeys);
+        transaction.setGetGeneratedKeys(restoreBatchGeneratedKeys);
       }
     }
   }

--- a/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
+++ b/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
@@ -269,8 +269,8 @@ public abstract class SpiTransactionProxy implements SpiTransaction {
   }
 
   @Override
-  public void setBatchGetGeneratedKeys(boolean getGeneratedKeys) {
-    transaction.setBatchGetGeneratedKeys(getGeneratedKeys);
+  public void setGetGeneratedKeys(boolean getGeneratedKeys) {
+    transaction.setGetGeneratedKeys(getGeneratedKeys);
   }
 
   @Override
@@ -279,18 +279,18 @@ public abstract class SpiTransactionProxy implements SpiTransaction {
   }
 
   @Override
-  public void setBatchFlushOnMixed(boolean batchFlushOnMixed) {
-    transaction.setBatchFlushOnMixed(batchFlushOnMixed);
+  public void setFlushOnMixed(boolean batchFlushOnMixed) {
+    transaction.setFlushOnMixed(batchFlushOnMixed);
   }
 
   @Override
-  public void setBatchFlushOnQuery(boolean batchFlushOnQuery) {
-    transaction.setBatchFlushOnQuery(batchFlushOnQuery);
+  public void setFlushOnQuery(boolean batchFlushOnQuery) {
+    transaction.setFlushOnQuery(batchFlushOnQuery);
   }
 
   @Override
-  public boolean isBatchFlushOnQuery() {
-    return transaction.isBatchFlushOnQuery();
+  public boolean isFlushOnQuery() {
+    return transaction.isFlushOnQuery();
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/server/query/DefaultOrmQueryEngine.java
+++ b/src/main/java/io/ebeaninternal/server/query/DefaultOrmQueryEngine.java
@@ -54,7 +54,7 @@ public class DefaultOrmQueryEngine implements OrmQueryEngine {
   private <T> void flushJdbcBatchOnQuery(OrmQueryRequest<T> request) {
 
     SpiTransaction t = request.getTransaction();
-    if (t.isBatchFlushOnQuery()) {
+    if (t.isFlushOnQuery()) {
       // before we perform a query, we need to flush any
       // previous persist requests that are queued/batched.
       // The query may read data affected by those requests.

--- a/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -302,11 +302,11 @@ class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEventCode
   }
 
   @Override
-  public void setBatchGetGeneratedKeys(boolean getGeneratedKeys) {
+  public void setGetGeneratedKeys(boolean getGeneratedKeys) {
   }
 
   @Override
-  public void setBatchFlushOnMixed(boolean batchFlushOnMixed) {
+  public void setFlushOnMixed(boolean batchFlushOnMixed) {
   }
 
   /**
@@ -325,12 +325,12 @@ class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEventCode
   }
 
   @Override
-  public boolean isBatchFlushOnQuery() {
+  public boolean isFlushOnQuery() {
     return false;
   }
 
   @Override
-  public void setBatchFlushOnQuery(boolean batchFlushOnQuery) {
+  public void setFlushOnQuery(boolean batchFlushOnQuery) {
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -589,7 +589,7 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   }
 
   @Override
-  public void setBatchGetGeneratedKeys(boolean getGeneratedKeys) {
+  public void setGetGeneratedKeys(boolean getGeneratedKeys) {
     this.batchGetGeneratedKeys = getGeneratedKeys;
     if (batchControl != null) {
       batchControl.setGetGeneratedKeys(getGeneratedKeys);
@@ -597,7 +597,7 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   }
 
   @Override
-  public void setBatchFlushOnMixed(boolean batchFlushOnMixed) {
+  public void setFlushOnMixed(boolean batchFlushOnMixed) {
     this.batchFlushOnMixed = batchFlushOnMixed;
     if (batchControl != null) {
       batchControl.setBatchFlushOnMixed(batchFlushOnMixed);
@@ -624,12 +624,12 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   }
 
   @Override
-  public boolean isBatchFlushOnQuery() {
+  public boolean isFlushOnQuery() {
     return batchFlushOnQuery;
   }
 
   @Override
-  public void setBatchFlushOnQuery(boolean batchFlushOnQuery) {
+  public void setFlushOnQuery(boolean batchFlushOnQuery) {
     this.batchFlushOnQuery = batchFlushOnQuery;
   }
 

--- a/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
+++ b/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
@@ -233,19 +233,19 @@ class NoTransaction implements SpiTransaction {
   }
 
   @Override
-  public void setBatchGetGeneratedKeys(boolean getGeneratedKeys) {
+  public void setGetGeneratedKeys(boolean getGeneratedKeys) {
   }
 
   @Override
-  public void setBatchFlushOnMixed(boolean batchFlushOnMixed) {
+  public void setFlushOnMixed(boolean batchFlushOnMixed) {
   }
 
   @Override
-  public void setBatchFlushOnQuery(boolean batchFlushOnQuery) {
+  public void setFlushOnQuery(boolean batchFlushOnQuery) {
   }
 
   @Override
-  public boolean isBatchFlushOnQuery() {
+  public boolean isFlushOnQuery() {
     return false;
   }
 

--- a/src/test/java/org/tests/batchinsert/TestBatchInsertSimple.java
+++ b/src/test/java/org/tests/batchinsert/TestBatchInsertSimple.java
@@ -34,7 +34,7 @@ public class TestBatchInsertSimple extends BaseTestCase {
       transaction.setBatchOnCascade(true);
       transaction.setBatchSize(30);
       // setBatchGetGeneratedKeys MUST be turned off for MS SQL Server because :(
-      transaction.setBatchGetGeneratedKeys(false);
+      transaction.setGetGeneratedKeys(false);
 
       for (int i = 0; i < numOfMasters; i++) {
         UTMaster master = createMasterAndDetails(i, 20);
@@ -108,7 +108,7 @@ public class TestBatchInsertSimple extends BaseTestCase {
       transaction.setBatchOnCascade(true);
       transaction.setBatchSize(30);
       // setBatchGetGeneratedKeys MUST be turned off for MS SQL Server because :(
-      transaction.setBatchGetGeneratedKeys(false);
+      transaction.setGetGeneratedKeys(false);
 
       for (int i = 0; i < numOfMasters; i++) {
         UTMaster master = createMaster(i);

--- a/src/test/java/org/tests/transaction/TestSqlServerBatch.java
+++ b/src/test/java/org/tests/transaction/TestSqlServerBatch.java
@@ -49,11 +49,11 @@ public class TestSqlServerBatch extends BaseTestCase {
       txn.setBatchSize(3);
 
       // control flushing when mixing save and queries
-      txn.setBatchFlushOnQuery(false);
+      txn.setFlushOnQuery(false);
 
       // for large batch insert processing when we do not
       // ... need the generatedKeys, don't get them
-      txn.setBatchGetGeneratedKeys(false);
+      txn.setGetGeneratedKeys(false);
 
       // explicitly flush the JDBC batch buffer
       txn.flushBatch();


### PR DESCRIPTION
- `setBatchGetGeneratedKeys(...)` migrate to `setGetGeneratedKeys(...)`
- `setBatchFlushOnMixed(...)` migrate to `setFlushOnMixed(...)`
- `setBatchFlushOnQuery(...)` migrate to `setFlushOnQuery(...)`
- `isBatchFlushOnQuery(...)` migrate to `isFlushOnQuery(...)`