### PR TITLE
FIX: mutation info is not restored on cache hit

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyJsonMapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyJsonMapper.java
@@ -5,6 +5,7 @@ import io.ebean.bean.EntityBean;
 import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.bean.MutableValueInfo;
 import io.ebean.bean.MutableValueNext;
+import io.ebean.bean.PersistenceContext;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.ScalarType;
 import io.ebean.text.TextException;
@@ -104,6 +105,18 @@ public class BeanPropertyJsonMapper extends BeanPropertyJsonBasic {
       throw new PersistenceException("Error readSet on " + descriptor + "." + name, e);
     }
   }
+  
+  @Override
+  public void setCacheDataValue(EntityBean bean, Object cacheData, PersistenceContext context) {
+    if (cacheData instanceof String) {
+      // parse back from string to support optimisation of java object serialisation
+      final MutableValueInfo hash = createMutableInfo((String)cacheData);
+      bean._ebean_getIntercept().mutableInfo(propertyIndex, hash);
+      cacheData = scalarType.parse((String) cacheData);
+    }
+    setValue(bean, cacheData);
+  }
+
 
   private static final class NextPair implements MutableValueNext {
 

--- a/ebean-core/src/test/java/org/tests/changelog/TestChangeLog.java
+++ b/ebean-core/src/test/java/org/tests/changelog/TestChangeLog.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class TestChangeLog extends BaseTestCase {
 
@@ -158,6 +158,25 @@ public class TestChangeLog extends BaseTestCase {
     assertThat(change.getData()).contains("\"plainBean\":{\"name\":\"B\"");
     assertThat(change.getOldData()).contains("\"plainBean\":{\"name\":\"A\"");
   }
+  
+  @Test
+  public void testMutationWithCache() throws Exception {
+    EBasicChangeLog bean = new EBasicChangeLog();
+    bean.setName("Name1");
+    bean.setPlainBean(new PlainBean("foo", 42));
+    server.save(bean);
+    BeanChange change = firstChange();
+    assertThat(change.getData()).contains("\"plainBean\"");
+
+    server.find(EBasicChangeLog.class, bean.getId()); // load cache
+    bean = server.find(EBasicChangeLog.class, bean.getId()); // hit cache
+    bean.setShortDescription("Desc");
+    server.save(bean);
+
+    change = firstChange();
+    assertThat(change.getData()).doesNotContain("\"plainBean\"");
+  }
+
   private Database createServer() {
 
     DatabaseConfig config = new DatabaseConfig();


### PR DESCRIPTION
When a bean is read from bean cache, mutationInfo was not set, so dirty/change recognition did not work properly