### PR TITLE
Add failing test case for lazy loaded list of SoftDeletes

### DIFF
--- a/src/test/java/org/tests/softdelete/TestSoftDeleteBasic.java
+++ b/src/test/java/org/tests/softdelete/TestSoftDeleteBasic.java
@@ -227,6 +227,26 @@ public class TestSoftDeleteBasic extends BaseTestCase {
   }
 
   @Test
+  public void testFindSoftDeletedList() {
+    EBasicSoftDelete bean = new EBasicSoftDelete();
+    bean.setName("softDelFetch");
+    DB.save(bean);
+
+    EBasicSDChild bean2 = new EBasicSDChild(bean, "softDelFetchus", 1L);
+    DB.save(bean2);
+    DB.delete(bean2);
+
+    EBasicSDChild child = DB
+      .find(EBasicSDChild.class)
+      .setIncludeSoftDeletes()
+      .where()
+      .idEq(bean.getId())
+      .findOne();
+    assertThat(child).isNotNull();
+    assertThat(child.getOwner().getChildren().size()).isEqualTo(1);
+  }
+
+  @Test
   public void testDeleteById_and_findCount() {
 
     EBasicSoftDelete bean = new EBasicSoftDelete();


### PR DESCRIPTION
Example:
One X can have many Ys. Ys can be soft deleted.

Y1 -> X1 -> Y1

Y1 is soft deleted

When Y1 is loaded, lazy-loading X1 and then lazy-loading the list of Ys associated with X1,
the list should contain Y1. This test asserts that is true.