### PR TITLE
Fix: setting json values to null was throwing a NPE when persisting

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonList.java
@@ -122,9 +122,6 @@ class ScalarTypeJsonList {
 
     @Override
     public final String formatValue(List value) {
-      if (value.isEmpty()) {
-        return "[]";
-      }
       try {
         return EJson.write(value);
       } catch (IOException e) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
@@ -122,9 +122,6 @@ final class ScalarTypeJsonSet {
 
     @Override
     public final String formatValue(Set value) {
-      if (value.isEmpty()) {
-        return "[]";
-      }
       try {
         return EJson.write(value);
       } catch (IOException e) {

--- a/ebean-core/src/test/java/org/tests/json/TestJsonNullValues.java
+++ b/ebean-core/src/test/java/org/tests/json/TestJsonNullValues.java
@@ -1,0 +1,42 @@
+package org.tests.json;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import org.junit.Test;
+import org.tests.model.json.EBasicOldValue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJsonNullValues extends BaseTestCase {
+
+  @Test
+  public void testSetToNull() {
+    EBasicOldValue bean = new EBasicOldValue();
+    DB.save(bean);
+    bean = DB.find(EBasicOldValue.class, bean.getId());
+
+    bean.setStringList(null);
+    bean.setStringSet(null);
+    bean.setObjectMap(null);
+    bean.setLongList(null);
+    bean.setLongSet(null);
+    bean.setLongMap(null);
+    bean.setIntList(null);
+    bean.setIntSet(null);
+    bean.setIntMap(null);
+
+    DB.save(bean);
+    bean = DB.find(EBasicOldValue.class, bean.getId());
+
+    assertThat(bean.getStringList()).isEmpty();
+    assertThat(bean.getStringSet()).isEmpty();
+    assertThat(bean.getObjectMap()).isEmpty();
+    assertThat(bean.getLongList()).isEmpty();
+    assertThat(bean.getLongSet()).isEmpty();
+    assertThat(bean.getLongMap()).isEmpty();
+    assertThat(bean.getIntList()).isEmpty();
+    assertThat(bean.getIntSet()).isEmpty();
+    assertThat(bean.getIntMap()).isEmpty();
+  }
+
+}


### PR DESCRIPTION
This is a regression introduced with #2309. When the value on a json property (Set or List) is set to `null` and `formatValue` is called, there was no null-check for a call to `value.isEmpty()`. My solution for this, is to delete the if-case, because `EJson.write` returns the exact same thing and it should decide on how to serialize an empty value. Also this was inconsistent to e.g. handling of a Map.