### PR TITLE
PersistenceException when calling executeBatch() on SqlUpdate

### DIFF
--- a/ebean-core/src/test/java/org/tests/update/TestSqlUpdateBatch.java
+++ b/ebean-core/src/test/java/org/tests/update/TestSqlUpdateBatch.java
@@ -1,0 +1,65 @@
+package org.tests.update;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.SqlUpdate;
+import io.ebean.Transaction;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Testclass that ensures the correct behaviour of SqlUpdate in combination with batching.
+ *
+ * @author Jonas P&ouml;hler, FOCONIS AG
+ */
+public class TestSqlUpdateBatch extends BaseTestCase {
+
+  /**
+   * This test ensures the correct behaviour of update batching in the {@code BatchedPstmtHolder} after a flush. Two batch updates
+   * are executed with each a batchsize of 21, which is the default limit for automatic flushing on {@code addBatch()}. After that
+   * the statements are each executed with {@code executeBatch()}. The desired behaviour is, that each execution succeeds although
+   * technically the batch was already flushed.
+   */
+  @Test
+  public void testTwoParallelBatches() {
+    try (Transaction txn = DB.beginTransaction()) {
+      // Dummy updates, that effectively do nothing, but ebean doesn't need to know this.
+      final SqlUpdate update = DB.sqlUpdate("update uuone set name = ? where 0=1");
+      final SqlUpdate delete = DB.sqlUpdate("delete from uuone where ?=-1");
+
+      for (int i = 0; i <= 20; i++) {
+        update
+          .setParameter(1, String.valueOf(i))
+          .addBatch();
+        delete
+          .setParameter(1, String.valueOf(i))
+          .addBatch();
+      }
+
+      delete.executeBatch();
+      update.executeBatch();
+    }
+  }
+
+  /**
+   * This test checks that for a batch update a correct array with update counts is returned. If a update with 40 entries is
+   * executed, it is expected, that {@code executeBatch()} returns a array with 40 elements each containing the update count for
+   * the given parameters.
+   */
+  @Test
+  public void testBatchReturnArrayLength() {
+    try (Transaction txn = DB.beginTransaction()) {
+      // Dummy update, that effectively does nothing, but ebean doesn't need to know this.
+      final SqlUpdate update = DB.sqlUpdate("update uuone set name = ? where 0=1");
+
+      for (int i = 0; i <= 40; i++) {
+        update
+          .setParameter(1, String.valueOf(i))
+          .addBatch();
+      }
+      assertEquals(40, update.executeBatch().length);
+    }
+  }
+
+}


### PR DESCRIPTION
Hello Rob,

we have discovered a problem in a routine in our application that fills two batched updates in one for-loop and after that calls `executeBatch()` on them. This seems to work perfectely in almost all cases, except, when the number of batched updates equals the maxBatchSize (or `number % maxBatchSize == 0`). In that case we receive the following exception (reproducable with `testTwoParallelBatches`):

```
javax.persistence.PersistenceException: No batched statement found for key update uuone set name = ? where 0=1

	at io.ebeaninternal.server.persist.BatchedPstmtHolder.execute(BatchedPstmtHolder.java:91)
	at io.ebeaninternal.server.persist.BatchControl.execute(BatchControl.java:355)
	at io.ebeaninternal.server.persist.DefaultPersister.executeBatch(DefaultPersister.java:135)
	at io.ebeaninternal.server.core.DefaultServer.executeBatch(DefaultServer.java:1958)
	at io.ebeaninternal.server.core.DefaultSqlUpdate.executeBatch(DefaultSqlUpdate.java:167)
	at org.tests.update.TestSqlUpdateBatch.testTwoParallelBatches(TestSqlUpdateBatch.java:41)
	...
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
```

When we were trying to fix this, our first intention was, not to throw this exception and instead just return and do nothing (the updates were already flushed). But that brought up the question why the stmtMap in `BatchedPstmtHolder` is cleared in the first place. At every flush the map of `BatchedPstmt` is cleared, resulting in a new object of `BatchedPstmt` being created on the next call to `addBatch()`. Since this results in a wrong array of change-length returned from `executeBatch()` (see the second test: `testBatchReturnArrayLength`), this didn't look correct either.

A possible fix would maybe be not to clear the map, but rather clear the list of "elements-still-to-flush" for every `BatchedPstmt` and not recreate the statement after each flush. But since I am not all that sure about the overall architecture thoughts on this matter, I decided, to just provide these two tests and maybe start a discussion.

I hope that I made the problem clear enough for you to understand, the code might explain it even better. 
Looking forward to your thoughts on this!

All the best
Jonas