### PR TITLE
Failing testcase that shows wipe of all children on save

### DIFF
--- a/ebean-core/src/test/java/org/tests/cascade/TestOnlyKillOrphans.java
+++ b/ebean-core/src/test/java/org/tests/cascade/TestOnlyKillOrphans.java
@@ -1,0 +1,43 @@
+package org.tests.cascade;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOnlyKillOrphans extends BaseTestCase {
+
+  @Test
+  public void test() {
+    final COOne one = setup();
+
+    assertThat(one.getChildren()).hasSize(2);
+
+    CORoot root = new CORoot("P1", one);
+    DB.insert(root);
+
+    // assert
+    CORoot check = DB.find(CORoot.class, root.getId());
+    assertThat(check.getOne().getChildren()).hasSize(2);
+    DB.delete(check);
+  }
+
+  private COOne setup() {
+    COOne one = new COOne("P0");
+    one.setChildren(createManies("M1", "M2"));
+    DB.insert(one);
+    return one;
+  }
+
+  private List<COOneMany> createManies(String... names) {
+    List<COOneMany> manies = new ArrayList<>();
+    for (String name : names) {
+      manies.add(new COOneMany(name));
+    }
+    return manies;
+  }
+}


### PR DESCRIPTION
When adding a newly saved bean (A) to another bean (B), all children
in A are wiped on saving B.

This was most likely caused by #2127 .