### PR TITLE
Improve and fix EbeanVersion checks

### DIFF
--- a/ebean-api/pom.xml
+++ b/ebean-api/pom.xml
@@ -107,6 +107,24 @@
   </dependencies>
 
   <build>
+    <resources>
+      <!-- We only want to apply filtering on the pom.properties file -->
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>**/pom.properties</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>**/pom.properties</exclude>
+        </excludes>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/ebean-api/src/main/java/io/ebean/EbeanVersion.java
+++ b/ebean-api/src/main/java/io/ebean/EbeanVersion.java
@@ -17,6 +17,8 @@ public class EbeanVersion {
   private static final Logger logger = LoggerFactory.getLogger(EbeanVersion.class);
 
   private static String version = "unknown";
+  private static String requiredAgentVersion = "unknown";
+  private static String currentAgentVersion = null;
 
   static {
     try {
@@ -24,11 +26,27 @@ public class EbeanVersion {
       try (InputStream in = DB.class.getResourceAsStream("/META-INF/maven/io.ebean/ebean/pom.properties")) {
         if (in != null) {
           prop.load(in);
-          in.close();
           version = prop.getProperty("version");
+          requiredAgentVersion = prop.getProperty("agent.version");
         }
       }
-      logger.info("ebean version: {}", version);
+      try {
+        Class<?> cls = Class.forName("io.ebean.enhance.Transformer");
+        currentAgentVersion = (String) cls.getMethod("getVersion").invoke(null);
+      } catch (Exception e) {
+        logger.trace("could not get run-time-agent version", e);
+      }
+      logger.info("ebean version: {} (depends on agent {})", version, requiredAgentVersion);
+      if (currentAgentVersion != null) {
+        if (!currentAgentVersion.equals(requiredAgentVersion)) {
+          logger.error("Runtime enhancement detected. Agent version mismatch");
+          logger.error("      Current:  {}", currentAgentVersion);
+          logger.error("      Required: {}", requiredAgentVersion);
+          logger.error("THIS CAN RESULT IN UNEXPECTED BEHAVIOUR!");
+        } else {
+          logger.info("Runtime enhancement detected. Agent version matches with required version.");
+        }
+      }
     } catch (IOException e) {
       logger.warn("Could not determine ebean version: {}", e.getMessage());
     }

--- a/ebean-api/src/main/resources/META-INF/maven/io.ebean/ebean/pom.properties
+++ b/ebean-api/src/main/resources/META-INF/maven/io.ebean/ebean/pom.properties
@@ -1,0 +1,4 @@
+version=${project.version}
+groupId=${project.groupId}
+artifactId=${project.artifactId}
+agent.version=${ebean-agent.version}

--- a/ebean-bom/pom.xml
+++ b/ebean-bom/pom.xml
@@ -12,16 +12,6 @@
   <artifactId>ebean-bom</artifactId>
   <packaging>pom</packaging>
 
-  <properties>
-    <ebean-ddl-runner.version>1.0</ebean-ddl-runner.version>
-    <ebean-migration-auto.version>1.1</ebean-migration-auto.version>
-    <ebean-migration.version>12.11.0</ebean-migration.version>
-    <ebean-test-docker.version>4.1</ebean-test-docker.version>
-    <ebean-datasource.version>7.0</ebean-datasource.version>
-    <ebean-agent.version>12.11.0</ebean-agent.version>
-    <ebean-maven-plugin.version>12.11.0</ebean-maven-plugin.version>
-  </properties>
-
   <dependencyManagement>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,15 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <ebean-datasource.version>7.0</ebean-datasource.version>
     <jackson.version>2.12.1</jackson.version>
+
+    <ebean-ddl-runner.version>1.0</ebean-ddl-runner.version>
+    <ebean-migration-auto.version>1.1</ebean-migration-auto.version>
+    <ebean-migration.version>12.11.0</ebean-migration.version>
+    <ebean-test-docker.version>4.1</ebean-test-docker.version>
+    <ebean-datasource.version>7.0</ebean-datasource.version>
+    <ebean-agent.version>12.11.0</ebean-agent.version>
+    <ebean-maven-plugin.version>12.11.0</ebean-maven-plugin.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Hi Rob,

this PR extends EbeanVersion to also check the required ebean-agent version against the actually running version of the agent. We acutally experienced a couple of problems with mismatched agent versions and I have also seen some concern around runtime enhancement on the forum targeting "unexplainable" errors on the forum. This version now only logs with error, if the agent version doesn't match. Since a mismatched version doesn't have to result in chaos, this seems more sensible than failing hard.

While implementing this, I realized, that the original version of EbeanVersion did not work as well, because the pom.properties file could not be retrieved. I'm unsure if this broke, when the project structure was changed, or if it never worked. For the agent version check I have now introduced a pom.properties file which with the help of maven's resource-filtering is being filled in with the correct versions and stats. For this I had to move the version properties from ebean-bom into the parent pom, so that ebean-api can also access them. Since datasource already was up there and thus duplicated, I moved them all, so that in case of an update only one line in the parent pom has to be changed.

Hope that this is a helpful improvement to Ebean
Cheers
Jonas