### PR TITLE
Experimental: JSON-Mutable support

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/MutableValue.java
+++ b/ebean-api/src/main/java/io/ebean/bean/MutableValue.java
@@ -1,0 +1,6 @@
+package io.ebean.bean;
+
+public interface MutableValue {
+  Object get();
+  boolean isEqual(Object object, boolean update);
+}

--- a/ebean-core-type/src/main/java/io/ebean/core/type/ScalarType.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/ScalarType.java
@@ -2,6 +2,8 @@ package io.ebean.core.type;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+
+import io.ebean.bean.MutableValue;
 import io.ebean.text.StringFormatter;
 import io.ebean.text.StringParser;
 
@@ -97,6 +99,11 @@ public interface ScalarType<T> extends StringParser, StringFormatter, ScalarData
    */
   @Override
   T read(DataReader reader) throws SQLException;
+  
+  /**
+   * Reads the value as mutable value.
+   */
+  MutableValue readMutable(DataReader reader) throws SQLException;
 
   /**
    * Ignore the reading of this value. Typically this means moving the index

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -3185,7 +3185,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       int propertyIndex = beanProperty.getPropertyIndex();
       if (!ebi.isDirtyProperty(propertyIndex) && ebi.isLoadedProperty(propertyIndex)) {
         Object value = beanProperty.getValue(ebi.getOwner());
-        if (value != null && beanProperty.isDirtyValue(value)) {
+        if (value != null && beanProperty.isDirtyValue(ebi, value)) {
           // mutable scalar value which is considered dirty so mark
           // it as such so that it is included in an update
           ebi.markPropertyAsChanged(propertyIndex);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import io.ebean.ValuePair;
 import io.ebean.bean.EntityBean;
 import io.ebean.bean.EntityBeanIntercept;
+import io.ebean.bean.MutableValue;
 import io.ebean.bean.PersistenceContext;
 import io.ebean.config.EncryptKey;
 import io.ebean.config.dbplatform.DbEncryptFunction;
@@ -640,6 +641,10 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
   public Object read(DbReadContext ctx) throws SQLException {
     return scalarType.read(ctx.getDataReader());
   }
+  
+  public MutableValue readMutable(DbReadContext ctx) throws SQLException {
+    return scalarType.readMutable(ctx.getDataReader());
+  }
 
   public Object readSet(DbReadContext ctx, EntityBean bean) throws SQLException {
     try {
@@ -759,7 +764,7 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
       throw new RuntimeException(setterErrorMsg(bean, value, "set "), ex);
     }
   }
-
+  
   /**
    * Set the value of the property.
    */
@@ -771,6 +776,10 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
     }
   }
 
+  public void setMutableOrigValue(EntityBean bean, MutableValue mutableValue) {
+    bean._ebean_getIntercept().setOriginalValue(propertyIndex, mutableValue);
+  }
+  
   /**
    * Return an error message when calling a setter.
    */
@@ -1016,10 +1025,10 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
 
   /**
    * Return true if the mutable value is considered dirty.
-   * This is only used for 'mutable' scalar types like hstore etc.
+   * This is only used for 'mutable' scalar types like hstore or json etc.
    */
-  boolean isDirtyValue(Object value) {
-    return scalarType.isDirty(value);
+  boolean isDirtyValue(EntityBeanIntercept ebi, Object value) {
+    return ebi.isDirtyValue(propertyIndex, value);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBase.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBase.java
@@ -1,5 +1,8 @@
 package io.ebeaninternal.server.type;
 
+import java.sql.SQLException;
+
+import io.ebean.bean.MutableValue;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.ScalarType;
 
@@ -39,6 +42,29 @@ public abstract class ScalarTypeBase<T> implements ScalarType<T> {
     return false;
   }
 
+  /**
+   * Must be overridden on mutable types.
+   */
+  @Override
+  public MutableValue readMutable(DataReader reader) throws SQLException {
+    T obj = read(reader);
+    if (obj == null) {
+      return null;
+    }
+    return new MutableValue() {
+      
+      @Override
+      public boolean isEqual(Object object, boolean update) {
+        return !isDirty(object);
+      }
+      
+      @Override
+      public Object get() {
+        return obj;
+      }
+    };
+  }
+  
   /**
    * Default to true.
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBytesEncrypted.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBytesEncrypted.java
@@ -2,6 +2,8 @@ package io.ebeaninternal.server.type;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+
+import io.ebean.bean.MutableValue;
 import io.ebean.core.type.DataBinder;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.DocPropertyType;
@@ -125,6 +127,11 @@ public class ScalarTypeBytesEncrypted implements ScalarType<byte[]> {
     byte[] data = baseType.read(reader);
     data = dataEncryptSupport.decrypt(data);
     return data;
+  }
+  
+  @Override
+  public MutableValue readMutable(DataReader reader) throws SQLException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeUUIDBase.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeUUIDBase.java
@@ -26,16 +26,6 @@ public abstract class ScalarTypeUUIDBase extends ScalarTypeBase<UUID> implements
   }
 
   @Override
-  public boolean isMutable() {
-    return false;
-  }
-
-  @Override
-  public boolean isDirty(Object value) {
-    return true;
-  }
-
-  @Override
   public String formatValue(UUID value) {
     return value.toString();
   }

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
@@ -113,7 +113,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set name=?, plain_bean=?, version=? where");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set name=?, version=? where");
   }
 
   public void update_when_dirty() {
@@ -126,7 +126,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set plain_bean=?, tags=?, version=? where id=? and version=?");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set tags=?, version=? where id=? and version=?");
   }
 
   public void update_when_dirty_flags() {
@@ -139,7 +139,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set plain_bean=?, flags=?, version=? where id=? and version=?;");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set flags=?, version=? where id=? and version=?;");
   }
 
   public void update_when_dirty_SetListMap() {
@@ -154,7 +154,7 @@ public class TestDbJson_List extends BaseTestCase {
     List<String> sql = LoggedSqlCollector.stop();
 
     // we don't update the phone numbers (as they are not dirty)
-    assertSql(sql.get(0)).contains("update ebasic_json_list set beans=?, bean_list=?, bean_map=?, plain_bean=?, version=? where id=? and version=?");
+    assertSql(sql.get(0)).contains("update ebasic_json_list set beans=?, bean_list=?, bean_map=?, version=? where id=? and version=?");
   }
 
   @Test


### PR DESCRIPTION
Hello Rob,
I'm still struggling with the "dirty detection" of JSONs

I have 3 different approaches now
1. My old solution, where I do a deepCopy in ScalarType https://github.com/ebean-orm/ebean/pull/1595 
2. The Idea that stores the origin-json String for each object in a Map: https://github.com/ebean-orm/ebean/pull/2258
3. This solution, that uses a special "readMutable" method, which produces a "MutableValue" that returns a new instance of each "get" call.

We use a lot of JSON data and we would need some kind of dirty detection to avoid some unneccessary data updates.
We also need the "originalValue" of any data object, as we often do an object comparison of the user data (similar to changelog)

So the first approach works best in our environment (it is also the solution we are using since some years)
Unfortunately, this doubles the memory footprint, as every json object is held in the bean value and also in the "originalValue" and MAY have also a performance impact, as the deepCopy mehtod serializes/deserializes the object again

The second approach has a good dirty recognizion, but does not provide access to the "EBI.originalValues". It is also a bit unconventional, as it uses "WeakReferences" 

The third approach (this PR) tries to store only the original JSON string in the "EBI.originalValues". In detail, the JSON string is encapsulated in a MutableValue with the scalarType, so that a call to `get()` will desereialize the JSON again.
This has a lower memory footprint and should also have a low performance impact, as deserializion only the data on demand.
Unfortunately, the current draft seems a bit complex, as I need a lot of special cases.


Maybe you can give me some advice, how to continue with this task. My preferred way would be solution 1, as I know, that it is working.

Acceptance criterias that should be fulfilled:
- Stable dirty detection on `@DbJson` annotated values (could be theoretically fulfilled by implementing ModifyAwareType, but needs a lot of additional code in our JSON-models)
- Provide access to the old/original value 

cheers
Roland
