### PR TITLE
"insert into table default values" is invalid MySQL syntax

### DIFF
--- a/src/main/java/io/ebeaninternal/server/persist/dml/InsertMeta.java
+++ b/src/main/java/io/ebeaninternal/server/persist/dml/InsertMeta.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.persist.dml;
 
+import io.ebean.annotation.Platform;
 import io.ebean.bean.EntityBean;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebeaninternal.server.core.PersistRequestBean;
@@ -44,7 +45,10 @@ final class InsertMeta {
 
   private final String[] identityDbColumns;
 
+  private final Platform platform;
+
   InsertMeta(DatabasePlatform dbPlatform, BeanDescriptor<?> desc, Bindable shadowFKey, BindableId id, BindableList all) {
+    this.platform = dbPlatform.getPlatform();
     this.discriminator = getDiscriminator(desc);
     this.id = id;
     this.all = all;
@@ -162,7 +166,11 @@ final class InsertMeta {
 
     request.append("insert into ").append(table);
     if (nullId && noColumnsForInsert(draftTable)) {
-      request.append(" default values");
+      if (this.platform.base() == Platform.MYSQL) {
+        request.append(" values (default)");
+      } else {
+        request.append(" default values");
+      }
       return request.toString();
     }
 

--- a/src/test/java/org/tests/defaultvalues/DefaultsModel.java
+++ b/src/test/java/org/tests/defaultvalues/DefaultsModel.java
@@ -1,0 +1,48 @@
+package org.tests.defaultvalues;
+
+import io.ebean.annotation.Draft;
+import io.ebean.annotation.Draftable;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.List;
+
+@Entity
+@Draftable
+public class DefaultsModel {
+
+  @Id
+  Integer id;
+
+  @Draft
+  boolean draft;
+
+  @OneToMany(cascade = CascadeType.ALL)
+  List<ReferencedDefaultsModel> relatedModels;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public List<ReferencedDefaultsModel> getRelatedModels() {
+    return relatedModels;
+  }
+
+  public void setRelatedModels(final List<ReferencedDefaultsModel> relatedModels) {
+    this.relatedModels = relatedModels;
+  }
+
+  public boolean isDraft() {
+    return draft;
+  }
+
+  public void setDraft(final boolean draft) {
+    this.draft = draft;
+  }
+}

--- a/src/test/java/org/tests/defaultvalues/ReferencedDefaultsModel.java
+++ b/src/test/java/org/tests/defaultvalues/ReferencedDefaultsModel.java
@@ -1,0 +1,44 @@
+package org.tests.defaultvalues;
+
+import io.ebean.annotation.Draft;
+import io.ebean.annotation.Draftable;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Draftable
+public class ReferencedDefaultsModel {
+
+  @Id
+  Integer id;
+
+  String name;
+
+  @Draft
+  boolean draft;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public boolean isDraft() {
+    return draft;
+  }
+
+  public void setDraft(final boolean draft) {
+    this.draft = draft;
+  }
+}

--- a/src/test/java/org/tests/defaultvalues/TestDefaults.java
+++ b/src/test/java/org/tests/defaultvalues/TestDefaults.java
@@ -1,0 +1,36 @@
+package org.tests.defaultvalues;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import org.ebeantest.LoggedSqlCollector;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDefaults extends BaseTestCase {
+
+  @Test
+  public void testInsertDefaultValues() {
+    final DefaultsModel main = new DefaultsModel();
+
+    for (int i = 0; i < 5; i++) {
+      final ReferencedDefaultsModel ref = new ReferencedDefaultsModel();
+      ref.setName("r" + i);
+      main.getRelatedModels().add(ref);
+    }
+
+    LoggedSqlCollector.start();
+    Ebean.save(main);
+    final List<String> current = LoggedSqlCollector.current();
+
+    assertThat(current).isNotEmpty();
+    if (isMySql()) {
+      assertThat(current.get(0)).contains("insert into defaults_model_draft values (default);");
+    } else {
+      assertThat(current.get(0)).contains("insert into defaults_model_draft default values;");
+    }
+  }
+
+}


### PR DESCRIPTION
Hi Rob,

while writing a testcase for another bugfix (coming up next) I found that MySQL has a problem when only inserting default values into a table. This might be kind of an edge case, because there are not many ways of letting a column fallback to the db default, but I fixed it anyway. 
Can you have look, if I did this right?

Best regards
Jonas