### PR TITLE
Do not override empty json collections, when database value is null

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlBeanLoad.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlBeanLoad.java
@@ -6,6 +6,9 @@ import io.ebeaninternal.api.SpiQuery.Mode;
 import io.ebeaninternal.server.deploy.BeanProperty;
 import io.ebeaninternal.server.deploy.DbReadContext;
 
+import java.util.Collection;
+import java.util.Map;
+
 /**
  * Controls the loading of property data into a bean.
  * <p>
@@ -70,12 +73,7 @@ public class SqlBeanLoad {
 
     try {
       Object dbVal = prop.read(ctx);
-      if (!refreshLoading) {
-        prop.setValue(bean, dbVal);
-      } else {
-        prop.setValueIntercept(bean, dbVal);
-      }
-
+      load(prop, dbVal);
       return dbVal;
 
     } catch (Exception e) {
@@ -89,6 +87,14 @@ public class SqlBeanLoad {
    * Load the given value into the property.
    */
   public void load(BeanProperty target, Object dbVal) {
+    if (dbVal == null) {
+      Object current = target.getValue(bean);
+      if ((current instanceof Collection && ((Collection<?>) current).isEmpty())
+        || current instanceof Map && ((Map<?, ?>) current).isEmpty()) {
+        dbVal = current; // do not modify
+      }
+    }
+
     if (!refreshLoading) {
       target.setValue(bean, dbVal);
     } else {

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
@@ -221,4 +221,18 @@ public class TestDbJson_List extends BaseTestCase {
 
     DB.delete(bean);
   }
+
+  @Test
+  public void testNullToEmpty() {
+    EBasicJsonList bean = new EBasicJsonList();
+    bean.setFlags(null);
+    bean.setTags(null);
+    bean.setBeanMap(null);
+    DB.save(bean);
+
+    bean = DB.find(EBasicJsonList.class)
+      .setId(bean.getId()).findOne();
+
+    assertThat(bean.getFlags()).isEmpty();
+  }
 }

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
@@ -234,5 +234,7 @@ public class TestDbJson_List extends BaseTestCase {
       .setId(bean.getId()).findOne();
 
     assertThat(bean.getFlags()).isEmpty();
+    assertThat(bean.getTags()).isEmpty();
+    assertThat(bean.getBeanMap()).isEmpty();
   }
 }


### PR DESCRIPTION
Currently, when a Bean initializes a DbJson Collection property with an empty Collection in the constructor, Ebean overrides that with `null`, if the column in the database is null. Usually the value might be null, when the column has been added through migration and no default has been given. This leads to problems where a seemingly non-null property becomes null, when the bean is loaded from the database. We use annotations like @Nonnull for IDE nullability-checks and kinda rely on that to add null-checks where needed. It probably is a similar (maybe worse) case for Kotlin users, where a compile-time non-null property becomes null and there simply are no null-checks then.
This PR changes the behaviour, so that if the column is null and the constructor provides a default, the default is kept, so you don't run into unexpected NPEs.