### PR TITLE
Fix for NPE in mutableNext in EBI

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -1232,7 +1232,8 @@ public final class EntityBeanIntercept implements Serializable {
     if (mutableNext == null) {
       return null;
     }
-    return mutableNext[propertyIndex].content();
+    final MutableValueNext next = mutableNext[propertyIndex];
+    return next != null ? next.content() : null;
   }
 
 }

--- a/ebean-core/src/test/java/org/tests/json/TestJsonNullValues.java
+++ b/ebean-core/src/test/java/org/tests/json/TestJsonNullValues.java
@@ -5,6 +5,8 @@ import io.ebean.DB;
 import org.junit.Test;
 import org.tests.model.json.EBasicOldValue;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonNullValues extends BaseTestCase {
@@ -37,6 +39,28 @@ public class TestJsonNullValues extends BaseTestCase {
     assertThat(bean.getIntList()).isEmpty();
     assertThat(bean.getIntSet()).isEmpty();
     assertThat(bean.getIntMap()).isEmpty();
+  }
+
+  @Test
+  public void testSetOneToNullAnotherToEmpty() {
+    EBasicOldValue bean = new EBasicOldValue();
+    DB.save(bean);
+    bean = DB.find(EBasicOldValue.class, bean.getId());
+
+    bean.setStringList(null);
+    bean.setStringSet(null);
+
+    DB.save(bean);
+    bean = DB.find(EBasicOldValue.class, bean.getId());
+
+    bean.setStringList(new ArrayList<>());
+    bean.setStringSet(null);
+
+    DB.save(bean);
+    bean = DB.find(EBasicOldValue.class, bean.getId());
+
+    assertThat(bean.getStringList()).isEmpty();
+    assertThat(bean.getStringSet()).isEmpty();
   }
 
 }


### PR DESCRIPTION
This change fixes an error, where the mutableValueNext was null and thus a NPE occured on call to `content()`, when two Json properties were changed on a bean with one empty and the other `null`.