### PR TITLE
Ignore javax.persistence.Transient in query beans

### DIFF
--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -200,7 +200,11 @@ class ProcessingContext implements Constants {
 
   private boolean isStaticOrTransient(VariableElement field) {
     Set<Modifier> modifiers = field.getModifiers();
-    return (modifiers.contains(Modifier.STATIC) || modifiers.contains(Modifier.TRANSIENT));
+    return (
+      modifiers.contains(Modifier.STATIC) ||
+      modifiers.contains(Modifier.TRANSIENT) ||
+      hasAnnotations(field, "javax.persistence.Transient")
+    );
   }
 
   private static boolean hasAnnotations(Element element, String... annotations) {

--- a/kotlin-querybean-generator/src/test/kotlin/io/ebean/querybean/generator/AddressTest.kt
+++ b/kotlin-querybean-generator/src/test/kotlin/io/ebean/querybean/generator/AddressTest.kt
@@ -1,0 +1,29 @@
+package io.ebean.querybean.generator
+
+import org.example.domain.Address
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+
+class AddressTest {
+
+  private val fieldsInQueryBean = javaClass.classLoader.loadClass("org.example.domain.query.QAddress")
+    ?.declaredFields
+    ?: fail()
+  private val fieldsInBean = Address::class.java.declaredFields
+
+  @Test
+  fun `assert no transient fields`() {
+    assertFieldsNotExists("javaxPersistenceTransient")
+    assertFieldsNotExists("kotlinJvmTransient")
+  }
+
+  private fun assertFieldsNotExists(fieldName: String) {
+    assertTrue(fieldsInBean.any { it.name == fieldName }) {
+      "$fieldName does not exist in Address."
+    }
+    assertTrue(fieldsInQueryBean.none { it.name == fieldName}) {
+      "$fieldName does exists in query bean for Address (QAddress)."
+    }
+  }
+}

--- a/kotlin-querybean-generator/src/test/kotlin/org/example/domain/Address.kt
+++ b/kotlin-querybean-generator/src/test/kotlin/org/example/domain/Address.kt
@@ -20,5 +20,9 @@ class Address(
   @Size(max = 100)
   var city: String,
   // Dummy metadata field just to test generation
-  val metadata: GenericType<GenericTypeArgument>
+  val metadata: GenericType<GenericTypeArgument>,
+  @Transient
+  val javaxPersistenceTransient: Set<String>,
+  @kotlin.jvm.Transient
+  val kotlinJvmTransient: Set<String>,
 ) : BaseModel()

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -171,7 +171,11 @@ class ProcessingContext implements Constants {
 
   private boolean isStaticOrTransient(VariableElement field) {
     Set<Modifier> modifiers = field.getModifiers();
-    return (modifiers.contains(Modifier.STATIC) || modifiers.contains(Modifier.TRANSIENT));
+    return (
+      modifiers.contains(Modifier.STATIC) ||
+      modifiers.contains(Modifier.TRANSIENT) ||
+      hasAnnotations(field, "javax.persistence.Transient")
+    );
   }
 
   private static boolean hasAnnotations(Element element, String... annotations) {


### PR DESCRIPTION
Currently `@javax.persistence.Transient` annotated properties are not ignored when generating query beans, but properties marked with jvm `transient` are. This adds a (kotlin) test case for them and ignores those marked with jpa `@Transient`.