### PR TITLE
Refactor SQL generation - remove excess whitespace (double spaces before where, join and order by)

### DIFF
--- a/src/main/java/io/ebeaninternal/server/deploy/DbSqlContext.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/DbSqlContext.java
@@ -45,7 +45,7 @@ public interface DbSqlContext {
   /**
    * Add a raw column to the sql.
    */
-  void appendRawColumn(String rawcolumnWithTableAlias);
+  void appendRawColumn(String rawColumnWithTableAlias);
 
   /**
    * Append a column with an explicit table alias.

--- a/src/main/java/io/ebeaninternal/server/deploy/TableJoin.java
+++ b/src/main/java/io/ebeaninternal/server/deploy/TableJoin.java
@@ -134,7 +134,7 @@ public final class TableJoin {
     String a1 = ctx.getTableAlias(names[0]);
     String a2 = ctx.getTableAlias(prefix);
     addJoin(joinType, a1, a2, ctx);
-    ctx.append("and ").append(a2).append(predicate);
+    ctx.append(" and ").append(a2).append(predicate);
   }
 
   public SqlJoinType addJoin(SqlJoinType joinType, String prefix, DbSqlContext ctx) {

--- a/src/main/java/io/ebeaninternal/server/query/DefaultDbSqlContext.java
+++ b/src/main/java/io/ebeaninternal/server/query/DefaultDbSqlContext.java
@@ -164,7 +164,6 @@ class DefaultDbSqlContext implements DbSqlContext {
     if (addAsOfOnClause) {
       sb.append(" and ").append(historySupport.getAsOfPredicate(a2));
     }
-    sb.append(" ");
   }
 
   private void appendTable(String table, String draftTable) {
@@ -219,14 +218,11 @@ class DefaultDbSqlContext implements DbSqlContext {
 
   @Override
   public void appendFormulaJoin(String sqlFormulaJoin, SqlJoinType joinType) {
-
     // replace ${ta} place holder with the real table alias...
     String tableAlias = tableAliasStack.peek();
     String converted = sqlFormulaJoin.replace(tableAliasPlaceHolder, tableAlias);
-
     if (formulaJoins == null) {
       formulaJoins = new HashSet<>();
-
     } else if (formulaJoins.contains(converted)) {
       // skip adding a formula join because
       // the same join has already been added.
@@ -235,7 +231,6 @@ class DefaultDbSqlContext implements DbSqlContext {
 
     // we only want to add this join once
     formulaJoins.add(converted);
-
     sb.append(" ");
     if (joinType == SqlJoinType.OUTER) {
       if ("join".equals(sqlFormulaJoin.substring(0, 4).toLowerCase())) {
@@ -243,9 +238,7 @@ class DefaultDbSqlContext implements DbSqlContext {
         append(" left ");
       }
     }
-
     sb.append(converted);
-    sb.append(" ");
   }
 
   @Override
@@ -317,9 +310,9 @@ class DefaultDbSqlContext implements DbSqlContext {
   }
 
   @Override
-  public void appendRawColumn(String rawColumnWithAlias) {
+  public void appendRawColumn(String rawColumnWithTableAlias) {
     sb.append(COMMA);
-    sb.append(rawColumnWithAlias);
+    sb.append(rawColumnWithTableAlias);
   }
 
   @Override

--- a/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
+++ b/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
@@ -592,7 +592,7 @@ class SqlTreeNodeBean implements SqlTreeNode {
         ctx.append(" and");
       }
       String ta = ctx.getTableAlias(prefix);
-      ctx.append(" ").append(extraWhere.replace("${ta}", ta)).append(" ");
+      ctx.append(" ").append(extraWhere.replace("${ta}", ta));
     }
   }
 
@@ -669,7 +669,7 @@ class SqlTreeNodeBean implements SqlTreeNode {
        appendJoinDiscriminator(ctx);
     }
     if (desc.isSoftDelete() && temporalMode != SpiQuery.TemporalMode.SOFT_DELETED) {
-      ctx.append("and ").append(desc.getSoftDeletePredicate(ctx.getTableAlias(prefix))).append(" ");
+      ctx.append(" and ").append(desc.getSoftDeletePredicate(ctx.getTableAlias(prefix)));
     }
     return sqlJoinType;
   }
@@ -699,7 +699,7 @@ class SqlTreeNodeBean implements SqlTreeNode {
   void appendJoinDiscriminator(DbSqlContext ctx) {
     if (inheritInfo.getWhere() == null) return;
     String alias = ctx.getTableAlias(prefix);
-    ctx.append(" and ").append(alias).append(".").append(inheritInfo.getWhere()).append(" ");
+    ctx.append(" and ").append(alias).append(".").append(inheritInfo.getWhere());
   }
 
   /**

--- a/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeManyWhereJoin.java
+++ b/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeManyWhereJoin.java
@@ -100,18 +100,17 @@ class SqlTreeNodeManyWhereJoin implements SqlTreeNode {
     if (nodeBeanProp instanceof STreePropertyAssocOne) {
       nodeBeanProp.addJoin(joinType, parentAlias, alias, ctx);
       if (softDelete) {
-        ctx.append("and ").append(target.getSoftDeletePredicate(alias)).append(" ");
+        ctx.append(" and ").append(target.getSoftDeletePredicate(alias));
       }
     } else {
       STreePropertyAssocMany manyProp = (STreePropertyAssocMany) nodeBeanProp;
       if (!manyProp.hasJoinTable()) {
         manyProp.addJoin(joinType, parentAlias, alias, ctx);
         if (softDelete) {
-          ctx.append("and ").append(target.getSoftDeletePredicate(alias)).append(" ");
+          ctx.append(" and ").append(target.getSoftDeletePredicate(alias));
         }
       } else {
         String alias2 = alias + "z_";
-
         TableJoin manyToManyJoin = manyProp.getIntersectionTableJoin();
         manyToManyJoin.addJoin(joinType, parentAlias, alias2, ctx);
         manyProp.addJoin(joinType, alias2, alias, ctx);

--- a/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeRoot.java
+++ b/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeRoot.java
@@ -75,17 +75,14 @@ final class SqlTreeNodeRoot extends SqlTreeNodeBean {
    */
   @Override
   public SqlJoinType appendFromBaseTable(DbSqlContext ctx, SqlJoinType joinType) {
-
     ctx.append(baseTable);
     ctx.append(" ").append(baseTableAlias);
     ctx.appendFromForUpdate();
-
     if (includeJoin != null) {
       String a1 = baseTableAlias;
       String a2 = "int_"; // unique alias for intersection join
       includeJoin.addJoin(joinType, a1, a2, ctx);
     }
-
     return joinType;
   }
 

--- a/src/test/java/io/ebean/FetchGroupTest.java
+++ b/src/test/java/io/ebean/FetchGroupTest.java
@@ -110,7 +110,7 @@ public class FetchGroupTest extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("select t0.id, t0.name, t0.version, t1.id, t1.line_1, t1.line_2, t1.city, t2.code, t2.name from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id  left join o_country t2 on t2.code = t1.country_code ");
+    assertSql(sql.get(0)).contains("select t0.id, t0.name, t0.version, t1.id, t1.line_1, t1.line_2, t1.city, t2.code, t2.name from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id left join o_country t2 on t2.code = t1.country_code ");
   }
 
   @Test

--- a/src/test/java/io/ebean/UpdateQueryTest.java
+++ b/src/test/java/io/ebean/UpdateQueryTest.java
@@ -189,7 +189,7 @@ public class UpdateQueryTest extends BaseTestCase {
 
     query.update();
 
-    assertThat(sqlOf(query)).contains("update o_customer set status=?, updtime=?  where id in (select t0.id from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id  where t0.status = ? and t1.country_code = ? and t0.id > ?)");
+    assertThat(sqlOf(query)).contains("update o_customer set status=?, updtime=?  where id in (select t0.id from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id where t0.status = ? and t1.country_code = ? and t0.id > ?)");
   }
 
   @ForPlatform({Platform.H2, Platform.POSTGRES})
@@ -211,7 +211,7 @@ public class UpdateQueryTest extends BaseTestCase {
       .update();
 
     final List<String> sql = LoggedSqlCollector.stop();
-    assertSql(sql.get(0)).contains("update o_customer set status=?  where id in (select t0.id from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id  where t1.country_code = ? and t0.id > ? limit 100)");
+    assertSql(sql.get(0)).contains("update o_customer set status=?  where id in (select t0.id from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id where t1.country_code = ? and t0.id > ? limit 100)");
   }
 
   @ForPlatform({Platform.H2, Platform.POSTGRES, Platform.MYSQL, Platform.MARIADB})

--- a/src/test/java/io/ebeaninternal/server/expression/IsEmptyExpressionQueryTest.java
+++ b/src/test/java/io/ebeaninternal/server/expression/IsEmptyExpressionQueryTest.java
@@ -125,7 +125,7 @@ public class IsEmptyExpressionQueryTest extends BaseTestCase {
       assertThat(sqlOf(query)).contains("select distinct on (t0.id) t0.id from o_customer t0 join contact u1 on u1.customer_id = t0.id  where not exists (select 1 from contact_note x where x.contact_id = u1.id)");
 
     } else {
-      assertThat(sqlOf(query)).contains("select distinct t0.id from o_customer t0 join contact u1 on u1.customer_id = t0.id  where not exists (select 1 from contact_note x where x.contact_id = u1.id)");
+      assertThat(sqlOf(query)).contains("select distinct t0.id from o_customer t0 join contact u1 on u1.customer_id = t0.id where not exists (select 1 from contact_note x where x.contact_id = u1.id)");
     }
   }
 
@@ -144,7 +144,7 @@ public class IsEmptyExpressionQueryTest extends BaseTestCase {
       assertThat(sqlOf(query)).contains("select distinct on (t0.id) t0.id from o_customer t0 join contact u1 on u1.customer_id = t0.id  where exists (select 1 from contact_note x where x.contact_id = u1.id)");
 
     } else {
-      assertThat(sqlOf(query)).contains("select distinct t0.id from o_customer t0 join contact u1 on u1.customer_id = t0.id  where exists (select 1 from contact_note x where x.contact_id = u1.id)");
+      assertThat(sqlOf(query)).contains("select distinct t0.id from o_customer t0 join contact u1 on u1.customer_id = t0.id where exists (select 1 from contact_note x where x.contact_id = u1.id)");
     }
   }
 

--- a/src/test/java/io/ebeaninternal/server/grammer/EqlParserTest.java
+++ b/src/test/java/io/ebeaninternal/server/grammer/EqlParserTest.java
@@ -507,7 +507,7 @@ public class EqlParserTest extends BaseTestCase {
     Query<Customer> query = parse("select name fetch billingAddress (line1, city) fetch shippingAddress (line1) limit 10");
     query.findList();
 
-    assertSql(query, 12).contains("select t0.id, t0.name, t1.id, t1.line_1, t1.city, t2.id, t2.line_1 from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id  left join o_address t2 on t2.id = t0.shipping_address_id");
+    assertSql(query, 12).contains("select t0.id, t0.name, t1.id, t1.line_1, t1.city, t2.id, t2.line_1 from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id left join o_address t2 on t2.id = t0.shipping_address_id");
   }
 
   @Test
@@ -702,7 +702,7 @@ public class EqlParserTest extends BaseTestCase {
     List<OrderDetail> details = query.findList();
 
     assertThat(details).isNotEmpty();
-    assertSql(query).contains("select sum(t0.order_qty), t1.id from o_order_detail t0 join o_order t1 on t1.id = t0.order_id  group by t1.id");
+    assertSql(query).contains("select sum(t0.order_qty), t1.id from o_order_detail t0 join o_order t1 on t1.id = t0.order_id group by t1.id");
   }
 
   @Test

--- a/src/test/java/org/tests/aggregateformula/TestAggregateFormula.java
+++ b/src/test/java/org/tests/aggregateformula/TestAggregateFormula.java
@@ -122,7 +122,7 @@ public class TestAggregateFormula extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(2);
     assertSql(sql.get(0)).contains("select t0.last_name, min(t0.customer_id) from contact t0 group by t0.last_name");
-    assertSql(sql.get(1)).contains("select t0.id, t0.name, t0.status, t1.id, t1.city, t1.country_code from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id  where");
+    assertSql(sql.get(1)).contains("select t0.id, t0.name, t0.status, t1.id, t1.city, t1.country_code from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id where");
 
     assertThat(contacts).isNotEmpty();
 

--- a/src/test/java/org/tests/delete/TestDeleteByQuery.java
+++ b/src/test/java/org/tests/delete/TestDeleteByQuery.java
@@ -79,7 +79,7 @@ public class TestDeleteByQuery extends BaseTestCase {
 
     List<String> loggedSql = LoggedSqlCollector.stop();
     assertThat(loggedSql).hasSize(1);
-    assertThat(trimSql(loggedSql.get(0), 1)).contains("delete from bbookmark_user where id in (select t0.id from bbookmark_user t0 left join bbookmark_org t1 on t1.id = t0.org_id  where t1.name");
+    assertThat(trimSql(loggedSql.get(0), 1)).contains("delete from bbookmark_user where id in (select t0.id from bbookmark_user t0 left join bbookmark_org t1 on t1.id = t0.org_id where t1.name");
 
     Query<BBookmarkUser> query2 = server.find(BBookmarkUser.class)
       .where().eq("name", "NotARealFirstName").query();
@@ -119,7 +119,7 @@ public class TestDeleteByQuery extends BaseTestCase {
 
     List<String> loggedSql = LoggedSqlCollector.stop();
     assertThat(loggedSql).hasSize(1);
-    assertThat(trimSql(loggedSql.get(0), 1)).contains("select t0.id from contact t0 left join contact_group t1 on t1.id = t0.group_id  where t1.name = ?");
+    assertThat(trimSql(loggedSql.get(0), 1)).contains("select t0.id from contact t0 left join contact_group t1 on t1.id = t0.group_id where t1.name = ?");
 
     Query<Contact> query2 = server.find(Contact.class).where().eq("firstName", "NotARealFirstName").query();
 

--- a/src/test/java/org/tests/inheritance/bothsides/TestInheritanceBothSides.java
+++ b/src/test/java/org/tests/inheritance/bothsides/TestInheritanceBothSides.java
@@ -21,7 +21,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
     final Query<SourceBase> query = DB.find(SourceBase.class).order("pos");
     query.findList();
 
-    assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id  order by t0.pos");
+    assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id order by t0.pos");
   }
 
   @Test
@@ -30,7 +30,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
     final Query<SourceA> query = DB.find(SourceA.class).order("pos");
     query.findList();
 
-    assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id  where t0.dtype = 'SourceA' order by t0.pos");
+    assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id where t0.dtype = 'SourceA' order by t0.pos");
   }
 
   @Test
@@ -39,7 +39,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
     final Query<SourceA> query = DB.find(SourceA.class).fetch("target", "name").order("pos");
     query.findList();
 
-    assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t1.id, t1.name from source_base t0 left join target_base t1 on t1.id = t0.target_id  and t1.dtype = 'Target1'  where t0.dtype = 'SourceA' order by t0.pos");
+    assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t1.id, t1.name from source_base t0 left join target_base t1 on t1.id = t0.target_id and t1.dtype = 'Target1' where t0.dtype = 'SourceA' order by t0.pos");
   }
 
   @Test
@@ -89,7 +89,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
 
     final List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t1.id, t1.name from source_base t0 left join target_base t1 on t1.id = t0.target_id  and t1.dtype = 'Target1'  where t0.dtype = 'SourceA' order by t0.pos");
+    assertSql(sql.get(0)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t1.id, t1.name from source_base t0 left join target_base t1 on t1.id = t0.target_id and t1.dtype = 'Target1' where t0.dtype = 'SourceA' order by t0.pos");
   }
 
   /**
@@ -117,7 +117,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
 
     assertThat(sql).hasSize(3);
     //assertSql(sql.get(0)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t0.target_id, t0.target_id from source_base t0 order by t0.pos");
-    assertSql(sql.get(0)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id  order by t0.pos");
+    assertSql(sql.get(0)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id order by t0.pos");
     assertSql(sql.get(1)).contains("select t0.dtype, t0.id, t0.name from target_base t0 where t0.dtype = 'Target1' and t0.id ");
     assertSql(sql.get(2)).contains("select t0.dtype, t0.id, t0.name from target_base t0 where t0.dtype = 'Target2' and t0.id = ?");
   }

--- a/src/test/java/org/tests/merge/TestMergeBasic.java
+++ b/src/test/java/org/tests/merge/TestMergeBasic.java
@@ -50,7 +50,7 @@ public class TestMergeBasic extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     // fetch the Ids ... used to identity inserts, updates and deletes
-    assertSql(sql.get(0)).contains("select t0.id, t1.id from uuone t0 left join uutwo t1 on t1.master_id = t0.id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t1.id from uuone t0 left join uutwo t1 on t1.master_id = t0.id where t0.id = ?");
 
     // deletes of Ids that are no longer in the graph
     assertSql(sql.get(1)).contains("delete from uutwo where id=?");
@@ -98,7 +98,7 @@ public class TestMergeBasic extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     // fetch the Ids ... used to identity inserts, updates and deletes
-    assertSql(sql.get(0)).contains("select t0.id, t1.id from uuone t0 left join uutwo t1 on t1.master_id = t0.id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t1.id from uuone t0 left join uutwo t1 on t1.master_id = t0.id where t0.id = ?");
 
     // deletes of Ids that are no longer in the graph
     assertSql(sql.get(1)).contains("delete from uutwo where id=?");

--- a/src/test/java/org/tests/merge/TestMergeCustomer.java
+++ b/src/test/java/org/tests/merge/TestMergeCustomer.java
@@ -96,7 +96,7 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(5);
-    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id  left join maddress t1 on t1.id = t0.billing_address_id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
     assertSql(sql.get(1)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
     assertSqlBind(sql, 2, 3);
     assertThat(sql.get(4)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
@@ -125,7 +125,7 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(6);
-    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id  left join maddress t1 on t1.id = t0.billing_address_id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
     assertSql(sql.get(1)).contains("insert into maddress (id, street, city, version) values (?,?,?,?)");
     assertSqlBind(sql.get(2));
     assertThat(sql.get(3)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
@@ -158,7 +158,7 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(7);
-    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id  left join maddress t1 on t1.id = t0.billing_address_id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
 
     // Additional check to see if the address with the unknown UUID is 'insert' or 'update'
     assertSql(sql.get(1)).contains("select t0.id from maddress t0 where t0.id = ?");
@@ -217,7 +217,7 @@ public class TestMergeCustomer extends BaseTestCase {
     if (isPersistBatchOnCascade()) {
       assertThat(sql).hasSize(20);
     }
-    assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id where t0.id = ?");
     assertSql(sql.get(1)).contains("delete from mcontact_message where contact_id = ?");
     assertThat(sql.get(3)).contains("delete from mcontact where id=?");
     assertThat(sql.get(19)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
@@ -243,7 +243,7 @@ public class TestMergeCustomer extends BaseTestCase {
     if (isPersistBatchOnCascade()) {
       assertThat(sql).hasSize(20);
     }
-    assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id where t0.id = ?");
     assertSql(sql.get(1)).contains("delete from mcontact_message where contact_id = ?");
     assertThat(sql.get(3)).contains("delete from mcontact where id=?");
     assertThat(sql.get(19)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
@@ -280,7 +280,7 @@ public class TestMergeCustomer extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
     if (isPersistBatchOnCascade()) {
       assertThat(sql).hasSize(16);
-      assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id  where t0.id = ?");
+      assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id where t0.id = ?");
       assertSql(sql.get(1)).contains("delete from mcontact_message where contact_id = ?");
       assertThat(sql.get(3)).contains("delete from mcontact where id=?");
       assertThat(sql.get(7)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
@@ -320,7 +320,7 @@ public class TestMergeCustomer extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
     if (isPersistBatchOnCascade()) {
 
-      assertSql(sql.get(0)).contains("select t0.id, t3.id, t1.id, t2.id from mcustomer t0 left join maddress t3 on t3.id = t0.shipping_address_id  left join maddress t1 on t1.id = t0.billing_address_id  left join mcontact t2 on t2.customer_id = t0.id  where t0.id = ?");
+      assertSql(sql.get(0)).contains("select t0.id, t3.id, t1.id, t2.id from mcustomer t0 left join maddress t3 on t3.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id left join mcontact t2 on t2.customer_id = t0.id where t0.id = ?");
       if (isH2() || isHana()) {
         // with nested OneToMany .. we need a second query to read the contact message ids
         assertSql(sql.get(1)).contains("select t0.contact_id, t0.id from mcontact_message t0 where (t0.contact_id) in (?,?,?,?,?,?,?,?,?,?)");

--- a/src/test/java/org/tests/model/aggregation/TestAggregationMany.java
+++ b/src/test/java/org/tests/model/aggregation/TestAggregationMany.java
@@ -63,7 +63,7 @@ public class TestAggregationMany extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("select t0.id, t0.name, t1.name, sum(t1.use_secs), sum(t1.fuel) from dmachine t0 left join d_machine_aux_use t1 on t1.machine_id = t0.id  where t0.organisation_id = ? group by t0.id, t0.name, t1.name order by t0.id");
+    assertSql(sql.get(0)).contains("select t0.id, t0.name, t1.name, sum(t1.use_secs), sum(t1.fuel) from dmachine t0 left join d_machine_aux_use t1 on t1.machine_id = t0.id where t0.organisation_id = ? group by t0.id, t0.name, t1.name order by t0.id");
   }
 
   @Test
@@ -89,6 +89,6 @@ public class TestAggregationMany extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("select t0.id, t0.name, sum(t1.use_secs), sum(t1.fuel) from dmachine t0 left join d_machine_aux_use t1 on t1.machine_id = t0.id  where t0.organisation_id = ? group by t0.id, t0.name order by t0.id");
+    assertSql(sql.get(0)).contains("select t0.id, t0.name, sum(t1.use_secs), sum(t1.fuel) from dmachine t0 left join d_machine_aux_use t1 on t1.machine_id = t0.id where t0.organisation_id = ? group by t0.id, t0.name order by t0.id");
   }
 }

--- a/src/test/java/org/tests/model/aggregation/TestAggregationTopLevel.java
+++ b/src/test/java/org/tests/model/aggregation/TestAggregationTopLevel.java
@@ -143,7 +143,7 @@ public class TestAggregationTopLevel extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("select sum(t0.total_kms), sum(t0.hours), t1.id, t1.name from d_machine_stats t0 join dmachine t1 on t1.id = t0.machine_id  where t0.edate > ? group by t1.id, t1.name having sum(t0.hours) > ?");
+    assertSql(sql.get(0)).contains("select sum(t0.total_kms), sum(t0.hours), t1.id, t1.name from d_machine_stats t0 join dmachine t1 on t1.id = t0.machine_id where t0.edate > ? group by t1.id, t1.name having sum(t0.hours) > ?");
   }
 
   @Test
@@ -163,8 +163,7 @@ public class TestAggregationTopLevel extends BaseTestCase {
 
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("select t0.edate, sum(t0.total_kms), sum(t0.hours), t1.id, t1.name from d_machine_stats t0 join dmachine t1 on t1.id = t0.machine_id  where t0.edate > ? group by t0.edate, t1.id, t1.name having sum(t0.hours) > ?");
-  }
+    assertSql(sql.get(0)).contains("select t0.edate, sum(t0.total_kms), sum(t0.hours), t1.id, t1.name from d_machine_stats t0 join dmachine t1 on t1.id = t0.machine_id where t0.edate > ? group by t0.edate, t1.id, t1.name having sum(t0.hours) > ?");  }
 
 
   @Test
@@ -242,7 +241,7 @@ public class TestAggregationTopLevel extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(1);
 
-    assertThat(sqlOf(query)).contains("select t0.id, t0.name, sum(t1.total_kms) from dmachine t0 left join d_machine_stats t1 on t1.machine_id = t0.id  where t0.name = ? group by t0.id, t0.name order by t0.id");
+    assertThat(sqlOf(query)).contains("select t0.id, t0.name, sum(t1.total_kms) from dmachine t0 left join d_machine_stats t1 on t1.machine_id = t0.id where t0.name = ? group by t0.id, t0.name order by t0.id");
   }
 
   @Test
@@ -268,7 +267,7 @@ public class TestAggregationTopLevel extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
     assertThat(sql).hasSize(1);
 
-    assertThat(sqlOf(query)).contains("select t0.id, t0.name, t1.edate, max(t1.rate), sum(t1.total_kms) from dmachine t0 left join d_machine_stats t1 on t1.machine_id = t0.id  where t0.name = ? group by t0.id, t0.name, t1.edate order by t0.id");
+    assertThat(sqlOf(query)).contains("select t0.id, t0.name, t1.edate, max(t1.rate), sum(t1.total_kms) from dmachine t0 left join d_machine_stats t1 on t1.machine_id = t0.id where t0.name = ? group by t0.id, t0.name, t1.edate order by t0.id");
   }
 
 

--- a/src/test/java/org/tests/model/carwheeltruck/TestMTOInheritNoDiscriminator.java
+++ b/src/test/java/org/tests/model/carwheeltruck/TestMTOInheritNoDiscriminator.java
@@ -31,7 +31,7 @@ public class TestMTOInheritNoDiscriminator extends BaseTestCase {
 
     assertThat(sql).hasSize(1);
     if (isH2() || isPostgres()) {
-      assertSql(sql.get(0)).contains("select t0.id, t0.name, t0.version, t2.type, t0.truck_plate_no, t0.basic_id, t1.id, t1.some_uid, t1.foo, t1.owner_id from ttruck_holder t0 join tcar t2 on t2.plate_no = t0.truck_plate_no  left join ttruck_holder_item t1 on t1.owner_id = t0.id  where t0.id = ?   order by t0.id");
+      assertSql(sql.get(0)).contains("select t0.id, t0.name, t0.version, t2.type, t0.truck_plate_no, t0.basic_id, t1.id, t1.some_uid, t1.foo, t1.owner_id from ttruck_holder t0 join tcar t2 on t2.plate_no = t0.truck_plate_no left join ttruck_holder_item t1 on t1.owner_id = t0.id where t0.id = ?   order by t0.id");
     }
   }
 

--- a/src/test/java/org/tests/model/history/TestHistoryOneToMany.java
+++ b/src/test/java/org/tests/model/history/TestHistoryOneToMany.java
@@ -54,7 +54,7 @@ public class TestHistoryOneToMany extends BaseTestCase {
     if (isH2()) {
       assertThat(sql).hasSize(2);
       assertSql(sql.get(0)).contains("from hi_tone_with_history t0 where (t0.sys_period_start <= ? and (t0.sys_period_end is null or t0.sys_period_end > ?)) and lower(t0.name) like ? escape''  limit 10");
-      assertSql(sql.get(1)).contains("from hi_ttwo_with_history t0 left join hi_tthree_with_history t1 on t1.hi_ttwo_id = t0.id and (t1.sys_period_start <= ? and (t1.sys_period_end is null or t1.sys_period_end > ?))  where (t0.sys_period_start <= ? and (t0.sys_period_end is null or t0.sys_period_end > ?)) and (t0.hi_tone_id) in (?)");
+      assertSql(sql.get(1)).contains("from hi_ttwo_with_history t0 left join hi_tthree_with_history t1 on t1.hi_ttwo_id = t0.id and (t1.sys_period_start <= ? and (t1.sys_period_end is null or t1.sys_period_end > ?)) where (t0.sys_period_start <= ? and (t0.sys_period_end is null or t0.sys_period_end > ?)) and (t0.hi_tone_id) in (?)");
     }
 
     assertThat(list).hasSize(1);

--- a/src/test/java/org/tests/model/inheritmany/TestMediaInheritanceJoinToMany.java
+++ b/src/test/java/org/tests/model/inheritmany/TestMediaInheritanceJoinToMany.java
@@ -27,7 +27,7 @@ public class TestMediaInheritanceJoinToMany extends BaseTestCase {
     Assert.assertNotNull(profile);
 
     String generatedSql = query.getGeneratedSql();
-    assertSql(generatedSql).contains("select t0.id, t0.name, t1.type, t1.id, t1.url, t1.note from mprofile t0 left join mmedia t1 on t1.id = t0.picture_id  and t1.type = 'Picture'  where t0.name = ?");
+    assertSql(generatedSql).contains("select t0.id, t0.name, t1.type, t1.id, t1.url, t1.note from mprofile t0 left join mmedia t1 on t1.id = t0.picture_id and t1.type = 'Picture' where t0.name = ?");
     assertSql(generatedSql).contains("where t0.name = ?");
   }
 

--- a/src/test/java/org/tests/model/onetoone/TestOneToOneOptionalRelationship.java
+++ b/src/test/java/org/tests/model/onetoone/TestOneToOneOptionalRelationship.java
@@ -31,7 +31,7 @@ public class TestOneToOneOptionalRelationship extends BaseTestCase {
 
     String sql = trimSql(loggedSql.get(0), 1);
     Assert.assertTrue(sql.contains("select t0.id, t0.name"));
-    Assert.assertTrue(sql.contains(" from oto_account t0 left join oto_user t1 on t1.account_id = t0.id  where t0.id = ?"));
+    Assert.assertTrue(sql.contains(" from oto_account t0 left join oto_user t1 on t1.account_id = t0.id where t0.id = ?"));
   }
 
 
@@ -66,7 +66,7 @@ public class TestOneToOneOptionalRelationship extends BaseTestCase {
 
     String sql = trimSql(loggedSql.get(0), 1);
     Assert.assertTrue(sql.contains("select t0.id, t0.name"));
-    Assert.assertTrue(sql.contains(" from oto_account t0 left join oto_user t1 on t1.account_id = t0.id  where t0.id = ?"));
+    Assert.assertTrue(sql.contains(" from oto_account t0 left join oto_user t1 on t1.account_id = t0.id where t0.id = ?"));
 
     String lazyLoadSql = trimSql(loggedSql.get(1), 5);
     Assert.assertTrue(lazyLoadSql.contains("select t0.id, t0.name, t0.version, t0.when_created, t0.when_modified, t0.account_id from oto_user t0 where t0.id = ?"));
@@ -104,6 +104,6 @@ public class TestOneToOneOptionalRelationship extends BaseTestCase {
 
     String sql = trimSql(loggedSql.get(0), 1);
     Assert.assertTrue(sql.contains("select t0.id, t0.name"));
-    Assert.assertTrue(sql.contains(" from oto_account t0 left join oto_user t1 on t1.account_id = t0.id  where t0.id = ?"));
+    Assert.assertTrue(sql.contains(" from oto_account t0 left join oto_user t1 on t1.account_id = t0.id where t0.id = ?"));
   }
 }

--- a/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoin.java
+++ b/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoin.java
@@ -46,7 +46,7 @@ public class TestOneToOnePrimaryKeyJoin extends BaseTestCase {
     OtoPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_prime t0 join oto_prime_extra t1 on t1.eid = t0.pid  where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_prime t0 join oto_prime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
     assertThat(oneWith.getExtra().getExtra()).isEqualTo("e" + desc);

--- a/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
+++ b/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinBidi.java
@@ -45,7 +45,7 @@ public class TestOneToOnePrimaryKeyJoinBidi extends BaseTestCase {
     OtoUBPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 left join oto_ubprime_extra t1 on t1.eid = t0.pid  where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 10)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version, t1.eid from oto_ubprime t0 left join oto_ubprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
     assertThat(oneWith.getExtra().getExtra()).isEqualTo("v" + desc);

--- a/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
+++ b/src/test/java/org/tests/model/onetoone/TestOneToOnePrimaryKeyJoinOptional.java
@@ -66,7 +66,7 @@ public class TestOneToOnePrimaryKeyJoinOptional extends BaseTestCase {
     OtoUPrime oneWith = queryWithFetch.findOne();
 
     assertThat(oneWith).isNotNull();
-    assertThat(sqlOf(queryWithFetch, 6)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid  where t0.pid = ?")
+    assertThat(sqlOf(queryWithFetch, 6)).contains("select t0.pid, t0.name, t0.version, t1.eid, t1.extra, t1.version from oto_uprime t0 left join oto_uprime_extra t1 on t1.eid = t0.pid where t0.pid = ?")
       .as("we join to oto_prime_extra");
 
 

--- a/src/test/java/org/tests/model/pview/TestPview.java
+++ b/src/test/java/org/tests/model/pview/TestPview.java
@@ -23,7 +23,7 @@ public class TestPview extends BaseTestCase {
     query.findList();
     String generatedSql = sqlOf(query, 1);
 
-    assertThat(generatedSql).contains("select distinct t0.amount, t1.value from paggview t0 join pp u1 on u1.id = t0.pview_id  join pp_to_ww u2z_ on u2z_.pp_id = u1.id  join wview u2 on u2.id = u2z_.ww_id  left join pp t1 on t1.id = t0.pview_id  where u2.id = ? order by t1.value");
+    assertThat(generatedSql).contains("select distinct t0.amount, t1.value from paggview t0 join pp u1 on u1.id = t0.pview_id join pp_to_ww u2z_ on u2z_.pp_id = u1.id join wview u2 on u2.id = u2z_.ww_id left join pp t1 on t1.id = t0.pview_id where u2.id = ? order by t1.value");
 
   }
 

--- a/src/test/java/org/tests/model/view/TestViewBaseEntity.java
+++ b/src/test/java/org/tests/model/view/TestViewBaseEntity.java
@@ -65,6 +65,6 @@ public class TestViewBaseEntity extends BaseTestCase {
       assertThat(details).isNotEmpty();
     }
 
-    assertSql(query).contains("from order_agg_vw t0 left join o_order t1 on t1.id = t0.order_id  left join o_customer t3 on t3.id = t1.kcustomer_id  left join o_order_detail t2 on t2.order_id = t1.id  and t2.id > 0  where t0.order_total > ?");
+    assertSql(query).contains("from order_agg_vw t0 left join o_order t1 on t1.id = t0.order_id left join o_customer t3 on t3.id = t1.kcustomer_id left join o_order_detail t2 on t2.order_id = t1.id and t2.id > 0 where t0.order_total > ?");
   }
 }

--- a/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTable.java
+++ b/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTable.java
@@ -64,7 +64,7 @@ public class TestOneToManyJoinTable extends BaseTestCase {
 
     sql = LoggedSqlCollector.current();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("from troop t0 left join troop_monkey t1z_ on t1z_.troop_pid = t0.pid  left join monkey t1 on t1.mid = t1z_.monkey_mid  where t0.pid = ?");
+    assertSql(sql.get(0)).contains("from troop t0 left join troop_monkey t1z_ on t1z_.troop_pid = t0.pid left join monkey t1 on t1.mid = t1z_.monkey_mid where t0.pid = ?");
     assertSql(sql.get(0)).contains("select t0.pid, t0.name, t0.version, t1.mid, t1.name, t1.food_preference, t1.version");
 
     DB.delete(troop);

--- a/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableNoTableName.java
+++ b/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableNoTableName.java
@@ -65,7 +65,7 @@ public class TestOneToManyJoinTableNoTableName extends BaseTestCase {
 
     sql = LoggedSqlCollector.current();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("from mkeygroup t0 left join mkeygroup_monkey t1z_ on t1z_.mkeygroup_pid = t0.pid  left join monkey t1 on t1.mid = t1z_.monkey_mid  where t0.pid = ?");
+    assertSql(sql.get(0)).contains("from mkeygroup t0 left join mkeygroup_monkey t1z_ on t1z_.mkeygroup_pid = t0.pid left join monkey t1 on t1.mid = t1z_.monkey_mid where t0.pid = ?");
     assertSql(sql.get(0)).contains("select t0.pid, t0.name, t0.version, t1.mid, t1.name, t1.food_preference, t1.version");
 
     Ebean.delete(troop);

--- a/src/test/java/org/tests/query/TestAddOrderByWithFirstRowsMaxRows.java
+++ b/src/test/java/org/tests/query/TestAddOrderByWithFirstRowsMaxRows.java
@@ -51,7 +51,7 @@ public class TestAddOrderByWithFirstRowsMaxRows extends BaseTestCase {
 
     assertThat(loggedSql).hasSize(1);
     if (isH2()) {
-      assertThat(loggedSql.get(0)).contains("from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id  limit 10");
+      assertThat(loggedSql.get(0)).contains("from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id limit 10");
     }
   }
 
@@ -112,7 +112,7 @@ public class TestAddOrderByWithFirstRowsMaxRows extends BaseTestCase {
 
     assertThat(loggedSql).hasSize(1);
     if (isH2()) {
-      assertThat(loggedSql.get(0)).contains("join o_customer t1 on t1.id = t0.kcustomer_id  limit 10");
+      assertThat(loggedSql.get(0)).contains("join o_customer t1 on t1.id = t0.kcustomer_id limit 10");
     }
   }
 

--- a/src/test/java/org/tests/query/TestImplicitJoinOnParentRelationship.java
+++ b/src/test/java/org/tests/query/TestImplicitJoinOnParentRelationship.java
@@ -24,11 +24,11 @@ public class TestImplicitJoinOnParentRelationship extends BaseTestCase {
     query.findList();
 
     if (isPostgres()) {
-      String expectedSql = "select distinct on (t0.id) t0.id, t0.name from o_customer t0 join o_order u1 on u1.kcustomer_id = t0.id  join o_order_detail u2 on u2.order_id = u1.id  join o_product u3 on u3.id = u2.product_id  where u3.name = ?";
+      String expectedSql = "select distinct on (t0.id) t0.id, t0.name from o_customer t0 join o_order u1 on u1.kcustomer_id = t0.id  join o_order_detail u2 on u2.order_id = u1.id  join o_product u3 on u3.id = u2.product_id where u3.name = ?";
       assertThat(sqlOf(query, 1)).contains(expectedSql);
 
     } else {
-      String expectedSql = "select distinct t0.id, t0.name from o_customer t0 join o_order u1 on u1.kcustomer_id = t0.id  join o_order_detail u2 on u2.order_id = u1.id  join o_product u3 on u3.id = u2.product_id  where u3.name = ?";
+      String expectedSql = "select distinct t0.id, t0.name from o_customer t0 join o_order u1 on u1.kcustomer_id = t0.id join o_order_detail u2 on u2.order_id = u1.id join o_product u3 on u3.id = u2.product_id where u3.name = ?";
       assertThat(sqlOf(query, 1)).contains(expectedSql);
     }
 
@@ -55,10 +55,10 @@ public class TestImplicitJoinOnParentRelationship extends BaseTestCase {
     query.findList();
 
     if (isPostgres()) {
-      String expectedSql = "select distinct on (t0.id) t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id  left join o_order_detail u2 on u2.order_id = u1.id  left join o_product u3 on u3.id = u2.product_id  where (u3.name = ? or t0.id = ?)";
+      String expectedSql = "select distinct on (t0.id) t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id  left join o_order_detail u2 on u2.order_id = u1.id  left join o_product u3 on u3.id = u2.product_id where (u3.name = ? or t0.id = ?)";
       assertThat(sqlOf(query, 1)).contains(expectedSql);
     } else {
-      String expectedSql = "select distinct t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id  left join o_order_detail u2 on u2.order_id = u1.id  left join o_product u3 on u3.id = u2.product_id  where (u3.name = ? or t0.id = ?)";
+      String expectedSql = "select distinct t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id left join o_order_detail u2 on u2.order_id = u1.id left join o_product u3 on u3.id = u2.product_id where (u3.name = ? or t0.id = ?)";
       assertThat(sqlOf(query, 1)).contains(expectedSql);
     }
   }
@@ -76,11 +76,11 @@ public class TestImplicitJoinOnParentRelationship extends BaseTestCase {
     query.findList();
 
     if (isPostgres()) {
-      String expectedSql = "select distinct on (t0.id) t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id  left join o_order_detail u2 on u2.order_id = u1.id  left join o_product u3 on u3.id = u2.product_id  where (u3.name = ? or t0.id = ?)";
+      String expectedSql = "select distinct on (t0.id) t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id  left join o_order_detail u2 on u2.order_id = u1.id  left join o_product u3 on u3.id = u2.product_id where (u3.name = ? or t0.id = ?)";
       assertThat(sqlOf(query, 1)).contains(expectedSql);
 
     } else {
-      String expectedSql = "select distinct t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id  left join o_order_detail u2 on u2.order_id = u1.id  left join o_product u3 on u3.id = u2.product_id  where (u3.name = ? or t0.id = ?)";
+      String expectedSql = "select distinct t0.id, t0.name from o_customer t0 left join o_order u1 on u1.kcustomer_id = t0.id left join o_order_detail u2 on u2.order_id = u1.id left join o_product u3 on u3.id = u2.product_id where (u3.name = ? or t0.id = ?)";
       assertThat(sqlOf(query, 1)).contains(expectedSql);
     }
   }

--- a/src/test/java/org/tests/query/TestManyWhereJoin.java
+++ b/src/test/java/org/tests/query/TestManyWhereJoin.java
@@ -41,7 +41,7 @@ public class TestManyWhereJoin extends BaseTestCase {
     }
     assertThat(sql).contains("join o_order ");
     assertThat(sql).contains(".status = ?");
-    assertThat(sql).contains("t0.id, t0.status from o_customer t0 join o_order u1 on u1.kcustomer_id = t0.id  where u1.status = ?");
+    assertThat(sql).contains("t0.id, t0.status from o_customer t0 join o_order u1 on u1.kcustomer_id = t0.id where u1.status = ?");
   }
 
   @Test

--- a/src/test/java/org/tests/query/TestWhereIn.java
+++ b/src/test/java/org/tests/query/TestWhereIn.java
@@ -66,7 +66,7 @@ public class TestWhereIn extends BaseTestCase {
       .where().inOrEmpty("customer.billingAddress.id", Arrays.asList(1)).query();
 
     query.findList();
-    assertThat(sqlOf(query)).contains("select t0.id from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id  where t1.billing_address_id ");
+    assertThat(sqlOf(query)).contains("select t0.id from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id where t1.billing_address_id ");
   }
 
 

--- a/src/test/java/org/tests/query/aggregation/TestAggregationCount.java
+++ b/src/test/java/org/tests/query/aggregation/TestAggregationCount.java
@@ -199,7 +199,7 @@ public class TestAggregationCount extends BaseTestCase {
 
     query0.findList();
     String sql = sqlOf(query0, 5);
-    assertThat(sql).contains("select t0.id, t0.name, count(u1.id), t1.id, t1.name from tevent_one t0 left join tevent t1 on t1.id = t0.event_id  join tevent_many u1 on u1.event_id = t0.id ");
+    assertThat(sql).contains("select t0.id, t0.name, count(u1.id), t1.id, t1.name from tevent_one t0 left join tevent t1 on t1.id = t0.event_id join tevent_many u1 on u1.event_id = t0.id ");
     assertThat(sql).contains("group by t0.id, t0.name, t1.id, t1.name");
   }
 

--- a/src/test/java/org/tests/query/joins/TestDisjunctWhereOuterOnMany.java
+++ b/src/test/java/org/tests/query/joins/TestDisjunctWhereOuterOnMany.java
@@ -58,11 +58,11 @@ public class TestDisjunctWhereOuterOnMany extends BaseTestCase {
     Assert.assertEquals(2, rowCount);
 
     if (isPostgres()) {
-      String expectedSql = "select distinct on (t0.id) t0.id, t0.name, t0.description, t0.version from uuone t0 left join uutwo u1 on u1.master_id = t0.id  where (t0.name = ? or u1.name = ?)";
+      String expectedSql = "select distinct on (t0.id) t0.id, t0.name, t0.description, t0.version from uuone t0 left join uutwo u1 on u1.master_id = t0.id where (t0.name = ? or u1.name = ?)";
       assertSql(query).contains(expectedSql);
 
     } else {
-      String expectedSql = "select distinct t0.id, t0.name, t0.description, t0.version from uuone t0 left join uutwo u1 on u1.master_id = t0.id  where (t0.name = ? or u1.name = ?)";
+      String expectedSql = "select distinct t0.id, t0.name, t0.description, t0.version from uuone t0 left join uutwo u1 on u1.master_id = t0.id where (t0.name = ? or u1.name = ?)";
       assertSql(query).contains(expectedSql);
     }
 

--- a/src/test/java/org/tests/query/joins/TestQueryManyToOneWhereClauseJoin.java
+++ b/src/test/java/org/tests/query/joins/TestQueryManyToOneWhereClauseJoin.java
@@ -26,7 +26,7 @@ public class TestQueryManyToOneWhereClauseJoin extends BaseTestCase {
     query.findList();
 
     //select t0.id c0, t0.status c1, t0.order_date c2, t0.ship_date c3, t1.name c4, t0.cretime c5, t0.updtime c6, t0.kcustomer_id c7
-    String expectedSql = "from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id  where lower(t1.name) like ";
+    String expectedSql = "from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id where lower(t1.name) like ";
     Assert.assertTrue(query.getGeneratedSql().contains(expectedSql));
 
     // select t0.id c0, t0.status c1, t0.order_date c2, t0.ship_date c3, t1.name c4, t0.cretime c5, t0.updtime c6, t0.kcustomer_id c7
@@ -50,7 +50,7 @@ public class TestQueryManyToOneWhereClauseJoin extends BaseTestCase {
     query.findList();
 
     //select t0.id c0, t0.status c1, t0.order_date c2, t0.ship_date c3, t1.name c4, t0.cretime c5, t0.updtime c6, t0.kcustomer_id c7
-    String expectedSql = "from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id  where (lower(t1.name) like ";
+    String expectedSql = "from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id where (lower(t1.name) like ";
     Assert.assertTrue(query.getGeneratedSql().contains(expectedSql));
 
     // select t0.id c0, t0.status c1, t0.order_date c2, t0.ship_date c3, t1.name c4, t0.cretime c5, t0.updtime c6, t0.kcustomer_id c7

--- a/src/test/java/org/tests/query/orderby/TestOrderByOnComplex.java
+++ b/src/test/java/org/tests/query/orderby/TestOrderByOnComplex.java
@@ -38,7 +38,7 @@ public class TestOrderByOnComplex extends BaseTestCase {
 
     List<Order> list = query.findList();
 
-    assertThat(sqlOf(query)).contains("select t0.id, t0.status, t0.order_date, t0.ship_date, t1.name, t0.cretime, t0.updtime, t0.kcustomer_id from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id  order by case when t0.status=3 then 10 when t0.status=2 then 11 else 99 end");
+    assertThat(sqlOf(query)).contains("select t0.id, t0.status, t0.order_date, t0.ship_date, t1.name, t0.cretime, t0.updtime, t0.kcustomer_id from o_order t0 join o_customer t1 on t1.id = t0.kcustomer_id order by case when t0.status=3 then 10 when t0.status=2 then 11 else 99 end");
     assertThat(list).isNotEmpty();
   }
 

--- a/src/test/java/org/tests/query/other/TestFetchPreference.java
+++ b/src/test/java/org/tests/query/other/TestFetchPreference.java
@@ -38,7 +38,7 @@ public class TestFetchPreference extends BaseTestCase {
     String sql = sqlOf(query, 1);
 
     // join to group (the ToOne part only) and participants (our preferred ToMany path)
-    assertThat(sql).contains(" from c_conversation t0 left join c_group t1 on t1.id = t0.group_id  left join c_participation t2");
+    assertThat(sql).contains(" from c_conversation t0 left join c_group t1 on t1.id = t0.group_id left join c_participation t2");
   }
 
   @Test

--- a/src/test/java/org/tests/query/other/TestQueryConversationRowCount.java
+++ b/src/test/java/org/tests/query/other/TestQueryConversationRowCount.java
@@ -66,7 +66,7 @@ public class TestQueryConversationRowCount extends BaseTestCase {
     Assert.assertEquals(1, loggedSql.size());
 
     String countSql = trimSql(loggedSql.get(0), 0);
-    assertThat(countSql).contains("select count(*) from ( select distinct t0.id from c_conversation t0 left join c_participation u1 on u1.conversation_id = t0.id  where t0.group_id = ? and ((t0.isopen = ? and u1.user_id = ?) or t0.isopen = ?))");
+    assertThat(countSql).contains("select count(*) from ( select distinct t0.id from c_conversation t0 left join c_participation u1 on u1.conversation_id = t0.id where t0.group_id = ? and ((t0.isopen = ? and u1.user_id = ?) or t0.isopen = ?))");
   }
 
 }

--- a/src/test/java/org/tests/query/other/TestQueryRawExpressionMany.java
+++ b/src/test/java/org/tests/query/other/TestQueryRawExpressionMany.java
@@ -30,6 +30,6 @@ public class TestQueryRawExpressionMany extends BaseTestCase {
     query.findCount();
     List<String> sql = LoggedSqlCollector.stop();
 
-    assertThat(trimSql(sql.get(0), 1)).contains("select count(*) from ( select distinct t0.id from o_order t0 left join o_order_detail t1 on t1.order_id = t0.id  where t1.order_qty = ?)");
+    assertThat(trimSql(sql.get(0), 1)).contains("select count(*) from ( select distinct t0.id from o_order t0 left join o_order_detail t1 on t1.order_id = t0.id where t1.order_qty = ?)");
   }
 }

--- a/src/test/java/org/tests/query/other/TestQueryRowCountWithMany.java
+++ b/src/test/java/org/tests/query/other/TestQueryRowCountWithMany.java
@@ -69,7 +69,7 @@ public class TestQueryRowCountWithMany extends BaseTestCase {
     assertEquals(list.size(), rowCount);
     assertEquals(2, sqlLogged.size());
     assertThat(trimSql(sqlLogged.get(1), 1)).contains(
-      "select count(*) from ( select distinct t0.id from o_order t0 join o_order_detail u1 on u1.order_id = t0.id  where u1.product_id = ?)");
+      "select count(*) from ( select distinct t0.id from o_order t0 join o_order_detail u1 on u1.order_id = t0.id where u1.product_id = ?)");
 
   }
 
@@ -95,7 +95,7 @@ public class TestQueryRowCountWithMany extends BaseTestCase {
     List<String> sqlLogged = LoggedSqlCollector.stop();
 
     assertEquals(1, sqlLogged.size());
-    assertThat(trimSql(sqlLogged.get(0), 1)).contains("select count(*) from ( select distinct t0.id from o_order t0 join o_order_detail u1 on u1.order_id = t0.id  where u1.product_id = ?)");
+    assertThat(trimSql(sqlLogged.get(0), 1)).contains("select count(*) from ( select distinct t0.id from o_order t0 join o_order_detail u1 on u1.order_id = t0.id where u1.product_id = ?)");
 
     query.findList();
   }

--- a/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -161,7 +161,7 @@ public class TestQuerySingleAttribute extends BaseTestCase {
 
     List<String> names = query.findSingleAttributeList();
 
-    assertThat(sqlOf(query)).contains("select distinct t0.name from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id  where t0.status = ? and lower(t1.city) like ");
+    assertThat(sqlOf(query)).contains("select distinct t0.name from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id where t0.status = ? and lower(t1.city) like ");
     assertThat(names).isNotNull();
   }
 
@@ -224,7 +224,7 @@ public class TestQuerySingleAttribute extends BaseTestCase {
 
     List<String> cities = query.findSingleAttributeList();
 
-    assertThat(sqlOf(query)).contains("select distinct t2.city from contact t0 join o_customer t1 on t1.id = t0.customer_id  left join o_address t2 on t2.id = t1.billing_address_id");
+    assertThat(sqlOf(query)).contains("select distinct t2.city from contact t0 join o_customer t1 on t1.id = t0.customer_id left join o_address t2 on t2.id = t1.billing_address_id");
     assertThat(cities).contains("Auckland").containsNull();
   }
 
@@ -404,7 +404,7 @@ public class TestQuerySingleAttribute extends BaseTestCase {
 
     query.findSingleAttributeList();
 
-    assertThat(sqlOf(query)).contains("select distinct t1.billing_address_id from contact t0 join o_customer t1 on t1.id = t0.customer_id  order by t1.billing_address_id desc");
+    assertThat(sqlOf(query)).contains("select distinct t1.billing_address_id from contact t0 join o_customer t1 on t1.id = t0.customer_id order by t1.billing_address_id desc");
   }
 
   @Test
@@ -422,8 +422,8 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     assertThat(ids).isNotEmpty();
 
     assertThat(sqlOf(query)).contains("select distinct t1.billing_address_id from contact t0 "
-      + "join o_customer t1 on t1.id = t0.customer_id  "  // two spaces!
-      + "left join o_address t2 on t2.id = t1.billing_address_id  "
+      + "join o_customer t1 on t1.id = t0.customer_id "
+      + "left join o_address t2 on t2.id = t1.billing_address_id "
       + "where t2.city = ? "
       + "order by t1.billing_address_id desc");
   }
@@ -443,8 +443,8 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     assertThat(ids).isNotEmpty();
 
     assertThat(sqlOf(query)).contains("select distinct t1.billing_address_id from contact t0 "
-      + "join o_customer t1 on t1.id = t0.customer_id  "
-      + "left join o_address t2 on t2.id = t1.billing_address_id  "
+      + "join o_customer t1 on t1.id = t0.customer_id "
+      + "left join o_address t2 on t2.id = t1.billing_address_id "
       + "where t2.city = ? "
       + "order by t1.billing_address_id desc");
   }
@@ -464,8 +464,8 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     assertThat(ids).isNotEmpty();
 
     assertThat(sqlOf(query)).contains("select distinct t1.billing_address_id from contact t0 "
-      + "join o_customer t1 on t1.id = t0.customer_id  "
-      + "left join o_address t2 on t2.id = t1.billing_address_id  "
+      + "join o_customer t1 on t1.id = t0.customer_id "
+      + "left join o_address t2 on t2.id = t1.billing_address_id "
       + "where t2.city = ? "
       + "order by t1.billing_address");
   }
@@ -485,8 +485,8 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     assertThat(ids).isNotEmpty();
 
     assertThat(sqlOf(query)).contains("select distinct t1.billing_address_id from contact t0 "
-      + "join o_customer t1 on t1.id = t0.customer_id  "
-      + "left join o_address t2 on t2.id = t1.shipping_address_id  "
+      + "join o_customer t1 on t1.id = t0.customer_id "
+      + "left join o_address t2 on t2.id = t1.shipping_address_id "
       + "where t2.city = ? "
       + "order by t1.billing_address_id desc");
 
@@ -536,8 +536,8 @@ public class TestQuerySingleAttribute extends BaseTestCase {
       .findSingleAttributeList();
     assertThat(sqlOf(query)).contains("select r1.attribute_, count(*) from ("
       + "select t2.line_1 as attribute_ "
-      + "from contact t0 join o_customer t1 on t1.id = t0.customer_id  "
-      + "left join o_address t2 on t2.id = t1.shipping_address_id "
+      + "from contact t0 join o_customer t1 on t1.id = t0.customer_id "
+      + "left join o_address t2 on t2.id = t1.shipping_address_id"
       + ") r1 group by r1.attribute_ order by r1.attribute_");
     assertThat(list2.get(0)).isInstanceOf(CountedValue.class);
     //assertThat(list2.toString()).isEqualTo("[1: null, 3: 1 Banana St, 5: 12 Apple St, 3: 15 Kumera Way]");
@@ -550,8 +550,8 @@ public class TestQuerySingleAttribute extends BaseTestCase {
       .findSingleAttributeList();
     assertThat(sqlOf(query)).contains("select r1.attribute_, count(*) from ("
       + "select t0.first_name as attribute_ from contact t0 "
-      + "join o_customer t1 on t1.id = t0.customer_id  "
-      + "left join o_address t2 on t2.id = t1.shipping_address_id  where t2.line_1 = ?"
+      + "join o_customer t1 on t1.id = t0.customer_id "
+      + "left join o_address t2 on t2.id = t1.shipping_address_id where t2.line_1 = ?"
       + ") r1 group by r1.attribute_ order by r1.attribute_");
     assertThat(list3.get(0)).isInstanceOf(CountedValue.class);
     //assertThat(list3.toString()).isEqualTo("[1: Bugs1, 1: Fiona, 1: Fred1, 1: Jim1, 1: Tracy]");
@@ -567,9 +567,9 @@ public class TestQuerySingleAttribute extends BaseTestCase {
       .findSingleAttributeList();
     assertThat(sqlOf(query)).contains("select r1.attribute_, count(*) from ("
       + "select t2.line_1 as attribute_ "
-      + "from contact t0 join o_customer t1 on t1.id = t0.customer_id  "
-      + "left join o_address t2 on t2.id = t1.billing_address_id  "
-      + "left join o_address t3 on t3.id = t1.shipping_address_id  "
+      + "from contact t0 join o_customer t1 on t1.id = t0.customer_id "
+      + "left join o_address t2 on t2.id = t1.billing_address_id "
+      + "left join o_address t3 on t3.id = t1.shipping_address_id "
       + "where (t3.line_1 <> ? or t3.line_1 is null)"
       + ") r1 group by r1.attribute_ order by r1.attribute_");
     assertThat(list4.get(0)).isInstanceOf(CountedValue.class);
@@ -584,12 +584,12 @@ public class TestQuerySingleAttribute extends BaseTestCase {
       .findSingleAttributeList();
 
     if (isOracle()) {
-      assertSql(query).contains("select r1.attribute_, count(*) from (select t2.line_1 as attribute_ from contact t0 join o_customer t1 on t1.id = t0.customer_id  left join o_address t2 on t2.id = t1.billing_address_id  where t2.line_1 is not null) r1 group by r1.attribute_ order by r1.attribute_ desc offset 1 rows fetch next 2 rows only");
+      assertSql(query).contains("select r1.attribute_, count(*) from (select t2.line_1 as attribute_ from contact t0 join o_customer t1 on t1.id = t0.customer_id  left join o_address t2 on t2.id = t1.billing_address_id where t2.line_1 is not null) r1 group by r1.attribute_ order by r1.attribute_ desc offset 1 rows fetch next 2 rows only");
     } else {
       assertSql(query).contains("select r1.attribute_, count(*) from ("
         + "select t2.line_1 as attribute_ from contact t0 "
-        + "join o_customer t1 on t1.id = t0.customer_id  "
-        + "left join o_address t2 on t2.id = t1.billing_address_id  "
+        + "join o_customer t1 on t1.id = t0.customer_id "
+        + "left join o_address t2 on t2.id = t1.billing_address_id "
         + "where t2.line_1 is not null"
         + ") r1 group by r1.attribute_ order by r1.attribute_ desc ");
     }

--- a/src/test/java/org/tests/softdelete/TestSoftDeleteStatelessUpdate.java
+++ b/src/test/java/org/tests/softdelete/TestSoftDeleteStatelessUpdate.java
@@ -56,7 +56,7 @@ public class TestSoftDeleteStatelessUpdate extends BaseTestCase {
 
     sql = LoggedSql.collect();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("left join esd_detail t1 on t1.master_id = t0.id  where t0.id = ?");
+    assertSql(sql.get(0)).contains("left join esd_detail t1 on t1.master_id = t0.id where t0.id = ?");
 
     EsdMaster fetchedWithOutSoftDeletes = DB.find(EsdMaster.class)
       .setId(master.getId())
@@ -68,7 +68,7 @@ public class TestSoftDeleteStatelessUpdate extends BaseTestCase {
     sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
     if (isPlatformBooleanNative()) {
-      assertSql(sql.get(0)).contains("left join esd_detail t1 on t1.master_id = t0.id and t1.deleted = false  where t0.id = ?");
+      assertSql(sql.get(0)).contains("left join esd_detail t1 on t1.master_id = t0.id and t1.deleted = false where t0.id = ?");
     }
   }
 }


### PR DESCRIPTION
The SQL generation has been included double spaces before `where`, `join` and `order by`.  

This change cleans this up by being consistent with "whitespace is added prior" and remove any code that appended whitespace to the end.