### PR TITLE
Add bitwise operators to query beans

### DIFF
--- a/ebean-querybean/src/main/java/io/ebean/typequery/PInteger.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/PInteger.java
@@ -24,4 +24,70 @@ public class PInteger<R> extends PBaseNumber<R,Integer> {
     super(name, root, prefix);
   }
 
+  /**
+   * Add bitwise AND expression of the given bit flags to compare with the match/mask.
+   * <p>
+   * <pre>{@code
+   *
+   * // Flags Bulk + Size = Size
+   * // ... meaning Bulk is not set and Size is set
+   *
+   * int selectedFlags = BwFlags.HAS_BULK + BwFlags.HAS_SIZE;
+   * int mask = BwFlags.HAS_SIZE; // Only Size flag set
+   *
+   * bitwiseAnd(selectedFlags, mask)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAnd(int flags, int mask) {
+    expr().bitwiseAnd(_name, flags, mask);
+    return _root;
+  }
+
+  /**
+   * Add expression for ALL of the given bit flags to be set.
+   * <pre>{@code
+   *
+   * bitwiseAll(BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAll(int flags) {
+    expr().bitwiseAll(_name, flags);
+    return _root;
+  }
+
+  /**
+   * Add expression for ANY of the given bit flags to be set.
+   * <pre>{@code
+   *
+   * bitwiseAny(BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAny(int flags) {
+    expr().bitwiseAny(_name, flags);
+    return _root;
+  }
+
+  /**
+   * Add expression for the given bit flags to be NOT set.
+   * <pre>{@code
+   *
+   * bitwiseNot(BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseNot(int flags) {
+    expr().bitwiseNot(_name, flags);
+    return _root;
+  }
 }

--- a/ebean-querybean/src/main/java/io/ebean/typequery/PLong.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/PLong.java
@@ -5,7 +5,7 @@ package io.ebean.typequery;
  *
  * @param <R> the root query bean type
  */
-public class PLong<R> extends PBaseNumber<R,Long> {
+public class PLong<R> extends PBaseNumber<R, Long> {
 
   /**
    * Construct with a property name and root instance.
@@ -14,7 +14,7 @@ public class PLong<R> extends PBaseNumber<R,Long> {
    * @param root the root query bean instance
    */
   public PLong(String name, R root) {
-    super(name , root);
+    super(name, root);
   }
 
   /**
@@ -24,4 +24,70 @@ public class PLong<R> extends PBaseNumber<R,Long> {
     super(name, root, prefix);
   }
 
+  /**
+   * Add bitwise AND expression of the given bit flags to compare with the match/mask.
+   * <p>
+   * <pre>{@code
+   *
+   * // Flags Bulk + Size = Size
+   * // ... meaning Bulk is not set and Size is set
+   *
+   * long selectedFlags = BwFlags.HAS_BULK + BwFlags.HAS_SIZE;
+   * long mask = BwFlags.HAS_SIZE; // Only Size flag set
+   *
+   * bitwiseAnd(selectedFlags, mask)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAnd(long flags, long mask) {
+    expr().bitwiseAnd(_name, flags, mask);
+    return _root;
+  }
+
+  /**
+   * Add expression for ALL of the given bit flags to be set.
+   * <pre>{@code
+   *
+   * bitwiseAll(BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAll(long flags) {
+    expr().bitwiseAll(_name, flags);
+    return _root;
+  }
+
+  /**
+   * Add expression for ANY of the given bit flags to be set.
+   * <pre>{@code
+   *
+   * bitwiseAny(BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAny(long flags) {
+    expr().bitwiseAny(_name, flags);
+    return _root;
+  }
+
+  /**
+   * Add expression for the given bit flags to be NOT set.
+   * <pre>{@code
+   *
+   * bitwiseNot(BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseNot(long flags) {
+    expr().bitwiseNot(_name, flags);
+    return _root;
+  }
 }

--- a/ebean-querybean/src/main/java/io/ebean/typequery/PShort.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/PShort.java
@@ -5,7 +5,7 @@ package io.ebean.typequery;
  *
  * @param <R> the root query bean type
  */
-public class PShort<R> extends PBaseNumber<R,Short> {
+public class PShort<R> extends PBaseNumber<R, Short> {
 
   /**
    * Construct with a property name and root instance.
@@ -24,4 +24,70 @@ public class PShort<R> extends PBaseNumber<R,Short> {
     super(name, root, prefix);
   }
 
+  /**
+   * Add bitwise AND expression of the given bit flags to compare with the match/mask.
+   * <p>
+   * <pre>{@code
+   *
+   * // Flags Bulk + Size = Size
+   * // ... meaning Bulk is not set and Size is set
+   *
+   * short selectedFlags = BwFlags.HAS_BULK + BwFlags.HAS_SIZE;
+   * short mask = BwFlags.HAS_SIZE; // Only Size flag set
+   *
+   * bitwiseAnd(selectedFlags, mask)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAnd(short flags, short mask) {
+    expr().bitwiseAnd(_name, flags, mask);
+    return _root;
+  }
+
+  /**
+   * Add expression for ALL of the given bit flags to be set.
+   * <pre>{@code
+   *
+   * bitwiseAll(BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAll(short flags) {
+    expr().bitwiseAll(_name, flags);
+    return _root;
+  }
+
+  /**
+   * Add expression for ANY of the given bit flags to be set.
+   * <pre>{@code
+   *
+   * bitwiseAny(BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseAny(short flags) {
+    expr().bitwiseAny(_name, flags);
+    return _root;
+  }
+
+  /**
+   * Add expression for the given bit flags to be NOT set.
+   * <pre>{@code
+   *
+   * bitwiseNot(BwFlags.HAS_COLOUR)
+   *
+   * }</pre>
+   *
+   * @param flags        The flags we are looking for
+   */
+  public R bitwiseNot(short flags) {
+    expr().bitwiseNot(_name, flags);
+    return _root;
+  }
 }


### PR DESCRIPTION
Bitwise operators are missing from `PShort`, `PInteger`, `PLong` and `PBigInteger`). This PR adds those missing methods to `PShort`, `PInteger` and `PLong`.