### PR TITLE
FIX: orderBy does not work when used on formula property 

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -616,11 +616,19 @@ class CQueryBuilder {
         if (request.isInlineCountDistinct()) {
           sb.append(")");
         }
-        if (distinct && dbOrderBy != null && !query.isSingleAttribute()) {
+        if (distinct && dbOrderBy != null) {
           // add the orderBy columns to the select clause (due to distinct)
           final OrderBy<?> orderBy = query.getOrderBy();
           if (orderBy != null && orderBy.supportsSelect()) {
-            sb.append(", ").append(DbOrderByTrim.trim(dbOrderBy));
+            String trimmed = DbOrderByTrim.trim(dbOrderBy);
+            if (query.isSingleAttribute() && trimmed.equals(select.getSelectSql())) {
+              // NOP, already in SQL
+              // TODO: what to do if we select("id").orderBy("prop,id")?
+              // Can we live with a query like "select t0.id, t0.prop, t0.id from"
+              // or should we elliminate the second "t0.id" from select
+            } else {
+              sb.append(", ").append(trimmed);
+            }
           }
         }
       }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -53,6 +53,7 @@ import io.ebeaninternal.server.deploy.BeanNaturalKey;
 import io.ebeaninternal.server.deploy.BeanPropertyAssocMany;
 import io.ebeaninternal.server.deploy.InheritInfo;
 import io.ebeaninternal.server.deploy.TableJoin;
+import io.ebeaninternal.server.el.ElPropertyDeploy;
 import io.ebeaninternal.server.expression.DefaultExpressionList;
 import io.ebeaninternal.server.expression.IdInExpression;
 import io.ebeaninternal.server.expression.SimpleExpression;
@@ -536,6 +537,14 @@ public class DefaultOrmQuery<T> implements SpiQuery<T> {
     }
     if (havingExpressions != null) {
       havingExpressions.containsMany(beanDescriptor, manyWhereJoins);
+    }
+    if (orderBy != null) {
+      for (Property orderProperty : orderBy.getProperties()) {
+        ElPropertyDeploy elProp = beanDescriptor.getElPropertyDeploy(orderProperty.getProperty());
+        if (elProp != null && elProp.containsFormulaWithJoin()) {
+          manyWhereJoins.addFormulaWithJoin(orderProperty.getProperty());
+        }
+      }
     }
   }
 

--- a/ebean-core/src/test/java/org/tests/basic/TestFetchId.java
+++ b/ebean-core/src/test/java/org/tests/basic/TestFetchId.java
@@ -1,10 +1,14 @@
 package org.tests.basic;
 
 import io.ebean.BaseTestCase;
+import io.ebean.DB;
 import io.ebean.Ebean;
 import io.ebean.FutureIds;
 import io.ebean.Query;
+import io.ebeantest.LoggedSql;
+
 import org.tests.model.basic.Order;
+import org.tests.model.basic.OrderDetail;
 import org.tests.model.basic.ResetBasicData;
 import org.junit.Test;
 
@@ -35,5 +39,37 @@ public class TestFetchId extends BaseTestCase {
     // wait for all the id's to be fetched
     List<Object> idList = futureIds.get();
     assertThat(idList).isNotEmpty();
+  }
+  
+  @Test
+  public void testFetchIdWithExists() throws InterruptedException, ExecutionException {
+
+    ResetBasicData.reset();
+
+    Query<OrderDetail> subQuery = Ebean.find(OrderDetail.class)
+        .alias("sq")
+        .where().raw("details.id = sq.id").query();
+    Query<Order> query = Ebean.find(Order.class)
+      .where().exists(subQuery)
+      .orderBy("orderDate").query();
+
+    List<Object> ids = query.findIds();
+    // TODO: assert(query.getGeneratedSql())
+    assertThat(ids).isNotEmpty();
+    FutureIds<Order> futureIds = query.findFutureIds();
+
+    // wait for all the id's to be fetched
+    List<Object> idList = futureIds.get();
+    assertThat(idList).isNotEmpty();
+  }
+  
+  @Test
+  public void testFetchIdWithOrderFormula() throws InterruptedException, ExecutionException {
+
+    ResetBasicData.reset();
+
+    Query<Order> query = DB.find(Order.class).orderBy("totalItems");
+    query.findIds();
+    // TODO: assert(query.getGeneratedSql())
   }
 }


### PR DESCRIPTION
or in conjunction with "exists" query

Hello @rbygrave 
We have found a severe bug, when using "orderBy" + "findIds"
- on a formula property: The property is not part of the select, so the join will not be added
- using it on an exists query (probably also other distinct queries), the order by will not be added to the select.

Please take a look at my solution. I'm not sure if the change in DefaultOrmQuery::createExtraJoinsToSupportManyWhereClause is really the right place (as method name suggests something different)

Cheers
Roland