### PR TITLE
ADD: jdbc batch flush doesnt execute sql statements created in lifecycle methods (e.g. beans saved in PostInsert etc)

### DIFF
--- a/ebean-core/src/test/java/org/tests/lifecycle/TestLifecycleWithLog.java
+++ b/ebean-core/src/test/java/org/tests/lifecycle/TestLifecycleWithLog.java
@@ -1,0 +1,80 @@
+package org.tests.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.tests.model.basic.EBasicLog;
+import org.tests.model.basic.EBasicWithLog;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.Ebean;
+
+public class TestLifecycleWithLog extends BaseTestCase {
+
+  private List<String> getLogs() {
+    List<String> ret = DB.find(EBasicLog.class)
+        .select("name")
+        .findSingleAttributeList();
+    DB.find(EBasicLog.class).delete();
+    return ret;
+  }
+
+  @Test
+  public void testCUD() {
+
+    EBasicWithLog bean = new EBasicWithLog();
+    bean.setId(1L);
+    bean.setName("Test1");
+
+    DB.save(bean);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "prePersist", "postPersist");
+
+    bean.setName("Test2");
+
+    DB.save(bean);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "preUpdate", "postUpdate");
+
+    DB.delete(bean);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "preSoftDelete", "postSoftDelete");
+
+    DB.deletePermanent(bean);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "preRemove", "postRemove");
+  }
+
+  @Test
+  public void testCUDBatch() {
+
+    EBasicWithLog bean = new EBasicWithLog();
+    bean.setId(2L);
+    bean.setName("Test2");
+
+    List<EBasicWithLog> beans = Arrays.asList(bean);
+
+    DB.saveAll(beans);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "prePersist", "postPersist");
+
+    bean.setName("Test2");
+
+    DB.saveAll(beans);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "preUpdate", "postUpdate");
+
+    DB.deleteAll(beans);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "preSoftDelete", "postSoftDelete");
+
+    DB.deleteAllPermanent(beans);
+
+    assertThat(getLogs()).contains("onPersistTrigger", "preRemove", "postRemove");
+  }
+
+}

--- a/ebean-core/src/test/java/org/tests/model/basic/EBasicLog.java
+++ b/ebean-core/src/test/java/org/tests/model/basic/EBasicLog.java
@@ -1,0 +1,32 @@
+package org.tests.model.basic;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "e_basic_log")
+public class EBasicLog {
+
+  @Id
+  Long id;
+
+  String name;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+}

--- a/ebean-core/src/test/java/org/tests/model/basic/EBasicWithLog.java
+++ b/ebean-core/src/test/java/org/tests/model/basic/EBasicWithLog.java
@@ -1,0 +1,131 @@
+package org.tests.model.basic;
+
+import io.ebean.DB;
+import io.ebean.annotation.PostSoftDelete;
+import io.ebean.annotation.PreSoftDelete;
+import io.ebean.annotation.SoftDelete;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.PostLoad;
+import javax.persistence.PostPersist;
+import javax.persistence.PostRemove;
+import javax.persistence.PostUpdate;
+import javax.persistence.PrePersist;
+import javax.persistence.PreRemove;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+@Entity
+@Table(name = "e_basic_withlog")
+public class EBasicWithLog {
+
+  @Id
+  Long id;
+
+  String name;
+
+  @SoftDelete
+  boolean deleted;
+
+  @Version
+  Long version;
+
+  @PrePersist
+  public void prePersist() {
+    writeLog("prePersist");
+  }
+
+  @PostPersist
+  public void postPersist() {
+    writeLog("postPersist");
+  }
+
+  @PreUpdate
+  public void preUpdate() {
+    writeLog("preUpdate");
+  }
+
+  @PostUpdate
+  public void postUpdate() {
+    writeLog("postUpdate");
+  }
+
+  @PreRemove
+  public void preRemove() {
+    writeLog("preRemove");
+  }
+
+  @PostRemove
+  public void postRemove() {
+    writeLog("postRemove");
+  }
+
+  @PostSoftDelete
+  public void postSoftDelete() {
+    writeLog("postSoftDelete");
+  }
+
+  @PreSoftDelete
+  public void preSoftDelete() {
+    writeLog("preSoftDelete");
+  }
+
+  @PostLoad
+  public void postLoad() {
+    writeLog("postLoad");
+  }
+
+  @PostConstruct
+  public void postConstruct() {
+    writeLog("postConstruct");
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(Long version) {
+    this.version = version;
+  }
+
+  public void _ebean_onPersistTrigger() {
+    writeLog("onPersistTrigger");
+  }
+
+  /**
+   * @param string
+   */
+  private void writeLog(String title) {
+    EBasicLog log = new EBasicLog();
+    log.setName(title);
+    DB.save(log);
+  }
+
+}


### PR DESCRIPTION
hi @rbygrave, Issue where DB.saveAll wouldn't execute sql statements created in lifecycle methods. In the commit are test methods which reproduce the issue.