### PR TITLE
Fix additional autotune runtimeExceptions due to toString() calls instead of asString()

### DIFF
--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/AutoTuneDiffCollection.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/AutoTuneDiffCollection.java
@@ -113,7 +113,7 @@ public class AutoTuneDiffCollection {
 
     diffCount++;
 
-    Origin origin = createOrigin(entry, point, tuneDetail.toString());
+    Origin origin = createOrigin(entry, point, tuneDetail.asString());
     ProfileDiff diff = document.getProfileDiff();
     if (diff == null) {
       diff = new ProfileDiff();
@@ -147,7 +147,7 @@ public class AutoTuneDiffCollection {
     Origin origin = new Origin();
     origin.setKey(point.getKey());
     origin.setBeanType(point.getBeanType());
-    origin.setDetail(entry.getDetail().toString());
+    origin.setDetail(entry.getDetail().asString());
     origin.setCallStack(point.getCallOrigin().getFullDescription());
     origin.setOriginal(query);
 

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/TunedQueryInfo.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/TunedQueryInfo.java
@@ -65,7 +65,7 @@ public class TunedQueryInfo implements Serializable {
 
   @Override
   public String toString() {
-    return tunedDetail.toString();
+    return tunedDetail.asString();
   }
 
 }


### PR DESCRIPTION
Autotune still throws RuntimeExceptions due to existing
 ORMQueryDetail.toString() calls, replaced them with ORMQueryDetail.asString()



