### PR TITLE
Switch DB2 driver to the publicly available JCC driver

### DIFF
--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -20,22 +20,13 @@
 
   <profiles>
     <profile>
-      <!-- Note: to use this profile, you need to download manually the db2jcc4 driver.
-        After that, install it into your local maven repository:
-
-        mvn install:install-file \
-          -Dfile=db2jcc4.jar \
-          -DgroupId=com.ibm.jdbc \
-          -DartifactId=db2jcc4 \
-          -Dversion=4.23.42 \
-          -Dpackaging=jar
-      -->
       <id>db2</id>
       <dependencies>
+        <!-- https://mvnrepository.com/artifact/com.ibm.db2/jcc -->
         <dependency>
-          <groupId>com.ibm.jdbc</groupId>
-          <artifactId>db2jcc4</artifactId>
-          <version>4.23.42</version>
+          <groupId>com.ibm.db2</groupId>
+          <artifactId>jcc</artifactId>
+          <version>11.5.5.0</version>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Hello Rob, 
the `com.ibm.jdbc.db2jcc4` driver is only available from the login protected website of IBM:
https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads

To run tests against a DB2 server another driver `com.ibm.db2.jcc` may be useful.

A docker container can be set up via:
```yaml
    ebean_db2:
        image: ibmcom/db2:11.5.5.0
        container_name: ebean_db2
        hostname: ebean_db2
        privileged: true
        ports:
            - "50000:50000"
            - "55000:55000"
```