### PR TITLE
Remove support for "query hints" like +query(50)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
@@ -96,15 +96,11 @@ public class OrmQueryProperties implements Serializable {
     OrmQueryPropertiesParser.Response response = OrmQueryPropertiesParser.parse(rawProperties);
     this.properties = response.properties;
     this.included = response.included;
-    this.cache = response.cache;
-    this.readOnly = response.readOnly;
     if (fetchConfig != null) {
       this.fetchConfig = fetchConfig;
-      if (fetchConfig.isCache()) {
-        this.cache = true;
-      }
+      this.cache = fetchConfig.isCache();
     } else {
-      this.fetchConfig = response.fetchConfig;
+      this.fetchConfig = DEFAULT_FETCH;
     }
   }
 
@@ -151,6 +147,7 @@ public class OrmQueryProperties implements Serializable {
   /**
    * Move a OrderBy.Property from the main query to this query join.
    */
+  @SuppressWarnings("rawtypes")
   void addSecJoinOrderProperty(OrderBy.Property orderProp) {
     if (orderBy == null) {
       orderBy = new OrderBy();
@@ -166,7 +163,7 @@ public class OrmQueryProperties implements Serializable {
    * Return the expressions used to filter on this path. This should be a many path to use this
    * method.
    */
-  @SuppressWarnings({"unchecked"})
+  @SuppressWarnings({"rawtypes","unchecked"})
   public <T> SpiExpressionList<T> filterMany(Query<T> rootQuery) {
     if (filterMany == null) {
       FilterExprPath exprPath = new FilterExprPath(path);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
@@ -41,8 +41,6 @@ public class OrmQueryProperties implements Serializable {
 
   private boolean cache;
 
-  private boolean readOnly;
-
   /**
    * Included bean joins.
    */
@@ -111,7 +109,6 @@ public class OrmQueryProperties implements Serializable {
     this.included = included;
     this.properties = String.join(",", included);
     this.cache = false;
-    this.readOnly = false;
     this.fetchConfig = DEFAULT_FETCH;
   }
 
@@ -124,7 +121,6 @@ public class OrmQueryProperties implements Serializable {
     this.path = source.path;
     this.properties = source.properties;
     this.cache = source.cache;
-    this.readOnly = source.readOnly;
     this.filterMany = source.filterMany;
     this.markForQueryJoin = source.markForQueryJoin;
     this.included = (source.included == null) ? null : new LinkedHashSet<>(source.included);
@@ -365,13 +361,6 @@ public class OrmQueryProperties implements Serializable {
 
   public int getBatchSize() {
     return fetchConfig.getBatchSize();
-  }
-
-  /**
-   * Return true if this path has the +readonly option.
-   */
-  public boolean isReadOnly() {
-    return readOnly;
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
@@ -33,13 +33,12 @@ public class OrmQueryProperties implements Serializable {
   private final String properties;
   private final Set<String> included;
   private final FetchConfig fetchConfig;
+  private final boolean cache;
 
   /**
    * Flag set when this fetch path needs to be a query join.
    */
   private boolean markForQueryJoin;
-
-  private boolean cache;
 
   /**
    * Included bean joins.
@@ -80,6 +79,7 @@ public class OrmQueryProperties implements Serializable {
     this.parentPath = SplitName.parent(path);
     this.properties = null;
     this.included = null;
+    this.cache = false;
     this.fetchConfig = DEFAULT_FETCH;
   }
 
@@ -94,18 +94,13 @@ public class OrmQueryProperties implements Serializable {
     OrmQueryPropertiesParser.Response response = OrmQueryPropertiesParser.parse(rawProperties);
     this.properties = response.properties;
     this.included = response.included;
-    if (fetchConfig != null) {
-      this.fetchConfig = fetchConfig;
-      this.cache = fetchConfig.isCache();
-    } else {
-      this.fetchConfig = DEFAULT_FETCH;
-    }
+    this.fetchConfig = fetchConfig != null ? fetchConfig : DEFAULT_FETCH;
+    this.cache = fetchConfig.isCache();
   }
 
   public OrmQueryProperties(String path, Set<String> included) {
     this.path = path;
     this.parentPath = SplitName.parent(path);
-    // for rawSql parsedProperties can be empty (when only fetching Id property)
     this.included = included;
     this.properties = String.join(",", included);
     this.cache = false;
@@ -364,7 +359,7 @@ public class OrmQueryProperties implements Serializable {
   }
 
   /**
-   * Return true if this path has the +cache option to hit the cache.
+   * Return true if this path should hit the L2 cache.
    */
   public boolean isCache() {
     return cache;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryPropertiesParser.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryPropertiesParser.java
@@ -1,9 +1,7 @@
 package io.ebeaninternal.server.querydefn;
 
-import io.ebean.FetchConfig;
 import io.ebeaninternal.server.util.DSelectColumnsParser;
 
-import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -18,30 +16,15 @@ class OrmQueryPropertiesParser {
    */
   static class Response {
 
-    final boolean readOnly;
-    final boolean cache;
-    final FetchConfig fetchConfig;
     final String properties;
     final Set<String> included;
 
-    Response(boolean readOnly, boolean cache, int queryFetchBatch, int lazyFetchBatch, String properties, Set<String> included) {
-      this.readOnly = readOnly;
-      this.cache = cache;
+    private Response(String properties, Set<String> included) {
       this.properties = properties;
       this.included = included;
-      if (queryFetchBatch > 0) {
-        this.fetchConfig = FetchConfig.ofQuery(queryFetchBatch);
-      } else if (lazyFetchBatch > 0) {
-        this.fetchConfig = FetchConfig.ofLazy(lazyFetchBatch);
-      } else {
-        this.fetchConfig = OrmQueryProperties.DEFAULT_FETCH;
-      }
     }
 
-    Response() {
-      this.readOnly = false;
-      this.cache = false;
-      this.fetchConfig = OrmQueryProperties.DEFAULT_FETCH;
+    private Response() {
       this.properties = "";
       this.included = null;
     }
@@ -57,10 +40,6 @@ class OrmQueryPropertiesParser {
 
   private final String inputProperties;
   private boolean allProperties;
-  private boolean readOnly;
-  private boolean cache;
-  private int queryFetchBatch;
-  private int lazyFetchBatch;
 
   private OrmQueryPropertiesParser(String inputProperties) {
     this.inputProperties = inputProperties;
@@ -74,50 +53,20 @@ class OrmQueryPropertiesParser {
       return EMPTY;
     }
     if (inputProperties.equals("*")) {
-      // explicit all properties
-      allProperties = true;
-      return new Response(readOnly, cache, queryFetchBatch, lazyFetchBatch, "*", null);
+      return new Response("*", null);
     }
-    boolean hints = false;
     Set<String> fields = splitRawSelect(inputProperties);
-    final Iterator<String> iterator = fields.iterator();
-    while (iterator.hasNext()) {
-      String val = iterator.next();
-      if (val.startsWith("+")) {
-        hints = true;
-        iterator.remove();
-        parseHint(val);
-      } else if (val.equals("*")) {
+    for (String val : fields) {
+      if (val.equals("*")) {
         allProperties = true;
+        break;
       }
     }
-    String properties = allProperties ? "*" : hints ? String.join(",", fields) : inputProperties;
+    String properties = allProperties ? "*" : inputProperties;
     if (fields.isEmpty()) {
       fields = null;
     }
-    return new Response(readOnly, cache, queryFetchBatch, lazyFetchBatch, properties, fields);
-  }
-
-  private void parseHint(String val) {
-    if (val.equals("+readonly")) {
-      readOnly = true;
-    } else if (val.equals("+cache")) {
-      cache = true;
-    } else if (val.startsWith("+query")) {
-      queryFetchBatch = parseBatch(val);
-    } else if (val.startsWith("+lazy")) {
-      lazyFetchBatch = parseBatch(val);
-    }
-  }
-
-  private int parseBatch(String val) {
-    if (val.endsWith(")")) {
-      int start = val.lastIndexOf('(');
-      if (start > 0) {
-        return Integer.parseInt(val.substring(start + 1, val.length() - 1));
-      }
-    }
-    return 0;
+    return new Response(properties, fields);
   }
 
   /**

--- a/ebean-core/src/test/java/io/ebeaninternal/server/grammer/EqlParserTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/grammer/EqlParserTest.java
@@ -624,7 +624,7 @@ public class EqlParserTest extends BaseTestCase {
   public void fetch_query50_asHint() {
 
     ResetBasicData.reset();
-    Query<Customer> query = parse("fetch billingAddress (+query(50),city)");
+    Query<Customer> query = parse("fetch query(50) billingAddress (city)");
     query.findList();
 
     assertSql(query).doesNotContain(", t1.city");
@@ -634,7 +634,7 @@ public class EqlParserTest extends BaseTestCase {
   public void fetch_lazy50_asHint() {
 
     ResetBasicData.reset();
-    Query<Customer> query = parse("fetch billingAddress (+lazy(50),city) order by id");
+    Query<Customer> query = parse("fetch lazy(50) billingAddress (city) order by id");
     List<Customer> list = query.findList();
 
     assertSql(query).doesNotContain(", t1.city");

--- a/ebean-core/src/test/java/io/ebeaninternal/server/querydefn/OrmQueryPropertiesParserTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/querydefn/OrmQueryPropertiesParserTest.java
@@ -31,91 +31,17 @@ public class OrmQueryPropertiesParserTest {
   }
 
   @Test
-  public void when_hasCache() {
+  public void when_no_spaces() {
 
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("+cache");
-    assertThat(res.cache).isTrue();
-    assertThat(res.included).isNull();
-  }
-
-  @Test
-  public void when_hasCache_first() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("+cache,id");
-    assertThat(res.cache).isTrue();
-    assertThat(res.included).containsExactly("id");
-  }
-
-  @Test
-  public void when_hasCache_last() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("name,+cache");
-    assertThat(res.cache).isTrue();
-    assertThat(res.included).containsExactly("name");
-  }
-
-  @Test
-  public void when_hasCache_middle() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("name,+cache, id");
-    assertThat(res.cache).isTrue();
-    assertThat(res.included).containsExactly("name", "id");
-  }
-
-  @Test
-  public void when_hasReadOnly() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("+readonly");
-    assertThat(res.readOnly).isTrue();
-    assertThat(res.included).isNull();
-  }
-
-  @Test
-  public void when_hasLazy() {
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("+lazy");
-    //FIXME: assertThat(res.fetchConfig.getBatchSize()).isEqualTo(0);
-    assertThat(res.included).isNull();
-  }
-
-  @Test
-  public void when_hasLazyValue() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("+lazy(20)");
-    assertThat(res.fetchConfig.getBatchSize()).isEqualTo(20);
-    assertThat(res.included).isNull();
-  }
-
-  @Test
-  public void when_hasLazyValue_last() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("name,+lazy(20)");
-    assertThat(res.fetchConfig.getBatchSize()).isEqualTo(20);
-    assertThat(res.included).containsExactly("name");
-  }
-
-  @Test
-  public void when_hasLazyValue_first() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("+lazy(20),id,name");
-    assertThat(res.fetchConfig.getBatchSize()).isEqualTo(20);
+    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("id,name");
     assertThat(res.included).containsExactly("id", "name");
   }
 
   @Test
-  public void when_allProperties() {
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("+query(4),+lazy(5)");
-    assertThat(res.fetchConfig.getBatchSize()).isEqualTo(4);
-    assertThat(res.included).isNull();
-  }
+  public void when_spaced() {
 
-  @Test
-  public void when_everything_set() {
-
-    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("id, name, +readonly ,+lazy(20), +query(30) ,+cache");
+    OrmQueryPropertiesParser.Response res = OrmQueryPropertiesParser.parse("id, name");
     assertThat(res.included).containsExactly("id", "name");
-    assertThat(res.fetchConfig.getBatchSize()).isEqualTo(30);
-    assertThat(res.readOnly).isTrue();
-    assertThat(res.cache).isTrue();
   }
 
   @Test
@@ -126,8 +52,6 @@ public class OrmQueryPropertiesParserTest {
   }
 
   private void assertAllDefaults(OrmQueryPropertiesParser.Response res) {
-    assertThat(res.cache).isFalse();
-    assertThat(res.readOnly).isFalse();
     assertThat(res.included).isNull();
   }
 }

--- a/ebean-core/src/test/java/org/tests/batchload/TestLazyJoin.java
+++ b/ebean-core/src/test/java/org/tests/batchload/TestLazyJoin.java
@@ -21,7 +21,7 @@ public class TestLazyJoin extends BaseTestCase {
 
     Query<Order> query = Ebean.find(Order.class)
       .select("status")
-      .fetch("customer", "+lazy(10) name, status")
+      .fetchLazy("customer", "name, status")
       .fetch("customer.contacts")
       .order().asc("id");
 

--- a/ebean-core/src/test/java/org/tests/batchload/TestQueryJoin.java
+++ b/ebean-core/src/test/java/org/tests/batchload/TestQueryJoin.java
@@ -28,7 +28,7 @@ public class TestQueryJoin extends BaseTestCase {
 
     Query<Order> query = Ebean.find(Order.class).select("status")
       // .join("details","+query(10)")
-      .fetch("customer", "+lazy(10), name, status").fetch("customer.contacts").order().asc("id");
+      .fetchLazy("customer", "name, status").fetch("customer.contacts").order().asc("id");
     // .join("customer.billingAddress");
 
     List<Order> list = query.findList();


### PR DESCRIPTION
For example we can no longer use EQL query (string that is parsed) of:

`"fetch billingAddress (+lazy(50),city) order by id";`

but instead would use:

`"fetch lazy(50) billingAddress (city) order by id";`

---
Note that most people are not using EQL at all and instead would just use a `fetchLazy()` or `fetchQuery()` method on query beans or criteria query like:

```java
DB.find(Customer.class)
  .fetchLazy("billingAddress", "city")
  .orderBy("id)
  .findList()
```

or

```java
new QCustomer()
  .billingAddress.fetchLazy(QAdress.Alias.city)
  .orderBy()
    .id.asc()
  .findList() 
```

So most users of Ebean will probably not be aware of these old query hints etc and not be using them.
