### PR TITLE
Enables select + exists for dynamic formula properties

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -2519,7 +2519,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
     if (propName.indexOf('(') > -1) {
       return findSqlTreeFormula(propName, path);
     }
-    return _findBeanProperty(propName);
+    return findProperty(propName);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -365,11 +365,11 @@ public final class SqlTreeBuilder {
    * This means it can included individual properties of an embedded bean.
    * </p>
    */
-  private void addPropertyToSubQuery(SqlTreeProperties selectProps, STreeType desc, String propName) {
-    STreeProperty p = desc.findProperty(propName);
+  private void addPropertyToSubQuery(SqlTreeProperties selectProps, STreeType desc, String propName, String path) {
+    STreeProperty p = desc.findPropertyWithDynamic(propName, path);
     if (p == null) {
       logger.error("property [" + propName + "]not found on " + desc + " for query - excluding it.");
-
+      return;
     } else if (p instanceof STreePropertyAssoc && p.isEmbedded()) {
       // if the property is embedded we need to lookup the real column name
       int pos = propName.indexOf('.');
@@ -383,7 +383,7 @@ public final class SqlTreeBuilder {
 
   private void addProperty(SqlTreeProperties selectProps, STreeType desc, OrmQueryProperties queryProps, String propName) {
     if (subQuery) {
-      addPropertyToSubQuery(selectProps, desc, propName);
+      addPropertyToSubQuery(selectProps, desc, propName, queryProps.getPath());
       return;
     }
 

--- a/ebean-core/src/test/java/org/tests/query/TestQueryAlias.java
+++ b/ebean-core/src/test/java/org/tests/query/TestQueryAlias.java
@@ -1,7 +1,7 @@
 package org.tests.query;
 
 import io.ebean.BaseTestCase;
-import io.ebean.Ebean;
+import io.ebean.DB;
 import io.ebean.Query;
 import org.junit.Test;
 import org.tests.model.basic.CKeyParent;
@@ -16,11 +16,11 @@ public class TestQueryAlias extends BaseTestCase {
 
     ResetBasicData.reset();
 
-    Query<CKeyParent> sq = Ebean.createQuery(CKeyParent.class)
+    Query<CKeyParent> sq = DB.createQuery(CKeyParent.class)
       .select("id.oneKey").alias("st0")
       .setAutoTune(false).where().query();
 
-    Query<CKeyParent> pq = Ebean.find(CKeyParent.class).alias("myt0").where().in("id.oneKey", sq).query();
+    Query<CKeyParent> pq = DB.find(CKeyParent.class).alias("myt0").where().in("id.oneKey", sq).query();
 
     pq.findList();
 
@@ -36,17 +36,36 @@ public class TestQueryAlias extends BaseTestCase {
     assertThat(sql).contains("ckey_parent myt0");
     assertThat(sql).contains("(myt0.one_key) in (select st0.one_key from ckey_parent st0)");
   }
+  
+  @Test
+  public void testExistsWithConcat() {
+
+    ResetBasicData.reset();
+
+    Query<CKeyParent> sq = DB.createQuery(CKeyParent.class)
+      .select("concat(id.oneKey,id.twoKey)").alias("st0")
+      .setAutoTune(false).where().query();
+
+    Query<CKeyParent> pq = DB.find(CKeyParent.class).alias("myt0").where().in("concat(id.oneKey,id.twoKey)", sq).query();
+
+    pq.findList();
+
+    String sql = pq.getGeneratedSql();
+
+    assertThat(sql).contains("ckey_parent myt0");
+    assertThat(sql).contains("(concat(myt0.one_key,myt0.two_key)) in (select concat(st0.one_key,st0.two_key) from ckey_parent st0)");
+  }
 
   @Test
   public void testNotExists() {
 
     ResetBasicData.reset();
 
-    Query<CKeyParent> sq = Ebean.createQuery(CKeyParent.class)
+    Query<CKeyParent> sq = DB.createQuery(CKeyParent.class)
       .select("id.oneKey").alias("st0")
       .setAutoTune(false).where().query();
 
-    Query<CKeyParent> pq = Ebean.find(CKeyParent.class).alias("myt0").where().notIn("id.oneKey", sq).query();
+    Query<CKeyParent> pq = DB.find(CKeyParent.class).alias("myt0").where().notIn("id.oneKey", sq).query();
 
     pq.findList();
 


### PR DESCRIPTION
We have the use case where we use a formula in `query.select("concat(p1,p2)")`
I wrote a test where this is used in conjunction with an "exists" query.