### PR TITLE
#2177 - Fix where schema not provided by JDBC driver

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -2473,7 +2473,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
    * Return the property path given the db table and column.
    */
   public String findBeanPath(String schemaName, String tableName, String columnName) {
-    if (matchBaseTable(schemaName, tableName)) {
+    if (matchBaseTable(tableName)) {
       return columnPath.get(columnName);
     }
     BeanPropertyAssoc<?> assocProperty = tablePath.get(tableName);
@@ -2489,10 +2489,10 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType {
     return null;
   }
 
-  private boolean matchBaseTable(String schemaName, String tableName) {
+  boolean matchBaseTable(String tableName) {
     return tableName.isEmpty()
       || baseTable.equalsIgnoreCase(tableName)
-      || baseTable.equalsIgnoreCase(schemaName + "." + tableName);
+      || baseTable.endsWith("." + tableName);
   }
 
   /**


### PR DESCRIPTION
For @Table with schema, using findNative with a JDBC driver that does not provide the schema this fix matches by just using the table name.