### PR TITLE
@OrderdColum did not work properly with cached beans

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
@@ -294,8 +294,13 @@ final class BeanDescriptorCacheHelp<T> {
 
     List<Object> idList = entry.getIdList();
     bc.checkEmptyLazyLoad();
+    int i = 0;
     for (Object id : idList) {
-      many.add(bc, targetDescriptor.createReference(readOnly, id, persistenceContext));
+      final EntityBean ref = targetDescriptor.createReference(readOnly, id, persistenceContext);
+      if (many.hasOrderColumn()) {
+        ref._ebean_getIntercept().setSortOrder(++i);
+      }
+      many.add(bc, ref);
     }
     return true;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import static io.ebeaninternal.server.persist.DmlUtil.isNullOrZero;
@@ -165,11 +164,15 @@ public final class SaveManyBeans extends SaveManyBase {
         if (many.hasJoinTable()) {
           skipSavingThisBean = targetDescriptor.isReference(ebi);
         } else {
-          if (orderColumn != null && !Objects.equals(sortOrder, orderColumn.getValue(detail))) {
-            orderColumn.setValue(detail, sortOrder);
-            ebi.setDirty(true);
+          int originalOrder = 0;
+          if (orderColumn != null) {
+            originalOrder = detail._ebean_getIntercept().getSortOrder();
+            if (sortOrder != originalOrder) {
+              detail._ebean_intercept().setSortOrder(sortOrder);
+              ebi.setDirty(true);
+            }
           }
-          if (targetDescriptor.isReference(ebi)) {
+          if (targetDescriptor.isReference(ebi) && originalOrder == 0) {
             // we can skip this one
             skipSavingThisBean = true;
           } else if (ebi.isNewOrDirty()) {

--- a/ebean-core/src/test/java/org/tests/cascade/OmCacheOrderedDetail.java
+++ b/ebean-core/src/test/java/org/tests/cascade/OmCacheOrderedDetail.java
@@ -1,0 +1,60 @@
+package org.tests.cascade;
+
+import io.ebean.annotation.Cache;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Version;
+
+@Entity
+@Cache
+public class OmCacheOrderedDetail {
+
+  @Id
+  Long id;
+
+  String name;
+
+  @ManyToOne
+  OmCacheOrderedMaster master;
+
+  @Version
+  Long version;
+
+  public OmCacheOrderedDetail(String name) {
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public OmCacheOrderedMaster getMaster() {
+    return master;
+  }
+
+  public void setMaster(OmCacheOrderedMaster master) {
+    this.master = master;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(Long version) {
+    this.version = version;
+  }
+}

--- a/ebean-core/src/test/java/org/tests/cascade/OmCacheOrderedMaster.java
+++ b/ebean-core/src/test/java/org/tests/cascade/OmCacheOrderedMaster.java
@@ -1,0 +1,66 @@
+package org.tests.cascade;
+
+import io.ebean.annotation.Cache;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import javax.persistence.Version;
+import java.util.List;
+
+@Entity
+@Cache
+public class OmCacheOrderedMaster {
+
+  @Id
+  Long id;
+
+  String name;
+
+  /**
+   * Cascade ALL set automatically as we set order values when cascading.
+   */
+  @OneToMany(mappedBy = "master") //, cascade = CascadeType.ALL)
+  @OrderColumn(name = "sort_order")
+  List<OmCacheOrderedDetail> details;
+
+  @Version
+  Long version;
+
+  public OmCacheOrderedMaster(String name) {
+    this.name = name;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<OmCacheOrderedDetail> getDetails() {
+    return details;
+  }
+
+  public void setDetails(List<OmCacheOrderedDetail> details) {
+    this.details = details;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(Long version) {
+    this.version = version;
+  }
+}


### PR DESCRIPTION
This PR fixes a problem, where a bean with a OneToMany relation with @OrderColumn retrieved from cache didn't have a sortOrder set and when the list was modified, the change was not detected and the saving of the bean skipped. With the provided test, we can see, that beans from cache have to behave the same as ones without cache.