### PR TITLE
@OrderColumn does not work on inheritance models

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -1002,6 +1002,7 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
     orderProperty.setDbInsertable(orderColumn.isInsertable());
     orderProperty.setDbUpdateable(orderColumn.isUpdatable());
     orderProperty.setDbRead(true);
+    orderProperty.setOwningType(targetDesc.getBeanType());
 
     targetDesc.setOrderColumn(orderProperty);
   }

--- a/src/test/java/org/tests/order/OrderMaster.java
+++ b/src/test/java/org/tests/order/OrderMaster.java
@@ -1,0 +1,34 @@
+package org.tests.order;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import java.util.List;
+
+@Entity
+public class OrderMaster {
+
+  @Id
+  Long id;
+
+  @OneToMany(mappedBy = "master")
+  @OrderColumn(name = "sort_order")
+  List<OrderReferencedChild> children;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(final Long id) {
+    this.id = id;
+  }
+
+  public List<OrderReferencedChild> getChildren() {
+    return children;
+  }
+
+  public void setChildren(final List<OrderReferencedChild> children) {
+    this.children = children;
+  }
+}

--- a/src/test/java/org/tests/order/OrderReferencedChild.java
+++ b/src/test/java/org/tests/order/OrderReferencedChild.java
@@ -1,0 +1,35 @@
+package org.tests.order;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+@Entity
+@DiscriminatorValue("D")
+public class OrderReferencedChild extends OrderReferencedParent {
+
+  String childName;
+
+  @ManyToOne
+  OrderMaster master;
+
+  public OrderReferencedChild(final String name) {
+    super(name);
+  }
+
+  public String getChildName() {
+    return childName;
+  }
+
+  public void setChildName(final String childName) {
+    this.childName = childName;
+  }
+
+  public OrderMaster getMaster() {
+    return master;
+  }
+
+  public void setMaster(final OrderMaster master) {
+    this.master = master;
+  }
+}

--- a/src/test/java/org/tests/order/OrderReferencedParent.java
+++ b/src/test/java/org/tests/order/OrderReferencedParent.java
@@ -1,0 +1,43 @@
+package org.tests.order;
+
+import io.ebean.annotation.Index;
+
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.MappedSuperclass;
+
+@Entity
+@MappedSuperclass
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+@Index(columnNames = "type")
+public class OrderReferencedParent {
+
+  @Id
+  Long id;
+
+  String name;
+
+  public OrderReferencedParent(final String name) {
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(final Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/tests/order/TestOrderColumn.java
+++ b/src/test/java/org/tests/order/TestOrderColumn.java
@@ -1,0 +1,31 @@
+package org.tests.order;
+
+import io.ebean.Ebean;
+import io.ebean.TransactionalTestCase;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOrderColumn extends TransactionalTestCase {
+
+  @Test
+  public void testOrderColumnInheritance() {
+    final OrderMaster master = new OrderMaster();
+
+    for (int i = 0; i < 5; i++) {
+      final OrderReferencedChild child = new OrderReferencedChild("p" + i);
+      child.setChildName("c" + i);
+
+      master.getChildren().add(child);
+    }
+
+    Ebean.save(master);
+
+    final OrderMaster result = Ebean.find(OrderMaster.class).findOne();
+
+    assertThat(result.getChildren()).hasSize(5);
+    assertThat(result.getChildren()).extracting(OrderReferencedChild::getName).containsExactly("p0", "p1", "p2", "p3", "p4");
+    assertThat(result.getChildren()).extracting(OrderReferencedChild::getChildName).containsExactly("c0", "c1", "c2", "c3", "c4");
+  }
+
+}


### PR DESCRIPTION
Hello Rob,

when using @OrderColumn on a reference to a model using inheritance, a NullPointerException¹ is raised, when trying to access the elements after loading the parent from the databse. I provided a testcase and a one-line-fix. I hope, that I got the right spot for fixing this issue.

Best regards
Jonas

¹ Stacktrace:
```
java.lang.NullPointerException
	at io.ebeaninternal.server.deploy.BeanProperty.isAssignableFrom(BeanProperty.java:623)
	at io.ebeaninternal.server.query.SqlBeanLoad.load(SqlBeanLoad.java:60)
	at io.ebeaninternal.server.deploy.BeanProperty.load(BeanProperty.java:633)
	at io.ebeaninternal.server.deploy.BeanDescriptor.inheritanceLoad(BeanDescriptor.java:3033)
	at io.ebeaninternal.server.query.SqlTreeNodeBean$LoadInherit.loadProperties(SqlTreeNodeBean.java:249)
	at io.ebeaninternal.server.query.SqlTreeNodeBean$Load.initialise(SqlTreeNodeBean.java:469)
	at io.ebeaninternal.server.query.SqlTreeNodeBean.load(SqlTreeNodeBean.java:481)
	at io.ebeaninternal.server.query.CQuery.readNextBean(CQuery.java:451)
	at io.ebeaninternal.server.query.CQuery.hasNext(CQuery.java:535)
	at io.ebeaninternal.server.query.CQuery.readCollection(CQuery.java:566)
	at io.ebeaninternal.server.query.CQueryEngine.findMany(CQueryEngine.java:396)
	at io.ebeaninternal.server.query.DefaultOrmQueryEngine.findMany(DefaultOrmQueryEngine.java:131)
	at io.ebeaninternal.server.core.OrmQueryRequest.findList(OrmQueryRequest.java:472)
	at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1618)
	at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1594)
	at io.ebeaninternal.server.core.DefaultBeanLoader.executeQuery(DefaultBeanLoader.java:180)
	at io.ebeaninternal.server.core.DefaultBeanLoader.loadMany(DefaultBeanLoader.java:45)
	at io.ebeaninternal.server.core.DefaultServer.loadMany(DefaultServer.java:563)
	at io.ebeaninternal.server.loadcontext.DLoadManyContext$LoadBuffer.loadMany(DLoadManyContext.java:233)
	at io.ebean.common.AbstractBeanCollection.lazyLoadCollection(AbstractBeanCollection.java:98)
	at io.ebean.common.BeanList.init(BeanList.java:135)
	at io.ebean.common.BeanList.size(BeanList.java:459)
	at org.assertj.core.util.IterableUtil.sizeOf(IterableUtil.java:48)
	at org.assertj.core.internal.Iterables.assertHasSize(Iterables.java:197)
	at org.assertj.core.api.AbstractIterableAssert.hasSize(AbstractIterableAssert.java:159)
	at org.tests.order.TestOrderColumn.testOrderColumnInheritance(TestOrderColumn.java:26)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at io.ebean.ConditionalTestRunner.runChild(ConditionalTestRunner.java:33)
	at io.ebean.ConditionalTestRunner.runChild(ConditionalTestRunner.java:16)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)
```