### PR TITLE
Wrong beans in Persistcontext avoid proper lazy load

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -215,7 +215,7 @@ class DefaultBeanLoader {
       desc.contextPut(pc, id, bean);
       ebi.setPersistenceContext(pc);
     }
-
+    // desc.contextPut(pc, id, bean); // this will fix one of the two tests
     boolean draft = desc.isDraftInstance(bean);
 
     if (embeddedOwnerIndex == -1) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DefaultPersistenceContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DefaultPersistenceContext.java
@@ -296,6 +296,10 @@ public final class DefaultPersistenceContext implements PersistenceContext {
     }
 
     private void put(Object id, Object b) {
+      Object existing = map.get(id);
+      if (existing != null && existing != b) {
+        System.out.println("DEBUG: Overwriting object");
+      } // else // will fix both tests
       map.put(id, b);
     }
 

--- a/ebean-core/src/test/java/org/tests/cache/TestM2MCache.java
+++ b/ebean-core/src/test/java/org/tests/cache/TestM2MCache.java
@@ -1,0 +1,78 @@
+package org.tests.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.tests.model.cache.M2MCacheChild;
+import org.tests.model.cache.M2MCacheMaster;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+
+public class TestM2MCache extends BaseTestCase {
+
+  @Test
+  public void testM2MWithCache() throws Exception {
+    M2MCacheChild cld = new M2MCacheChild();
+    cld.setName("test");
+    cld.setId(1);
+    DB.save(cld);
+
+    M2MCacheMaster cfg = new M2MCacheMaster();
+    cfg.setId(42);
+    cfg.getSet1().add(cld);
+    cfg.getSet2().add(cld);
+    DB.save(cfg);
+
+    // find master and access set1 + set2.
+    // lazy load something from set1
+    M2MCacheMaster cfg1 = DB.find(M2MCacheMaster.class, 42);
+
+    cfg1.getSet1().size();
+    cfg1.getSet2().size();
+    assertThat(cfg1.getSet1().iterator().next().getName()).isEqualTo("test");
+
+    // do it again
+    cfg1 = DB.find(M2MCacheMaster.class, 42);
+
+    cfg1.getSet1().size();
+    cfg1.getSet2().size();
+
+    assertThat(cfg1.getSet1().iterator().next().getName()).isEqualTo("test");
+    // do it again
+    cfg1 = DB.find(M2MCacheMaster.class, 42);
+
+    cfg1.getSet1().size();
+    cfg1.getSet2().size();
+
+    assertThat(cfg1.getSet1().iterator().next().getName()).isEqualTo("test");
+
+  }
+
+  @Test
+  public void testM2MWithCacheMinimal() throws Exception {
+    M2MCacheChild cld = new M2MCacheChild();
+    cld.setName("test");
+    cld.setId(2);
+    DB.save(cld);
+
+    M2MCacheMaster cfg = new M2MCacheMaster();
+    cfg.setId(43);
+    cfg.getSet1().add(cld);
+    cfg.getSet2().add(cld);
+    DB.save(cfg);
+
+    DB.find(M2MCacheMaster.class, 43);
+
+    M2MCacheMaster cfg1 = DB.find(M2MCacheMaster.class, 43);
+    cfg1.getSet2().size();
+
+    cfg1 = DB.find(M2MCacheMaster.class, 43);
+
+    cfg1.getSet1().size();
+    cfg1.getSet2().size();
+
+    assertThat(cfg1.getSet1().iterator().next().getName()).isEqualTo("test");
+
+  }
+}

--- a/ebean-core/src/test/java/org/tests/model/cache/M2MCacheChild.java
+++ b/ebean-core/src/test/java/org/tests/model/cache/M2MCacheChild.java
@@ -1,0 +1,33 @@
+package org.tests.model.cache;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import io.ebean.annotation.Cache;
+
+@Entity
+@Cache(enableQueryCache = true, enableBeanCache = true)
+public class M2MCacheChild {
+
+  @Id
+  private Integer id;
+
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+}

--- a/ebean-core/src/test/java/org/tests/model/cache/M2MCacheMaster.java
+++ b/ebean-core/src/test/java/org/tests/model/cache/M2MCacheMaster.java
@@ -1,0 +1,53 @@
+package org.tests.model.cache;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+
+import io.ebean.annotation.Cache;
+
+@Entity
+@Cache(enableQueryCache = true, enableBeanCache = true)
+public class M2MCacheMaster {
+
+  @Id
+  private Integer id;
+
+  @ManyToMany(cascade = CascadeType.ALL)
+  @JoinTable(name = "m2mcache_set1")
+  private Set<M2MCacheChild> set1 = new LinkedHashSet<>();
+
+  @ManyToMany(cascade = CascadeType.ALL)
+  @JoinTable(name = "m2mcache_set2")
+  private Set<M2MCacheChild> set2 = new LinkedHashSet<>();
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public Set<M2MCacheChild> getSet1() {
+    return set1;
+  }
+
+  public void setSet1(Set<M2MCacheChild> set1) {
+    this.set1 = set1;
+  }
+
+  public Set<M2MCacheChild> getSet2() {
+    return set2;
+  }
+
+  public void setSet2(Set<M2MCacheChild> set2) {
+    this.set2 = set2;
+  }
+
+}


### PR DESCRIPTION
Hello @rbygrave,

I'm struggling with a rare NPE problem in our application. (Only certain click paths triggered the bug, in our app when lazy loading beans)
It took some time, to find a test case that reproduces the isse.
We are still using our ebean 11 fork, but the bug is still present in Ebean 12
First I did this: https://github.com/FOCONIS/ebean/commits/cache-mismatch and found at least one issue (#2063) that did some change, so that the test in this PR passes now, but I could not really explain why.

I changed the test slightly in this PR and it still fails.

Basically I am doing this three times and in the last try `cfg1.set1[0].name` is null

```java
    cfg1 = DB.find(M2MCacheMaster.class, 42);

    cfg1.getSet1().size();
    cfg1.getSet2().size();
    assertThat(cfg1.getSet1().iterator().next().getName()).isEqualTo("test");
```

Then I tried to comment out every line that is not neccessary to trigger the bug. See testM2MWithCacheMinimal

The problem seems, that the lazy load of the M2M bean does not work correctly.

My first try was to change the "DefaultBeanLoader". So the bean that is lazily loaded is in the PC (but this fixes only one of the two test cases)
My second try was not overwriting any bean in the PC (as it does not make really sense in my mind)
The put was called from "BeanDescriptor.createReference", so adding a "putIfAbsent" here, also will fix the problem
```java
      ebi.setReference(idPropertyIndex);
      if (Boolean.TRUE == readOnly) {
        ebi.setReadOnly(true);
      }
      if (pc != null) {
        Object ref = contextPutIfAbsent(pc, id, eb); // use putIfAbsent here
        if (ref != null) {
          System.out.println("DEBUG: got ref");
          return (T) ref;
        }
        ebi.setPersistenceContext(pc);
      }
      return (T) eb;
```
But then, the `createReference` method may return a bean, where the arguments `readOnly` and `disableLazyLoad` are not properly honored.

So it would be great if you find some time to take a look at this bug.

Cheers
Roland


/edit: This is my current fix
https://github.com/FOCONIS/ebean/pull/33/commits/88eee5a70a4132e936d7eb4d2a8b7c193c88267a
I think it makes sense, when creating a reference bean, that the one from the PC is taken