### PR TITLE
FIX: Changelog-oldValue did not work for Json mutable properties

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -395,6 +395,15 @@ public final class EntityBeanIntercept implements Serializable {
     this.owner._ebean_setEmbeddedLoaded();
     this.lazyLoadProperty = -1;
     this.origValues = null;
+    // after save, transfer the mutable next values back to mutable info
+    if (mutableNext != null) {
+      for (int i = 0; i < mutableNext.length; i++) {
+        MutableValueNext next = mutableNext[i];
+        if (next != null) {
+          mutableInfo(i, next.info());
+        }
+      }
+    }
     this.mutableNext = null;
     for (int i = 0; i < flags.length; i++) {
       flags[i] &= ~(FLAG_CHANGED_PROP | FLAG_ORIG_VALUE_SET);
@@ -1223,9 +1232,7 @@ public final class EntityBeanIntercept implements Serializable {
     if (mutableNext == null) {
       return null;
     }
-    final MutableValueNext next = mutableNext[propertyIndex];
-    mutableInfo(propertyIndex, next.info());
-    return next.content();
+    return mutableNext[propertyIndex].content();
   }
 
 }

--- a/ebean-core/src/test/java/org/tests/model/basic/EBasicChangeLog.java
+++ b/ebean-core/src/test/java/org/tests/model/basic/EBasicChangeLog.java
@@ -2,6 +2,7 @@ package org.tests.model.basic;
 
 import io.ebean.annotation.Cache;
 import io.ebean.annotation.ChangeLog;
+import io.ebean.annotation.DbJson;
 import io.ebean.annotation.ReadAudit;
 import io.ebean.annotation.WhenCreated;
 import io.ebean.annotation.WhenModified;
@@ -12,11 +13,16 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Version;
 import javax.validation.constraints.Size;
+
+import org.tests.model.json.PlainBean;
+
+import static io.ebean.annotation.MutationDetection.SOURCE;
+
 import java.sql.Timestamp;
 
 @Cache(enableQueryCache = true)
 @ReadAudit
-@ChangeLog(updatesThatInclude = {"name", "shortDescription"})
+@ChangeLog(updatesThatInclude = {"name", "shortDescription", "plainBean"})
 @Entity
 public class EBasicChangeLog {
 
@@ -46,6 +52,9 @@ public class EBasicChangeLog {
 
   @Version
   Long version;
+  
+  @DbJson(length = 500, mutationDetection = SOURCE) // such that we can rebuild old values
+  PlainBean plainBean;
 
   public Long getId() {
     return id;
@@ -117,5 +126,13 @@ public class EBasicChangeLog {
 
   public void setVersion(Long version) {
     this.version = version;
+  }
+
+  public PlainBean getPlainBean() {
+    return plainBean;
+  }
+
+  public void setPlainBean(PlainBean plainBean) {
+    this.plainBean = plainBean;
   }
 }


### PR DESCRIPTION
Hello @rbygrave 

we found an issue with the new dirty detection & changelog.
While current-value and old value access works fine in the BeanPersistControllers, it does not work for the changelog stuff. The reason is, changelog is handled after binding the values, where the mutableNext to mutableInfo transfer is done.
I wrote a test and I moved the transfer to the `setLoaded()` as it should be the correct place IMHO.

cheers
Roland