### PR TITLE
Updating ebean-ddl-generator version in ebean-core

### DIFF
--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-ddl-generator</artifactId>
-      <version>12.9.4-RC1</version>
+      <version>12.11.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Hello together, I think the version was behind the currently needed. Am I right? Without this "fix" the current maven compilation fails locally.