### PR TITLE
fetchIds with order by and distinct does not work

### DIFF
--- a/ebean-core/src/test/java/org/tests/basic/TestFetchId.java
+++ b/ebean-core/src/test/java/org/tests/basic/TestFetchId.java
@@ -25,6 +25,7 @@ public class TestFetchId extends BaseTestCase {
       .fetch("details")
       .where().gt("id", 1)
       .gt("details.id", 0)
+      .orderBy("orderDate")
       .query();
 
     List<Object> ids = query.findIds();


### PR DESCRIPTION
Hello Rob,
we found a bug in fetch-ids in conjunction with order by and joins that appends "distinct" to the query:
```
Order by expression "T0.ORDER_DATE" must be in the result list in this case; SQL statement:
select distinct t0.id 
   from o_order t0
   join o_order_detail u1 on u1.order_id = t0.id where t0.id > ? and u1.id > ?
   order by t0.order_date
```
I will do a short investigation, if I can fix this.