### PR TITLE
Bug? Wrong order in batch save

### DIFF
--- a/ebean-test/src/test/java/io/ebeaninternal/server/transaction/TransactionTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/transaction/TransactionTest.java
@@ -1,0 +1,70 @@
+package io.ebeaninternal.server.transaction;
+
+import io.ebean.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.relates.*;
+
+public class TransactionTest extends BaseTestCase {
+  private Relation1 r1 = new Relation1("R1");
+  private Relation2 r2 = new Relation2("R2");
+  private Relation3 r3 = new Relation3("R3");
+
+  private Transaction txn;
+
+  @BeforeEach
+  void beginTransaction() {
+    txn = DB.beginTransaction();
+    txn.setBatchMode(true);
+  }
+
+  @AfterEach
+  void commitTransaction() {
+    txn.commit();
+    txn.close();
+  }
+
+  @Test
+  public void testMultiSave1() {
+    r2.setWithCascade(r3);
+    r1.setWithCascade(r2);
+    DB.save(r1);
+  }
+
+  @Test
+  public void testMultiSave2() {
+    r2.setWithCascade(r3);
+    r1.setWithCascade(r2);
+    DB.save(r3);
+    DB.save(r1);
+  }
+
+  @Test
+  public void testMultiSave3() {
+    r2.setWithCascade(r3);
+    r1.setWithCascade(r2);
+    DB.save(r3);
+    DB.save(r2);
+    DB.save(r1);
+  }
+
+  @Test
+  public void testMultiSave4() {
+    r2.setNoCascade(r3);
+    r1.setWithCascade(r2);
+    DB.save(r3);
+    // Workaround: txn.flush();
+    DB.save(r1);
+  }
+
+  @Test
+  public void testMultiSave5() {
+    r2.setNoCascade(r3);
+    r1.setNoCascade(r2);
+    DB.save(r3);
+    DB.save(r2);
+    DB.save(r1);
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/basic/relates/Relation1.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/relates/Relation1.java
@@ -1,0 +1,64 @@
+package org.tests.model.basic.relates;
+
+
+import java.util.UUID;
+
+import javax.persistence.*;
+
+import io.ebean.annotation.ChangeLog;
+
+/**
+ * Relation entity
+ */
+@Entity
+@ChangeLog
+public class Relation1 {
+
+  @Id
+  private UUID id = UUID.randomUUID();
+
+  private String name;
+
+  public Relation1(String name) {
+    this.name = name;
+  }
+
+  @ManyToOne
+  private Relation2 noCascade;
+
+  @ManyToOne(cascade = CascadeType.ALL)
+  private Relation2 withCascade;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Relation2 getNoCascade() {
+    return noCascade;
+  }
+
+  public void setNoCascade(Relation2 noCascade) {
+    this.noCascade = noCascade;
+  }
+
+  public Relation2 getWithCascade() {
+    return withCascade;
+  }
+
+  public void setWithCascade(Relation2 withCascade) {
+    this.withCascade = withCascade;
+  }
+  
+}

--- a/ebean-test/src/test/java/org/tests/model/basic/relates/Relation2.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/relates/Relation2.java
@@ -1,0 +1,64 @@
+package org.tests.model.basic.relates;
+
+
+import java.util.UUID;
+
+import javax.persistence.*;
+
+import io.ebean.annotation.ChangeLog;
+
+/**
+ * Relation entity
+ */
+@Entity
+@ChangeLog
+public class Relation2 {
+
+  @Id
+  private UUID id = UUID.randomUUID();
+
+  private String name;
+
+  public Relation2(String name) {
+    this.name = name;
+  }
+
+  @ManyToOne
+  private Relation3 noCascade;
+
+  @ManyToOne(cascade = CascadeType.ALL)
+  private Relation3 withCascade;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Relation3 getNoCascade() {
+    return noCascade;
+  }
+
+  public void setNoCascade(Relation3 noCascade) {
+    this.noCascade = noCascade;
+  }
+
+  public Relation3 getWithCascade() {
+    return withCascade;
+  }
+
+  public void setWithCascade(Relation3 withCascade) {
+    this.withCascade = withCascade;
+  }
+  
+}

--- a/ebean-test/src/test/java/org/tests/model/basic/relates/Relation3.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/relates/Relation3.java
@@ -1,0 +1,42 @@
+package org.tests.model.basic.relates;
+
+
+import java.util.UUID;
+
+import javax.persistence.*;
+
+import io.ebean.annotation.ChangeLog;
+
+/**
+ * Relation entity
+ */
+@Entity
+@ChangeLog
+public class Relation3 {
+
+  @Id
+  private UUID id = UUID.randomUUID();
+
+  private String name;
+
+  public Relation3(String name) {
+    this.name = name;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+}


### PR DESCRIPTION
Hello Rob,

we have a chain of related models which references each other: M1-> M2-> M3
We use a Transacton with enabled batch mode (Without batchMode, everything is fine)

When `CascadeType.ALL` is used, everything is fine, if just M1 is saved. (Ebean recognizes, that M3 has to be saved first, then M2 and finally M1). See `testMultiSave1`

But when M3 is saved manually and then M1, ebean recognizes, that M3 is already in batch (but with wrong depth) and will try to save M2, M1 and then M3 in the wrong order. This will not work, if the beans have already an ID, because in this case, no deferred relationship will be creaated by `BindableAssocOne`: See `testMultiSave2`

I could fix this case by modifiying the "alreadyInBatch" check. We have to flush, if the depth in the batch is bigger than the current order (or modify the order of the existing bean/beanHolder in the queue)

But there is one annoying testcase `testMultiSave4` (This was also discovered in our application)
In this case, M2->M3 has no cascadeType set. Saving of M3 has no immediate effect, so saving of M1 will always fail, as there is no cascade-relation to M3

Do you think, this is a bug in Ebean or do we use the cascadeTypes in the wrong way?

Cheers
Roland
