### PR TITLE
enabled and fixed the TestDbJson_Jackson3 Test

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -3198,7 +3198,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   public void checkMutableProperties(EntityBeanIntercept ebi) {
     for (BeanProperty beanProperty : propertiesMutable) {
       int propertyIndex = beanProperty.getPropertyIndex();
-      if (!ebi.isDirtyProperty(propertyIndex) && ebi.isLoadedProperty(propertyIndex)) {
+      if (/*!ebi.isDirtyProperty(propertyIndex) && */ebi.isLoadedProperty(propertyIndex)) {
         Object value = beanProperty.getValue(ebi.getOwner());
         if (value != null && beanProperty.isDirtyValue(value, ebi)) {
           // mutable scalar value which is considered dirty so mark

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -3198,9 +3198,9 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   public void checkMutableProperties(EntityBeanIntercept ebi) {
     for (BeanProperty beanProperty : propertiesMutable) {
       int propertyIndex = beanProperty.getPropertyIndex();
-      if (/*!ebi.isDirtyProperty(propertyIndex) && */ebi.isLoadedProperty(propertyIndex)) {
+      if (ebi.isLoadedProperty(propertyIndex)) {
         Object value = beanProperty.getValue(ebi.getOwner());
-        if (/*value != null &&*/ beanProperty.isDirtyValue(value, ebi)) {
+        if (beanProperty.updateMutableValue(value, ebi.isDirtyProperty(propertyIndex), ebi)) {
           // mutable scalar value which is considered dirty so mark
           // it as such so that it is included in an update
           ebi.markPropertyAsChanged(propertyIndex);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -3200,7 +3200,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       int propertyIndex = beanProperty.getPropertyIndex();
       if (/*!ebi.isDirtyProperty(propertyIndex) && */ebi.isLoadedProperty(propertyIndex)) {
         Object value = beanProperty.getValue(ebi.getOwner());
-        if (value != null && beanProperty.isDirtyValue(value, ebi)) {
+        if (/*value != null &&*/ beanProperty.isDirtyValue(value, ebi)) {
           // mutable scalar value which is considered dirty so mark
           // it as such so that it is included in an update
           ebi.markPropertyAsChanged(propertyIndex);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -1015,11 +1015,12 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
   }
 
   /**
-   * Return true if the mutable value is considered dirty.
-   * This is only used for 'mutable' scalar types like hstore etc.
+   * Return true if the mutable value is considered dirty. 
+   * This is only used for 'mutable' scalar types like hstore or DbJson etc.
+   * The method is called for all loaded properties once and may also update the MutableValueInfo
    */
-  boolean isDirtyValue(Object value, EntityBeanIntercept ebi) {
-    return value != null && scalarType.isDirty(value);
+  boolean updateMutableValue(Object value, boolean alreadyDirty,  EntityBeanIntercept ebi) {
+    return alreadyDirty || value != null && scalarType.isDirty(value);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -1019,7 +1019,7 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
    * This is only used for 'mutable' scalar types like hstore etc.
    */
   boolean isDirtyValue(Object value, EntityBeanIntercept ebi) {
-    return scalarType.isDirty(value);
+    return value != null && scalarType.isDirty(value);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyJsonMapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyJsonMapper.java
@@ -55,7 +55,7 @@ public class BeanPropertyJsonMapper extends BeanProperty {
    * This is only used for 'mutable' scalar types like hstore etc.
    */
   @Override
-  boolean isDirtyValue(Object value, EntityBeanIntercept ebi) {
+  boolean updateMutableValue(Object value, boolean alreadyDirty, EntityBeanIntercept ebi) {
     // dirty detection based on json content or checksum of json content
     // only perform serialisation to json once
     final String json = scalarType.format(value);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
@@ -222,13 +222,13 @@ public class DeployUtil {
   }
 
   private void setDbJsonType(DeployBeanProperty prop, int dbType, int dbLength, boolean dirtyDetection, boolean keepSource) {
+    prop.setJsonOptions(dirtyDetection, keepSource);
     ScalarType<?> scalarType = typeManager.getJsonScalarType(prop, dbType, dbLength);
     if (scalarType == null) {
       throw new RuntimeException("No ScalarType for JSON property [" + prop + "] [" + dbType + "]");
     }
     prop.setDbType(dbType);
     prop.setScalarType(scalarType);
-    prop.setJsonOptions(dirtyDetection, keepSource);
     if (dbType == Types.VARCHAR || dbLength > 0) {
       // determine the db column size
       int columnLength = (dbLength > 0) ? dbLength : DEFAULT_JSON_VARCHAR_LENGTH;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
@@ -222,13 +222,13 @@ public class DeployUtil {
   }
 
   private void setDbJsonType(DeployBeanProperty prop, int dbType, int dbLength, boolean dirtyDetection, boolean keepSource) {
-    prop.setJsonOptions(dirtyDetection, keepSource);
-    ScalarType<?> scalarType = typeManager.getJsonScalarType(prop, dbType, dbLength);
+    ScalarType<?> scalarType = typeManager.getJsonScalarType(prop, dbType, dbLength, keepSource);
     if (scalarType == null) {
       throw new RuntimeException("No ScalarType for JSON property [" + prop + "] [" + dbType + "]");
     }
     prop.setDbType(dbType);
     prop.setScalarType(scalarType);
+    prop.setJsonOptions(dirtyDetection, keepSource);
     if (dbType == Types.VARCHAR || dbLength > 0) {
       // determine the db column size
       int columnLength = (dbLength > 0) ? dbLength : DEFAULT_JSON_VARCHAR_LENGTH;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -426,7 +426,8 @@ public final class DefaultTypeManager implements TypeManager {
     if (objectMapper == null) {
       throw new IllegalArgumentException("Type [" + type + "] unsupported for @DbJson mapping - Jackson ObjectMapper not present");
     }
-    return ScalarTypeJsonObjectMapper.createTypeFor(jsonManager, (AnnotatedField) prop.getJacksonField(), dbType, docType);
+    boolean modifyAwareCollection = !prop.isKeepSource();
+    return ScalarTypeJsonObjectMapper.createTypeFor(jsonManager, (AnnotatedField) prop.getJacksonField(), dbType, docType, modifyAwareCollection);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -336,7 +336,7 @@ public final class DefaultTypeManager implements TypeManager {
   }
 
   @Override
-  public ScalarType<?> getJsonScalarType(DeployBeanProperty prop, int dbType, int dbLength) {
+  public ScalarType<?> getJsonScalarType(DeployBeanProperty prop, int dbType, int dbLength, boolean keepSource) {
     Class<?> type = prop.getPropertyType();
     Type genericType = prop.getGenericType();
     boolean hasJacksonAnnotations = objectMapperPresent && checkJacksonAnnotations(prop);
@@ -346,7 +346,7 @@ public final class DefaultTypeManager implements TypeManager {
       if (!hasJacksonAnnotations && isValueTypeSimple(genericType)) {
         return ScalarTypeJsonList.typeFor(postgres, dbType, docType, prop.isNullable());
       } else {
-        return createJsonObjectMapperType(prop, dbType, docType);
+        return createJsonObjectMapperType(prop, dbType, docType, keepSource);
       }
     }
     if (type.equals(Set.class)) {
@@ -354,14 +354,14 @@ public final class DefaultTypeManager implements TypeManager {
       if (!hasJacksonAnnotations && isValueTypeSimple(genericType)) {
         return ScalarTypeJsonSet.typeFor(postgres, dbType, docType, prop.isNullable());
       } else {
-        return createJsonObjectMapperType(prop, dbType, docType);
+        return createJsonObjectMapperType(prop, dbType, docType, keepSource);
       }
     }
     if (type.equals(Map.class)) {
       if (!hasJacksonAnnotations && isMapValueTypeObject(genericType)) {
         return ScalarTypeJsonMap.typeFor(postgres, dbType);
       } else {
-        return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT);
+        return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT, keepSource);
       }
     }
     if (objectMapperPresent) {
@@ -380,7 +380,7 @@ public final class DefaultTypeManager implements TypeManager {
         }
       }
     }
-    return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT);
+    return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT, keepSource);
   }
 
   /**
@@ -421,13 +421,12 @@ public final class DefaultTypeManager implements TypeManager {
     return Object.class.equals(typeArgs[1]) || "?".equals(typeArgs[1].toString());
   }
 
-  private ScalarType<?> createJsonObjectMapperType(DeployBeanProperty prop, int dbType, DocPropertyType docType) {
+  private ScalarType<?> createJsonObjectMapperType(DeployBeanProperty prop, int dbType, DocPropertyType docType, boolean keepSource) {
     Class<?> type = prop.getPropertyType();
     if (objectMapper == null) {
       throw new IllegalArgumentException("Type [" + type + "] unsupported for @DbJson mapping - Jackson ObjectMapper not present");
     }
-    boolean modifyAwareCollection = !prop.isKeepSource();
-    return ScalarTypeJsonObjectMapper.createTypeFor(jsonManager, (AnnotatedField) prop.getJacksonField(), dbType, docType, modifyAwareCollection);
+    return ScalarTypeJsonObjectMapper.createTypeFor(jsonManager, (AnnotatedField) prop.getJacksonField(), dbType, docType, keepSource);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
@@ -34,18 +34,19 @@ class ScalarTypeJsonObjectMapper {
   /**
    * Create and return the appropriate ScalarType.
    */
-  static ScalarType<?> createTypeFor(TypeJsonManager jsonManager, AnnotatedField field, int dbType, DocPropertyType docType, boolean modifyAwareCollection) {
+  static ScalarType<?> createTypeFor(TypeJsonManager jsonManager, AnnotatedField field, int dbType, DocPropertyType docType, boolean keepSource) {
     Class<?> type = field.getRawType();
-    if (modifyAwareCollection) {
-      if (Set.class.equals(type)) {
-        return new OmSet(jsonManager, field, dbType, docType);
-      }
-      if (List.class.equals(type)) {
-        return new OmList(jsonManager, field, dbType, docType);
-      }
-      if (Map.class.equals(type)) {
-        return new OmMap(jsonManager, field, dbType);
-      }
+    if (keepSource) {
+      return new GenericObject(jsonManager, field, dbType, type);
+    }
+    if (Set.class.equals(type)) {
+      return new OmSet(jsonManager, field, dbType, docType);
+    }
+    if (List.class.equals(type)) {
+      return new OmList(jsonManager, field, dbType, docType);
+    }
+    if (Map.class.equals(type)) {
+      return new OmMap(jsonManager, field, dbType);
     }
     return new GenericObject(jsonManager, field, dbType, type);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
@@ -34,16 +34,18 @@ class ScalarTypeJsonObjectMapper {
   /**
    * Create and return the appropriate ScalarType.
    */
-  static ScalarType<?> createTypeFor(TypeJsonManager jsonManager, AnnotatedField field, int dbType, DocPropertyType docType) {
+  static ScalarType<?> createTypeFor(TypeJsonManager jsonManager, AnnotatedField field, int dbType, DocPropertyType docType, boolean modifyAwareCollection) {
     Class<?> type = field.getRawType();
-    if (Set.class.equals(type)) {
-      return new OmSet(jsonManager, field, dbType, docType);
-    }
-    if (List.class.equals(type)) {
-      return new OmList(jsonManager, field, dbType, docType);
-    }
-    if (Map.class.equals(type)) {
-      return new OmMap(jsonManager, field, dbType);
+    if (modifyAwareCollection) {
+      if (Set.class.equals(type)) {
+        return new OmSet(jsonManager, field, dbType, docType);
+      }
+      if (List.class.equals(type)) {
+        return new OmList(jsonManager, field, dbType, docType);
+      }
+      if (Map.class.equals(type)) {
+        return new OmMap(jsonManager, field, dbType);
+      }
     }
     return new GenericObject(jsonManager, field, dbType, type);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeManager.java
@@ -59,7 +59,7 @@ public interface TypeManager {
    * Note that type expected to be JsonNode or Map.
    * </p>
    */
-  ScalarType<?> getJsonScalarType(DeployBeanProperty prop, int dbType, int dbLength);
+  ScalarType<?> getJsonScalarType(DeployBeanProperty prop, int dbType, int dbLength, boolean keepSource);
 
   /**
    * Return the ScalarType used to handle DB ARRAY.

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_Jackson3.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_Jackson3.java
@@ -161,10 +161,8 @@ public class TestDbJson_Jackson3 extends BaseTestCase {
     final EBasicJsonList found = DB.find(EBasicJsonList.class, bean.getId());
     found.getBeanList().get(0).setName("p1-mod");
 
-//    BeanState state = DB.getBeanState(found);
-//    assertThat(state.getChangedProps()).containsExactlyInAnyOrder("beanList");
-    // this test fails, because we have a OmList instead of a GenericObject
-    // TODO: Can/Should we enhance the @DbJson/@DbJsonB annotations with a property "dirtyDetection"
+    BeanState state = DB.getBeanState(found);
+    assertThat(state.getChangedProps()).containsExactlyInAnyOrder("beanList");
 
   }
 }

--- a/ebean-core/src/test/java/org/tests/model/json/EBasicJsonJackson3.java
+++ b/ebean-core/src/test/java/org/tests/model/json/EBasicJsonJackson3.java
@@ -15,11 +15,14 @@ public class EBasicJsonJackson3 extends Model {
 
   String name;
 
-  @DbJson(length = 500)
+  @DbJson(length = 500, keepSource = true)
   PlainBeanDirtyAware plainValue;
 
   @DbJson(length = 500)
   PlainBeanDirtyAware plainValue2;
+  
+  @DbJson(length = 500, dirtyDetection = false) // CHECKME should this fall back to ModifyAwareType
+  PlainBeanDirtyAware plainValue3;
   
   @Version
   long version;
@@ -54,6 +57,14 @@ public class EBasicJsonJackson3 extends Model {
 
   public void setPlainValue2(PlainBeanDirtyAware plainValue2) {
     this.plainValue2 = plainValue2;
+  }
+  
+  public PlainBeanDirtyAware getPlainValue3() {
+    return plainValue3;
+  }
+  
+  public void setPlainValue3(PlainBeanDirtyAware plainValue3) {
+    this.plainValue3 = plainValue3;
   }
   
   public long getVersion() {

--- a/ebean-core/src/test/java/org/tests/model/json/EBasicJsonList.java
+++ b/ebean-core/src/test/java/org/tests/model/json/EBasicJsonList.java
@@ -25,7 +25,7 @@ public class EBasicJsonList {
   @DbJson(length = 700, name = "beans")
   Set<PlainBean> beanSet;
 
-  @DbJsonB
+  @DbJsonB(keepSource = true)
   List<PlainBean> beanList;
 
   @DbJson(length = 700)


### PR DESCRIPTION
Hello Rob. This will fix the disabled test when a list with plainbeans is modified.

Normally, Lists are handled as ModifyAwareLists. I think it is a good tradeoff, to handle them as GenericObject if `@DbJson(keepSource=true)` is set.