### PR TITLE
FIX: mutationDetection = SOURCE works also for special json types

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -364,7 +364,7 @@ public final class DefaultTypeManager implements TypeManager {
         return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT);
       }
     }
-    if (objectMapperPresent) {
+    if (objectMapperPresent && prop.getMutationDetection() == MutationDetection.DEFAULT) {
       if (type.equals(JsonNode.class)) {
         switch (dbType) {
           case Types.VARCHAR:

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonList.java
@@ -24,24 +24,24 @@ public class ScalarTypeJsonList {
   /**
    * Return the appropriate ScalarType based requested dbType and if Postgres.
    */
-  public static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docType, boolean nullable) {
+  public static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docType, boolean nullable, boolean keepSource) {
     if (postgres) {
       switch (dbType) {
         case DbPlatformType.JSONB:
-          return new ScalarTypeJsonList.JsonB(docType, nullable);
+          return new ScalarTypeJsonList.JsonB(docType, nullable, keepSource);
         case DbPlatformType.JSON:
-          return new ScalarTypeJsonList.Json(docType, nullable);
+          return new ScalarTypeJsonList.Json(docType, nullable, keepSource);
       }
     }
-    return new ScalarTypeJsonList.Varchar(docType, nullable);
+    return new ScalarTypeJsonList.Varchar(docType, nullable, keepSource);
   }
 
   /**
    * List mapped to DB VARCHAR.
    */
   public static class Varchar extends ScalarTypeJsonList.Base {
-    public Varchar(DocPropertyType docType, boolean nullable) {
-      super(Types.VARCHAR, docType, nullable);
+    public Varchar(DocPropertyType docType, boolean nullable, boolean keepSource) {
+      super(Types.VARCHAR, docType, nullable, keepSource);
     }
   }
 
@@ -49,8 +49,8 @@ public class ScalarTypeJsonList {
    * List mapped to Postgres JSON.
    */
   private static class Json extends ScalarTypeJsonList.PgBase {
-    public Json(DocPropertyType docType, boolean nullable) {
-      super(DbPlatformType.JSON, PostgresHelper.JSON_TYPE, docType, nullable);
+    public Json(DocPropertyType docType, boolean nullable, boolean keepSource) {
+      super(DbPlatformType.JSON, PostgresHelper.JSON_TYPE, docType, nullable, keepSource);
     }
   }
 
@@ -58,8 +58,8 @@ public class ScalarTypeJsonList {
    * List mapped to Postgres JSONB.
    */
   private static class JsonB extends ScalarTypeJsonList.PgBase {
-    public JsonB(DocPropertyType docType, boolean nullable) {
-      super(DbPlatformType.JSONB, PostgresHelper.JSONB_TYPE, docType, nullable);
+    public JsonB(DocPropertyType docType, boolean nullable, boolean keepSource) {
+      super(DbPlatformType.JSONB, PostgresHelper.JSONB_TYPE, docType, nullable, keepSource);
     }
   }
 
@@ -68,14 +68,24 @@ public class ScalarTypeJsonList {
    */
   @SuppressWarnings("rawtypes")
   private abstract static class Base extends ScalarTypeJsonCollection<List> {
+    private final boolean keepSource;
 
-    public Base(int dbType, DocPropertyType docType, boolean nullable) {
+    public Base(int dbType, DocPropertyType docType, boolean nullable, boolean keepSource) {
       super(List.class, dbType, docType, nullable);
+      this.keepSource = keepSource;
+    }
+    
+    @Override
+    public boolean isJsonMapper() {
+      return keepSource;
     }
 
     @Override
     public List read(DataReader reader) throws SQLException {
       String json = reader.getString();
+      if (isJsonMapper()) {
+        reader.pushJson(json);
+      }
       try {
         // parse JSON into modifyAware list
         return EJson.parseList(json, true);
@@ -85,17 +95,15 @@ public class ScalarTypeJsonList {
     }
 
     @Override
-    public void bind(DataBinder binder, List value) throws SQLException {
+    public final void bind(DataBinder binder, List value) throws SQLException {
+      String rawJson = isJsonMapper() ? binder.popJson() : null;
+      if (rawJson == null && value != null) {
+        rawJson = formatValue(value);
+      }
       if (value == null) {
         bindNull(binder);
-      } else if (value.isEmpty()) {
-        binder.setString("[]");
       } else {
-        try {
-          binder.setString(EJson.write(value));
-        } catch (IOException e) {
-          throw new SQLException("Failed to format List into JSON content", e);
-        }
+        bindRawJson(binder, rawJson);
       }
     }
 
@@ -107,9 +115,16 @@ public class ScalarTypeJsonList {
         binder.setString("[]");
       }
     }
+    
+    protected void bindRawJson(DataBinder binder, String rawJson) throws SQLException {
+      binder.setString(rawJson);
+    }
 
     @Override
     public String formatValue(List value) {
+      if (value.isEmpty()) {
+        return "[]"; 
+      }
       try {
         return EJson.write(value);
       } catch (IOException e) {
@@ -144,19 +159,14 @@ public class ScalarTypeJsonList {
 
     final String pgType;
 
-    PgBase(int jdbcType, String pgType, DocPropertyType docType, boolean nullable) {
-      super(jdbcType, docType, nullable);
+    PgBase(int jdbcType, String pgType, DocPropertyType docType, boolean nullable, boolean keepSource) {
+      super(jdbcType, docType, nullable, keepSource);
       this.pgType = pgType;
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
-    public void bind(DataBinder binder, List value) throws SQLException {
-      if (value == null) {
-        bindNull(binder);
-      } else {
-        binder.setObject(PostgresHelper.asObject(pgType, formatValue(value)));
-      }
+    protected void bindRawJson(DataBinder binder, String rawJson) throws SQLException {
+      binder.setObject(PostgresHelper.asObject(pgType, rawJson));
     }
 
     @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonMapPostgres.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonMapPostgres.java
@@ -4,7 +4,6 @@ import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.core.type.DataBinder;
 
 import java.sql.SQLException;
-import java.util.Map;
 
 /**
  * Support for the Postgres DB types JSON and JSONB.
@@ -13,15 +12,18 @@ public abstract class ScalarTypeJsonMapPostgres extends ScalarTypeJsonMap {
 
   final String postgresType;
 
-  ScalarTypeJsonMapPostgres(int jdbcType, String postgresType) {
-    super(jdbcType);
+  ScalarTypeJsonMapPostgres(int jdbcType, String postgresType, boolean keepSource) {
+    super(jdbcType, keepSource);
     this.postgresType = postgresType;
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
-  public void bind(DataBinder binder, Map value) throws SQLException {
-    String rawJson = (value == null) ? null : formatValue(value);
+  protected void bindNull(DataBinder binder) throws SQLException {
+    binder.setObject(PostgresHelper.asObject(postgresType, null));
+  }
+  
+  @Override
+  protected void bindJson(DataBinder binder, String rawJson) throws SQLException {
     binder.setObject(PostgresHelper.asObject(postgresType, rawJson));
   }
 
@@ -30,8 +32,8 @@ public abstract class ScalarTypeJsonMapPostgres extends ScalarTypeJsonMap {
    */
   public static class JSON extends ScalarTypeJsonMapPostgres {
 
-    public JSON() {
-      super(DbPlatformType.JSON, PostgresHelper.JSON_TYPE);
+    public JSON(boolean keepSource) {
+      super(DbPlatformType.JSON, PostgresHelper.JSON_TYPE, keepSource);
     }
   }
 
@@ -40,8 +42,8 @@ public abstract class ScalarTypeJsonMapPostgres extends ScalarTypeJsonMap {
    */
   public static class JSONB extends ScalarTypeJsonMapPostgres {
 
-    public JSONB() {
-      super(DbPlatformType.JSONB, PostgresHelper.JSONB_TYPE);
+    public JSONB(boolean keepSource) {
+      super(DbPlatformType.JSONB, PostgresHelper.JSONB_TYPE, keepSource);
     }
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
@@ -26,24 +26,24 @@ public class ScalarTypeJsonSet {
   /**
    * Return the appropriate ScalarType for the requested dbType and Postgres.
    */
-  public static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docPropertyType, boolean nullable) {
+  public static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docPropertyType, boolean nullable, boolean keepSource) {
     if (postgres) {
       switch (dbType) {
         case DbPlatformType.JSONB:
-          return new ScalarTypeJsonSet.JsonB(docPropertyType, nullable);
+          return new ScalarTypeJsonSet.JsonB(docPropertyType, nullable, keepSource);
         case DbPlatformType.JSON:
-          return new ScalarTypeJsonSet.Json(docPropertyType, nullable);
+          return new ScalarTypeJsonSet.Json(docPropertyType, nullable, keepSource);
       }
     }
-    return new ScalarTypeJsonSet.Varchar(docPropertyType, nullable);
+    return new ScalarTypeJsonSet.Varchar(docPropertyType, nullable, keepSource);
   }
 
   /**
    * List mapped to DB VARCHAR.
    */
   public static class Varchar extends ScalarTypeJsonSet.Base {
-    public Varchar(DocPropertyType docPropertyType, boolean nullable) {
-      super(Types.VARCHAR, docPropertyType, nullable);
+    public Varchar(DocPropertyType docPropertyType, boolean nullable, boolean keepSource) {
+      super(Types.VARCHAR, docPropertyType, nullable, keepSource);
     }
   }
 
@@ -51,8 +51,8 @@ public class ScalarTypeJsonSet {
    * List mapped to Postgres JSON.
    */
   private static class Json extends ScalarTypeJsonSet.PgBase {
-    public Json(DocPropertyType docPropertyType, boolean nullable) {
-      super(DbPlatformType.JSON, PostgresHelper.JSON_TYPE, docPropertyType, nullable);
+    public Json(DocPropertyType docPropertyType, boolean nullable, boolean keepSource) {
+      super(DbPlatformType.JSON, PostgresHelper.JSON_TYPE, docPropertyType, nullable, keepSource);
     }
   }
 
@@ -60,8 +60,8 @@ public class ScalarTypeJsonSet {
    * List mapped to Postgres JSONB.
    */
   private static class JsonB extends ScalarTypeJsonSet.PgBase {
-    public JsonB(DocPropertyType docPropertyType, boolean nullable) {
-      super(DbPlatformType.JSONB, PostgresHelper.JSONB_TYPE, docPropertyType, nullable);
+    public JsonB(DocPropertyType docPropertyType, boolean nullable, boolean keepSource) {
+      super(DbPlatformType.JSONB, PostgresHelper.JSONB_TYPE, docPropertyType, nullable, keepSource);
     }
   }
 
@@ -71,13 +71,25 @@ public class ScalarTypeJsonSet {
   @SuppressWarnings("rawtypes")
   private abstract static class Base extends ScalarTypeJsonCollection<Set> {
 
-    public Base(int dbType, DocPropertyType docPropertyType, boolean nullable) {
+    private boolean keepSource;
+    
+    public Base(int dbType, DocPropertyType docPropertyType, boolean nullable, boolean keepSource) {
       super(Set.class, dbType, docPropertyType, nullable);
+      this.keepSource = keepSource;
     }
 
+    
+    @Override
+    public boolean isJsonMapper() {
+      return keepSource;
+    }
+    
     @Override
     public Set read(DataReader reader) throws SQLException {
       String json = reader.getString();
+      if (isJsonMapper()) {
+        reader.pushJson(json);
+      }
       try {
         // parse JSON into modifyAware list
         return EJson.parseSet(json, true);
@@ -87,17 +99,15 @@ public class ScalarTypeJsonSet {
     }
 
     @Override
-    public void bind(DataBinder binder, Set value) throws SQLException {
+    public final void bind(DataBinder binder, Set value) throws SQLException {
+      String rawJson = isJsonMapper() ? binder.popJson() : null;
+      if (rawJson == null && value != null) {
+        rawJson = formatValue(value);
+      }
       if (value == null) {
         bindNull(binder);
-      } else if (value.isEmpty()) {
-        binder.setString("[]");
       } else {
-        try {
-          binder.setString(EJson.write(value));
-        } catch (IOException e) {
-          throw new SQLException("Failed to format Set into JSON content", e);
-        }
+        bindRawJson(binder, rawJson);
       }
     }
 
@@ -110,8 +120,15 @@ public class ScalarTypeJsonSet {
       }
     }
 
+    protected void bindRawJson(DataBinder binder, String rawJson) throws SQLException {
+      binder.setString(rawJson);
+    }
+
     @Override
     public String formatValue(Set value) {
+      if (value.isEmpty()) {
+        return "[]";
+      }
       try {
         return EJson.write(value);
       } catch (IOException e) {
@@ -151,19 +168,14 @@ public class ScalarTypeJsonSet {
 
     final String pgType;
 
-    PgBase(int jdbcType, String pgType, DocPropertyType docPropertyType, boolean nullable) {
-      super(jdbcType, docPropertyType, nullable);
+    PgBase(int jdbcType, String pgType, DocPropertyType docPropertyType, boolean nullable, boolean keepSource) {
+      super(jdbcType, docPropertyType, nullable, keepSource);
       this.pgType = pgType;
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
-    public void bind(DataBinder binder, Set value) throws SQLException {
-      if (value == null) {
-        bindNull(binder);
-      } else {
-        binder.setObject(PostgresHelper.asObject(pgType, formatValue(value)));
-      }
+    protected void bindRawJson(DataBinder binder, String rawJson) throws SQLException {
+      binder.setObject(PostgresHelper.asObject(pgType, rawJson));
     }
 
     @Override

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeJsonListTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeJsonListTest.java
@@ -11,19 +11,19 @@ public class ScalarTypeJsonListTest extends BasePlatformArrayTypeFactoryTest {
   @Test
   public void typeFor_expect_nullToEmpty_when_postgresNonNull() throws SQLException {
 
-    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, false));
-    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, false));
+    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, false, false));
+    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, false, false));
 
-    assertBindNullTo_EmptyString(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, false));
+    assertBindNullTo_EmptyString(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, false, false));
   }
 
   @Test
   public void typeFor_expect_nullToNull_when_nullable() throws SQLException {
 
-    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, true));
-    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, true));
+    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, true, false));
+    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, true, false));
 
-    assertBindNullTo_Null(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, true));
+    assertBindNullTo_Null(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, true, false));
   }
 
 }

--- a/ebean-core/src/test/java/org/tests/json/TestOldValue.java
+++ b/ebean-core/src/test/java/org/tests/json/TestOldValue.java
@@ -1,0 +1,120 @@
+package org.tests.json;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.ValuePair;
+import io.ebean.annotation.ForPlatform;
+import io.ebean.annotation.Platform;
+import io.ebean.text.TextException;
+
+import org.assertj.core.api.SoftAssertions;
+import org.ebeantest.LoggedSqlCollector;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.tests.model.json.EBasicJsonList;
+import org.tests.model.json.EBasicOldValue;
+import org.tests.model.json.PlainBean;
+
+import javax.persistence.PersistenceException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestOldValue extends BaseTestCase {
+
+  
+  
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @Test
+  public void testDbJsonOldValue() throws Exception {
+    EBasicOldValue bean = new EBasicOldValue();
+
+    bean.getStringList().add("sl1");
+    bean.getStringSet().add("ss1");
+    bean.getObjectMap().put("sk1","sm1");
+    bean.getLongList().add(1L);
+    bean.getLongSet().add(1001L);
+    bean.getLongMap().put("lk1",2001L);
+    bean.getIntList().add(2);
+    bean.getIntSet().add(1002);
+    bean.getIntMap().put("ik1",2002);
+
+    DB.save(bean);
+    bean = DB.find(EBasicOldValue.class, bean.getId());
+
+    bean.getStringList().add("sl2");
+    bean.getStringSet().add("ss2");
+    bean.getObjectMap().put("sk2","sm2");
+    bean.getLongList().add(5L);
+    bean.getLongSet().add(1005L);
+    bean.getLongMap().put("lk2",2005L);
+    bean.getIntList().add(6);
+    bean.getIntSet().add(1006);
+    bean.getIntMap().put("ik2",2006);
+
+    
+    Map<String, ValuePair> dirty = DB.getBeanState(bean).getDirtyValues();
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(dirty).hasSize(9);
+
+    softly.assertThat((List)dirty.get("stringList").getOldValue()).containsExactly("sl1");
+    softly.assertThat((List)dirty.get("stringList").getNewValue()).containsExactly("sl1", "sl2");
+    softly.assertThat((List)dirty.get("longList").getOldValue()).containsExactly(1L);
+    softly.assertThat((List)dirty.get("longList").getNewValue()).containsExactly(1L, 5L);
+    softly.assertThat((List)dirty.get("intList").getOldValue()).containsExactly(2);
+    softly.assertThat((List)dirty.get("intList").getNewValue()).containsExactly(2, 6);
+
+    softly.assertThat((Set)dirty.get("stringSet").getOldValue()).containsExactly("ss1");
+    softly.assertThat((Set)dirty.get("stringSet").getNewValue()).containsExactly("ss1", "ss2");
+    softly.assertThat((Set)dirty.get("longSet").getOldValue()).containsExactly(1001L);
+    softly.assertThat((Set)dirty.get("longSet").getNewValue()).containsExactly(1001L, 1005L);
+    softly.assertThat((Set)dirty.get("intSet").getOldValue()).containsExactly(1002);
+    softly.assertThat((Set)dirty.get("intSet").getNewValue()).containsExactly(1002, 1006);
+
+    softly.assertThat((Map)dirty.get("objectMap").getOldValue()).containsEntry("sk1","sm1").hasSize(1);
+    softly.assertThat((Map)dirty.get("objectMap").getNewValue()).containsEntry("sk1","sm1").containsEntry("sk2","sm2").hasSize(2);
+    softly.assertThat((Map)dirty.get("longMap").getOldValue()).containsEntry("lk1",2001L).hasSize(1);
+    softly.assertThat((Map)dirty.get("longMap").getNewValue()).containsEntry("lk1",2001L).containsEntry("lk2",2005L).hasSize(2);
+    softly.assertThat((Map)dirty.get("intMap").getOldValue()).containsEntry("ik1",2002).hasSize(1);
+    softly.assertThat((Map)dirty.get("intMap").getNewValue()).containsEntry("ik1",2002).containsEntry("ik2",2006).hasSize(2);
+
+    softly.assertAll();
+
+  }
+  
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @Test
+  @Ignore("Old value detection does not work for @DbArray")
+  public void testDbArrayOldValue() throws Exception {
+    EBasicOldValue bean = new EBasicOldValue();
+
+    bean.getStringArr().add("sa1");
+  
+
+    DB.save(bean);
+    bean = DB.find(EBasicOldValue.class, bean.getId());
+
+    bean.getStringArr().add("sa2");
+    
+
+    
+    Map<String, ValuePair> dirty = DB.getBeanState(bean).getDirtyValues();
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(dirty).hasSize(1);
+
+    softly.assertThat((List)dirty.get("stringArr").getOldValue()).containsExactly("sa1");
+    softly.assertThat((List)dirty.get("stringArr").getNewValue()).containsExactly("sa1", "sa2");
+
+    softly.assertAll();
+
+  }
+}

--- a/ebean-core/src/test/java/org/tests/model/json/EBasicOldValue.java
+++ b/ebean-core/src/test/java/org/tests/model/json/EBasicOldValue.java
@@ -1,0 +1,146 @@
+package org.tests.model.json;
+
+import io.ebean.annotation.DbArray;
+import io.ebean.annotation.DbJson;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.*;
+
+import static io.ebean.annotation.MutationDetection.SOURCE;
+
+@Entity
+public class EBasicOldValue {
+
+  @Id
+  Long id;
+
+  String name;
+
+  @DbJson(mutationDetection = SOURCE)
+  Set<String> stringSet = new LinkedHashSet<>();
+
+  @DbJson(mutationDetection = SOURCE)
+  Set<Long> longSet = new LinkedHashSet<>();
+  
+  @DbJson(mutationDetection = SOURCE)
+  Set<Integer> intSet = new LinkedHashSet<>();
+  
+  @DbJson(mutationDetection = SOURCE)
+  List<String> stringList = new ArrayList<>();
+
+  @DbJson(mutationDetection = SOURCE)
+  List<Long> longList = new ArrayList<>();
+  
+  @DbJson(mutationDetection = SOURCE)
+  List<Integer> intList = new ArrayList<>();
+  
+  @DbJson(mutationDetection = SOURCE)
+  Map<String, Object> objectMap = new LinkedHashMap<>();
+
+  @DbJson(mutationDetection = SOURCE)
+  Map<String, Long> longMap = new LinkedHashMap<>();
+  
+  @DbJson(mutationDetection = SOURCE)
+  Map<String, Integer> intMap = new LinkedHashMap<>();
+
+  @DbArray()
+  List<String> stringArr = new ArrayList<>();
+  
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Set<String> getStringSet() {
+    return stringSet;
+  }
+
+  public void setStringSet(Set<String> stringSet) {
+    this.stringSet = stringSet;
+  }
+
+  public Set<Long> getLongSet() {
+    return longSet;
+  }
+
+  public void setLongSet(Set<Long> longSet) {
+    this.longSet = longSet;
+  }
+
+  public Set<Integer> getIntSet() {
+    return intSet;
+  }
+
+  public void setIntSet(Set<Integer> intSet) {
+    this.intSet = intSet;
+  }
+
+  public List<String> getStringList() {
+    return stringList;
+  }
+
+  public void setStringList(List<String> stringList) {
+    this.stringList = stringList;
+  }
+
+  public List<Long> getLongList() {
+    return longList;
+  }
+
+  public void setLongList(List<Long> longList) {
+    this.longList = longList;
+  }
+
+  public List<Integer> getIntList() {
+    return intList;
+  }
+
+  public void setIntList(List<Integer> intList) {
+    this.intList = intList;
+  }
+
+  public Map<String, Object> getObjectMap() {
+    return objectMap;
+  }
+
+  public void setObjectMap(Map<String, Object> objectMap) {
+    this.objectMap = objectMap;
+  }
+
+  public Map<String, Long> getLongMap() {
+    return longMap;
+  }
+
+  public void setLongMap(Map<String, Long> longMap) {
+    this.longMap = longMap;
+  }
+
+  public Map<String, Integer> getIntMap() {
+    return intMap;
+  }
+
+  public void setIntMap(Map<String, Integer> intMap) {
+    this.intMap = intMap;
+  }
+  
+  public List<String> getStringArr() {
+    return stringArr;
+  }
+
+  public void setStringArr(List<String> stringArr) {
+    this.stringArr = stringArr;
+  }
+
+}

--- a/ebean-core/src/test/java/org/tests/model/json/EBasicOldValue.java
+++ b/ebean-core/src/test/java/org/tests/model/json/EBasicOldValue.java
@@ -5,6 +5,9 @@ import io.ebean.annotation.DbJson;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
 import java.util.*;
 
 import static io.ebean.annotation.MutationDetection.SOURCE;
@@ -44,8 +47,12 @@ public class EBasicOldValue {
   @DbJson(mutationDetection = SOURCE)
   Map<String, Integer> intMap = new LinkedHashMap<>();
 
+  @DbJson(mutationDetection = SOURCE)
+  JsonNode jsonNode;
+  
   @DbArray()
   List<String> stringArr = new ArrayList<>();
+  
   
   public Long getId() {
     return id;
@@ -133,6 +140,14 @@ public class EBasicOldValue {
 
   public void setIntMap(Map<String, Integer> intMap) {
     this.intMap = intMap;
+  }
+  
+  public JsonNode getJsonNode() {
+    return jsonNode;
+  }
+  
+  public void setJsonNode(JsonNode jsonNode) {
+    this.jsonNode = jsonNode;
   }
   
   public List<String> getStringArr() {


### PR DESCRIPTION
Hello Rob, I discovered a bug in the new mutationDetection.

While  
```java
@DbSource(mutationDetection = SOURCE)
List<PlainBean> plainBeanList;
```
works well, it does not work for 
```java
@DbSource(mutationDetection = SOURCE)
List<String> stringList;
```
because here Ebean uses `ScalarTypeJsonList`

I tried to write a test for all `@DbJson` annotations. The same problem would occur with `@DbArray` (which we did not use)
We currently use a lot of `@DbJson` annotations and we rely on a proper dirtyValue (oldValue<->newValue) recognition.

cheers
Roland
