### PR TITLE
Failing testcase that shows wipe of all old children on save

### DIFF
--- a/ebean-core/src/test/java/org/tests/cascade/TestOnlyKillOrphans.java
+++ b/ebean-core/src/test/java/org/tests/cascade/TestOnlyKillOrphans.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,6 +25,23 @@ public class TestOnlyKillOrphans extends BaseTestCase {
     // assert
     CORoot check = DB.find(CORoot.class, root.getId());
     assertThat(check.getOne().getChildren()).hasSize(2);
+    DB.delete(check);
+  }
+
+  @Test
+  public void test2() {
+    final COOne one = setup();
+
+    assertThat(one.getChildren()).hasSize(2);
+
+    one.getChildren().add(new COOneMany("_M1"));
+
+    DB.save(one);
+
+    // assert
+    COOne check = DB.find(COOne.class, one.getId());
+    assertThat(check.getChildren().stream().map(it -> it.getName()).sorted().collect(Collectors.toList()))
+      .isEqualTo(Stream.of("M1", "M2", "_M1").sorted().collect(Collectors.toList()));
     DB.delete(check);
   }
 


### PR DESCRIPTION
When adding a child to a newly saved bean (A), all other children are killed on save of A.