### PR TITLE
NEW: DeleteIdRequest can return beanType

### DIFF
--- a/ebean-api/src/main/java/io/ebean/event/BeanDeleteIdRequest.java
+++ b/ebean-api/src/main/java/io/ebean/event/BeanDeleteIdRequest.java
@@ -1,5 +1,6 @@
 package io.ebean.event;
 
+import io.ebean.Database;
 import io.ebean.EbeanServer;
 import io.ebean.Transaction;
 
@@ -10,13 +11,26 @@ public interface BeanDeleteIdRequest {
 
   /**
    * Return the server processing the request.
+   * @deprecated use {@link #getDatabase()}
    */
   EbeanServer getEbeanServer();
 
   /**
+   * Return the DB processing the request.
+   */
+  default Database getDatabase() {
+    return getEbeanServer();
+  }
+  
+  /**
    * Return the Transaction associated with this request.
    */
   Transaction getTransaction();
+  
+  /**
+   * Returns the bean type of the bean being deleted.
+   */
+  Class<?> getBeanType();
 
   /**
    * Returns the Id value of the bean being deleted.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -824,7 +824,7 @@ public final class DefaultPersister implements Persister {
 
     BeanPersistController controller = descriptor.getPersistController();
     if (controller != null) {
-      DeleteIdRequest request = new DeleteIdRequest(server, transaction, id);
+      DeleteIdRequest request = new DeleteIdRequest(server, transaction, descriptor.getBeanType(), id);
       if (idList == null) {
         controller.preDelete(request);
       } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DeleteIdRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DeleteIdRequest.java
@@ -9,11 +9,13 @@ final class DeleteIdRequest implements BeanDeleteIdRequest {
 
   private final EbeanServer server;
   private final Transaction transaction;
+  private Class<?> beanType;
   private Object id;
 
-  DeleteIdRequest(SpiEbeanServer server, Transaction transaction, Object id) {
+  DeleteIdRequest(SpiEbeanServer server, Transaction transaction, Class<?> beanType, Object id) {
     this.server = server;
     this.transaction = transaction;
+    this.beanType = beanType;
     this.id = id;
   }
 
@@ -29,6 +31,11 @@ final class DeleteIdRequest implements BeanDeleteIdRequest {
   @Override
   public Transaction getTransaction() {
     return transaction;
+  }
+  
+  @Override 
+  public Class<?> getBeanType() {
+    return beanType;
   }
 
   @Override


### PR DESCRIPTION
... Also provide alternative for deprecated 'getEbeanServer'

When a BeanPersistController was registered for multiple types and a deleteById is performed, it is now possible to retrieve the affected beanType.