### PR TITLE
POM and BOM fixes

### DIFF
--- a/ebean-api/pom.xml
+++ b/ebean-api/pom.xml
@@ -49,13 +49,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>persistence-api</artifactId>
-      <version>2.2.4</version>
+      <version>${ebean-persistence-api.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-annotation</artifactId>
-      <version>6.15</version>
+      <version>${ebean-annotation.version}</version>
     </dependency>
 
     <dependency>

--- a/ebean-bom/pom.xml
+++ b/ebean-bom/pom.xml
@@ -12,21 +12,17 @@
   <artifactId>ebean-bom</artifactId>
   <packaging>pom</packaging>
 
-  <properties>
-    <ebean-ddl-runner.version>1.0</ebean-ddl-runner.version>
-    <ebean-migration-auto.version>1.0</ebean-migration-auto.version>
-    <ebean-migration.version>12.4.0</ebean-migration.version>
-    <ebean-test-docker.version>4.1</ebean-test-docker.version>
-    <ebean-datasource.version>7.0</ebean-datasource.version>
-    <ebean-agent.version>12.6.2</ebean-agent.version>
-    <ebean-maven-plugin.version>12.6.2</ebean-maven-plugin.version>
-  </properties>
-
   <dependencyManagement>
 
     <dependencies>
 
       <!-- dependencies external to this ebean.git build -->
+
+      <dependency>
+        <groupId>io.ebean</groupId>
+        <artifactId>ebean-annotation</artifactId>
+        <version>${ebean-annotation.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>

--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-ddl-runner</artifactId>
-      <version>1.0</version>
+      <version>${ebean-ddl-runner.version}</version>
     </dependency>
 
     <dependency>
@@ -63,14 +63,14 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-migration-auto</artifactId>
-      <version>1.0</version>
+      <version>${ebean-migration-auto.version}</version>
     </dependency>
 
     <!-- keep testing in core using ebean-ddl-generator & ebean-migration -->
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-migration</artifactId>
-      <version>12.4.0</version>
+      <version>${ebean-migration.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-ddl-generator/pom.xml
+++ b/ebean-ddl-generator/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-migration</artifactId>
-      <version>12.4.0</version>
+      <version>${ebean-migration.version}</version>
     </dependency>
 
     <dependency>

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test-docker</artifactId>
-      <version>4.1</version>
+      <version>${ebean-test-docker.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,15 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>false</nexus.staging.autoReleaseAfterClose>
+    <ebean-agent.version>12.6.2</ebean-agent.version>
+    <ebean-annotation.version>6.15</ebean-annotation.version>
     <ebean-datasource.version>7.0</ebean-datasource.version>
+    <ebean-ddl-runner.version>1.0</ebean-ddl-runner.version>
+    <ebean-maven-plugin.version>12.6.2</ebean-maven-plugin.version>
+    <ebean-migration-auto.version>1.0</ebean-migration-auto.version>
+    <ebean-migration.version>12.4.0</ebean-migration.version>
+    <ebean-persistence-api.version>2.2.4</ebean-persistence-api.version>
+    <ebean-test-docker.version>4.1</ebean-test-docker.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
~* ebean-migration's version is in BOM.~
* Add ebean-postgis, ebean-redis and ebean-core-type version to BOM
~* Use old version of ebean-ddl-generator for tests to avoid
  Maven blowing up on the (not really) circular dependency.~
~* Fix compile error found by using single version of
  ebean-migration.~