### PR TITLE
Change the default of jsonDirtyByDefault to be false

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -195,9 +195,8 @@ public class DatabaseConfig {
 
   /**
    * When true then by default DbJson beans are assumed to be dirty.
-   * I believe we want to change this default to false in the future.
    */
-  private boolean jsonDirtyByDefault = true;
+  private boolean jsonDirtyByDefault;
 
   /**
    * The database platform name. Used to imply a DatabasePlatform to use.
@@ -746,15 +745,16 @@ public class DatabaseConfig {
   /**
    * Return true if DbJson beans are assumed dirty by default.
    * <p>
-   * That is, when true beans that do not implement ModifyAwareType are by
-   * default assumed to be dirty and included in updates.
+   * That is, when true DbJson bean properties that do not implement
+   * ModifyAwareType are by default assumed to be dirty and included
+   * in updates.
    */
   public boolean isJsonDirtyByDefault() {
     return jsonDirtyByDefault;
   }
 
   /**
-   * Set to false if we want DbJson beans to not be assumed to be dirty.
+   * Set to true if we want DbJson beans to be assumed to be dirty.
    * <p>
    * That is, when true beans that do not implement ModifyAwareType are by
    * default assumed to be dirty and included in updates.

--- a/ebean-core/src/test/java/io/ebean/config/ServerConfigTest.java
+++ b/ebean-core/src/test/java/io/ebean/config/ServerConfigTest.java
@@ -62,7 +62,7 @@ public class ServerConfigTest {
     props.setProperty("dbOffline", "true");
     props.setProperty("jsonDateTime", "MILLIS");
     props.setProperty("jsonDate", "MILLIS");
-    props.setProperty("jsonDirtyByDefault", "false");
+    props.setProperty("jsonDirtyByDefault", "true");
     props.setProperty("autoReadOnlyDataSource", "true");
     props.setProperty("disableL2Cache", "true");
     props.setProperty("notifyL2CacheInForeground", "true");
@@ -104,9 +104,9 @@ public class ServerConfigTest {
     assertEquals(PlatformConfig.DbUuid.BINARY, serverConfig.getPlatformConfig().getDbUuid());
     assertEquals(JsonConfig.DateTime.MILLIS, serverConfig.getJsonDateTime());
     assertEquals(JsonConfig.Date.MILLIS, serverConfig.getJsonDate());
-    assertFalse(serverConfig.isJsonDirtyByDefault());
-    serverConfig.setJsonDirtyByDefault(true);
     assertTrue(serverConfig.isJsonDirtyByDefault());
+    serverConfig.setJsonDirtyByDefault(false);
+    assertFalse(serverConfig.isJsonDirtyByDefault());
 
     assertEquals("r0,users,orgs", serverConfig.getEnabledL2Regions());
 
@@ -159,7 +159,7 @@ public class ServerConfigTest {
     assertFalse(serverConfig.isIdGeneratorAutomatic());
     assertEquals(JsonConfig.DateTime.ISO8601, serverConfig.getJsonDateTime());
     assertEquals(JsonConfig.Date.ISO8601, serverConfig.getJsonDate());
-    assertTrue(serverConfig.isJsonDirtyByDefault());
+    assertFalse(serverConfig.isJsonDirtyByDefault());
     assertTrue(serverConfig.getPlatformConfig().isCaseSensitiveCollation());
     assertTrue(serverConfig.isAutoLoadModuleInfo());
 

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_Jackson3.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_Jackson3.java
@@ -74,6 +74,6 @@ public class TestDbJson_Jackson3 extends BaseTestCase {
 
     final List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
-    assertThat(sql.get(0)).contains("update ebasic_json_list set name=?, bean_list=?, plain_bean=?, version=? where id=?");
+    assertThat(sql.get(0)).contains("update ebasic_json_list set name=?, bean_list=?, version=? where id=?");
   }
 }

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
@@ -113,7 +113,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set name=?, plain_bean=?, version=? where");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set name=?, version=? where");
   }
 
   public void update_when_dirty() {
@@ -126,7 +126,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set plain_bean=?, tags=?, version=? where id=? and version=?");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set tags=?, version=? where id=? and version=?");
   }
 
   public void update_when_dirty_flags() {
@@ -139,7 +139,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set plain_bean=?, flags=?, version=? where id=? and version=?;");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set flags=?, version=? where id=? and version=?;");
   }
 
   public void update_when_dirty_SetListMap() {
@@ -154,7 +154,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set beans=?, bean_list=?, bean_map=?, plain_bean=?, version=? where id=? and version=?");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set beans=?, bean_list=?, bean_map=?, version=? where id=? and version=?");
   }
 
   @Test


### PR DESCRIPTION
This means that by default DbJson beans that do not implement ModifyAwareType are not considered dirty and will NOT be included in update statements. For updating they are expected to be set with a different instance rather than mutated.