### PR TITLE
Removing elements with @OrderColumn with a tree depth > 1 doesn't work

### DIFF
--- a/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -40,6 +40,8 @@ public final class EntityBeanIntercept implements Serializable {
 
   private String ebeanServerName;
 
+  private boolean deletedFromCollection;
+
   /**
    * The actual entity bean that 'owns' this intercept.
    */
@@ -1168,5 +1170,19 @@ public final class EntityBeanIntercept implements Serializable {
       }
     }
     return ret;
+  }
+
+  /**
+   * Returns true if the entity was removed from a BeanCollection. This can be used to track movement from one collection to another.
+   */
+  public boolean isDeletedFromCollection() {
+    return deletedFromCollection;
+  }
+
+  /**
+   * Set if the entity was deleted from a BeanCollection.
+   */
+  public void setDeletedFromCollection(final boolean deletedFromCollection) {
+    this.deletedFromCollection = deletedFromCollection;
   }
 }

--- a/src/main/java/io/ebean/common/ModifyHolder.java
+++ b/src/main/java/io/ebean/common/ModifyHolder.java
@@ -1,5 +1,7 @@
 package io.ebean.common;
 
+import io.ebean.bean.EntityBean;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -54,6 +56,11 @@ class ModifyHolder<E> implements Serializable {
   void modifyAddition(E bean) {
     if (bean != null) {
       touched = true;
+
+      if (bean instanceof EntityBean) {
+        ((EntityBean) bean)._ebean_getIntercept().setDeletedFromCollection(false);
+      }
+
       // If it is to delete then just remove the deletion
       if (!undoDeletion(bean)) {
         // Insert
@@ -70,6 +77,11 @@ class ModifyHolder<E> implements Serializable {
   void modifyRemoval(Object bean) {
     if (bean != null) {
       touched = true;
+
+      if (bean instanceof EntityBean) {
+        ((EntityBean) bean)._ebean_getIntercept().setDeletedFromCollection(true);
+      }
+
       // If it is to be added then just remove the addition
       if (!undoAddition(bean)) {
         modifyDeletions.add((E) bean);

--- a/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static io.ebeaninternal.server.persist.DmlUtil.isNullOrZero;
@@ -108,7 +109,7 @@ public class SaveManyBeans extends SaveManyBase {
     BeanProperty orderColumn = null;
     boolean hasOrderColumn = many.hasOrderColumn();
     if (hasOrderColumn) {
-      if (!insertedParent && canSkipForOrderColumn()) {
+      if (!insertedParent && canSkipForOrderColumn() && saveRecurseSkippable) {
         return;
       }
       orderColumn = targetDescriptor.getOrderColumn();
@@ -157,7 +158,7 @@ public class SaveManyBeans extends SaveManyBase {
         if (many.hasJoinTable()) {
           skipSavingThisBean = targetDescriptor.isReference(ebi);
         } else {
-          if (orderColumn != null) {
+          if (orderColumn != null && !Objects.equals(sortOrder, orderColumn.getValue(detail))) {
             orderColumn.setValue(detail, sortOrder);
             ebi.setDirty(true);
           }

--- a/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -69,7 +69,7 @@ public class SaveManyBeans extends SaveManyBase {
         resetModifyState();
       }
     } else {
-      if (isModifyListenMode()) {
+      if (isModifyListenMode() || many.hasOrderColumn()) {
         // delete any removed beans via private owned. Needs to occur before
         // a 'deleteMissingChildren' statement occurs
         removeAssocManyPrivateOwned();
@@ -343,14 +343,25 @@ public class SaveManyBeans extends SaveManyBase {
 
       BeanCollection<?> c = (BeanCollection<?>) value;
       Set<?> modifyRemovals = c.getModifyRemovals();
-      modifyListenReset(c);
+
+      if (insertedParent) {
+        // after insert set the modify listening mode for private owned etc
+        c.setModifyListening(many.getModifyListenMode());
+      }
+
+      // We must not reset when we still have to update other entities in the collection and set their new orderColumn value
+      if (!many.hasOrderColumn()) {
+        c.modifyReset();
+      }
       if (modifyRemovals != null && !modifyRemovals.isEmpty()) {
         for (Object removedBean : modifyRemovals) {
           if (removedBean instanceof EntityBean) {
             EntityBean eb = (EntityBean) removedBean;
             if (!eb._ebean_getIntercept().isNew()) {
-              // only delete if the bean was loaded meaning that it is known to exist in the DB
-              persister.deleteRequest(persister.createDeleteRemoved(removedBean, transaction, request.getFlags()));
+              if (eb._ebean_intercept().isDeletedFromCollection()) {
+                // only delete if the bean was loaded meaning that it is known to exist in the DB
+                persister.deleteRequest(persister.createDeleteRemoved(removedBean, transaction, request.getFlags()));
+              }
             }
           }
         }

--- a/src/test/java/org/tests/cascade/TestOrderedList.java
+++ b/src/test/java/org/tests/cascade/TestOrderedList.java
@@ -85,11 +85,10 @@ public class TestOrderedList extends BaseTestCase {
     Ebean.save(fresh);
 
     sql = LoggedSqlCollector.current();
-    assertThat(sql).hasSize(8);
-    assertSql(sql.get(0)).contains("update om_ordered_master set name=?, version=?");
-    assertSql(sql.get(1)).contains("update om_ordered_detail set version=?, sort_order=? where id=? and version=?");
-    assertThat(sql.get(3)).contains("update om_ordered_detail set name=?, version=?, sort_order=? where id=? and version=?");
-
+    assertThat(sql).hasSize(3);
+    assertSql(sql.get(0)).contains("update om_ordered_master set name=?, version=? where id=? and version=?; -- bind(m1-mod3");
+    assertSql(sql.get(1)).contains("update om_ordered_detail set name=?, version=?, sort_order=? where id=? and version=?");
+    assertThat(sql.get(2)).contains("bind(was 1,3,2,");
 
     Ebean.delete(fresh);
 

--- a/src/test/java/org/tests/model/version/TestVersionHierarchyModification.java
+++ b/src/test/java/org/tests/model/version/TestVersionHierarchyModification.java
@@ -1,0 +1,118 @@
+package org.tests.model.version;
+
+import io.ebean.BaseTestCase;
+import io.ebean.Ebean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestVersionHierarchyModification extends BaseTestCase {
+
+  @Before
+  public void setup() {
+    final VersionParent parent = new VersionParent();
+    parent.setName("vParent");
+
+    final VersionChild child1 = new VersionChild();
+    child1.setName("vChild1");
+    parent.getChildren().add(child1);
+
+    final VersionToy toy11 = new VersionToy();
+    toy11.setName("vToy1.1");
+    child1.getToys().add(toy11);
+
+    final VersionToy toy12 = new VersionToy();
+    toy12.setName("vToy1.2");
+    child1.getToys().add(toy12);
+
+    final VersionChild child2 = new VersionChild();
+    child2.setName("vChild2");
+    parent.getChildren().add(child2);
+
+    final VersionToy toy21 = new VersionToy();
+    toy21.setName("vToy2.1");
+    child2.getToys().add(toy21);
+
+    final VersionToy toy22 = new VersionToy();
+    toy22.setName("vToy2.2");
+    child2.getToys().add(toy22);
+
+    Ebean.save(parent);
+  }
+
+  @After
+  public void cleanUp() {
+    Ebean.find(VersionParent.class).delete();
+  }
+
+  @Test
+  public void testMoveDown() {
+    VersionParent parent = Ebean.find(VersionParent.class).findOne();
+    assertThat(parent).isNotNull();
+    assertThat(parent.getChildren()).hasSize(2);
+
+    VersionChild firstChild = parent.getChildren().get(0);
+    VersionChild secondChild = parent.getChildren().get(1);
+
+    assertThat(firstChild.getToys()).hasSize(2);
+    assertThat(secondChild.getToys()).hasSize(2);
+    assertThat(firstChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy1.1", "vToy1.2");
+    assertThat(secondChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy2.1", "vToy2.2");
+
+    final VersionToy toyToMove = firstChild.getToys().get(0);
+    firstChild.getToys().remove(toyToMove);
+    toyToMove.setChild(secondChild);
+    secondChild.getToys().add(1, toyToMove);
+
+    Ebean.save(parent);
+
+    parent = Ebean.find(VersionParent.class).findOne();
+    assertThat(parent).isNotNull();
+    assertThat(parent.getChildren()).hasSize(2);
+
+    firstChild = parent.getChildren().get(0);
+    secondChild = parent.getChildren().get(1);
+
+    assertThat(firstChild.getToys()).hasSize(1);
+    assertThat(secondChild.getToys()).hasSize(3);
+    assertThat(firstChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy1.2");
+    assertThat(secondChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy2.1", "vToy1.1", "vToy2.2");
+  }
+
+  @Test
+  public void testMoveUp() {
+    VersionParent parent = Ebean.find(VersionParent.class).findOne();
+    assertThat(parent).isNotNull();
+    assertThat(parent.getChildren()).hasSize(2);
+
+    VersionChild firstChild = parent.getChildren().get(0);
+    VersionChild secondChild = parent.getChildren().get(1);
+
+    assertThat(firstChild.getToys()).hasSize(2);
+    assertThat(secondChild.getToys()).hasSize(2);
+    assertThat(firstChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy1.1", "vToy1.2");
+    assertThat(secondChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy2.1", "vToy2.2");
+
+    final VersionToy toyToMove = secondChild.getToys().get(0);
+    secondChild.getToys().remove(toyToMove);
+    toyToMove.setChild(firstChild);
+    firstChild.getToys().add(1, toyToMove);
+
+    Ebean.save(parent);
+
+    parent = Ebean.find(VersionParent.class).findOne();
+    assertThat(parent).isNotNull();
+    assertThat(parent.getChildren()).hasSize(2);
+
+    firstChild = parent.getChildren().get(0);
+    secondChild = parent.getChildren().get(1);
+
+    assertThat(secondChild.getToys()).hasSize(1);
+    assertThat(firstChild.getToys()).hasSize(3);
+    assertThat(secondChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy2.2");
+    assertThat(firstChild.getToys()).extracting(VersionToy::getName).containsExactly("vToy1.1", "vToy2.1", "vToy1.2");
+  }
+
+}

--- a/src/test/java/org/tests/model/version/VersionChild.java
+++ b/src/test/java/org/tests/model/version/VersionChild.java
@@ -1,0 +1,70 @@
+package org.tests.model.version;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import javax.persistence.Version;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class VersionChild {
+
+  @Id
+  Integer id;
+
+  String name;
+
+  @Version
+  Integer version;
+
+  @OneToMany(mappedBy = "child", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderColumn(name = "position")
+  List<VersionToy> toys = new ArrayList<>();
+
+  @ManyToOne
+  VersionParent parent;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public Integer getVersion() {
+    return version;
+  }
+
+  public void setVersion(final Integer version) {
+    this.version = version;
+  }
+
+  public List<VersionToy> getToys() {
+    return toys;
+  }
+
+  public void setToys(final List<VersionToy> toys) {
+    this.toys = toys;
+  }
+
+  public VersionParent getParent() {
+    return parent;
+  }
+
+  public void setParent(final VersionParent parent) {
+    this.parent = parent;
+  }
+}

--- a/src/test/java/org/tests/model/version/VersionParent.java
+++ b/src/test/java/org/tests/model/version/VersionParent.java
@@ -1,0 +1,58 @@
+package org.tests.model.version;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import javax.persistence.Version;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class VersionParent {
+
+  @Id
+  Integer id;
+
+  @Version
+  Integer version;
+
+  String name;
+
+  @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderColumn(name = "position")
+  List<VersionChild> children = new ArrayList<>();
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public Integer getVersion() {
+    return version;
+  }
+
+  public void setVersion(final Integer version) {
+    this.version = version;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public List<VersionChild> getChildren() {
+    return children;
+  }
+
+  public void setChildren(final List<VersionChild> children) {
+    this.children = children;
+  }
+}

--- a/src/test/java/org/tests/model/version/VersionToy.java
+++ b/src/test/java/org/tests/model/version/VersionToy.java
@@ -1,0 +1,53 @@
+package org.tests.model.version;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Version;
+
+@Entity
+public class VersionToy {
+
+  @Id
+  Integer id;
+
+  String name;
+
+  @Version
+  Integer version;
+
+  @ManyToOne
+  VersionChild child;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public Integer getVersion() {
+    return version;
+  }
+
+  public void setVersion(final Integer version) {
+    this.version = version;
+  }
+
+  public VersionChild getChild() {
+    return child;
+  }
+
+  public void setChild(final VersionChild child) {
+    this.child = child;
+  }
+}

--- a/src/test/java/org/tests/order/OrderReferencedChild.java
+++ b/src/test/java/org/tests/order/OrderReferencedChild.java
@@ -1,8 +1,12 @@
 package org.tests.order;
 
+import javax.persistence.CascadeType;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import java.util.List;
 
 @Entity
 @DiscriminatorValue("D")
@@ -12,6 +16,10 @@ public class OrderReferencedChild extends OrderReferencedParent {
 
   @ManyToOne
   OrderMaster master;
+
+  @OneToMany(cascade = CascadeType.ALL, mappedBy = "child", orphanRemoval = true)
+  @OrderColumn(name = "sort_order")
+  List<OrderToy> toys;
 
   public OrderReferencedChild(final String name) {
     super(name);
@@ -31,5 +39,13 @@ public class OrderReferencedChild extends OrderReferencedParent {
 
   public void setMaster(final OrderMaster master) {
     this.master = master;
+  }
+
+  public List<OrderToy> getToys() {
+    return toys;
+  }
+
+  public void setToys(final List<OrderToy> toys) {
+    this.toys = toys;
   }
 }

--- a/src/test/java/org/tests/order/OrderToy.java
+++ b/src/test/java/org/tests/order/OrderToy.java
@@ -1,0 +1,45 @@
+package org.tests.order;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class OrderToy {
+
+  @Id
+  Integer id;
+
+  String title;
+
+  @ManyToOne
+  OrderReferencedChild child;
+
+  public OrderToy(final String title) {
+    this.title = title;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(final Integer id) {
+    this.id = id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(final String title) {
+    this.title = title;
+  }
+
+  public OrderReferencedChild getChild() {
+    return child;
+  }
+
+  public void setChild(final OrderReferencedChild child) {
+    this.child = child;
+  }
+}

--- a/src/test/java/org/tests/order/TestOrderColumn.java
+++ b/src/test/java/org/tests/order/TestOrderColumn.java
@@ -2,7 +2,10 @@ package org.tests.order;
 
 import io.ebean.Ebean;
 import io.ebean.TransactionalTestCase;
+import org.ebeantest.LoggedSqlCollector;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,6 +29,52 @@ public class TestOrderColumn extends TransactionalTestCase {
     assertThat(result.getChildren()).hasSize(5);
     assertThat(result.getChildren()).extracting(OrderReferencedChild::getName).containsExactly("p0", "p1", "p2", "p3", "p4");
     assertThat(result.getChildren()).extracting(OrderReferencedChild::getChildName).containsExactly("c0", "c1", "c2", "c3", "c4");
+  }
+
+  @Test
+  public void testModifyTree() {
+    final OrderMaster master = new OrderMaster();
+
+    for (int i = 0; i < 5; i++) {
+      final OrderReferencedChild child = new OrderReferencedChild("p" + i);
+      child.setChildName("c" + i);
+
+      for (int j = 0; j < 3; j++) {
+        final OrderToy toy = new OrderToy("t" + i + j);
+        child.getToys().add(toy);
+      }
+
+      master.getChildren().add(child);
+    }
+
+    Ebean.save(master);
+
+    final OrderMaster result = Ebean.find(OrderMaster.class).findOne();
+
+    final List<OrderReferencedChild> children = result.getChildren();
+    assertThat(children).hasSize(5);
+
+    for (int i = 0; i < 5; i++) {
+      final List<OrderToy> toys = children.get(i).getToys();
+
+      for (int j = 0; j < 3; j++) {
+        final OrderToy toy = toys.get(j);
+        assertThat(toy.getTitle()).isEqualTo("t" + i + j);
+      }
+    }
+
+    // modify two toys
+    children.get(1).getToys().get(0).setTitle("tt10");
+    children.get(3).getToys().get(2).setTitle("tt32");
+
+    LoggedSqlCollector.start();
+    Ebean.save(result);
+    final List<String> sql = LoggedSqlCollector.current();
+    assertThat(sql).hasSize(3);
+
+    assertThat(sql.get(0)).contains("update order_toy set title=?, sort_order=? where id=?");
+    assertThat(sql.get(1)).contains("bind(tt10");
+    assertThat(sql.get(2)).contains("bind(tt32");
   }
 
 }

--- a/src/test/java/org/tests/order/TestOrderColumn.java
+++ b/src/test/java/org/tests/order/TestOrderColumn.java
@@ -77,4 +77,41 @@ public class TestOrderColumn extends TransactionalTestCase {
     assertThat(sql.get(2)).contains("bind(tt32");
   }
 
+  @Test
+  public void testRemoveElement() {
+    final OrderMaster master = new OrderMaster();
+
+    for (int i = 0; i < 5; i++) {
+      final OrderReferencedChild child = new OrderReferencedChild("p" + i);
+      child.setChildName("c" + i);
+
+      for (int j = 0; j < 3; j++) {
+        final OrderToy toy = new OrderToy("t" + i + j);
+        child.getToys().add(toy);
+      }
+
+      master.getChildren().add(child);
+    }
+
+    Ebean.save(master);
+
+    final OrderMaster result = Ebean.find(OrderMaster.class).findOne();
+
+    final List<OrderReferencedChild> children = result.getChildren();
+    assertThat(children).hasSize(5);
+
+    final OrderReferencedChild child = children.get(0);
+
+    child.getToys().remove(1);
+
+    LoggedSqlCollector.start();
+    Ebean.save(result);
+    final List<String> sql = LoggedSqlCollector.stop();
+
+    assertThat(sql).hasSize(4);
+    assertSql(sql.get(0)).contains("delete from order_toy where id=?");
+    assertSql(sql.get(2)).contains("update order_toy set sort_order=? where id=?");
+    assertSql(sql.get(3)).contains("bind(2,");
+  }
+
 }


### PR DESCRIPTION
This PR fixes a problem that from the depth > 1 a element is not being deleted from the database when removed from the collection. The other elements get an updated sort order, but the element is not deleted.
During trying to fix this, I also wrote another test for reordering elements on that same level, because my first attempt of fixing this effectively broke that case.
This also depends on this PR: https://github.com/ebean-orm/ebean/pull/1985, which fixes the insert of elements on that level.
The effective diff of this PR is this: https://github.com/FOCONIS/ebean/compare/bugfix/order_column_tree_depth...FOCONIS:bugfix/order_column_remove_and_reorder (sorry for the mess)