### PR TITLE
Add more assertions for nested one-to-many fetch

### DIFF
--- a/ebean-core/src/test/java/org/tests/query/joins/TestQueryJoinManyNonRoot.java
+++ b/ebean-core/src/test/java/org/tests/query/joins/TestQueryJoinManyNonRoot.java
@@ -11,6 +11,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -53,6 +54,17 @@ public class TestQueryJoinManyNonRoot extends BaseTestCase {
     assertTrue(!list.isEmpty());
     assertTrue(sql.contains("join o_customer t1 on t1.id "));
     assertTrue(sql.contains("left join contact t2 on"));
+
+    Map<Integer, Order> ordersById = Ebean.find(Order.class).setMapKey("id").where().gt("id", 0).query().findMap();
+    for (Order o: list) {
+      int withoutFetch = ordersById.get(o.getId()).getCustomer().getContacts().size();
+      int withFetch = o.getCustomer().getContacts().size();
+      assertEquals(String.format("order.customer.contacts for order %d did not match. " +
+              "Items without fetch: %d, with fetch: %d", o.getId(), withoutFetch, withFetch),
+              withoutFetch,
+              withFetch);
+    }
+
 
     // select t0.id c0, t0.status c1, t0.order_date c2, t0.ship_date c3, t1.name c4, t0.cretime c5, t0.updtime c6,
     //        t1.id c7, t1.status c8, t1.name c9, t1.smallnote c10, t1.anniversary c11, t1.cretime c12, t1.updtime c13, t1.billing_address_id c14, t1.shipping_address_id c15,


### PR DESCRIPTION
Assertions showing that nested one-to-many fetches result in duplicates in the fetched collections.

Run:
```shell
mvn -am -pl=ebean-core test -DfailIfNoTests=false -Dtest=TestQueryJoinManyNonRoot
```