### PR TITLE
@OrderColumn is ignored on relations referencing a abstract inheritance-model

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -44,9 +44,9 @@ import io.ebeaninternal.server.deploy.meta.DeployBeanPropertyAssoc;
 import io.ebeaninternal.server.deploy.meta.DeployBeanPropertyAssocMany;
 import io.ebeaninternal.server.deploy.meta.DeployBeanPropertyAssocOne;
 import io.ebeaninternal.server.deploy.meta.DeployBeanTable;
+import io.ebeaninternal.server.deploy.meta.DeployIdentityMode;
 import io.ebeaninternal.server.deploy.meta.DeployOrderColumn;
 import io.ebeaninternal.server.deploy.meta.DeployTableJoin;
-import io.ebeaninternal.server.deploy.meta.DeployIdentityMode;
 import io.ebeaninternal.server.deploy.parse.DeployBeanInfo;
 import io.ebeaninternal.server.deploy.parse.DeployCreateProperties;
 import io.ebeaninternal.server.deploy.parse.DeployInherit;
@@ -1003,6 +1003,14 @@ public class BeanDescriptorManager implements BeanDescriptorMap {
     orderProperty.setDbUpdateable(orderColumn.isUpdatable());
     orderProperty.setDbRead(true);
     orderProperty.setOwningType(targetDesc.getBeanType());
+
+    final InheritInfo targetInheritInfo = targetDesc.getInheritInfo();
+    if (targetInheritInfo != null) {
+      for (InheritInfo child : targetInheritInfo.getChildren()) {
+        final DeployBeanDescriptor<?> childDescriptor = deployInfoMap.get(child.getType()).getDescriptor();
+        childDescriptor.setOrderColumn(orderProperty);
+      }
+    }
 
     targetDesc.setOrderColumn(orderProperty);
   }

--- a/src/test/java/org/tests/inheritance/TestInheritanceOrderColumn.java
+++ b/src/test/java/org/tests/inheritance/TestInheritanceOrderColumn.java
@@ -1,0 +1,68 @@
+package org.tests.inheritance;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import io.ebeantest.LoggedSql;
+import org.ebeantest.LoggedSqlCollector;
+import org.junit.Test;
+import org.tests.inheritance.order.OrderMasterInheritance;
+import org.tests.inheritance.order.OrderedA;
+import org.tests.inheritance.order.OrderedB;
+import org.tests.inheritance.order.OrderedParent;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestInheritanceOrderColumn extends BaseTestCase {
+
+  @Test
+  public void test() {
+    final OrderMasterInheritance master = new OrderMasterInheritance();
+    final OrderedA orderedA = new OrderedA();
+    orderedA.setCommonName("commonOrderedA");
+    orderedA.setOrderedAName("orderedA");
+
+    final OrderedB orderedB = new OrderedB();
+    orderedB.setCommonName("commonOrderedB");
+    orderedB.setOrderedBName("orderedB");
+
+    master.getReferenced().add(orderedA);
+    master.getReferenced().add(orderedB);
+
+    LoggedSqlCollector.start();
+    Ebean.save(master);
+    List<String> sql = LoggedSqlCollector.stop();
+    assertThat(sql).hasSize(5);
+    // Some platforms insert ids and others don't need to...
+    assertSql(sql.get(1))
+      .matches(
+        "txn\\[] insert into ordered_parent \\((id, )?order_master_inheritance_id, dtype, common_name, ordered_aname, sort_order\\).*");
+    assertSql(sql.get(3))
+      .matches(
+        "txn\\[] insert into ordered_parent \\((id, )?order_master_inheritance_id, dtype, common_name, ordered_bname, sort_order\\).*");
+
+    OrderMasterInheritance result = Ebean.find(OrderMasterInheritance.class).findOne();
+    assertThat(result.getReferenced())
+      .extracting(OrderedParent::getCommonName)
+      .containsExactly("commonOrderedA", "commonOrderedB");
+
+    // Swap the two
+    result.getReferenced().add(0, result.getReferenced().remove(1));
+    assertThat(result.getReferenced())
+      .extracting(OrderedParent::getCommonName)
+      .containsExactly("commonOrderedB", "commonOrderedA");
+
+    LoggedSql.start();
+    Ebean.save(result);
+    sql = LoggedSqlCollector.stop();
+    assertThat(sql).hasSize(3);
+    assertThat(sql.get(0)).contains("update ordered_parent set sort_order=? where id=?");
+
+    result = Ebean.find(OrderMasterInheritance.class).findOne();
+    assertThat(result.getReferenced())
+      .extracting(OrderedParent::getCommonName)
+      .containsExactly("commonOrderedB", "commonOrderedA");
+  }
+
+}

--- a/src/test/java/org/tests/inheritance/order/OrderMasterInheritance.java
+++ b/src/test/java/org/tests/inheritance/order/OrderMasterInheritance.java
@@ -1,0 +1,36 @@
+package org.tests.inheritance.order;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class OrderMasterInheritance {
+
+  @Id
+  Integer id;
+
+  @OneToMany(cascade = CascadeType.ALL)
+  @OrderColumn(name = "sort_order")
+  List<OrderedParent> referenced = new ArrayList<>();
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public List<OrderedParent> getReferenced() {
+    return referenced;
+  }
+
+  public void setReferenced(final List<OrderedParent> referenced) {
+    this.referenced = referenced;
+  }
+}

--- a/src/test/java/org/tests/inheritance/order/OrderedA.java
+++ b/src/test/java/org/tests/inheritance/order/OrderedA.java
@@ -1,0 +1,17 @@
+package org.tests.inheritance.order;
+
+import javax.persistence.Entity;
+
+@Entity
+public class OrderedA extends OrderedParent {
+
+  String orderedAName;
+
+  public String getOrderedAName() {
+    return orderedAName;
+  }
+
+  public void setOrderedAName(final String orderedAName) {
+    this.orderedAName = orderedAName;
+  }
+}

--- a/src/test/java/org/tests/inheritance/order/OrderedB.java
+++ b/src/test/java/org/tests/inheritance/order/OrderedB.java
@@ -1,0 +1,17 @@
+package org.tests.inheritance.order;
+
+import javax.persistence.Entity;
+
+@Entity
+public class OrderedB extends OrderedParent {
+
+  String orderedBName;
+
+  public String getOrderedBName() {
+    return orderedBName;
+  }
+
+  public void setOrderedBName(final String orderedBName) {
+    this.orderedBName = orderedBName;
+  }
+}

--- a/src/test/java/org/tests/inheritance/order/OrderedParent.java
+++ b/src/test/java/org/tests/inheritance/order/OrderedParent.java
@@ -1,0 +1,31 @@
+package org.tests.inheritance.order;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+
+@Entity
+@Inheritance
+public abstract class OrderedParent {
+
+  @Id
+  Integer id;
+
+  String commonName;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public String getCommonName() {
+    return commonName;
+  }
+
+  public void setCommonName(final String commonName) {
+    this.commonName = commonName;
+  }
+}


### PR DESCRIPTION
Hello Rob,

This PR shows a problem where the order-column is simply not inserted. The problem was, that the child-descriptor of the implementinig bean did not know of the order-column that was defined on a reference to the parent.
The fix is something probably up for debate. I am not entirly certain, that this is the right spot to fix this. I'm not sure, if this is not possibly too late and the DeployBeanDescriptor of the child was already read, but you should be able to assess this situation.

Best regards
Jonas