### PR TITLE
Make getSortOrder accessible in BeanState API

### DIFF
--- a/ebean-api/src/main/java/io/ebean/BeanState.java
+++ b/ebean-api/src/main/java/io/ebean/BeanState.java
@@ -118,4 +118,9 @@ public interface BeanState {
    */
   @Nullable
   Map<String, Exception> getLoadErrors();
+
+  /**
+   * Return the sort order value for an order column.
+   */
+  int getSortOrder();
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanState.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanState.java
@@ -94,4 +94,8 @@ public final class DefaultBeanState implements BeanState {
     return intercept.getLoadErrors();
   }
 
+  @Override
+  public int getSortOrder() {
+    return intercept.getSortOrder();
+  }
 }


### PR DESCRIPTION
Hello Rob,

this small change allows to retrieve the sortOrder of a bean retrieved from a BeanCollection with @OrderColumn directly using hte BeanState API, instead having to go a slightly more complicated way using EBI. So now you can do:
```java
int sortOrder = DB.getBeanState(bean).getSortOrder();
```
instead of
```java
int sortOrder = ((EntityBean) bean)._ebean_getIntercept().getSortOrder();
```
leaving out the cast to `EntityBean`. I think that this would be a preferred way of accessing the sortOrder, since the EBI is more of an "internal state representation" than a "public API" altough itself being included in ebean-api.

All the best