### PR TITLE
Treat json Jackson collections the same wrt mutation detection

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -194,12 +194,6 @@ public class DatabaseConfig {
   private JsonConfig.Include jsonInclude = JsonConfig.Include.ALL;
 
   /**
-   * When true then by default DbJson beans are assumed to be dirty.
-   * I believe we want to change this default to false in the future.
-   */
-  private boolean jsonDirtyByDefault = true;
-
-  /**
    * The database platform name. Used to imply a DatabasePlatform to use.
    */
   private String databasePlatformName;
@@ -741,26 +735,6 @@ public class DatabaseConfig {
    */
   public void setJsonInclude(JsonConfig.Include jsonInclude) {
     this.jsonInclude = jsonInclude;
-  }
-
-  /**
-   * Return true if DbJson beans are assumed dirty by default.
-   * <p>
-   * That is, when true beans that do not implement ModifyAwareType are by
-   * default assumed to be dirty and included in updates.
-   */
-  public boolean isJsonDirtyByDefault() {
-    return jsonDirtyByDefault;
-  }
-
-  /**
-   * Set to false if we want DbJson beans to not be assumed to be dirty.
-   * <p>
-   * That is, when true beans that do not implement ModifyAwareType are by
-   * default assumed to be dirty and included in updates.
-   */
-  public void setJsonDirtyByDefault(boolean jsonDirtyByDefault) {
-    this.jsonDirtyByDefault = jsonDirtyByDefault;
   }
 
   /**
@@ -2935,7 +2909,6 @@ public class DatabaseConfig {
     jsonInclude = p.getEnum(JsonConfig.Include.class, "jsonInclude", jsonInclude);
     jsonDateTime = p.getEnum(JsonConfig.DateTime.class, "jsonDateTime", jsonDateTime);
     jsonDate = p.getEnum(JsonConfig.Date.class, "jsonDate", jsonDate);
-    jsonDirtyByDefault = p.getBoolean("jsonDirtyByDefault", jsonDirtyByDefault);
 
     runMigration = p.getBoolean("migration.run", runMigration);
     ddlGenerate = p.getBoolean("ddl.generate", ddlGenerate);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -134,7 +134,7 @@ public final class DefaultTypeManager implements TypeManager {
     this.postgres = isPostgres(config.getDatabasePlatform());
     this.objectMapperPresent = config.getClassLoadConfig().isJacksonObjectMapperPresent();
     this.objectMapper = (objectMapperPresent) ? initObjectMapper(config) : null;
-    this.jsonManager = (objectMapperPresent) ? new TypeJsonManager(postgres, objectMapper, config.isJsonDirtyByDefault()) : null;
+    this.jsonManager = (objectMapperPresent) ? new TypeJsonManager(postgres, objectMapper) : null;
     this.extraTypeFactory = new DefaultTypeFactory(config);
     this.arrayTypeListFactory = arrayTypeListFactory(config.getDatabasePlatform());
     this.arrayTypeSetFactory = arrayTypeSetFactory(config.getDatabasePlatform());
@@ -556,7 +556,7 @@ public final class DefaultTypeManager implements TypeManager {
       // no override or further mapping required
       return scalarType;
     }
-    ScalarTypeEnum<?> scalarEnum = (ScalarTypeEnum<?>)scalarType;
+    ScalarTypeEnum<?> scalarEnum = (ScalarTypeEnum<?>) scalarType;
     if (scalarEnum != null && !scalarEnum.isOverrideBy(type)) {
       if (type != null && !scalarEnum.isCompatible(type)) {
         throw new IllegalStateException("Error mapping Enum type:" + enumType + " It is mapped using 2 different modes when only one is supported (ORDINAL, STRING or an Ebean mapping)");
@@ -673,7 +673,7 @@ public final class DefaultTypeManager implements TypeManager {
   private Object initObjectMapper(DatabaseConfig config) {
     Object objectMapper = config.getObjectMapper();
     if (objectMapper == null) {
-      objectMapper = new ObjectMapper();
+      objectMapper = InitObjectMapper.init();
       config.setObjectMapper(objectMapper);
     }
     return objectMapper;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/InitObjectMapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/InitObjectMapper.java
@@ -1,0 +1,22 @@
+package io.ebeaninternal.server.type;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Initialise the Jackson ObjectMapper.
+ */
+class InitObjectMapper {
+
+  /**
+   * Create and return the default ObjectMapper.
+   */
+  static Object init() {
+    SimpleModule module = new SimpleModule();
+    module.addAbstractTypeMapping(Set.class, LinkedHashSet.class);
+    return new ObjectMapper().registerModule(module);
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeJsonManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeJsonManager.java
@@ -2,25 +2,16 @@ package io.ebeaninternal.server.type;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ebean.ModifyAwareType;
-import io.ebean.config.DatabaseConfig;
 import io.ebean.config.dbplatform.DbPlatformType;
 
 class TypeJsonManager {
 
-  interface DirtyHandler {
-    boolean isDirty(Object value);
-  }
-
   private final boolean postgres;
   private final ObjectMapper objectMapper;
-  private final DirtyHandler defaultHandler;
-  private final DirtyHandler modifyAwareHandler;
 
-  TypeJsonManager(boolean postgres, Object objectMapper, boolean defaultDirty) {
+  TypeJsonManager(boolean postgres, Object objectMapper) {
     this.postgres = postgres;
     this.objectMapper = (ObjectMapper) objectMapper;
-    this.defaultHandler = new DefaultHandler(defaultDirty);
-    this.modifyAwareHandler = new ModifyAwareHandler();
   }
 
   ObjectMapper objectMapper() {
@@ -37,17 +28,6 @@ class TypeJsonManager {
       }
     }
     return null;
-  }
-
-  /**
-   * Return the DirtyHandler to use.
-   */
-  DirtyHandler dirtyHandler(Class<?> cls, Class<?> rawType) {
-    if (!Object.class.equals(cls) || ModifyAwareType.class.isAssignableFrom(rawType)) {
-      // Set, List and Map are modify aware
-      return modifyAwareHandler;
-    }
-    return defaultHandler;
   }
 
   /**
@@ -68,30 +48,6 @@ class TypeJsonManager {
       return true;
     } else {
       return false;
-    }
-  }
-
-  static final class ModifyAwareHandler implements DirtyHandler {
-    @Override
-    public boolean isDirty(Object value) {
-      return checkModifyAware(value);
-    }
-  }
-
-  /**
-   * Effectively constant based on {@link DatabaseConfig#isJsonDirtyByDefault()}
-   */
-  static final class DefaultHandler implements DirtyHandler {
-
-    private final boolean dirty;
-
-    DefaultHandler(boolean dirty) {
-      this.dirty = dirty;
-    }
-
-    @Override
-    public boolean isDirty(Object value) {
-      return dirty;
     }
   }
 

--- a/ebean-core/src/test/java/io/ebean/config/ServerConfigTest.java
+++ b/ebean-core/src/test/java/io/ebean/config/ServerConfigTest.java
@@ -104,9 +104,6 @@ public class ServerConfigTest {
     assertEquals(PlatformConfig.DbUuid.BINARY, serverConfig.getPlatformConfig().getDbUuid());
     assertEquals(JsonConfig.DateTime.MILLIS, serverConfig.getJsonDateTime());
     assertEquals(JsonConfig.Date.MILLIS, serverConfig.getJsonDate());
-    assertFalse(serverConfig.isJsonDirtyByDefault());
-    serverConfig.setJsonDirtyByDefault(true);
-    assertTrue(serverConfig.isJsonDirtyByDefault());
 
     assertEquals("r0,users,orgs", serverConfig.getEnabledL2Regions());
 
@@ -159,7 +156,6 @@ public class ServerConfigTest {
     assertFalse(serverConfig.isIdGeneratorAutomatic());
     assertEquals(JsonConfig.DateTime.ISO8601, serverConfig.getJsonDateTime());
     assertEquals(JsonConfig.Date.ISO8601, serverConfig.getJsonDate());
-    assertTrue(serverConfig.isJsonDirtyByDefault());
     assertTrue(serverConfig.getPlatformConfig().isCaseSensitiveCollation());
     assertTrue(serverConfig.isAutoLoadModuleInfo());
 

--- a/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
+++ b/ebean-core/src/test/java/org/tests/json/TestDbJson_List.java
@@ -76,10 +76,11 @@ public class TestDbJson_List extends BaseTestCase {
     update_when_dirty();
     update_when_dirty_flags();
     update_when_dirty_SetListMap();
+
+    DB.delete(found);
   }
 
-  //@Test//(dependsOnMethods = "insert")
-  public void json_parse_format() {
+  private void json_parse_format() {
 
     String asJson = DB.json().toJson(found);
     assertThat(asJson).contains("\"tags\":[\"one\",\"two\"]");
@@ -104,8 +105,7 @@ public class TestDbJson_List extends BaseTestCase {
     assertThat(fromJson.getBeanMap()).hasSize(2);
   }
 
-  //@Test//(dependsOnMethods = "insert")
-  public void update_when_notDirty() {
+  private void update_when_notDirty() {
 
     found.setName("mod");
     LoggedSqlCollector.start();
@@ -117,7 +117,7 @@ public class TestDbJson_List extends BaseTestCase {
     assertSql(sql.get(0)).contains("update ebasic_json_list set name=?, version=? where");
   }
 
-  public void update_when_dirty() {
+  private void update_when_dirty() {
 
     //found.setName("modAgain");
     found.getTags().add("three");
@@ -131,7 +131,7 @@ public class TestDbJson_List extends BaseTestCase {
     assertSql(sql.get(0)).contains("update ebasic_json_list set tags=?, version=? where id=? and version=?");
   }
 
-  public void update_when_dirty_flags() {
+  private void update_when_dirty_flags() {
 
     //found.setName("modAgain");
     found.getFlags().remove(42L);
@@ -145,7 +145,7 @@ public class TestDbJson_List extends BaseTestCase {
     assertSql(sql.get(0)).contains("update ebasic_json_list set flags=?, version=? where id=? and version=?;");
   }
 
-  public void update_when_dirty_SetListMap() {
+  private void update_when_dirty_SetListMap() {
 
     //found.setName("modAgain");
     found.getBeanSet().clear();

--- a/ebean-core/src/test/java/org/tests/model/json/EBasicJsonList.java
+++ b/ebean-core/src/test/java/org/tests/model/json/EBasicJsonList.java
@@ -20,6 +20,7 @@ public class EBasicJsonList {
 
   String name;
 
+  // @JsonDeserialize(as=LinkedHashSet.class)
   @DbJson(length = 700, name = "beans")
   Set<PlainBean> beanSet;
 


### PR DESCRIPTION
This remove the OmSet, OmList, OmMap ... and treats the collection types the same as bean types.

@rPraml 