### PR TITLE
Modification of a OneToMany-Relation with @OrderColumn was not detected

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
@@ -471,7 +471,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
       }
     }
 
-    
+
     if (softDelete) {
       String alias = hasJoinTable() ? "x2" : "x";
       sb.append(" and ").append(targetDescriptor.getSoftDeletePredicate(alias));
@@ -606,7 +606,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
     if (!manyToMany && childMasterProperty != null) {
       // bidirectional in the sense that the 'master' property
       // exists on the 'detail' bean
-      childMasterProperty.setValue(child, parent);
+      childMasterProperty.setValueIntercept(child, parent);
     }
   }
 
@@ -1072,7 +1072,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
   public void bindElementValue(SqlUpdate insert, Object value) {
     targetDescriptor.bindElementValue(insert, value);
   }
-  
+
   /**
    * Returns true, if we must create a m2m join table.
    */


### PR DESCRIPTION
**Needs fix for ebean-agent first: https://github.com/ebean-orm/ebean-agent/pull/169**

This (partially) PR fixes a problem, where a modification to a OneToMany-Relation with @OrderColumn was not detected and thus was not persisted. In this change I've added a test, as well as change the call from setValue to setValueIntercept in order to set the parent, when adding a child model to relation-list, because otherwise the child-model would not be dirty and doesn't need to be persisted, although it was added to the parent.
For more details see PR on ebean-agent: https://github.com/ebean-orm/ebean-agent/pull/169.