### PR TITLE
Cache with lazy load doesnt work

### DIFF
--- a/ebean-core/src/test/java/org/tests/model/lazywithcache/ChildWithCache.java
+++ b/ebean-core/src/test/java/org/tests/model/lazywithcache/ChildWithCache.java
@@ -1,0 +1,52 @@
+package org.tests.model.lazywithcache;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+
+import io.ebean.annotation.Cache;
+
+/**
+ * Class with @Cache and lazy load property.
+ *
+ * @author Noemi Szemenyei, FOCONIS AG
+ *
+ */
+@Entity
+@Cache(enableQueryCache = true)
+public class ChildWithCache {
+  
+  @Id
+  Long id;
+
+  String name;
+  
+  @Basic(fetch = FetchType.LAZY)
+  String address;
+  
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+  
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+  
+  public void setAddress(String address) {
+    this.address = address;
+  }
+  
+  public String getAddress() {
+    return address;
+  }
+
+}

--- a/ebean-core/src/test/java/org/tests/model/lazywithcache/ParentA.java
+++ b/ebean-core/src/test/java/org/tests/model/lazywithcache/ParentA.java
@@ -1,0 +1,46 @@
+package org.tests.model.lazywithcache;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+/**
+ * Parent class with ChildWithCache.
+ *
+ */
+@Entity
+public class ParentA {
+  
+  @Id
+  Long id;
+  
+  @ManyToOne(optional = true)
+  ChildWithCache child;
+  
+  String name;
+  
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+  
+  public ChildWithCache getChild() {
+    return child;
+  }
+
+  public void setChild(ChildWithCache child) {
+    this.child = child;
+  }
+  
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+}

--- a/ebean-core/src/test/java/org/tests/model/lazywithcache/ParentB.java
+++ b/ebean-core/src/test/java/org/tests/model/lazywithcache/ParentB.java
@@ -1,0 +1,36 @@
+package org.tests.model.lazywithcache;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+/**
+ * Parent class with ChildWithCache.
+ *
+ */
+@Entity
+public class ParentB {
+  
+  @Id
+  Long id;
+  
+  @ManyToOne(optional = true)
+  ChildWithCache child;
+    
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+  
+  public ChildWithCache getChild() {
+    return child;
+  }
+
+  public void setChild(ChildWithCache child) {
+    this.child = child;
+  }
+  
+}

--- a/ebean-core/src/test/java/org/tests/model/lazywithcache/TestWithCacheAndLazyLoad.java
+++ b/ebean-core/src/test/java/org/tests/model/lazywithcache/TestWithCacheAndLazyLoad.java
@@ -1,0 +1,54 @@
+package org.tests.model.lazywithcache;
+
+import org.junit.Test;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test with bean cache and lazy loaded property.
+ *
+ * @author Noemi Szemenyei, FOCONIS AG
+ *
+ */
+
+public class TestWithCacheAndLazyLoad extends BaseTestCase{
+
+  @Test
+  public void testGetters() {
+    
+    ChildWithCache child = new ChildWithCache();
+    child.setId(1L);
+    child.setName("Child With Cache");
+    child.setAddress("Address");
+    DB.save(child);
+    
+    ParentA parentA = new ParentA();
+    parentA.setId(1L);
+    parentA.setName("Parent A");
+    parentA.setChild(child);
+    DB.save(parentA);
+    
+    ParentB parentB = new ParentB();
+    parentB.setId(1L);
+    parentB.setChild(child);
+    DB.save(parentB);
+    
+   
+    ParentA tempA = DB.find(ParentA.class, 1L);
+    tempA.getChild().getName(); //load name
+    
+    ParentB tempB = DB.find(ParentB.class, 1L);
+    
+    ChildWithCache temp = tempB.getChild();
+    //if the next line is commented out, the test passes
+    temp.getName(); //load name from cache --> ebean_intercept.loadedFromCache = true
+    
+    String tempLazyProp = temp.getAddress();
+    assertThat(tempLazyProp).isEqualTo("Address");
+    
+  }
+
+}


### PR DESCRIPTION
Hi @rbygrave ,

we found another NPE in our application, I could have extracted it in an ebean test. It fails in ebean 12 as well.

It is about @Cache and lazy loads:

One entity (ChildWithCache) has a @Cache and a property with lazy load.
Two classes have reference to this entity. If both of them load the @Cache-entity and one (non lazy load) property of it, then calling a Getter of the lazy load property leads to a null value. I think it will be loaded from the cache:

    ParentA tempA = DB.find(ParentA.class, 1L);
    tempA.getChild().getName(); //load name

    ParentB tempB = DB.find(ParentB.class, 1L);

    ChildWithCache temp = tempB.getChild();
    //if the next line is commented out, the test passes
    temp.getName(); //load name from cache --> ebean_intercept.loadedFromCache = true

    String tempLazyProp = temp.getAddress();
    assertThat(tempLazyProp).isEqualTo("Address");

Can you please take a look at this bug?

Kind regards
Noemi
FOCONIS AG (Germany)
