### PR TITLE
Ask for Feedback: alternative isDirty detection for JSON objects

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareList.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 /**
  * Modify aware wrapper of a list.
  */
-public class ModifyAwareList<E> implements List<E>, ModifyAwareType, Serializable {
+public class ModifyAwareList<E> implements List<E>, ModifyAwareWrapper, Serializable {
 
   private static final long serialVersionUID = 1;
 
@@ -198,5 +198,10 @@ public class ModifyAwareList<E> implements List<E>, ModifyAwareType, Serializabl
    */
   public ModifyAwareSet<E> asSet() {
     return new ModifyAwareSet<>(owner, new LinkedHashSet<>(list));
+  }
+  
+  @Override
+  public Object unwrap() {
+    return list;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareMap.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareMap.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * Map that is wraps an underlying map for the purpose of detecting changes.
  */
-public class ModifyAwareMap<K, V> implements Map<K, V>, ModifyAwareType, Serializable {
+public class ModifyAwareMap<K, V> implements Map<K, V>, ModifyAwareWrapper, Serializable {
 
   private static final long serialVersionUID = 1;
 
@@ -139,4 +139,8 @@ public class ModifyAwareMap<K, V> implements Map<K, V>, ModifyAwareType, Seriali
     return new ModifyAwareSet<>(this, map.entrySet());
   }
 
+  @Override
+  public Object unwrap() {
+    return map;
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareSet.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareSet.java
@@ -11,7 +11,7 @@ import java.util.Set;
 /**
  * Wraps a Set for the purposes of detecting modifications.
  */
-public class ModifyAwareSet<E> implements Set<E>, ModifyAwareType, Serializable {
+public class ModifyAwareSet<E> implements Set<E>, ModifyAwareWrapper, Serializable {
 
   private static final long serialVersionUID = 1;
 
@@ -168,5 +168,10 @@ public class ModifyAwareSet<E> implements Set<E>, ModifyAwareType, Serializable 
   @Override
   public <T> T[] toArray(T[] a) {
     return set.toArray(a);
+  }
+  
+  @Override
+  public Object unwrap() {
+    return set;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareWrapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/json/ModifyAwareWrapper.java
@@ -1,0 +1,12 @@
+package io.ebeaninternal.json;
+
+import io.ebean.ModifyAwareType;
+
+/**
+ * Wrapper interface for ModifyAwareList/Set/Map.
+ */
+public interface ModifyAwareWrapper extends ModifyAwareType {
+
+  Object unwrap();
+
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
@@ -20,11 +20,18 @@ import javax.persistence.PersistenceException;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Supports @DbJson properties using Jackson ObjectMapper.
@@ -68,12 +75,12 @@ class ScalarTypeJsonObjectMapper {
       super(Set.class, jsonManager, field, dbType, docType);
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public Set read(DataReader reader) throws SQLException {
-      Set value = super.read(reader);
-      return value == null ? null : new ModifyAwareSet(value);
-    }
+//    @Override
+//    @SuppressWarnings("unchecked")
+//    public Set read(DataReader reader) throws SQLException {
+//      Set value = super.read(reader);
+//      return value == null ? null : new ModifyAwareSet(value);
+//    }
   }
 
   /**
@@ -86,12 +93,12 @@ class ScalarTypeJsonObjectMapper {
       super(List.class, jsonManager, field, dbType, docType);
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public List read(DataReader reader) throws SQLException {
-      List value = super.read(reader);
-      return value == null ? null : new ModifyAwareList(value);
-    }
+//    @Override
+//    @SuppressWarnings("unchecked")
+//    public List read(DataReader reader) throws SQLException {
+//      List value = super.read(reader);
+//      return value == null ? null : new ModifyAwareList(value);
+//    }
   }
 
   /**
@@ -104,12 +111,12 @@ class ScalarTypeJsonObjectMapper {
       super(Map.class, jsonManager, field, dbType, DocPropertyType.OBJECT);
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public Map read(DataReader reader) throws SQLException {
-      Map value = super.read(reader);
-      return value == null ? null : new ModifyAwareMap(value);
-    }
+//    @Override
+//    @SuppressWarnings("unchecked")
+//    public Map read(DataReader reader) throws SQLException {
+//      Map value = super.read(reader);
+//      return value == null ? null : new ModifyAwareMap(value);
+//    }
   }
 
   /**
@@ -149,11 +156,23 @@ class ScalarTypeJsonObjectMapper {
     }
 
     /**
-     * Return true if the value should be considered dirty (and included in an update).
+     * Return true if the value should be considered dirty (and included in an
+     * update).
      */
     @Override
     public boolean isDirty(Object value) {
-      return dirtyHandler.isDirty(value);
+      if (value == null)
+        return true;
+      TrackReference<Object> key = new TrackReference<Object>(value);
+      String json = originalJson.get(key);
+      if (json == null) {
+        return true;
+      }
+      try {
+        return !json.equals(objectWriter.writeValueAsString(value));
+      } catch (IOException e) {
+        return true; // Checkme: what to do
+      }
     }
 
     @Override
@@ -163,9 +182,50 @@ class ScalarTypeJsonObjectMapper {
         return null;
       }
       try {
-        return objectReader.readValue(json, deserType);
+        T ret = objectReader.readValue(json, deserType);
+        track(ret, json);
+        return ret;
       } catch (IOException e) {
         throw new TextException("Failed to parse JSON [{}] as " + deserType, json, e);
+      }
+    }
+    
+
+    private Map<TrackReference<T>, String> originalJson = new ConcurrentHashMap<>();
+    private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+    
+    private static class TrackReference<T> extends WeakReference<T> {
+
+      private final int hashCode;
+
+      public TrackReference(T referent) {
+        super(referent);
+        hashCode = System.identityHashCode(referent);
+      }
+      
+      public TrackReference(T referent, ReferenceQueue<? super T> q) {
+        super(referent, q);
+        hashCode = System.identityHashCode(referent);
+      }
+      
+      @Override
+      public int hashCode() {
+        return hashCode;
+      }
+      @Override
+      public boolean equals(Object other) {
+        return other instanceof TrackReference && this.get() == ((TrackReference<?>)other).get();
+      }
+    }
+    
+    private void track(T obj, String json) {
+      if (obj != null) {
+        TrackReference<T> ref = new TrackReference<T>(obj, queue);
+        originalJson.put(ref, json);
+
+        while (( ref = (TrackReference<T>) queue.poll()) != null) {
+          originalJson.remove(ref);
+        }
       }
     }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeJsonManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeJsonManager.java
@@ -1,14 +1,25 @@
 package io.ebeaninternal.server.type;
 
+import java.io.IOException;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
 import io.ebean.ModifyAwareType;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.config.dbplatform.DbPlatformType;
+import io.ebeaninternal.json.ModifyAwareWrapper;
 
 class TypeJsonManager {
 
   interface DirtyHandler {
-    boolean isDirty(Object value);
+    boolean isDirty(Object value, ObjectWriter writer);
+
+    void track(Object value, String json);
   }
 
   private final boolean postgres;
@@ -19,8 +30,9 @@ class TypeJsonManager {
   TypeJsonManager(boolean postgres, Object objectMapper, boolean defaultDirty) {
     this.postgres = postgres;
     this.objectMapper = (ObjectMapper) objectMapper;
-    this.defaultHandler = new DefaultHandler(defaultDirty);
-    this.modifyAwareHandler = new ModifyAwareHandler();
+    // TODO: make this configurable!
+    this.defaultHandler = new ReferenceTrackingHandler(); // DefaultHandler(defaultDirty);
+    this.modifyAwareHandler = defaultHandler; // new ModifyAwareHandler();
   }
 
   ObjectMapper objectMapper() {
@@ -73,9 +85,12 @@ class TypeJsonManager {
 
   static final class ModifyAwareHandler implements DirtyHandler {
     @Override
-    public boolean isDirty(Object value) {
+    public boolean isDirty(Object value, ObjectWriter writer) {
       return checkModifyAware(value);
     }
+    
+    @Override
+    public void track(Object value, String json) {}
   }
 
   /**
@@ -90,8 +105,80 @@ class TypeJsonManager {
     }
 
     @Override
-    public boolean isDirty(Object value) {
+    public boolean isDirty(Object value, ObjectWriter writer) {
       return dirty;
+    }
+    
+    @Override
+    public void track(Object value, String json) {}
+  }
+  
+  private static class TrackReference extends WeakReference<Object> {
+
+    private final int hashCode;
+
+    public TrackReference(Object referent) {
+      super(referent);
+      hashCode = System.identityHashCode(referent);
+    }
+    
+    public TrackReference(Object referent, ReferenceQueue<Object> q) {
+      super(referent, q);
+      hashCode = System.identityHashCode(referent);
+    }
+    
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof TrackReference && this.get() == ((TrackReference)other).get();
+    }
+  }
+  
+  /**
+   * Effectively constant based on {@link DatabaseConfig#isJsonDirtyByDefault()}
+   */
+  static final class ReferenceTrackingHandler implements DirtyHandler {
+
+    private Map<TrackReference, String> originalJson = new ConcurrentHashMap<>();
+    private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+    
+
+    @Override
+    public boolean isDirty(Object value, ObjectWriter writer) {
+      if (value == null) {
+        return true;
+      }
+      if (value instanceof ModifyAwareWrapper) {
+        if (((ModifyAwareWrapper) value).isMarkedDirty()) {
+          return true;
+        }
+        value = ((ModifyAwareWrapper) value).unwrap();
+      }
+      TrackReference key = new TrackReference(value);
+      String json = originalJson.get(key);
+      if (json == null) {
+        return true;
+      }
+      try {
+        return !json.equals(writer.writeValueAsString(value));
+      } catch (IOException e) {
+        return true; // Checkme: what to do
+      }
+    }
+    
+    
+    public void track(Object obj, String json) {
+      if (obj != null) {
+        TrackReference ref = new TrackReference(obj, queue);
+        originalJson.put(ref, json);
+
+        while (( ref = (TrackReference) queue.poll()) != null) {
+          originalJson.remove(ref);
+        }
+      }
     }
   }
 

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
@@ -113,7 +113,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set name=?, plain_bean=?, version=? where");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set name=?, version=? where");
   }
 
   public void update_when_dirty() {
@@ -126,7 +126,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set plain_bean=?, tags=?, version=? where id=? and version=?");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set tags=?, version=? where id=? and version=?");
   }
 
   public void update_when_dirty_flags() {
@@ -139,7 +139,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set plain_bean=?, flags=?, version=? where id=? and version=?;");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set flags=?, version=? where id=? and version=?;");
   }
 
   public void update_when_dirty_SetListMap() {
@@ -154,7 +154,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set beans=?, bean_list=?, bean_map=?, plain_bean=?, version=? where id=? and version=?");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set beans=?, bean_list=?, bean_map=?, version=? where id=? and version=?");
   }
 
   @Test

--- a/ebean-core/src/test/java/org/tests/model/json/EBasicJsonList.java
+++ b/ebean-core/src/test/java/org/tests/model/json/EBasicJsonList.java
@@ -7,6 +7,9 @@ import io.ebean.annotation.DbJsonType;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Version;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -23,7 +26,8 @@ public class EBasicJsonList {
   String name;
 
   @DbJson(length = 700, name = "beans")
-  Set<PlainBean> beanSet;
+  @JsonDeserialize(as = LinkedHashSet.class)
+  Set<PlainBean> beanSet = new LinkedHashSet<>();
 
   @DbJsonB
   List<PlainBean> beanList;


### PR DESCRIPTION
Hello @rbygrave,

I've an idea how to solve the dirty detection of JSON objects and need some feedback:

When a JSON value is read in DataReader.read (`T ret = objectReader.readValue(json, deserType);`)
I build a weakReference that tracks `ret` and acts as a Map key.
The map
```
private Map<TrackReference<T>, String> originalJson = new ConcurrentHashMap<>();
```
will store the original json for each weakReference-queue.
So when a value is returned by the read method, the ScalarType will remember the object id and the json.
If the same object will passed to the `isDirty` method, we can get the original json from the map and check if the json content is changed.

<strike>This code change should cover all of our use cases.</strike>
/edit: Unfortunaltely I loose the ability to fetch the valuePairs of changed properties in BeanPersistRequest.
For the long-term solution I only see the possibility to read an object twice.

Cheers
Roland