### PR TITLE
ADD: multiple to many outer joins cause wrong count in distinct count…

### DIFF
--- a/ebean-core/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/ebean-core/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -28,20 +28,33 @@ public class TestQuerySingleAttribute extends BaseTestCase {
 	@Test
 	  public void findSingleAttributesTwoToMany() {
 	    ResetBasicData.reset();
+	    // Query without ors with equals causing joins, only one Customer with name Rob exists
+	    Query<Customer> query0 = DB.find(Customer.class)
+		        .select("name")
+		        .setCountDistinct(CountDistinctOrder.COUNT_DESC_ATTR_ASC)
+		        .where()
+		        .eq("name", "Rob")
+		        .query();
+
+		    CountedValue<String> robs0 = (CountedValue<String>) query0.findSingleAttributeList().get(0);
+		    assertThat(robs0.getValue()).isEqualTo("Rob");
+		    assertThat(robs0.getCount()).isEqualTo(1);
+	    
+		 // Query with or with equals causing joins
 	    Query<Customer> query = DB.find(Customer.class)
 	        .select("name")
-	        //.apply(toFetchPath("name"))
 	        .setCountDistinct(CountDistinctOrder.COUNT_DESC_ATTR_ASC)
 	        .where()
 	        .eq("name", "Rob")
 	        .or()
 	         .eq("orders.status", Order.Status.NEW)
 	         .eq("contacts.firstName", "Fred1")
+	         .endOr()
 	        .query();
 
-	    List<Object> counted =  query.findSingleAttributeList();
-	    CountedValue<String> robs = (CountedValue<String>)counted.get(0);
+	    CountedValue<String> robs = (CountedValue<String>) query.findSingleAttributeList().get(0);
 	    assertThat(robs.getValue()).isEqualTo("Rob");
+	    // only one Customer named rob exists, but 7 is returned for the amount of Customers named Rob
 	    assertThat(robs.getCount()).isEqualTo(1);
 	    
 	    // TODO check correct future query

--- a/ebean-core/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/ebean-core/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -3,6 +3,7 @@ package org.tests.query.other;
 import io.ebean.BaseTestCase;
 import io.ebean.CountDistinctOrder;
 import io.ebean.CountedValue;
+import io.ebean.DB;
 import io.ebean.Ebean;
 import io.ebean.Query;
 import org.junit.Ignore;
@@ -23,6 +24,32 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestQuerySingleAttribute extends BaseTestCase {
+	
+	@Test
+	  public void findSingleAttributesTwoToMany() {
+	    ResetBasicData.reset();
+	    Query<Customer> query = DB.find(Customer.class)
+	        .select("name")
+	        //.apply(toFetchPath("name"))
+	        .setCountDistinct(CountDistinctOrder.COUNT_DESC_ATTR_ASC)
+	        .where()
+	        .eq("name", "Rob")
+	        .or()
+	         .eq("orders.status", Order.Status.NEW)
+	         .eq("contacts.firstName", "Fred1")
+	        .query();
+
+	    List<Object> counted =  query.findSingleAttributeList();
+	    CountedValue<String> robs = (CountedValue<String>)counted.get(0);
+	    assertThat(robs.getValue()).isEqualTo("Rob");
+	    assertThat(robs.getCount()).isEqualTo(1);
+	    
+	    // TODO check correct future query
+	    assertThat(sqlOf(query)).contains("select r1.attribute_1, count(*) cnt"
+	        + " from (select t1.id attribute_1 from main_entity_relation t0 left join main_entity t1 on t1.id = t0.id1 ) r1"
+	        + " group by r1.attribute_1"
+	        + " order by count(*) desc, r1.attribute_1");
+	  }
 
   @Test
   public void exampleUsage() {


### PR DESCRIPTION
hi @rbygrave, i found o problem with setCountDistinct queries where more than one @OneToMany, @ManyToMany edges (with data present) in the model cause a wrong result in the CountedValue.getCount() while calling findSingleAttributeList().