### PR TITLE
L1 cache was not invalidated, when reordering a reference with @OrderColumn

### DIFF
--- a/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -178,6 +178,11 @@ public class SaveManyBeans extends SaveManyBase {
 
         if (!skipSavingThisBean) {
           persister.saveRecurse(detail, transaction, parentBean, request.getFlags());
+          if (many.hasOrderColumn()) {
+            // Clear the bean from the PersistenceContext (L1 cache), because the order of referenced beans might have changed
+            final BeanDescriptor<?> beanDescriptor = many.getBeanDescriptor();
+            beanDescriptor.contextClear(transaction.getPersistenceContext(), beanDescriptor.getId(parentBean));
+          }
         }
       }
     }

--- a/src/test/java/org/tests/order/TestOrderColumn.java
+++ b/src/test/java/org/tests/order/TestOrderColumn.java
@@ -4,6 +4,8 @@ import io.ebean.Ebean;
 import io.ebean.TransactionalTestCase;
 import org.junit.Test;
 
+import java.util.Comparator;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOrderColumn extends TransactionalTestCase {
@@ -26,6 +28,35 @@ public class TestOrderColumn extends TransactionalTestCase {
     assertThat(result.getChildren()).hasSize(5);
     assertThat(result.getChildren()).extracting(OrderReferencedChild::getName).containsExactly("p0", "p1", "p2", "p3", "p4");
     assertThat(result.getChildren()).extracting(OrderReferencedChild::getChildName).containsExactly("c0", "c1", "c2", "c3", "c4");
+  }
+
+  @Test
+  public void testOrderColumnSortChange() {
+    final OrderMaster master = new OrderMaster();
+
+    for (int i = 0; i < 5; i++) {
+      final OrderReferencedChild child = new OrderReferencedChild("p" + i);
+      child.setChildName("c" + i);
+
+      master.getChildren().add(child);
+    }
+
+    Ebean.save(master);
+
+    OrderMaster result = Ebean.find(OrderMaster.class).findOne();
+
+    assertThat(result.getChildren()).hasSize(5);
+    assertThat(master.getChildren()).extracting(OrderReferencedChild::getName).containsExactly("p0", "p1", "p2", "p3", "p4");
+
+    master.getChildren().sort(Comparator.comparing(OrderReferencedChild::getName).reversed());
+    assertThat(master.getChildren()).extracting(OrderReferencedChild::getName).containsExactly("p4", "p3", "p2", "p1", "p0");
+
+    Ebean.save(master);
+
+    result = Ebean.find(OrderMaster.class).findOne();
+
+    assertThat(result.getChildren()).hasSize(5);
+    assertThat(result.getChildren()).extracting(OrderReferencedChild::getName).containsExactly("p4", "p3", "p2", "p1", "p0");
   }
 
 }


### PR DESCRIPTION
This PR shows a problem where the L1 cache doesn't get invalidated for a bean, when it has a reordered collection of entities referenced with @OrderColumn.
Unlike the expected condition in the test, the list is not retrieved in the correct order from the "database", because a cached bean with the old order is returned.