### PR TITLE
Use MD5 for QueryBindHash

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/BindHash.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/BindHash.java
@@ -1,0 +1,37 @@
+package io.ebeaninternal.api;
+
+/**
+ * BindHash implementation.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public interface BindHash {
+
+  /**
+   * Update with boolean value.
+   */
+  BindHash update(boolean boolValue);
+
+  /**
+   * Update with int value.
+   */
+  BindHash update(int intValue);
+
+  /**
+   * Update with long value.
+   */
+  BindHash update(long longValue);
+
+  /**
+   * Update with object value.
+   */
+  BindHash update(Object value);
+
+  /**
+   * finishes the hash. May be used to compute internal state. After finish, no
+   * update method must be called
+   */
+  void finish();
+
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/api/BindParams.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/BindParams.java
@@ -54,12 +54,11 @@ public class BindParams implements Serializable {
     positionedParameters.clear();
   }
 
-  public int queryBindHash() {
-    int hc = namedParameters.hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(positionedParameters.size());
     for (Param positionedParameter : positionedParameters) {
-      hc = hc * 92821 + positionedParameter.hashCode();
+       positionedParameter.queryBindHash(hash);
     }
-    return hc;
   }
 
   /**
@@ -420,6 +419,10 @@ public class BindParams implements Serializable {
       hc = hc * 92821 + (type);
       hc = hc * 92821 + (inValue == null ? 0 : inValue.hashCode());
       return hc;
+    }
+
+    void queryBindHash(BindHash hash) {
+      hash.update(isInParam).update(isOutParam).update(type).update(inValue);
     }
 
     @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/api/HashQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/HashQuery.java
@@ -7,12 +7,12 @@ public class HashQuery {
 
   private final CQueryPlanKey planHash;
 
-  private final int bindHash;
+  private final BindHash bindHash;
 
   /**
    * Create the HashQuery.
    */
-  public HashQuery(CQueryPlanKey planHash, int bindHash) {
+  public HashQuery(CQueryPlanKey planHash, BindHash bindHash) {
     this.planHash = planHash;
     this.bindHash = bindHash;
   }
@@ -25,7 +25,7 @@ public class HashQuery {
   @Override
   public int hashCode() {
     int hc = 92821 * planHash.hashCode();
-    hc = 92821 * hc + bindHash;
+    hc = 92821 * hc + bindHash.hashCode();
     return hc;
   }
 
@@ -39,6 +39,6 @@ public class HashQuery {
     }
 
     HashQuery e = (HashQuery) obj;
-    return e.bindHash == bindHash && e.planHash.equals(planHash);
+    return e.bindHash.equals(bindHash) && e.planHash.equals(planHash);
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiExpression.java
@@ -56,7 +56,7 @@ public interface SpiExpression extends Expression {
   /**
    * Return the hash value for the values that will be bound.
    */
-  int queryBindHash();
+  void queryBindHash(BindHash hash);
 
   /**
    * Return true if the expression is the same with respect to bind values.

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
@@ -635,7 +635,7 @@ public interface SpiQuery<T> extends Query<T>, SpiQueryFetch, TxnProfileEventCod
    * query).
    * </p>
    */
-  int queryBindHash();
+  void queryBindHash(BindHash hash);
 
   /**
    * Identifies queries that are exactly the same including bind variables.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/AbstractTextExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/AbstractTextExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
@@ -37,9 +38,9 @@ public abstract class AbstractTextExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return 0;
-  }
+  public void queryBindHash(BindHash hash) {
+    // do nothing, only execute against document store
+  };
 
   @Override
   public boolean isSameByBind(SpiExpression other) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/AllEqualsExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/AllEqualsExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -122,14 +123,13 @@ class AllEqualsExpression extends NonPrepareExpression {
   }
 
   @Override
-  public int queryBindHash() {
+  public void queryBindHash(BindHash hash) {
 
-    int hc = 92821;
+    hash.update(propMap.size());
     for (Object value : propMap.values()) {
-      hc = hc * 92821 + (value == null ? 0 : value.hashCode());
+      hash.update(value);
     }
 
-    return hc;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/ArrayContainsExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/ArrayContainsExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
@@ -49,12 +50,11 @@ public class ArrayContainsExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = values[0].hashCode();
-    for (int i = 1; i < values.length; i++) {
-      hc = hc * 92821 + values[i].hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(values.length);
+    for (int i = 0; i < values.length; i++) {
+      hash.update(values[i]);
     }
-    return hc;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/ArrayIsEmptyExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/ArrayIsEmptyExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
@@ -33,8 +34,8 @@ public class ArrayIsEmptyExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return empty ? 0 : 92821;
+  public void queryBindHash(BindHash hash) {
+    hash.update(empty);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/BetweenExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/BetweenExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
@@ -49,10 +50,8 @@ class BetweenExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = low().hashCode();
-    hc = hc * 92821 + high().hashCode();
-    return hc;
+  public void queryBindHash(BindHash hash) {
+    hash.update(low()).update(high());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/BetweenPropertyExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/BetweenPropertyExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.util.SplitName;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -95,8 +96,8 @@ class BetweenPropertyExpression extends NonPrepareExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return val().hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(val());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/BitwiseExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/BitwiseExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
@@ -39,8 +40,8 @@ class BitwiseExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return Long.hashCode(flags);
+  public void queryBindHash(BindHash hash) {
+    hash.update(flags).update(match);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/CaseInsensitiveEqualExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/CaseInsensitiveEqualExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.el.ElPropertyValue;
@@ -69,8 +70,8 @@ class CaseInsensitiveEqualExpression extends AbstractValueExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return val().hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(val());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExampleExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExampleExpression.java
@@ -5,6 +5,7 @@ import io.ebean.LikeType;
 import io.ebean.bean.EntityBean;
 import io.ebean.event.BeanQueryRequest;
 import io.ebean.util.SplitName;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
@@ -241,12 +242,11 @@ public class DefaultExampleExpression implements SpiExpression, ExampleExpressio
    * Return a hash for the actual bind values used.
    */
   @Override
-  public int queryBindHash() {
-    int hc = DefaultExampleExpression.class.getName().hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(list.size());
     for (SpiExpression aList : list) {
-      hc = hc * 92821 + aList.queryBindHash();
+      aList.queryBindHash(hash);
     }
-    return hc;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -26,6 +26,7 @@ import io.ebean.search.MultiMatch;
 import io.ebean.search.TextCommonTerms;
 import io.ebean.search.TextQueryString;
 import io.ebean.search.TextSimple;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
@@ -678,12 +679,11 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
    * Calculate a hash based on the expressions.
    */
   @Override
-  public int queryBindHash() {
-    int hash = DefaultExpressionList.class.getName().hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(list.size());
     for (SpiExpression aList : list) {
-      hash = hash * 92821 + aList.queryBindHash();
+      aList.queryBindHash(hash);
     }
-    return hash;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/ExistsQueryExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/ExistsQueryExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiEbeanServer;
@@ -91,8 +92,8 @@ class ExistsQueryExpression implements SpiExpression, UnsupportedDocStoreExpress
   }
 
   @Override
-  public int queryBindHash() {
-    return subQuery.queryBindHash();
+  public void queryBindHash(BindHash hash) {
+    subQuery.queryBindHash(hash);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/IdExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/IdExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -77,8 +78,8 @@ class IdExpression extends NonPrepareExpression implements SpiExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return value.hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(value);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/IdInExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/IdInExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -133,8 +134,11 @@ public class IdInExpression extends NonPrepareExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return idCollection.hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(idCollection.size());
+    for (Object elem : idCollection) {
+      hash.update(elem);
+    }
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/InExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/InExpression.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.expression;
 
 import io.ebean.bean.EntityBean;
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -176,12 +177,11 @@ class InExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = 92821;
+  public void queryBindHash(BindHash hash) {
+    hash.update(bindValues.size());
     for (Object bindValue : bindValues) {
-      hc = 92821 * hc + bindValue.hashCode();
+      hash.update(bindValue);
     }
-    return hc;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/InPairsExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/InPairsExpression.java
@@ -3,6 +3,7 @@ package io.ebeaninternal.server.expression;
 import io.ebean.Pairs;
 import io.ebean.Pairs.Entry;
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -124,12 +125,11 @@ class InPairsExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = 92821;
+  public void queryBindHash(BindHash hash) {
+    hash.update(entries.size());
     for (Pairs.Entry entry : entries) {
-      hc = 92821 * hc + entry.hashCode();
+      hash.update(entry.getA()).update(entry.getB());
     }
-    return hc;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/InQueryExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/InQueryExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -72,8 +73,8 @@ class InQueryExpression extends AbstractExpression implements UnsupportedDocStor
   }
 
   @Override
-  public int queryBindHash() {
-    return subQuery.queryBindHash();
+  public void queryBindHash(BindHash hash) {
+    subQuery.queryBindHash(hash);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/InRangeExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/InRangeExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
@@ -47,10 +48,8 @@ class InRangeExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = low().hashCode();
-    hc = hc * 92821 + high().hashCode();
-    return hc;
+  public void queryBindHash(BindHash hash) {
+    hash.update(low()).update(high());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/IsEmptyExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/IsEmptyExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -103,8 +104,8 @@ class IsEmptyExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return 1;
+  public void queryBindHash(BindHash hash) {
+    // no bind values
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/JsonPathExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/JsonPathExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
@@ -83,10 +84,8 @@ class JsonPathExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = (value == null) ? 0 : value.hashCode();
-    hc = (upperValue == null) ? hc : hc * 92821 + upperValue.hashCode();
-    return hc;
+  public void queryBindHash(BindHash hash) {
+    hash.update(value).update(upperValue);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
@@ -25,6 +25,7 @@ import io.ebean.search.MultiMatch;
 import io.ebean.search.TextCommonTerms;
 import io.ebean.search.TextQueryString;
 import io.ebean.search.TextSimple;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
@@ -225,13 +226,12 @@ class JunctionExpression<T> implements SpiJunction<T>, SpiExpression, Expression
   }
 
   @Override
-  public int queryBindHash() {
+  public void queryBindHash(BindHash hash) {
     int hc = JunctionExpression.class.getName().hashCode();
     List<SpiExpression> list = exprList.internalList();
     for (SpiExpression aList : list) {
-      hc = hc * 92821 + aList.queryBindHash();
+      aList.queryBindHash(hash);
     }
-    return hc;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/LikeExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/LikeExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.LikeType;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.el.ElPropertyValue;
@@ -70,8 +71,8 @@ class LikeExpression extends AbstractValueExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return strValue().hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(strValue());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/LogicExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/LogicExpression.java
@@ -3,6 +3,7 @@ package io.ebeaninternal.server.expression;
 import io.ebean.Expression;
 import io.ebean.Junction;
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
@@ -168,10 +169,8 @@ abstract class LogicExpression implements SpiExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = expOne.queryBindHash();
-    hc = hc * 92821 + expTwo.queryBindHash();
-    return hc;
+  public void queryBindHash(BindHash hash) {
+    hash.update(expOne).update(expTwo);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/NativeILikeExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/NativeILikeExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.LikeType;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.el.ElPropertyValue;
@@ -54,8 +55,8 @@ class NativeILikeExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return val.hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(val);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/NestedPathWrapperExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/NestedPathWrapperExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -79,8 +80,8 @@ class NestedPathWrapperExpression implements SpiExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return delegate.queryBindHash();
+  public void queryBindHash(BindHash hash) {
+    delegate.queryBindHash(hash);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/NoopExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/NoopExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
@@ -74,9 +75,8 @@ class NoopExpression implements SpiExpression {
   }
 
   @Override
-  public int queryBindHash() {
+  public void queryBindHash(BindHash hash) {
     // no bind values
-    return 0;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/NotExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/NotExpression.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.expression;
 
 import io.ebean.Expression;
 import io.ebean.event.BeanQueryRequest;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 import io.ebeaninternal.api.SpiExpression;
@@ -99,8 +100,8 @@ final class NotExpression implements SpiExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return exp.queryBindHash();
+  public void queryBindHash(BindHash hash) {
+    exp.queryBindHash(hash);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/NullExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/NullExpression.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.util.SplitName;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -94,7 +95,7 @@ class NullExpression extends AbstractExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return (notNull ? 1 : 0);
+  public void queryBindHash(BindHash hash) {
+    hash.update(notNull);
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/RawExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/RawExpression.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.expression;
 
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
@@ -73,12 +74,11 @@ class RawExpression extends NonPrepareExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    int hc = sql.hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(values.length);
     for (Object value : values) {
-      hc = hc * 92821 + value.hashCode();
+      hash.update(value);
     }
-    return hc;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/SimpleExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/SimpleExpression.java
@@ -5,6 +5,7 @@ import io.ebean.plugin.ExpressionPath;
 import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.el.ElPropertyValue;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.NaturalKeyQueryData;
 
 import java.io.IOException;
@@ -121,8 +122,8 @@ public class SimpleExpression extends AbstractValueExpression {
   }
 
   @Override
-  public int queryBindHash() {
-    return value().hashCode();
+  public void queryBindHash(BindHash hash) {
+    hash.update(value());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/HashCodeBindHash.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/HashCodeBindHash.java
@@ -1,0 +1,56 @@
+package io.ebeaninternal.server.querydefn;
+
+import java.util.Objects;
+
+import io.ebeaninternal.api.BindHash;
+
+/**
+ * HashCode builder that uses Object.hashCode for computing bind-hashes.
+ * This is a fast and lightweight implementation, but may produce collisions.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class HashCodeBindHash implements BindHash {
+
+  int hashCode;
+
+  @Override
+  public BindHash update(int intValue) {
+    hashCode = hashCode * 92821 + intValue;
+    return this;
+  }
+
+  @Override
+  public BindHash update(long longValue) {
+    hashCode = hashCode * 92821 + Long.hashCode(longValue);
+    return this;
+  }
+
+  @Override
+  public BindHash update(boolean boolValue) {
+    hashCode = hashCode * 92821 + Boolean.hashCode(boolValue);
+    return this;
+  }
+
+  @Override
+  public BindHash update(Object value) {
+    hashCode = hashCode * 92821 + Objects.hashCode(value);
+    return this;
+  }
+
+  @Override
+  public void finish() {
+    // nothing to do
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof HashCodeBindHash && ((HashCodeBindHash) obj).hashCode == hashCode;
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
+
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/MdBindHash.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/MdBindHash.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed Materials - Property of FOCONIS AG
+ * (C) Copyright FOCONIS AG.
+ */
+
+package io.ebeaninternal.server.querydefn;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.UUID;
+
+import io.ebeaninternal.api.BindHash;
+
+/**
+ * Bind hash that uses a MessageDigest to compute a collision resistent hash.
+ *
+ * @author Roland Praml, FOCONIS AG
+ *
+ */
+public class MdBindHash implements BindHash {
+  private MessageDigest md;
+  private byte[] buffer;
+  private int hashCode;
+
+  public MdBindHash(String algorithm) {
+    try {
+      md = MessageDigest.getInstance(algorithm);
+    } catch (NoSuchAlgorithmException nsae) {
+      throw new InternalError(algorithm + " not supported", nsae);
+    }
+  }
+
+  @Override
+  public BindHash update(int v) {
+    md.update((byte) (v >>> 24));
+    md.update((byte) (v >>> 16));
+    md.update((byte) (v >>> 8));
+    md.update((byte) (v >>> 0));
+    return this;
+  }
+
+  @Override
+  public BindHash update(long v) {
+    md.update((byte) (v >>> 56));
+    md.update((byte) (v >>> 48));
+    md.update((byte) (v >>> 40));
+    md.update((byte) (v >>> 32));
+    md.update((byte) (v >>> 24));
+    md.update((byte) (v >>> 16));
+    md.update((byte) (v >>> 8));
+    md.update((byte) (v >>> 0));
+    return this;
+  }
+
+  @Override
+  public BindHash update(boolean boolValue) {
+    md.update(boolValue ? (byte) 1 : (byte) 0);
+    return this;
+  }
+
+  @Override
+  public BindHash update(Object value) {
+    if (value == null) {
+      md.update((byte) 0);
+
+      // do some special handling for known object types
+    } else if (value instanceof String) {
+      md.update(((String) value).getBytes());
+
+    } else if (value instanceof Long) {
+      update(((Long) value).longValue());
+
+    } else if (value instanceof Double) {
+      double d = ((Double) value).doubleValue();
+      update(Double.doubleToLongBits(d));
+
+    } else if (value instanceof UUID) {
+      UUID uuid = (UUID) value;
+      update(uuid.getLeastSignificantBits());
+      update(uuid.getMostSignificantBits());
+
+    } else if (value instanceof Date) {
+      update(((Date) value).getTime());
+
+    } else if (value instanceof Instant) {
+      update(((Instant) value).getEpochSecond());
+      update(((Instant) value).getNano());
+
+    } else if (value instanceof LocalDate) {
+      update(((LocalDate) value).toEpochDay());
+
+    } else if (value instanceof LocalTime) {
+      update(((LocalTime) value).toSecondOfDay());
+      update(((LocalTime) value).toNanoOfDay());
+
+    } else if (value instanceof LocalDateTime) {
+      update(((LocalDateTime) value).toLocalDate().toEpochDay());
+      update(((LocalDateTime) value).toLocalTime().toSecondOfDay());
+      update(((LocalDateTime) value).toLocalTime().toNanoOfDay());
+
+    } else {
+      // Fall back to hashCode for all other types
+      updateOther(value);
+    }
+    return this;
+  }
+
+  /**
+   * Update all other object. May be overridden to handle joda dates.
+   */
+  protected void updateOther(Object value) {
+    // Fall back to hashCode for all other types
+    update(value.hashCode());
+  }
+
+  @Override
+  public void finish() {
+    buffer = md.digest();
+    hashCode = Arrays.hashCode(buffer);
+    md = null; // clear memory
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof MdBindHash && Arrays.equals(buffer, ((MdBindHash) obj).buffer);
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
+}

--- a/ebean-core/src/test/java/io/ebeaninternal/server/expression/RawExpressionTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/expression/RawExpressionTest.java
@@ -3,6 +3,8 @@ package io.ebeaninternal.server.expression;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import io.ebeaninternal.api.BindHash;
+import io.ebeaninternal.server.querydefn.HashCodeBindHash;
 
 public class RawExpressionTest extends BaseExpressionTest {
 
@@ -61,11 +63,17 @@ public class RawExpressionTest extends BaseExpressionTest {
   }
 
   public void assert_queryBindHash_isDifferent(RawExpression exp0, RawExpression exp1) {
-    assertThat(exp0.queryBindHash()).isNotEqualTo(exp1.queryBindHash());
+    assertThat(getHash(exp0)).isNotEqualTo(getHash(exp1));
   }
 
   public void assert_queryBindHash_isSame(RawExpression exp0, RawExpression exp1) {
-    assertThat(exp0.queryBindHash()).isEqualTo(exp1.queryBindHash());
+    assertThat(getHash(exp0)).isEqualTo(getHash(exp1));
   }
 
+  private int getHash(RawExpression query) {
+    BindHash hash = new HashCodeBindHash();
+    query.queryBindHash(hash);
+    hash.finish();
+    return hash.hashCode();
+  }
 }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/querydefn/DefaultOrmQueryTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/querydefn/DefaultOrmQueryTest.java
@@ -4,6 +4,7 @@ package io.ebeaninternal.server.querydefn;
 import io.ebean.BaseTestCase;
 import io.ebean.CacheMode;
 import io.ebean.Ebean;
+import io.ebeaninternal.api.BindHash;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.server.core.OrmQueryRequest;
 import org.junit.Test;
@@ -62,7 +63,7 @@ public class DefaultOrmQueryTest extends BaseTestCase {
 
     prepare(q1, q2);
     assertThat(q1.createQueryPlanKey()).isNotEqualTo(q2.createQueryPlanKey());
-    assertThat(q1.queryBindHash()).isNotEqualTo(q2.queryBindHash());
+    assertThat(getHash(q1)).isNotEqualTo(getHash(q2));
   }
 
   @Test
@@ -73,7 +74,7 @@ public class DefaultOrmQueryTest extends BaseTestCase {
 
     prepare(q1, q2);
     assertThat(q1.createQueryPlanKey()).isEqualTo(q2.createQueryPlanKey());
-    assertThat(q1.queryBindHash()).isNotEqualTo(q2.queryBindHash());
+    assertThat(getHash(q1)).isNotEqualTo(getHash(q2));
   }
 
   @Test
@@ -84,7 +85,7 @@ public class DefaultOrmQueryTest extends BaseTestCase {
 
     prepare(q1, q2);
     assertThat(q1.createQueryPlanKey()).isEqualTo(q2.createQueryPlanKey());
-    assertThat(q1.queryBindHash()).isEqualTo(q2.queryBindHash());
+    assertThat(getHash(q1)).isEqualTo(getHash(q2));
   }
 
   @Test
@@ -109,5 +110,12 @@ public class DefaultOrmQueryTest extends BaseTestCase {
 
     OrmQueryRequest<T> r2 = createQueryRequest(SpiQuery.Type.LIST, q2, null);
     q2.prepare(r2);
+  }
+
+  private int getHash(DefaultOrmQuery<Order> query) {
+    BindHash hash = new HashCodeBindHash();
+    query.queryBindHash(hash);
+    hash.finish();
+    return hash.hashCode();
   }
 }


### PR DESCRIPTION
As mentioned in #2261 - the current hashCode implementation has a high risk of collisions.
This PR use MD5 sum for QueryBindHash computation, which should minimize the risk.

It is prepared to be configurable, so it shoud be easy to switch from MD5 to any other MessageDigest, like SHA1 or SHA256
or even back to the old HashCode algorithm.

