### PR TITLE
Use temp variable to avoid NPE race

### DIFF
--- a/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -913,6 +913,7 @@ public final class EntityBeanIntercept implements Serializable {
   }
 
   private void preGetterCallback(int propertyIndex) {
+    PreGetterCallback preGetterCallback = this.preGetterCallback;
     if (preGetterCallback != null) {
       preGetterCallback.preGetterTrigger(propertyIndex);
     }


### PR DESCRIPTION
By using a temporary variable, avoid NullPointerException.

Resolves #1980