### PR TITLE
#2110 Part2 - addBatch() does not auto flush

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequest.java
@@ -104,7 +104,6 @@ public abstract class PersistRequest extends BeanRequest implements BatchPostExe
     return transaction.isLogSummary();
   }
 
-
   /**
    * Return true if this persist request should use JDBC batch.
    */
@@ -119,23 +118,22 @@ public abstract class PersistRequest extends BeanRequest implements BatchPostExe
     return transaction.translate(e.getMessage(), e);
   }
 
-  /**
-   * Execute the statement.
-   */
   int executeStatement() {
+    return executeStatement(false);
+  }
 
+  int executeStatement(boolean addBatch) {
     boolean batch = isBatchThisRequest();
-
     try {
       int rows;
       BatchControl control = transaction.getBatchControl();
       if (control != null) {
-        rows = control.executeStatementOrBatch(this, batch);
+        rows = control.executeStatementOrBatch(this, batch, addBatch);
 
       } else if (batch) {
         // need to create the BatchControl
         control = persistExecute.createBatchControl(transaction);
-        rows = control.executeStatementOrBatch(this, true);
+        rows = control.executeStatementOrBatch(this, true, addBatch);
       } else {
         rows = executeNow();
       }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestUpdateSql.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestUpdateSql.java
@@ -59,7 +59,7 @@ public final class PersistRequestUpdateSql extends PersistRequest {
    */
   public int addBatch() {
     this.addBatch = true;
-    return executeOrQueue();
+    return executeStatement(true);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchControl.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchControl.java
@@ -138,9 +138,8 @@ public final class BatchControl {
    * These all go straight to jdbc and use addBatch(). Entity beans goto a queue
    * and wait there so that the jdbc is executed in the correct order according
    * to the depth.
-   * </p>
    */
-  public int executeStatementOrBatch(PersistRequest request, boolean batch) throws BatchedSqlException {
+  public int executeStatementOrBatch(PersistRequest request, boolean batch, boolean addBatch) throws BatchedSqlException {
     if (!batch || (batchFlushOnMixed && !isBeansEmpty())) {
       // flush when mixing beans and updateSql
       flush();
@@ -149,7 +148,7 @@ public final class BatchControl {
       // execute the request immediately without batching
       return request.executeNow();
     }
-    if (pstmtHolder.getMaxSize() >= batchSize) {
+    if (!addBatch && pstmtHolder.getMaxSize() >= batchSize) {
       flush();
     }
     // for OrmUpdate, SqlUpdate, CallableSql there is no queue...

--- a/ebean-core/src/test/java/org/tests/update/TestSqlUpdateBatch.java
+++ b/ebean-core/src/test/java/org/tests/update/TestSqlUpdateBatch.java
@@ -6,6 +6,7 @@ import io.ebean.SqlUpdate;
 import io.ebean.Transaction;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -27,9 +28,8 @@ public class TestSqlUpdateBatch extends BaseTestCase {
       // Dummy updates, that effectively do nothing, but ebean doesn't need to know this.
       final SqlUpdate update = DB.sqlUpdate("update uuone set name = ? where 0=1");
       final SqlUpdate delete = DB.sqlUpdate("delete from uuone where ?=-1");
-      // txn.setBatchSize(40);
 
-      for (int i = 0; i <= 20; i++) {
+      for (int i = 0; i < 20; i++) {
         update
           .setParameter(1, String.valueOf(i))
           .addBatch();
@@ -38,8 +38,8 @@ public class TestSqlUpdateBatch extends BaseTestCase {
           .addBatch();
       }
 
-      delete.executeBatch();
-      update.executeBatch();
+      assertThat(delete.executeBatch().length).isEqualTo(20);
+      assertThat(update.executeBatch().length).isEqualTo(20);
       txn.commit();
     }
   }
@@ -52,7 +52,8 @@ public class TestSqlUpdateBatch extends BaseTestCase {
   @Test
   public void testBatchReturnArrayLength() {
     try (Transaction txn = DB.beginTransaction()) {
-      txn.setBatchSize(100); // something bigger than 40
+      // transaction batch size is ignored with addBatch()
+      txn.setBatchSize(10);
       // Dummy update, that effectively does nothing, but ebean doesn't need to know this.
       final SqlUpdate update = DB.sqlUpdate("update uuone set name = ? where 0=1");
       for (int i = 0; i < 40; i++) {


### PR DESCRIPTION
Hi @rPraml  @jonasPoehler  ... I think this is what you are looking for with `addBatch()` not "automatically flushing".  

Means that if we use `addBatch()` flush will occur with `executeBatch()` and `transaction.commit()`