### PR TITLE
Null check for soft-deleteable one-to-one exported assoc has extraneous soft-delete predicate

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeExtraJoin.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeExtraJoin.java
@@ -5,6 +5,7 @@ import io.ebean.bean.EntityBean;
 import io.ebean.core.type.ScalarType;
 import io.ebean.util.SplitName;
 import io.ebeaninternal.api.SpiQuery;
+import io.ebeaninternal.server.deploy.BeanPropertyAssocOne;
 import io.ebeaninternal.server.deploy.DbReadContext;
 import io.ebeaninternal.server.deploy.DbSqlContext;
 import io.ebeaninternal.server.deploy.TableJoin;
@@ -130,11 +131,19 @@ class SqlTreeNodeExtraJoin implements SqlTreeNode {
       }
     }
 
+    boolean oneToOneExported = false;
+    if (assocBeanProperty instanceof BeanPropertyAssocOne) {
+      BeanPropertyAssocOne<?> oneToOneProp = (BeanPropertyAssocOne<?>) assocBeanProperty;
+      if (oneToOneProp.isOneToOneExported()) {
+        oneToOneExported = true;
+      }
+    }
+
     if (pathContainsMany) {
       // "promote" to left join as the path contains a many
       joinType = SqlJoinType.OUTER;
     }
-    if (!manyToMany) {
+    if (!manyToMany && !oneToOneExported) {
       if (assocBeanProperty.isFormula()) {
         // add joins for formula beans
         assocBeanProperty.appendFrom(ctx, joinType);

--- a/ebean-core/src/test/java/org/tests/model/softdelete/ESoftDelX.java
+++ b/ebean-core/src/test/java/org/tests/model/softdelete/ESoftDelX.java
@@ -1,0 +1,54 @@
+package org.tests.model.softdelete;
+
+import io.ebean.annotation.SoftDelete;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+public class ESoftDelX {
+
+  @Id
+  private UUID id;
+
+  @OneToOne
+  private ESoftDelY y;
+
+  @ManyToOne
+  private ESoftDelZ organization;
+
+  @SoftDelete
+  boolean deleted;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public ESoftDelY getY() {
+    return y;
+  }
+
+  public void setY(ESoftDelY y) {
+    this.y = y;
+  }
+
+  public ESoftDelZ getOrganization() {
+    return organization;
+  }
+
+  public void setOrganization(ESoftDelZ organization) {
+    this.organization = organization;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
+  }
+}

--- a/ebean-core/src/test/java/org/tests/model/softdelete/ESoftDelY.java
+++ b/ebean-core/src/test/java/org/tests/model/softdelete/ESoftDelY.java
@@ -1,0 +1,53 @@
+package org.tests.model.softdelete;
+
+import io.ebean.annotation.SoftDelete;
+
+import javax.persistence.*;
+
+@Entity
+public class ESoftDelY {
+
+  @Id
+  private Long id;
+
+  @ManyToOne
+  private ESoftDelZ organization;
+
+  @OneToOne(mappedBy = "y")
+  private ESoftDelX x;
+
+  @SoftDelete
+  boolean deleted;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public ESoftDelZ getOrganization() {
+    return organization;
+  }
+
+  public void setOrganization(ESoftDelZ organization) {
+    this.organization = organization;
+  }
+
+  public ESoftDelX getX() {
+    return x;
+  }
+
+  public void setX(ESoftDelX x) {
+    this.x = x;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
+  }
+}

--- a/ebean-core/src/test/java/org/tests/model/softdelete/ESoftDelZ.java
+++ b/ebean-core/src/test/java/org/tests/model/softdelete/ESoftDelZ.java
@@ -1,0 +1,43 @@
+package org.tests.model.softdelete;
+
+import io.ebean.annotation.SoftDelete;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.UUID;
+
+@Entity
+public class ESoftDelZ {
+
+  @Id
+  private Long id;
+
+  @SoftDelete
+  private boolean deleted;
+
+  private UUID uuid;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
+  }
+
+  public UUID getUuid() {
+    return uuid;
+  }
+
+  public void setUuid(UUID uuid) {
+    this.uuid = uuid;
+  }
+}

--- a/ebean-core/src/test/java/org/tests/softdelete/TestSoftDeleteOptionalRelationship.java
+++ b/ebean-core/src/test/java/org/tests/softdelete/TestSoftDeleteOptionalRelationship.java
@@ -1,9 +1,15 @@
 package org.tests.softdelete;
 
 import io.ebean.BaseTestCase;
+import io.ebean.DB;
 import io.ebean.Ebean;
 import org.tests.model.softdelete.ESoftDelMid;
+import io.ebean.Finder;
 import org.junit.Test;
+import org.tests.model.softdelete.ESoftDelY;
+import org.tests.model.softdelete.ESoftDelZ;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,6 +28,31 @@ public class TestSoftDeleteOptionalRelationship extends BaseTestCase {
 
     assertThat(bean).isNotNull();
     assertThat(bean.getTop()).isNull();
+  }
+
+  @Test
+  public void testFindNullWhenMultiple() {
+    UUID uuid = UUID.randomUUID();
+    {
+      ESoftDelZ z = new ESoftDelZ();
+      z.setUuid(uuid);
+      DB.save(z);
+
+      ESoftDelY y = new ESoftDelY();
+      y.setOrganization(z);
+      y.setX(null);
+      DB.save(y);
+    }
+
+    Finder<Long, ESoftDelY> finder = new Finder<>(ESoftDelY.class);
+    ESoftDelY bean = finder
+      .query()
+      .where()
+      .eq("organization.uuid", uuid)
+      .isNull("x")
+      .findOne();
+
+    assertThat(bean).isNotNull();
   }
 
 


### PR DESCRIPTION
Hello,

> We ran into an bug where soft-deleted entities were not being returned correctly after we updated to 12.8.3
>
> The generated query for some reason has an extraneous soft-delete predicate tacked on that is causing the result to be missing some expected rows.
> 
> select t0.id, t0.deleted, t0.organization_id, t2.id
> from esoft_del_y t0
> left join esoft_del_x t2 on t2.y_id = t0.id and t2.deleted = false
> left join esoft_del_z t1 on t1.id = t0.organization_id and t1.deleted = false and t2.deleted = false
> where t1.uuid = ? and t2.id is null and t0.deleted = false
> 
> Note the t2.deleted = false on the second join when it's expected that t2 will be all null.
> 
> I was able to reproduce the bug as a unit test here: https://github.com/bayne/ebean/commit/ad52711fe172e70d5ab2f649f163399f2dc4ce62
> 
> If I named the field anything other than "organization", the test would pass.
> 
> Thanks,
> 
> Brian

https://groups.google.com/g/ebean/c/Ms-s9pl_mQA

I tracked down the extraneous soft-delete predicate to `SqlTreeNodeExtraJoin` and one-to-one exported associations. It appears the join for the one-to-one exported is already in the `ctx` by the time it reaches https://github.com/bayne/ebean/blob/42fc41975907274f44bb58bff35f1b1f573f8054/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeExtraJoin.java#L144. This resulted in the soft-delete predicate being added again.

Let me know what you think.

Thanks!

Brian