### PR TITLE
Set ddl-generator version to a public-available version + fix classpath for Java8

### DIFF
--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-ddl-generator</artifactId>
-      <version>12.8.4a</version>
+      <version>12.9.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -119,6 +119,15 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Provided scope so that the H2HistoryTrigger can live in Ebean core
+         and not require a separate module for it -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.4.199</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>javax.transaction</groupId>
       <artifactId>jta</artifactId>
@@ -212,15 +221,6 @@
       <artifactId>logback-classic</artifactId>
       <version>1.2.3</version>
       <scope>test</scope>
-    </dependency>
-
-    <!-- Provided scope so that the H2HistoryTrigger can live in Ebean core
-         and not require a separate module for it -->
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>1.4.199</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hello Rob,

I'm building against the current ebean version and found a couple problems with locally building Ebean.
Since the version 12.8.4a of ddl-generator is not available on the repo, I now entered the last released version 12.9.0 while still avoiding the cyclic dependency. I guess that you didn't have any problems with that previously, because you have a 12.8.4a in a local m2-repository.

Additionally Ebean was not able to run tests with Java 8. Switching to Java 11 fixed that, but I wanted to know what was wrong with Java 8. The problem was, that `ConnectionManager` didn't find the h2 driver in the classpath. A `Class.forName("org.h2.Driver")` also showed that it was a classpath problem. I don't really know what caused this issue (suspecting a combination of my maven as well as java 8 version), but moving the dependency-entry of h2 inside the ebean-core pom.xml solved the issue (didn't work neither in maven in bash, as well as IntelliJ-IDEA). The positive side-effect now is, that the dependency is among other provided-dependencies and not in between all the test-dependencies. Nevertheless I'm kinda bummed out, that I didn't find the reason for that.

Note: I had to run maven with `-Dgpg.skip` enabled, since I don't have gpg configured on my machine. As far as I understand it, it is only necessary when releasing ebean, so maybe it would be handy to turn it off otherwise (although I can live with that commandline). Also I don't have docker installed locally so builds for ebean-redis and ebean-postgis would fail, when running tests ("fixed" with `-pl '!ebean-redis,!ebean-postgis` to skip the entire modules). For that reason should I maybe also provide a small entry on "Building & Testing" for the Readme containing these aspects?

All the best
Jonas