### PR TITLE
Refactor internals, reduce the number of loggers used and simplify

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DbContext.java
+++ b/ebean-api/src/main/java/io/ebean/DbContext.java
@@ -15,8 +15,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 final class DbContext {
 
-  private static final Logger logger = LoggerFactory.getLogger(DbContext.class);
-
+  private static final Logger log = LoggerFactory.getLogger("io.ebean");
   static {
     EbeanVersion.getVersion();
   }
@@ -39,7 +38,6 @@ final class DbContext {
       if (!DbPrimary.isSkip()) {
         // look to see if there is a default server defined
         String defaultName = DbPrimary.getDefaultServerName();
-        logger.debug("defaultName:{}", defaultName);
         if (defaultName != null && !defaultName.trim().isEmpty()) {
           defaultDatabase = getWithCreate(defaultName.trim());
         }
@@ -54,7 +52,7 @@ final class DbContext {
       throw new DataSourceConfigurationException(msg, e);
 
     } catch (Throwable e) {
-      logger.error("Error trying to create the default Database", e);
+      log.error("Error trying to create the default Database", e);
       throw new RuntimeException(e);
     }
   }

--- a/ebean-api/src/main/java/io/ebean/EbeanVersion.java
+++ b/ebean-api/src/main/java/io/ebean/EbeanVersion.java
@@ -14,10 +14,9 @@ import java.util.Properties;
  */
 public class EbeanVersion {
 
-  private static final Logger logger = LoggerFactory.getLogger(EbeanVersion.class);
+  private static final Logger log = LoggerFactory.getLogger("io.ebean");
 
   private static String version = "unknown";
-
   static {
     try {
       Properties prop = new Properties();
@@ -28,9 +27,9 @@ public class EbeanVersion {
           version = prop.getProperty("version");
         }
       }
-      logger.info("ebean version: {}", version);
+      log.info("ebean version: {}", version);
     } catch (IOException e) {
-      logger.warn("Could not determine ebean version: {}", e.getMessage());
+      log.warn("Could not determine ebean version: {}", e.getMessage());
     }
   }
 

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -25,7 +25,7 @@ import java.sql.Types;
  */
 public class DatabasePlatform {
 
-  private static final Logger logger = LoggerFactory.getLogger(DatabasePlatform.class);
+  private static final Logger log = LoggerFactory.getLogger("io.ebean");
 
   /**
    * Behavior used when ending a query only transaction (at read committed isolation level).
@@ -640,7 +640,7 @@ public class DatabasePlatform {
         if (dbName.charAt(dbName.length() - 1) == BACK_TICK) {
           return openQuote + dbName.substring(1, dbName.length() - 1) + closeQuote;
         } else {
-          logger.error("Missing backquote on [" + dbName + "]");
+          log.error("Missing backquote on [" + dbName + "]");
         }
       } else if (allQuotedIdentifiers) {
         return openQuote + dbName + closeQuote;
@@ -694,7 +694,7 @@ public class DatabasePlatform {
 
   protected String withForUpdate(String sql, Query.LockWait lockWait, Query.LockType lockType) {
     // silently assume the database does not support the "for update" clause.
-    logger.info("it seems your database does not support the 'for update' clause");
+    log.info("it seems your database does not support the 'for update' clause");
     return sql;
   }
 
@@ -728,7 +728,7 @@ public class DatabasePlatform {
     if (!schemaExists(dbSchema, connection)) {
       Statement query = connection.createStatement();
       try {
-        logger.info("create schema:{}", dbSchema);
+        log.debug("create schema:{}", dbSchema);
         query.executeUpdate("create schema " + dbSchema);
       } finally {
         JdbcClose.close(query);
@@ -758,7 +758,6 @@ public class DatabasePlatform {
    * Return true if the table exists.
    */
   public boolean tableExists(Connection connection, String catalog, String schema, String table) throws SQLException {
-
     DatabaseMetaData metaData = connection.getMetaData();
     ResultSet tables = metaData.getTables(catalog, schema, table, null);
     try {

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
@@ -24,23 +24,14 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public abstract class SequenceIdGenerator implements PlatformIdGenerator {
 
-  protected static final Logger logger = LoggerFactory.getLogger("io.ebean.SEQ");
+  protected static final Logger log = LoggerFactory.getLogger("io.ebean.SEQ");
 
   private final ReentrantLock lock = new ReentrantLock();
-
-  /**
-   * The actual sequence name.
-   */
   protected final String seqName;
-
   protected final DataSource dataSource;
-
   protected final BackgroundExecutor backgroundExecutor;
-
   protected final NavigableSet<Long> idList = new TreeSet<>();
-
   protected final int allocationSize;
-
   protected AtomicBoolean currentlyBackgroundLoading = new AtomicBoolean(false);
 
   /**
@@ -129,7 +120,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
   protected void loadInBackground(final int requestSize) {
     if (currentlyBackgroundLoading.get()) {
       // skip as already background loading
-      logger.debug("... skip background sequence load (another load in progress)");
+      log.debug("... skip background sequence load (another load in progress)");
       return;
     }
     currentlyBackgroundLoading.set(true);
@@ -161,8 +152,8 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
       resultSet = statement.executeQuery();
 
       List<Long> newIds = readIds(resultSet, requestSize);
-      if (logger.isTraceEnabled()) {
-        logger.trace("seq:{} loaded:{} sql:{}", seqName, newIds.size(), sql);
+      if (log.isTraceEnabled()) {
+        log.trace("seq:{} loaded:{} sql:{}", seqName, newIds.size(), sql);
       }
       if (newIds.isEmpty()) {
         throw new PersistenceException("Always expecting more than 1 row from " + sql);
@@ -173,7 +164,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
     } catch (SQLException e) {
       if (e.getMessage().contains("Database is already closed")) {
         String msg = "Error getting SEQ when DB shutting down " + e.getMessage();
-        logger.error(msg);
+        log.error(msg);
         System.out.println(msg);
         return Collections.emptyList();
       } else {

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/SimpleSequenceIdGenerator.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/SimpleSequenceIdGenerator.java
@@ -2,8 +2,6 @@ package io.ebean.config.dbplatform;
 
 import io.ebean.Transaction;
 import io.ebean.util.JdbcClose;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import javax.sql.DataSource;
@@ -20,12 +18,8 @@ import java.sql.SQLException;
  */
 public class SimpleSequenceIdGenerator implements PlatformIdGenerator {
 
-  private static final Logger logger = LoggerFactory.getLogger(SimpleSequenceIdGenerator.class);
-
   private final String sql;
-
   private final DataSource dataSource;
-
   private final String seqName;
 
   /**

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/h2/H2HistoryTrigger.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/h2/H2HistoryTrigger.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
  */
 public class H2HistoryTrigger implements Trigger {
 
-  private static final Logger logger = LoggerFactory.getLogger(H2HistoryTrigger.class);
+  private static final Logger log = LoggerFactory.getLogger(H2HistoryTrigger.class);
 
   /**
    * Hardcoding the column and history table suffix for now. Not sure how to get that
@@ -69,7 +69,7 @@ public class H2HistoryTrigger implements Trigger {
     insertSql.append(");");
 
     this.insertHistorySql = insertSql.toString();
-    logger.debug("History table insert sql: {}", insertHistorySql);
+    log.debug("History table insert sql: {}", insertHistorySql);
   }
 
   @Override
@@ -82,8 +82,8 @@ public class H2HistoryTrigger implements Trigger {
         // update event. Set the effective start timestamp to now.
         newRow[effectStartPosition] = now;
       }
-      if (logger.isDebugEnabled()) {
-        logger.debug("History insert: {}", Arrays.toString(oldRow));
+      if (log.isTraceEnabled()) {
+        log.trace("History insert: {}", Arrays.toString(oldRow));
       }
       insertIntoHistory(connection, oldRow);
     }

--- a/ebean-api/src/main/java/io/ebean/event/ShutdownManager.java
+++ b/ebean-api/src/main/java/io/ebean/event/ShutdownManager.java
@@ -20,18 +20,13 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public final class ShutdownManager {
 
-  private static final Logger logger = LoggerFactory.getLogger(ShutdownManager.class);
-
+  private static final Logger log = LoggerFactory.getLogger("io.ebean");
   private static final ReentrantLock lock = new ReentrantLock();
-
   private static final List<Database> databases = new ArrayList<>();
-
   private static final ShutdownHook shutdownHook = new ShutdownHook();
 
   private static boolean stopping;
-
   private static SpiContainer container;
-
   static {
     // Register the Shutdown hook
     registerShutdownHook();
@@ -125,8 +120,8 @@ public final class ShutdownManager {
         // Already run shutdown...
         return;
       }
-      if (logger.isDebugEnabled()) {
-        logger.debug("Shutting down");
+      if (log.isDebugEnabled()) {
+        log.debug("Ebean shutting down");
       }
       stopping = true;
       deregisterShutdownHook();
@@ -138,7 +133,7 @@ public final class ShutdownManager {
           Runnable r = (Runnable) ClassUtil.newInstance(shutdownRunner);
           r.run();
         } catch (Exception e) {
-          logger.error("Error running custom shutdown runnable", e);
+          log.error("Error running custom shutdown runnable", e);
         }
       }
 
@@ -152,7 +147,7 @@ public final class ShutdownManager {
         try {
           server.shutdown();
         } catch (Exception ex) {
-          logger.error("Error executing shutdown runnable", ex);
+          log.error("Error executing shutdown runnable", ex);
           ex.printStackTrace();
         }
       }
@@ -170,10 +165,10 @@ public final class ShutdownManager {
     while (drivers.hasMoreElements()) {
       Driver driver = drivers.nextElement();
       try {
-        logger.info("De-registering jdbc driver: " + driver);
+        log.info("De-registering jdbc driver: " + driver);
         DriverManager.deregisterDriver(driver);
       } catch (SQLException e) {
-        logger.error("Error de-registering driver " + driver, e);
+        log.error("Error de-registering driver " + driver, e);
       }
     }
   }

--- a/ebean-api/src/main/java/io/ebean/text/csv/DefaultCsvCallback.java
+++ b/ebean-api/src/main/java/io/ebean/text/csv/DefaultCsvCallback.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultCsvCallback<T> implements CsvCallback<T> {
 
-  private static final Logger logger = LoggerFactory.getLogger(DefaultCsvCallback.class);
+  private static final Logger log = LoggerFactory.getLogger(DefaultCsvCallback.class);
 
   /**
    * The transaction to use (if not using CsvCallback).
@@ -124,13 +124,11 @@ public class DefaultCsvCallback<T> implements CsvCallback<T> {
    */
   @Override
   public void processBean(int row, String[] line, T bean) {
-
     // assumes single bean or Cascade.PERSIST will save any
     // related beans (e.g. customer -> customer.billingAddress
     server.save(bean, transaction);
-
     if (logInfoFrequency > 0 && (row % logInfoFrequency == 0)) {
-      logger.info("processed " + row + " rows");
+      log.debug("processed {} rows", row);
     }
   }
 
@@ -139,11 +137,9 @@ public class DefaultCsvCallback<T> implements CsvCallback<T> {
    */
   @Override
   public void end(int row) {
-
     commitTransactionIfCreated();
-
     exeTime = System.currentTimeMillis() - startTime;
-    logger.info("Csv finished, rows[" + row + "] exeMillis[" + exeTime + "]");
+    log.info("Csv finished, rows[{}] exeMillis[{}]", row, exeTime);
   }
 
   /**
@@ -159,23 +155,20 @@ public class DefaultCsvCallback<T> implements CsvCallback<T> {
    * and batch size.
    */
   protected void initTransactionIfRequired() {
-
     transaction = server.currentTransaction();
     if (transaction == null || !transaction.isActive()) {
-
       transaction = server.beginTransaction();
       createdTransaction = true;
       if (persistBatchSize > 1) {
-        logger.info("Creating transaction, batchSize[" + persistBatchSize + "]");
+        log.debug("Creating transaction, batchSize[{}]", persistBatchSize);
         transaction.setBatchMode(true);
         transaction.setBatchSize(persistBatchSize);
         transaction.setGetGeneratedKeys(false);
-
       } else {
         // explicitly turn off JDBC batching in case
         // is has been turned on globally
         transaction.setBatchMode(false);
-        logger.info("Creating transaction with no JDBC batching");
+        log.debug("Creating transaction with no JDBC batching");
       }
     }
   }
@@ -187,7 +180,7 @@ public class DefaultCsvCallback<T> implements CsvCallback<T> {
   protected void commitTransactionIfCreated() {
     if (createdTransaction) {
       transaction.commit();
-      logger.info("Committed transaction");
+      log.debug("Committed transaction");
     }
   }
 
@@ -198,7 +191,7 @@ public class DefaultCsvCallback<T> implements CsvCallback<T> {
   protected void rollbackTransactionIfCreated(Throwable e) {
     if (createdTransaction) {
       transaction.rollback(e);
-      logger.info("Rolled back transaction");
+      log.debug("Rolled back transaction");
     }
   }
 

--- a/ebean-api/src/main/java/io/ebean/util/JdbcClose.java
+++ b/ebean-api/src/main/java/io/ebean/util/JdbcClose.java
@@ -13,7 +13,7 @@ import java.sql.Statement;
  */
 public class JdbcClose {
 
-  private static final Logger logger = LoggerFactory.getLogger(JdbcClose.class);
+  private static final Logger log = LoggerFactory.getLogger("io.ebean");
 
   /**
    * Close the resultSet logging if an error occurs.
@@ -24,7 +24,7 @@ public class JdbcClose {
         statement.close();
       }
     } catch (SQLException e) {
-      logger.warn("Error closing statement", e);
+      log.warn("Error closing statement", e);
     }
   }
 
@@ -37,7 +37,7 @@ public class JdbcClose {
         resultSet.close();
       }
     } catch (SQLException e) {
-      logger.warn("Error closing resultSet", e);
+      log.warn("Error closing resultSet", e);
     }
   }
 
@@ -50,7 +50,7 @@ public class JdbcClose {
         connection.close();
       }
     } catch (SQLException e) {
-      logger.warn("Error closing connection", e);
+      log.warn("Error closing connection", e);
     }
   }
 
@@ -63,7 +63,7 @@ public class JdbcClose {
         connection.rollback();
       }
     } catch (SQLException e) {
-      logger.warn("Error on connection rollback", e);
+      log.warn("Error on connection rollback", e);
     }
   }
 
@@ -76,7 +76,7 @@ public class JdbcClose {
         stmt.cancel();
       }
     } catch (SQLException e) {
-      logger.warn("Error on cancelling statement", e);
+      log.warn("Error on cancelling statement", e);
     }
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/CoreLog.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/CoreLog.java
@@ -1,0 +1,13 @@
+package io.ebeaninternal.api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Common loggers used in ebean-core.
+ */
+public final class CoreLog {
+
+  public static final Logger log = LoggerFactory.getLogger("io.ebean.core");
+  public static final Logger internal = LoggerFactory.getLogger("io.ebean.internal");
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
@@ -8,7 +8,6 @@ import io.ebeaninternal.server.core.OrmQueryRequest;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanPropertyAssocMany;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +17,7 @@ import java.util.List;
  */
 public final class LoadManyRequest extends LoadRequest {
 
-  private static final Logger logger = LoggerFactory.getLogger(LoadManyRequest.class);
+  private static final Logger log = CoreLog.log;
 
   private final List<BeanCollection<?>> batch;
   private final LoadManyBuffer loadContext;
@@ -114,10 +113,10 @@ public final class LoadManyRequest extends LoadRequest {
     // in the +query or +lazy load due to no rows (predicates)
     for (BeanCollection<?> bc : batch) {
       if (bc.checkEmptyLazyLoad()) {
-        if (logger.isDebugEnabled()) {
+        if (log.isDebugEnabled()) {
           EntityBean ownerBean = bc.getOwnerBean();
           Object parentId = desc.getId(ownerBean);
-          logger.debug("BeanCollection after lazy load was empty. type:" + ownerBean.getClass().getName() + " id:" + parentId + " owner:" + ownerBean);
+          log.debug("BeanCollection after lazy load was empty. type:" + ownerBean.getClass().getName() + " id:" + parentId + " owner:" + ownerBean);
         }
       } else if (loadCache && many.isUseCache()) {
         desc.cacheManyPropPut(many, bc, desc.getId(bc.getOwnerBean()));

--- a/ebean-core/src/main/java/io/ebeaninternal/server/changelog/DefaultChangeLogListener.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/changelog/DefaultChangeLogListener.java
@@ -6,6 +6,7 @@ import io.ebean.event.changelog.ChangeSet;
 import io.ebean.event.changelog.ChangeType;
 import io.ebean.plugin.Plugin;
 import io.ebean.plugin.SpiServer;
+import io.ebeaninternal.api.CoreLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,11 +17,6 @@ import java.util.Properties;
  * Simply logs the change sets in JSON form to logger named <code>io.ebean.ChangeLog</code>.
  */
 public final class DefaultChangeLogListener implements ChangeLogListener, Plugin {
-
-  /**
-   * The usual application specific logger.
-   */
-  private static final Logger logger = LoggerFactory.getLogger(DefaultChangeLogListener.class);
 
   /**
    * The named logger we send the change set payload to. Can be externally configured as desired.
@@ -36,9 +32,6 @@ public final class DefaultChangeLogListener implements ChangeLogListener, Plugin
    * A bigger default buffer for bean inserts and updates (that have value pairs).
    */
   private int defaultBufferSize = 400;
-
-  public DefaultChangeLogListener() {
-  }
 
   /**
    * Configure the underlying JSON handler.
@@ -67,7 +60,6 @@ public final class DefaultChangeLogListener implements ChangeLogListener, Plugin
 
   @Override
   public void log(ChangeSet changeSet) {
-
     for (BeanChange beanChange : changeSet.getChanges()) {
       // log each bean change as a separate log entry
       try {
@@ -75,7 +67,7 @@ public final class DefaultChangeLogListener implements ChangeLogListener, Plugin
         jsonBuilder.writeBeanJson(writer, beanChange, changeSet);
         changeLog.info(writer.toString());
       } catch (Exception e) {
-        logger.error("Exception logging beanChange " + beanChange.toString(), e);
+        CoreLog.log.error("Exception logging beanChange " + beanChange, e);
       }
     }
   }
@@ -84,7 +76,6 @@ public final class DefaultChangeLogListener implements ChangeLogListener, Plugin
    * Return a decent buffer size based on the bean change.
    */
   private int getBufferSize(BeanChange beanChange) {
-
     return ChangeType.DELETE == beanChange.getEvent() ? 250 : defaultBufferSize;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
@@ -1,18 +1,15 @@
 package io.ebeaninternal.server.core;
 
 import io.ebean.EbeanServer;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class for find and persist requests.
  */
 public abstract class BeanRequest {
-
-  static final Logger log = LoggerFactory.getLogger(BeanRequest.class);
 
   protected final SpiEbeanServer server;
   protected SpiTransaction transaction;
@@ -64,7 +61,7 @@ public abstract class BeanRequest {
         // Just log this and carry on. A previous exception has been
         // thrown and if this rollback throws exception it likely means
         // that the connection is broken (and the dataSource and db will cleanup)
-        log.error("Error trying to rollback a transaction (after a prior exception thrown)", e);
+        CoreLog.log.error("Error trying to rollback a transaction (after a prior exception thrown)", e);
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DatabasePlatformFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DatabasePlatformFactory.java
@@ -20,10 +20,8 @@ import io.ebean.config.dbplatform.sqlanywhere.SqlAnywherePlatform;
 import io.ebean.config.dbplatform.sqlite.SQLitePlatform;
 import io.ebean.config.dbplatform.sqlserver.SqlServer16Platform;
 import io.ebean.config.dbplatform.sqlserver.SqlServer17Platform;
-import io.ebean.util.JdbcClose;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.DbOffline;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import javax.sql.DataSource;
@@ -41,8 +39,6 @@ import java.sql.SQLException;
  */
 public class DatabasePlatformFactory {
 
-  private static final Logger logger = LoggerFactory.getLogger(DatabasePlatformFactory.class);
-
   /**
    * Create the appropriate database specific platform.
    */
@@ -50,7 +46,7 @@ public class DatabasePlatformFactory {
     try {
       String offlinePlatform = DbOffline.getPlatform();
       if (offlinePlatform != null) {
-        logger.info("offline platform [{}]", offlinePlatform);
+        CoreLog.log.info("offline platform [{}]", offlinePlatform);
         return byDatabaseName(offlinePlatform);
       }
       if (config.getDatabasePlatformName() != null) {
@@ -142,7 +138,7 @@ public class DatabasePlatformFactory {
     String dbProductName = metaData.getDatabaseProductName().toLowerCase();
     final int majorVersion = metaData.getDatabaseMajorVersion();
     final int minorVersion = metaData.getDatabaseMinorVersion();
-    logger.debug("platform for productName[{}] version[{}.{}]", dbProductName, majorVersion, minorVersion);
+    CoreLog.log.debug("platform for productName[{}] version[{}.{}]", dbProductName, majorVersion, minorVersion);
 
     if (dbProductName.contains("oracle")) {
       return oracleVersion(majorVersion);
@@ -201,7 +197,7 @@ public class DatabasePlatformFactory {
         }
       }
     } catch (SQLException e) {
-      logger.warn("Error running detection query on Postgres", e);
+      CoreLog.log.warn("Error running detection query on Postgres", e);
     }
     if (majorVersion <= 9) {
       return new Postgres9Platform();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -7,18 +7,13 @@ import io.ebean.bean.BeanCollection;
 import io.ebean.bean.EntityBean;
 import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.bean.PersistenceContext;
-import io.ebeaninternal.api.LoadBeanRequest;
-import io.ebeaninternal.api.LoadManyRequest;
-import io.ebeaninternal.api.LoadRequest;
-import io.ebeaninternal.api.SpiQuery;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.api.SpiQuery.Mode;
-import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanDescriptor.EntityType;
 import io.ebeaninternal.server.deploy.BeanPropertyAssocMany;
 import io.ebeaninternal.server.transaction.DefaultPersistenceContext;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.List;
@@ -28,7 +23,7 @@ import java.util.List;
  */
 final class DefaultBeanLoader {
 
-  private static final Logger logger = LoggerFactory.getLogger(DefaultBeanLoader.class);
+  private static final Logger log = CoreLog.internal;
 
   private final DefaultServer server;
   private final boolean onIterateUseExtraTxn;
@@ -113,8 +108,8 @@ final class DefaultBeanLoader {
     server.findOne(query, t);
     if (beanCollection != null) {
       if (beanCollection.checkEmptyLazyLoad()) {
-        if (logger.isDebugEnabled()) {
-          logger.debug("BeanCollection after load was empty. Owner:" + beanCollection.getOwnerBean());
+        if (log.isDebugEnabled()) {
+          log.debug("BeanCollection after load was empty. Owner:" + beanCollection.getOwnerBean());
         }
       } else if (useManyIdCache) {
         parentDesc.cacheManyPropPut(many, beanCollection, parentId);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -12,6 +12,7 @@ import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.h2.H2Platform;
 import io.ebean.event.ShutdownManager;
 import io.ebean.service.SpiContainer;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.DbOffline;
 import io.ebeaninternal.api.SpiBackgroundExecutor;
 import io.ebeaninternal.api.SpiEbeanServer;
@@ -20,7 +21,6 @@ import io.ebeaninternal.server.core.bootup.BootupClassPathSearch;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.executor.DefaultBackgroundExecutor;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.sql.Connection;
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public final class DefaultContainer implements SpiContainer {
 
-  private static final Logger logger = LoggerFactory.getLogger("io.ebean.DB");
+  private static final Logger log = CoreLog.log;
 
   private final ReentrantLock lock = new ReentrantLock();
   private final ClusterManager clusterManager;
@@ -113,7 +113,7 @@ public final class DefaultContainer implements SpiContainer {
         startServer(online, server);
       }
       DbOffline.reset();
-      logger.info("started database[{}] platform[{}] in {}ms", config.getName(), config.getDatabasePlatform().getPlatform(), System.currentTimeMillis() - start);
+      log.info("Started database[{}] platform[{}] in {}ms", config.getName(), config.getDatabasePlatform().getPlatform(), System.currentTimeMillis() - start);
       return server;
     } finally {
       lock.unlock();
@@ -215,7 +215,7 @@ public final class DefaultContainer implements SpiContainer {
    */
   private void setDataSource(DatabaseConfig config) {
     if (isOfflineMode(config)) {
-      logger.debug("... DbOffline using platform [{}]", DbOffline.getPlatform());
+      log.debug("... DbOffline using platform [{}]", DbOffline.getPlatform());
     } else {
       InitDataSource.init(config);
     }
@@ -251,7 +251,7 @@ public final class DefaultContainer implements SpiContainer {
     }
     try (Connection connection = config.getDataSource().getConnection()) {
       if (connection.getAutoCommit()) {
-        logger.warn("DataSource [{}] has autoCommit defaulting to true!", config.getName());
+        log.warn("DataSource [{}] has autoCommit defaulting to true!", config.getName());
       }
       return true;
     } catch (SQLException ex) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -63,26 +63,8 @@ import io.ebean.plugin.Property;
 import io.ebean.plugin.SpiServer;
 import io.ebean.text.csv.CsvReader;
 import io.ebean.text.json.JsonContext;
-import io.ebeaninternal.api.ExtraMetrics;
-import io.ebeaninternal.api.LoadBeanRequest;
-import io.ebeaninternal.api.LoadManyRequest;
-import io.ebeaninternal.api.QueryPlanManager;
-import io.ebeaninternal.api.ScopedTransaction;
-import io.ebeaninternal.api.SpiBackgroundExecutor;
-import io.ebeaninternal.api.SpiDdlGenerator;
-import io.ebeaninternal.api.SpiDtoQuery;
-import io.ebeaninternal.api.SpiEbeanServer;
-import io.ebeaninternal.api.SpiJsonContext;
-import io.ebeaninternal.api.SpiLogManager;
-import io.ebeaninternal.api.SpiQuery;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.api.SpiQuery.Type;
-import io.ebeaninternal.api.SpiQueryBindCapture;
-import io.ebeaninternal.api.SpiQueryPlan;
-import io.ebeaninternal.api.SpiSqlQuery;
-import io.ebeaninternal.api.SpiSqlUpdate;
-import io.ebeaninternal.api.SpiTransaction;
-import io.ebeaninternal.api.SpiTransactionManager;
-import io.ebeaninternal.api.TransactionEventTable;
 import io.ebeaninternal.server.autotune.AutoTuneService;
 import io.ebeaninternal.server.cache.RemoteCacheEvent;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
@@ -118,7 +100,6 @@ import io.ebeaninternal.util.ParamTypeHelper;
 import io.ebeaninternal.util.ParamTypeHelper.TypeInfo;
 import io.ebeanservice.docstore.api.DocStoreIntegration;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.persistence.NonUniqueResultException;
@@ -146,7 +127,7 @@ import static java.util.stream.StreamSupport.stream;
  */
 public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
-  private static final Logger logger = LoggerFactory.getLogger(DefaultServer.class);
+  private static final Logger log = CoreLog.internal;
 
   private final ReentrantLock lock = new ReentrantLock();
   private final DatabaseConfig config;
@@ -400,7 +381,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     if (config.isQueryPlanCapture()) {
       long secs = config.getQueryPlanCapturePeriodSecs();
       if (secs > 10) {
-        logger.info("capture query plan enabled, every {}secs", secs);
+        log.info("capture query plan enabled, every {}secs", secs);
         backgroundExecutor.scheduleWithFixedDelay(this::collectQueryPlans, secs, secs, TimeUnit.SECONDS);
       }
     }
@@ -448,7 +429,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
    * Shutdown the services like threads and DataSource.
    */
   private void shutdownInternal(boolean shutdownDataSource, boolean deregisterDriver) {
-    logger.debug("Shutting down instance:{}", serverName);
+    log.trace("shutting down instance {}", serverName);
     if (shutdown) {
       // already shutdown
       return;
@@ -477,7 +458,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
       try {
         plugin.shutdown();
       } catch (Exception e) {
-        logger.error("Error when shutting down plugin", e);
+        log.error("Error when shutting down plugin", e);
       }
     }
   }
@@ -2193,7 +2174,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
             try {
               serverCacheManager.clearLocal(Class.forName(cache));
             } catch (Exception e) {
-              logger.error("Error clearing local cache for type " + cache, e);
+              log.error("Error clearing local cache for type " + cache, e);
             }
           }
         }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfigXmlMap.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfigXmlMap.java
@@ -1,11 +1,10 @@
 package io.ebeaninternal.server.core;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.dto.DtoNamedQueries;
 import io.ebeaninternal.xmapping.api.XmapDto;
 import io.ebeaninternal.xmapping.api.XmapEbean;
 import io.ebeaninternal.xmapping.api.XmapRawSql;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -15,8 +14,6 @@ import java.util.Map;
  * Reads the Xml deployment information.
  */
 final class InternalConfigXmlMap {
-
-  private static final Logger log = LoggerFactory.getLogger(InternalConfigXmlMap.class);
 
   private final List<XmapEbean> xmlEbeanList;
   private final ClassLoader classLoader;
@@ -58,7 +55,7 @@ final class InternalConfigXmlMap {
     try {
       dtoClass = Class.forName(dto.getClazz(), false, classLoader);
     } catch (Exception e) {
-      log.error("Could not load dto bean class " + dto.getClazz() + " for ebean xml entry");
+      CoreLog.internal.error("Could not load dto bean class " + dto.getClazz() + " for ebean xml entry");
       return;
     }
     DtoNamedQueries namedQueries = dtoNamedQueries.computeIfAbsent(dtoClass, aClass -> new DtoNamedQueries());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -1,11 +1,6 @@
 package io.ebeaninternal.server.core;
 
-import io.ebean.CacheMode;
-import io.ebean.CancelableQuery;
-import io.ebean.OrderBy;
-import io.ebean.PersistenceContextScope;
-import io.ebean.QueryIterator;
-import io.ebean.Version;
+import io.ebean.*;
 import io.ebean.bean.BeanCollection;
 import io.ebean.bean.EntityBean;
 import io.ebean.bean.PersistenceContext;
@@ -16,39 +11,17 @@ import io.ebean.common.CopyOnFirstWriteList;
 import io.ebean.event.BeanFindController;
 import io.ebean.event.BeanQueryAdapter;
 import io.ebean.text.json.JsonReadOptions;
-import io.ebeaninternal.api.BeanCacheResult;
-import io.ebeaninternal.api.CQueryPlanKey;
-import io.ebeaninternal.api.CacheIdLookup;
-import io.ebeaninternal.api.HashQuery;
-import io.ebeaninternal.api.LoadContext;
-import io.ebeaninternal.api.NaturalKeyQueryData;
-import io.ebeaninternal.api.NaturalKeySet;
-import io.ebeaninternal.api.SpiEbeanServer;
-import io.ebeaninternal.api.SpiQuery;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.api.SpiQuery.Type;
-import io.ebeaninternal.api.SpiQuerySecondary;
-import io.ebeaninternal.api.SpiTransaction;
-import io.ebeaninternal.server.deploy.BeanDescriptor;
-import io.ebeaninternal.server.deploy.BeanProperty;
-import io.ebeaninternal.server.deploy.BeanPropertyAssocMany;
-import io.ebeaninternal.server.deploy.DeployParser;
-import io.ebeaninternal.server.deploy.DeployPropertyParserMap;
+import io.ebeaninternal.server.deploy.*;
 import io.ebeaninternal.server.el.ElPropertyValue;
 import io.ebeaninternal.server.loadcontext.DLoadContext;
 import io.ebeaninternal.server.query.CQueryPlan;
 import io.ebeaninternal.server.transaction.DefaultPersistenceContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -56,8 +29,6 @@ import java.util.function.Predicate;
  * Wraps the objects involved in executing a Query.
  */
 public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQueryRequest<T> {
-
-  private static final Logger log = LoggerFactory.getLogger(OrmQueryRequest.class);
 
   private final BeanDescriptor<T> beanDescriptor;
   private final OrmQueryEngine queryEngine;
@@ -277,7 +248,7 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
         // Just log this and carry on. A previous exception has been
         // thrown and if this rollback throws exception it likely means
         // that the connection is broken (and the dataSource and db will cleanup)
-        log.error("Error trying to rollback a transaction (after a prior exception thrown)", e);
+        CoreLog.log.error("Error trying to rollback a transaction (after a prior exception thrown)", e);
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClassPathSearch.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClassPathSearch.java
@@ -2,9 +2,9 @@ package io.ebeaninternal.server.core.bootup;
 
 import io.avaje.classpath.scanner.ClassPathScanner;
 import io.ebean.config.DatabaseConfig;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.ClassPathScanners;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Set;
@@ -14,10 +14,9 @@ import java.util.Set;
  */
 public class BootupClassPathSearch {
 
-  private static final Logger logger = LoggerFactory.getLogger(BootupClassPathSearch.class);
+  private static final Logger log = CoreLog.internal;
 
   private final List<String> packages;
-
   private final List<ClassPathScanner> scanners;
 
   /**
@@ -60,7 +59,7 @@ public class BootupClassPathSearch {
       }
 
       long searchTime = System.currentTimeMillis() - st;
-      logger.debug("Classpath search entities[{}] searchTime[{}] in packages[{}]", bc.getEntities().size(), searchTime, packages);
+      log.debug("Classpath search entities[{}] searchTime[{}] in packages[{}]", bc.getEntities().size(), searchTime, packages);
       return bc;
 
     } catch (Exception ex) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClasses.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClasses.java
@@ -5,21 +5,15 @@ import io.ebean.config.DatabaseConfig;
 import io.ebean.config.IdGenerator;
 import io.ebean.config.ScalarTypeConverter;
 import io.ebean.core.type.ScalarType;
-import io.ebean.event.BeanFindController;
-import io.ebean.event.BeanPersistController;
-import io.ebean.event.BeanPersistListener;
-import io.ebean.event.BeanPostConstructListener;
-import io.ebean.event.BeanPostLoad;
-import io.ebean.event.BeanQueryAdapter;
-import io.ebean.event.ServerConfigStartup;
+import io.ebean.event.*;
 import io.ebean.event.changelog.ChangeLogListener;
 import io.ebean.event.changelog.ChangeLogPrepare;
 import io.ebean.event.changelog.ChangeLogRegister;
 import io.ebean.event.readaudit.ReadAuditLogger;
 import io.ebean.event.readaudit.ReadAuditPrepare;
 import io.ebean.util.AnnotationUtil;
+import io.ebeaninternal.api.CoreLog;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Embeddable;
@@ -37,7 +31,7 @@ import java.util.function.Predicate;
  */
 public class BootupClasses implements Predicate<Class<?>> {
 
-  private static final Logger logger = LoggerFactory.getLogger(BootupClasses.class);
+  private static final Logger log = CoreLog.internal;
 
   private final List<Class<?>> embeddableList = new ArrayList<>();
   private final List<Class<?>> entityList = new ArrayList<>();
@@ -211,13 +205,13 @@ public class BootupClasses implements Predicate<Class<?>> {
     try {
       return cls.getConstructor().newInstance();
     } catch (NoSuchMethodException e) {
-      logger.debug("Ignore/expected - no default constructor: " +e.getMessage());
+      log.debug("Ignore/expected - no default constructor: " +e.getMessage());
       return null;
 
     } catch (Exception e) {
       if (logOnException) {
         // not expected but we log and carry on
-        logger.error("Error creating " + cls, e);
+        log.error("Error creating " + cls, e);
         return null;
 
       } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/ManifestReader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/ManifestReader.java
@@ -1,9 +1,9 @@
 package io.ebeaninternal.server.core.bootup;
 
 import io.ebean.util.StringHelper;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.util.UrlHelper;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,10 +20,9 @@ import java.util.jar.Manifest;
  */
 class ManifestReader {
 
-  private static final Logger logger = LoggerFactory.getLogger(ManifestReader.class);
+  private static final Logger log = CoreLog.internal;
 
   private final Set<String> packageSet = new HashSet<>();
-
   private final ClassLoader classLoader;
 
   /**
@@ -65,7 +64,7 @@ class ManifestReader {
         }
       }
     } catch (IOException e) {
-      logger.warn("Error reading " + resourcePath + " manifest resources", e);
+      log.warn("Error reading " + resourcePath + " manifest resources", e);
     }
     return packageSet;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1,16 +1,8 @@
 package io.ebeaninternal.server.deploy;
 
-import io.ebean.PersistenceContextScope;
-import io.ebean.Query;
-import io.ebean.SqlUpdate;
-import io.ebean.Transaction;
-import io.ebean.ValuePair;
+import io.ebean.*;
 import io.ebean.annotation.DocStoreMode;
-import io.ebean.bean.BeanCollection;
-import io.ebean.bean.EntityBean;
-import io.ebean.bean.EntityBeanIntercept;
-import io.ebean.bean.PersistenceContext;
-import io.ebean.bean.SingleBeanLoader;
+import io.ebean.bean.*;
 import io.ebean.cache.QueryCacheEntry;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.config.EncryptKey;
@@ -18,12 +10,7 @@ import io.ebean.config.dbplatform.IdType;
 import io.ebean.config.dbplatform.PlatformIdGenerator;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.core.type.ScalarType;
-import io.ebean.event.BeanFindController;
-import io.ebean.event.BeanPersistController;
-import io.ebean.event.BeanPersistListener;
-import io.ebean.event.BeanPostConstructListener;
-import io.ebean.event.BeanPostLoad;
-import io.ebean.event.BeanQueryAdapter;
+import io.ebean.event.*;
 import io.ebean.event.changelog.BeanChange;
 import io.ebean.event.changelog.ChangeLogFilter;
 import io.ebean.event.changelog.ChangeType;
@@ -45,32 +32,15 @@ import io.ebeaninternal.api.json.SpiJsonWriter;
 import io.ebeaninternal.server.cache.CacheChangeSet;
 import io.ebeaninternal.server.cache.CachedBeanData;
 import io.ebeaninternal.server.cache.CachedManyIds;
-import io.ebeaninternal.server.core.CacheOptions;
-import io.ebeaninternal.server.core.DefaultSqlUpdate;
-import io.ebeaninternal.server.core.InternString;
-import io.ebeaninternal.server.core.PersistRequest;
-import io.ebeaninternal.server.core.PersistRequestBean;
+import io.ebeaninternal.server.core.*;
 import io.ebeaninternal.server.deploy.id.IdBinder;
 import io.ebeaninternal.server.deploy.id.IdBinderSimple;
 import io.ebeaninternal.server.deploy.id.ImportedId;
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
 import io.ebeaninternal.server.deploy.meta.DeployBeanPropertyLists;
-import io.ebeaninternal.server.el.ElComparator;
-import io.ebeaninternal.server.el.ElComparatorCompound;
-import io.ebeaninternal.server.el.ElComparatorNoop;
-import io.ebeaninternal.server.el.ElComparatorProperty;
-import io.ebeaninternal.server.el.ElPropertyChainBuilder;
-import io.ebeaninternal.server.el.ElPropertyDeploy;
-import io.ebeaninternal.server.el.ElPropertyValue;
+import io.ebeaninternal.server.el.*;
 import io.ebeaninternal.server.persist.DeleteMode;
-import io.ebeaninternal.server.query.CQueryPlan;
-import io.ebeaninternal.server.query.ExtraJoin;
-import io.ebeaninternal.server.query.STreeProperty;
-import io.ebeaninternal.server.query.STreePropertyAssoc;
-import io.ebeaninternal.server.query.STreePropertyAssocMany;
-import io.ebeaninternal.server.query.STreePropertyAssocOne;
-import io.ebeaninternal.server.query.STreeType;
-import io.ebeaninternal.server.query.SqlBeanLoad;
+import io.ebeaninternal.server.query.*;
 import io.ebeaninternal.server.querydefn.DefaultOrmQuery;
 import io.ebeaninternal.server.querydefn.OrmQueryDetail;
 import io.ebeaninternal.server.querydefn.OrmQueryProperties;
@@ -85,7 +55,6 @@ import io.ebeanservice.docstore.api.mapping.DocMappingBuilder;
 import io.ebeanservice.docstore.api.mapping.DocPropertyMapping;
 import io.ebeanservice.docstore.api.mapping.DocumentMapping;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.persistence.PersistenceException;
@@ -94,14 +63,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Modifier;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -113,7 +75,7 @@ import static io.ebeaninternal.server.persist.DmlUtil.isNullOrZero;
  */
 public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
 
-  private static final Logger logger = LoggerFactory.getLogger(BeanDescriptor.class);
+  private static final Logger log = CoreLog.internal;
 
   public enum EntityType {
     ORM, EMBEDDED, VIEW, SQL, DOC
@@ -511,8 +473,8 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * as they are used to get the imported and exported properties.
    */
   void initialiseId(BeanDescriptorInitContext initContext) {
-    if (logger.isTraceEnabled()) {
-      logger.trace("BeanDescriptor initialise " + fullName);
+    if (log.isTraceEnabled()) {
+      log.trace("BeanDescriptor initialise " + fullName);
     }
     if (draftable) {
       initContext.addDraft(baseTable, draftTable);
@@ -812,7 +774,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       changeJson.flush();
       return beanChange(ChangeType.UPDATE, request.beanId(), changeJson.newJson(), changeJson.oldJson());
     } catch (RuntimeException e) {
-      logger.error("Failed to write ChangeLog entry for update", e);
+      log.error("Failed to write ChangeLog entry for update", e);
       return null;
     }
   }
@@ -828,7 +790,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       jsonWriter.flush();
       return beanChange(ChangeType.INSERT, request.beanId(), writer.toString(), null);
     } catch (IOException e) {
-      logger.error("Failed to write ChangeLog entry for insert", e);
+      log.error("Failed to write ChangeLog entry for insert", e);
       return null;
     }
   }
@@ -2303,11 +2265,11 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   private ElComparator<T> createPropertyComparator(SortByClause.Property sortProp) {
     ElPropertyValue elGetValue = elGetValue(sortProp.getName());
     if (elGetValue == null) {
-      logger.error("Sort property [" + sortProp + "] not found in " + beanType + ". Cannot sort.");
+      log.error("Sort property [" + sortProp + "] not found in " + beanType + ". Cannot sort.");
       return new ElComparatorNoop<>();
     }
     if (elGetValue.isAssocMany()) {
-      logger.error("Sort property [" + sortProp + "] in " + beanType + " is a many-property. Cannot sort.");
+      log.error("Sort property [" + sortProp + "] in " + beanType + " is a many-property. Cannot sort.");
       return new ElComparatorNoop<>();
     }
     Boolean nullsHigh = sortProp.getNullsHigh();
@@ -2776,7 +2738,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   public void markAsDeleted(EntityBean bean) {
     if (softDeleteProperty == null) {
       Object id = getId(bean);
-      logger.info("(Lazy) loading unsuccessful for type:{} id:{} - expecting when bean has been deleted", name(), id);
+      log.info("(Lazy) loading unsuccessful for type:{} id:{} - expecting when bean has been deleted", name(), id);
       bean._ebean_getIntercept().setLazyLoadFailure(id);
     } else {
       softDeleteValue(bean);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
@@ -6,17 +6,9 @@ import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.bean.PersistenceContext;
 import io.ebean.cache.QueryCacheEntry;
 import io.ebean.cache.ServerCache;
-import io.ebeaninternal.api.BeanCacheResult;
-import io.ebeaninternal.api.SpiCacheControl;
-import io.ebeaninternal.api.SpiCacheRegion;
-import io.ebeaninternal.api.SpiTransaction;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.api.TransactionEventTable.TableIUD;
-import io.ebeaninternal.server.cache.CacheChangeSet;
-import io.ebeaninternal.server.cache.CachedBeanData;
-import io.ebeaninternal.server.cache.CachedBeanDataFromBean;
-import io.ebeaninternal.server.cache.CachedBeanDataToBean;
-import io.ebeaninternal.server.cache.CachedManyIds;
-import io.ebeaninternal.server.cache.SpiCacheManager;
+import io.ebeaninternal.server.cache.*;
 import io.ebeaninternal.server.core.CacheOptions;
 import io.ebeaninternal.server.core.PersistRequest;
 import io.ebeaninternal.server.core.PersistRequestBean;
@@ -25,15 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Helper for BeanDescriptor that manages the bean, query and collection caches.
@@ -42,7 +26,7 @@ import java.util.Set;
  */
 final class BeanDescriptorCacheHelp<T> {
 
-  private static final Logger logger = LoggerFactory.getLogger(BeanDescriptorCacheHelp.class);
+  private static final Logger log = CoreLog.internal;
 
   private static final Logger queryLog = LoggerFactory.getLogger("io.ebean.cache.QUERY");
   private static final Logger beanLog = LoggerFactory.getLogger("io.ebean.cache.BEAN");
@@ -120,10 +104,10 @@ final class BeanDescriptorCacheHelp<T> {
   void deriveNotifyFlags() {
     cacheNotifyOnAll = (invalidateQueryCache || beanCache != null || queryCache != null);
     cacheNotifyOnDelete = !cacheNotifyOnAll && isNotifyOnDeletes();
-    if (logger.isDebugEnabled()) {
+    if (log.isDebugEnabled()) {
       if (cacheNotifyOnAll || cacheNotifyOnDelete) {
         String notifyMode = cacheNotifyOnAll ? "All" : "Delete";
-        logger.debug("l2 caching on {} - beanCaching:{} queryCaching:{} notifyMode:{} ",
+        log.debug("l2 caching on {} - beanCaching:{} queryCaching:{} notifyMode:{} ",
           desc.fullName(), isBeanCaching(), isQueryCaching(), notifyMode);
       }
     }
@@ -324,7 +308,7 @@ final class BeanDescriptorCacheHelp<T> {
           }
           beanCache.put(parentId, newData);
         } catch (IOException e) {
-          logger.error("Error updating L2 cache", e);
+          log.error("Error updating L2 cache", e);
         }
       }
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -42,7 +42,6 @@ import io.ebeaninternal.xmapping.api.XmapRawSql;
 import io.ebeanservice.docstore.api.DocStoreBeanAdapter;
 import io.ebeanservice.docstore.api.DocStoreFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PersistenceException;
@@ -59,7 +58,7 @@ import java.util.concurrent.TimeUnit;
  */
 public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTypeManager {
 
-  private static final Logger logger = LoggerFactory.getLogger(BeanDescriptorManager.class);
+  private static final Logger log = CoreLog.internal;
 
   private static final BeanDescComparator beanDescComparator = new BeanDescComparator();
   public static final String JAVA_LANG_RECORD = "java.lang.Record";
@@ -310,7 +309,7 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
     } catch (BeanNotEnhancedException e) {
       throw e;
     } catch (RuntimeException e) {
-      logger.error("Error in deployment", e);
+      log.error("Error in deployment", e);
       throw e;
     }
   }
@@ -333,13 +332,13 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
     try {
       entityClass = Class.forName(entityClassName, false, classLoader);
     } catch (Exception e) {
-      logger.error("Could not load entity bean class " + entityClassName + " for ebean.xml entry");
+      log.error("Could not load entity bean class " + entityClassName + " for ebean.xml entry");
       return;
     }
 
     DeployBeanInfo<?> info = deployInfoMap.get(entityClass);
     if (info == null) {
-      logger.error("No entity bean for ebean.xml entry " + entityClassName);
+      log.error("No entity bean for ebean.xml entry " + entityClassName);
 
     } else {
       for (XmapRawSql sql : entityDeploy.getRawSql()) {
@@ -580,11 +579,11 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
     int pc = postConstructManager.getRegisterCount();
     int lc = persistListenerManager.getRegisterCount();
     int fc = beanFinderManager.getRegisterCount();
-    logger.debug("BeanPersistControllers[{}] BeanFinders[{}] BeanPersistListeners[{}] BeanQueryAdapters[{}] BeanPostLoaders[{}] BeanPostConstructors[{}]", cc, fc, lc, qa, pl, pc);
+    log.debug("BeanPersistControllers[{}] BeanFinders[{}] BeanPersistListeners[{}] BeanQueryAdapters[{}] BeanPostLoaders[{}] BeanPostConstructors[{}]", cc, fc, lc, qa, pl, pc);
   }
 
   private void logStatus() {
-    logger.debug("Entities[{}]", entityBeanCount);
+    log.debug("Entities[{}]", entityBeanCount);
   }
 
   /**
@@ -850,7 +849,7 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
 
             String m = "Implicitly found mappedBy for " + targetDesc + "." + prop;
             m += " by searching for [" + searchName + "] against " + matchSet;
-            logger.debug(m);
+            log.debug(m);
 
             return true;
           }
@@ -1209,12 +1208,12 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
     final DeployIdentityMode identityMode = desc.getIdentityMode();
     if (identityMode.isSequence() && !dbIdentity.isSupportsSequence()) {
       // explicit sequence but not supported by the DatabasePlatform
-      logger.info("Explicit sequence on " + desc.getFullName() + " but not supported by DB Platform - ignored");
+      log.info("Explicit sequence on " + desc.getFullName() + " but not supported by DB Platform - ignored");
       identityMode.setIdType(IdType.AUTO);
     }
     if (identityMode.isIdentity() && !dbIdentity.isSupportsIdentity()) {
       // explicit identity but not supported by the DatabasePlatform
-      logger.info("Explicit Identity on " + desc.getFullName() + " but not supported by DB Platform - ignored");
+      log.info("Explicit Identity on " + desc.getFullName() + " but not supported by DB Platform - ignored");
       identityMode.setIdType(IdType.AUTO);
     }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanFinderManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanFinderManager.java
@@ -1,10 +1,10 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.event.BeanFindController;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -13,7 +13,7 @@ import java.util.List;
  */
 final class BeanFinderManager {
 
-  private final Logger logger = LoggerFactory.getLogger(BeanFinderManager.class);
+  private static final Logger log = CoreLog.internal;
 
   private final List<BeanFindController> list;
 
@@ -31,7 +31,7 @@ final class BeanFinderManager {
   void addFindControllers(DeployBeanDescriptor<?> deployDesc) {
     for (BeanFindController c : list) {
       if (c.isRegisterFor(deployDesc.getBeanType())) {
-        logger.debug("BeanFindController on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
+        log.debug("BeanFindController on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
         deployDesc.setBeanFinder(c);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -15,6 +15,7 @@ import io.ebean.core.type.ScalarType;
 import io.ebean.plugin.Property;
 import io.ebean.text.StringParser;
 import io.ebean.util.SplitName;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.api.json.SpiJsonReader;
@@ -38,8 +39,6 @@ import io.ebeanservice.docstore.api.mapping.DocMappingBuilder;
 import io.ebeanservice.docstore.api.mapping.DocPropertyMapping;
 import io.ebeanservice.docstore.api.mapping.DocPropertyOptions;
 import io.ebeanservice.docstore.api.support.DocStructure;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.persistence.PersistenceException;
@@ -58,8 +57,6 @@ import java.util.Set;
  * as database column mapping information.
  */
 public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
-
-  private static final Logger logger = LoggerFactory.getLogger(BeanProperty.class);
 
   private static final String ENC_PREFIX = " " + EncryptAlias.PREFIX;
 
@@ -1412,7 +1409,7 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
           objValue = null;
           String msg = "Error trying to use Jackson ObjectMapper to read transient property "
             + fullName() + " - consider marking this property with @JsonIgnore";
-          logger.error(msg, e);
+          CoreLog.log.error(msg, e);
         }
       }
       if (jsonDeserialize) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
@@ -5,6 +5,7 @@ import io.ebean.bean.EntityBean;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.text.PathProperties;
 import io.ebean.util.SplitName;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.server.core.DefaultSqlUpdate;
@@ -24,8 +25,6 @@ import io.ebeaninternal.server.querydefn.DefaultOrmQuery;
 import io.ebeanservice.docstore.api.mapping.DocMappingBuilder;
 import io.ebeanservice.docstore.api.mapping.DocPropertyMapping;
 import io.ebeanservice.docstore.api.support.DocStructure;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.util.ArrayList;
@@ -35,8 +34,6 @@ import java.util.List;
  * Abstract base for properties mapped to an associated bean, list, set or map.
  */
 public abstract class BeanPropertyAssoc<T> extends BeanProperty implements STreePropertyAssoc {
-
-  private static final Logger logger = LoggerFactory.getLogger(BeanPropertyAssoc.class);
 
   /**
    * The descriptor of the target. This MUST be initialised after construction
@@ -435,8 +432,7 @@ public abstract class BeanPropertyAssoc<T> extends BeanProperty implements STree
     if (!idProp.isEmbedded()) {
       // simple single scalar id
       if (cols.length != 1) {
-        String msg = "No Imported Id column for [" + idProp + "] in table [" + join.getTable() + "]";
-        logger.error(msg);
+        CoreLog.log.error("No Imported Id column for [" + idProp + "] in table [" + join.getTable() + "]");
         return null;
       } else {
         BeanProperty[] idProps = {idProp};

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
@@ -11,10 +11,7 @@ import io.ebean.bean.EntityBean;
 import io.ebean.bean.PersistenceContext;
 import io.ebean.plugin.PropertyAssocMany;
 import io.ebean.text.PathProperties;
-import io.ebeaninternal.api.SpiEbeanServer;
-import io.ebeaninternal.api.SpiExpressionRequest;
-import io.ebeaninternal.api.SpiQuery;
-import io.ebeaninternal.api.SpiSqlUpdate;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.api.json.SpiJsonReader;
 import io.ebeaninternal.api.json.SpiJsonWriter;
 import io.ebeaninternal.server.deploy.id.ImportedId;
@@ -23,24 +20,16 @@ import io.ebeaninternal.server.el.ElPropertyChainBuilder;
 import io.ebeaninternal.server.el.ElPropertyValue;
 import io.ebeaninternal.server.query.STreePropertyAssocMany;
 import io.ebeaninternal.server.query.SqlBeanLoad;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Property mapped to a List Set or Map.
  */
 public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements STreePropertyAssocMany, PropertyAssocMany {
-
-  private static final Logger logger = LoggerFactory.getLogger(BeanPropertyAssocMany.class);
 
   private final BeanPropertyAssocManyJsonHelp jsonHelp;
   /**
@@ -664,7 +653,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
         }
       } catch (PersistenceException e) {
         // not found as individual scalar properties
-        logger.error("Could not find a exported property?", e);
+        CoreLog.log.error("Could not find a exported property?", e);
       }
     } else {
       if (idProp != null) {
@@ -959,7 +948,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
         setValue(bean, collection);
       }
     } catch (Exception e) {
-      logger.error("Error setting value from L2 cache", e);
+      CoreLog.log.error("Error setting value from L2 cache", e);
     }
   }
 
@@ -972,7 +961,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
       }
       return jsonWriteCollection(collection);
     } catch (Exception e) {
-      logger.error("Error building value element collection json for L2 cache", e);
+      CoreLog.log.error("Error building value element collection json for L2 cache", e);
       return null;
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanQueryAdapterManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanQueryAdapterManager.java
@@ -1,10 +1,9 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.event.BeanQueryAdapter;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -12,8 +11,6 @@ import java.util.List;
  * Default implementation for creating BeanControllers.
  */
 final class BeanQueryAdapterManager {
-
-  private static final Logger logger = LoggerFactory.getLogger(BeanQueryAdapterManager.class);
 
   private final List<BeanQueryAdapter> list;
 
@@ -31,7 +28,7 @@ final class BeanQueryAdapterManager {
   void addQueryAdapter(DeployBeanDescriptor<?> deployDesc) {
     for (BeanQueryAdapter c : list) {
       if (c.isRegisterFor(deployDesc.getBeanType())) {
-        logger.debug("BeanQueryAdapter on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
+        CoreLog.internal.debug("BeanQueryAdapter on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
         deployDesc.addQueryAdapter(c);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanTable.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanTable.java
@@ -1,11 +1,10 @@
 package io.ebeaninternal.server.deploy;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.InternString;
 import io.ebeaninternal.server.deploy.meta.DeployBeanTable;
 import io.ebeaninternal.server.deploy.meta.DeployTableJoin;
 import io.ebeaninternal.server.deploy.meta.DeployTableJoinColumn;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -18,8 +17,6 @@ import org.slf4j.LoggerFactory;
  * </p>
  */
 public final class BeanTable {
-
-  private static final Logger logger = LoggerFactory.getLogger(BeanTable.class);
 
   private final BeanDescriptorMap owner;
   private final Class<?> beanType;
@@ -108,7 +105,7 @@ public final class BeanTable {
     if (complexKey) {
       // just to copy the column name rather than prefix with the foreignKeyPrefix.
       // I think that with complex keys this is the more common approach.
-      logger.debug("On table[{}] foreign key column [{}]", baseTable, lc);
+      CoreLog.internal.debug("On table[{}] foreign key column [{}]", baseTable, lc);
       fk = lc;
     }
     if (sqlFormulaSelect != null) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PersistControllerManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PersistControllerManager.java
@@ -1,10 +1,9 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.event.BeanPersistController;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -12,8 +11,6 @@ import java.util.List;
  * Default implementation for creating BeanControllers.
  */
 final class PersistControllerManager {
-
-  private static final Logger logger = LoggerFactory.getLogger(PersistControllerManager.class);
 
   private final List<BeanPersistController> list;
 
@@ -31,7 +28,7 @@ final class PersistControllerManager {
   void addPersistControllers(DeployBeanDescriptor<?> deployDesc) {
     for (BeanPersistController c : list) {
       if (c.isRegisterFor(deployDesc.getBeanType())) {
-        logger.debug("BeanPersistController on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
+        CoreLog.log.debug("BeanPersistController on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
         deployDesc.addPersistController(c);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PersistListenerManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PersistListenerManager.java
@@ -1,10 +1,9 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.event.BeanPersistListener;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -13,8 +12,6 @@ import java.util.List;
  * respective DeployBeanDescriptor's.
  */
 final class PersistListenerManager {
-
-  private static final Logger logger = LoggerFactory.getLogger(PersistListenerManager.class);
 
   private final List<BeanPersistListener> list;
 
@@ -32,7 +29,7 @@ final class PersistListenerManager {
   <T> void addPersistListeners(DeployBeanDescriptor<T> deployDesc) {
     for (BeanPersistListener listener : list) {
       if (listener.isRegisterFor(deployDesc.getBeanType())) {
-        logger.debug("BeanPersistListener on[{}] {}", deployDesc.getFullName(), listener.getClass().getName());
+        CoreLog.log.debug("BeanPersistListener on[{}] {}", deployDesc.getFullName(), listener.getClass().getName());
         deployDesc.addPersistListener(listener);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PostConstructManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PostConstructManager.java
@@ -1,10 +1,9 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.event.BeanPostConstructListener;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -12,8 +11,6 @@ import java.util.List;
  * Default implementation for creating BeanControllers.
  */
 final class PostConstructManager {
-
-  private static final Logger logger = LoggerFactory.getLogger(PostConstructManager.class);
 
   private final List<BeanPostConstructListener> list;
 
@@ -31,7 +28,7 @@ final class PostConstructManager {
   void addPostConstructListeners(DeployBeanDescriptor<?> deployDesc) {
     for (BeanPostConstructListener c : list) {
       if (c.isRegisterFor(deployDesc.getBeanType())) {
-        logger.debug("BeanPostLoad on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
+        CoreLog.log.debug("BeanPostLoad on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
         deployDesc.addPostConstructListener(c);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PostLoadManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PostLoadManager.java
@@ -1,10 +1,9 @@
 package io.ebeaninternal.server.deploy;
 
 import io.ebean.event.BeanPostLoad;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -12,8 +11,6 @@ import java.util.List;
  * Default implementation for creating BeanControllers.
  */
 final class PostLoadManager {
-
-  private static final Logger logger = LoggerFactory.getLogger(PostLoadManager.class);
 
   private final List<BeanPostLoad> list;
 
@@ -31,7 +28,7 @@ final class PostLoadManager {
   void addPostLoad(DeployBeanDescriptor<?> deployDesc) {
     for (BeanPostLoad c : list) {
       if (c.isRegisterFor(deployDesc.getBeanType())) {
-        logger.debug("BeanPostLoad on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
+        CoreLog.log.debug("BeanPostLoad on[{}] {}", deployDesc.getFullName(), c.getClass().getName());
         deployDesc.addPostLoad(c);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanPropertyLists.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanPropertyLists.java
@@ -1,12 +1,11 @@
 package io.ebeaninternal.server.deploy.meta;
 
 import io.ebean.bean.EntityBean;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.deploy.*;
 import io.ebeaninternal.server.deploy.generatedproperty.GeneratedProperty;
 import io.ebeaninternal.server.properties.BeanPropertySetter;
 import io.ebeaninternal.server.type.ScalarTypeString;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -16,8 +15,6 @@ import java.util.List;
  * Helper object to classify BeanProperties into appropriate lists.
  */
 public final class DeployBeanPropertyLists {
-
-  private static final Logger logger = LoggerFactory.getLogger(DeployBeanPropertyLists.class);
 
   private static final NoopSetter NOOP_SETTER = new NoopSetter();
 
@@ -225,7 +222,7 @@ public final class DeployBeanPropertyLists {
           if (versionProperty == null) {
             versionProperty = prop;
           } else {
-            logger.warn("Multiple @Version properties - property " + prop.fullName() + " not treated as a version property");
+            CoreLog.internal.warn("Multiple @Version properties - property " + prop.fullName() + " not treated as a version property");
           }
         } else if (prop.isDraftDirty()) {
           draftDirty = prop;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocOnes.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocOnes.java
@@ -5,6 +5,7 @@ import io.ebean.annotation.FetchPreference;
 import io.ebean.annotation.TenantId;
 import io.ebean.annotation.Where;
 import io.ebean.config.NamingConvention;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.deploy.BeanDescriptorManager;
 import io.ebeaninternal.server.deploy.BeanTable;
 import io.ebeaninternal.server.deploy.PropertyForeignKey;
@@ -12,27 +13,13 @@ import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
 import io.ebeaninternal.server.deploy.meta.DeployBeanPropertyAssocOne;
 import io.ebeaninternal.server.deploy.meta.DeployTableJoinColumn;
 import io.ebeaninternal.server.query.SqlJoinType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.persistence.Column;
-import javax.persistence.ConstraintMode;
-import javax.persistence.Embedded;
-import javax.persistence.EmbeddedId;
-import javax.persistence.ForeignKey;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.PrimaryKeyJoinColumn;
+import javax.persistence.*;
 
 /**
  * Read the deployment annotations for Associated One beans.
  */
 final class AnnotationAssocOnes extends AnnotationAssoc {
-
-  private static final Logger log = LoggerFactory.getLogger(AnnotationAssocOnes.class);
 
   /**
    * Create with the deploy Info.
@@ -226,10 +213,10 @@ final class AnnotationAssocOnes extends AnnotationAssoc {
     prop.setPrimaryKeyJoin(true);
 
     if (!primaryKeyJoin.name().isEmpty()) {
-      log.info("Automatically determining join columns for @PrimaryKeyJoinColumn - ignoring PrimaryKeyJoinColumn.name attribute [{}] on {}", primaryKeyJoin.name(), prop.getFullBeanName());
+      CoreLog.internal.info("Automatically determining join columns for @PrimaryKeyJoinColumn - ignoring PrimaryKeyJoinColumn.name attribute [{}] on {}", primaryKeyJoin.name(), prop.getFullBeanName());
     }
     if (!primaryKeyJoin.referencedColumnName().isEmpty()) {
-      log.info("Automatically determining join columns for @PrimaryKeyJoinColumn - Ignoring PrimaryKeyJoinColumn.referencedColumnName attribute [{}] on {}", primaryKeyJoin.referencedColumnName(), prop.getFullBeanName());
+      CoreLog.internal.info("Automatically determining join columns for @PrimaryKeyJoinColumn - Ignoring PrimaryKeyJoinColumn.referencedColumnName attribute [{}] on {}", primaryKeyJoin.referencedColumnName(), prop.getFullBeanName());
     }
     BeanTable baseBeanTable = factory.beanTable(info.getDescriptor().getBeanType());
     String localPrimaryKey = baseBeanTable.getIdColumn();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationClass.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationClass.java
@@ -14,13 +14,12 @@ import io.ebean.annotation.ReadAudit;
 import io.ebean.annotation.StorageEngine;
 import io.ebean.annotation.View;
 import io.ebean.config.TableName;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.deploy.BeanDescriptor.EntityType;
 import io.ebeaninternal.server.deploy.IndexDefinition;
 import io.ebeaninternal.server.deploy.InheritInfo;
 import io.ebeaninternal.server.deploy.PartitionMeta;
 import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -37,8 +36,6 @@ import static io.ebean.util.AnnotationUtil.typeGet;
  * Read the class level deployment annotations.
  */
 final class AnnotationClass extends AnnotationParser {
-
-  private static final Logger logger = LoggerFactory.getLogger(AnnotationClass.class);
 
   private final String asOfViewSuffix;
   private final String versionsBetweenSuffix;
@@ -66,7 +63,7 @@ final class AnnotationClass extends AnnotationParser {
       Column column = override.column();
       DeployBeanProperty beanProperty = descriptor.getBeanProperty(propertyName);
       if (beanProperty == null) {
-        logger.error("AttributeOverride property [" + propertyName + "] not found on " + descriptor.getFullName());
+        CoreLog.log.error("AttributeOverride property [" + propertyName + "] not found on " + descriptor.getFullName());
       } else {
         readColumn(column, beanProperty);
       }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployCreateProperties.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployCreateProperties.java
@@ -1,32 +1,18 @@
 package io.ebeaninternal.server.deploy.parse;
 
 import io.ebean.Model;
-import io.ebean.annotation.DbArray;
-import io.ebean.annotation.DbJson;
-import io.ebean.annotation.DbJsonB;
-import io.ebean.annotation.DbMap;
-import io.ebean.annotation.UnmappedJson;
+import io.ebean.annotation.*;
 import io.ebean.core.type.ScalarType;
 import io.ebean.util.AnnotationUtil;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.deploy.DetermineManyType;
 import io.ebeaninternal.server.deploy.ManyType;
-import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
-import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
-import io.ebeaninternal.server.deploy.meta.DeployBeanPropertyAssocMany;
-import io.ebeaninternal.server.deploy.meta.DeployBeanPropertyAssocOne;
-import io.ebeaninternal.server.deploy.meta.DeployBeanPropertySimpleCollection;
+import io.ebeaninternal.server.deploy.meta.*;
 import io.ebeaninternal.server.type.TypeManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.persistence.ManyToOne;
 import javax.persistence.PersistenceException;
 import javax.persistence.Transient;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.WildcardType;
+import java.lang.reflect.*;
 
 /**
  * Create the properties for a bean.
@@ -36,8 +22,6 @@ import java.lang.reflect.WildcardType;
  * </p>
  */
 public final class DeployCreateProperties {
-
-  private static final Logger logger = LoggerFactory.getLogger(DeployCreateProperties.class);
 
   private final DetermineManyType determineManyType;
   private final TypeManager typeManager;
@@ -101,7 +85,7 @@ public final class DeployCreateProperties {
             if (replaced != null && !replaced.isTransient()) {
               String msg = "Huh??? property " + prop.getFullBeanName() + " being defined twice";
               msg += " but replaced property was not transient? This is not expected?";
-              logger.warn(msg);
+              CoreLog.log.warn(msg);
             }
           }
         }
@@ -128,7 +112,7 @@ public final class DeployCreateProperties {
         return new DeployBeanPropertySimpleCollection(desc, targetType, manyType);
       }
     } catch (NullPointerException e) {
-      logger.debug("expected non-scalar type {}", e.getMessage());
+      CoreLog.internal.debug("expected non-scalar type {}", e.getMessage());
     }
     return new DeployBeanPropertyAssocMany(desc, targetType, manyType);
   }
@@ -149,7 +133,7 @@ public final class DeployCreateProperties {
           // not supporting this field (generic type used)
           return null;
         }
-        logger.warn("Could not find parameter type (via reflection) on " + desc.getFullName() + " " + field.getName());
+        CoreLog.internal.warn("Could not find parameter type (via reflection) on " + desc.getFullName() + " " + field.getName());
       }
       return createManyType(desc, targetType, manyType);
     }
@@ -168,7 +152,7 @@ public final class DeployCreateProperties {
       return new DeployBeanPropertyAssocOne(desc, propertyType);
 
     } catch (Exception e) {
-      logger.error("Error with " + desc + " field:" + field.getName(), e);
+      CoreLog.log.error("Error with " + desc + " field:" + field.getName(), e);
       return null;
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaBuilder.java
@@ -1,8 +1,7 @@
 package io.ebeaninternal.server.dto;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.type.TypeManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -16,8 +15,6 @@ import java.util.List;
  * Use TypeManager to map bean property types to ScalarTypes.
  */
 final class DtoMetaBuilder {
-
-  private static final Logger log = LoggerFactory.getLogger(DtoMetaBuilder.class);
 
   private final TypeManager typeManager;
   private final Class<?> dtoType;
@@ -43,7 +40,7 @@ final class DtoMetaBuilder {
           final Class<?> propertyType = propertyType(method);
           properties.add(new DtoMetaProperty(typeManager, dtoType, method, name, propertyType));
         } catch (Exception e) {
-          log.debug("exclude on " + dtoType + " method " + method, e);
+          CoreLog.log.debug("exclude on " + dtoType + " method " + method, e);
         }
       }
     }
@@ -77,7 +74,7 @@ final class DtoMetaBuilder {
         constructorList.add(new DtoMetaConstructor(typeManager, constructor, dtoType));
       } catch (Exception e) {
         // we don't want that constructor
-        log.debug("exclude on " + dtoType + " constructor " + constructor, e);
+        CoreLog.log.debug("exclude on " + dtoType + " constructor " + constructor, e);
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/executor/DaemonScheduleThreadPool.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/executor/DaemonScheduleThreadPool.java
@@ -1,7 +1,7 @@
 package io.ebeaninternal.server.executor;
 
+import io.ebeaninternal.api.CoreLog;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -12,7 +12,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public final class DaemonScheduleThreadPool extends ScheduledThreadPoolExecutor {
 
-  private static final Logger logger = LoggerFactory.getLogger(DaemonScheduleThreadPool.class);
+  private static final Logger log = CoreLog.log;
 
   private final ReentrantLock lock = new ReentrantLock();
   private final String namePrefix;
@@ -38,19 +38,19 @@ public final class DaemonScheduleThreadPool extends ScheduledThreadPoolExecutor 
     lock.lock();
     try {
       if (super.isShutdown()) {
-        logger.debug("Already shutdown {}", namePrefix);
+        log.debug("Already shutdown threadPool {}", namePrefix);
         return;
       }
       try {
-        logger.trace("Shutting down {} ...", namePrefix);
+        log.trace("shutting down threadPool {}", namePrefix);
         super.shutdown();
         if (!super.awaitTermination(shutdownWaitSeconds, TimeUnit.SECONDS)) {
-          logger.info("Shutdown wait timeout exceeded. Terminating running threads for {}", namePrefix);
+          log.info("Shutdown wait timeout exceeded. Terminating running threads for {}", namePrefix);
           super.shutdownNow();
         }
-        logger.debug("Shutdown complete for {}", namePrefix);
+        log.trace("shutdown complete for threadPool {}", namePrefix);
       } catch (Exception e) {
-        logger.error("Error during shutdown of " + namePrefix, e);
+        log.error("Error during shutdown of threadPool " + namePrefix, e);
         e.printStackTrace();
       }
     } finally {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1RndIdGenerator.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1RndIdGenerator.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UuidV1RndIdGenerator implements PlatformIdGenerator {
 
-  protected static final Logger logger = LoggerFactory.getLogger("io.ebean.IDGEN");
+  protected static final Logger log = LoggerFactory.getLogger("io.ebean.IDGEN");
 
   // UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
   protected static final long UUID_EPOCH_OFFSET = 0x01B21DD213814000L;
@@ -106,7 +106,7 @@ public class UuidV1RndIdGenerator implements PlatformIdGenerator {
 
         delta = current - last;
         if (delta < -10000 * 20000) {
-          logger.info("Clock skew of {} ms detected", delta / -10000);
+          log.info("Clock skew of {} ms detected", delta / -10000);
           // The clock was adjusted back about 2 seconds, or we were generating a lot of ids too fast
           // if so, we try to set the current as last and also increment the clockSeq.
           lock.lock();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchedPstmt.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchedPstmt.java
@@ -1,9 +1,8 @@
 package io.ebeaninternal.server.persist;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiProfileTransactionEvent;
 import io.ebeaninternal.api.SpiTransaction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,8 +20,6 @@ import java.util.List;
  * </p>
  */
 public final class BatchedPstmt implements SpiProfileTransactionEvent {
-
-  private static final Logger log = LoggerFactory.getLogger(BatchedPstmt.class);
 
   /**
    * The underlying statement.
@@ -144,7 +141,7 @@ public final class BatchedPstmt implements SpiProfileTransactionEvent {
       try {
         pstmt.close();
       } catch (SQLException e) {
-        log.warn("Error closing statement", e);
+        CoreLog.log.warn("BatchedPstmt Error closing statement", e);
       } finally {
         pstmt = null;
       }
@@ -208,7 +205,7 @@ public final class BatchedPstmt implements SpiProfileTransactionEvent {
         try {
           inputStream.close();
         } catch (IOException e) {
-          log.warn("Error closing inputStream ", e);
+          CoreLog.log.warn("BatchedPstmt Error closing inputStream ", e);
         }
       }
       inputStreams = null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/Binder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/Binder.java
@@ -4,27 +4,16 @@ import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.ScalarType;
 import io.ebeaninternal.api.BindParams;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiLogManager;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
 import io.ebeaninternal.server.expression.platform.DbExpressionHandler;
 import io.ebeaninternal.server.persist.platform.MultiValueBind;
-import io.ebeaninternal.server.type.DataBind;
-import io.ebeaninternal.server.type.GeoTypeBinder;
-import io.ebeaninternal.server.type.PostgresHelper;
-import io.ebeaninternal.server.type.RsetDataReader;
-import io.ebeaninternal.server.type.TypeManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.ebeaninternal.server.type.*;
 
 import javax.persistence.PersistenceException;
 import java.math.BigDecimal;
-import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.util.ArrayList;
+import java.sql.*;
 import java.util.Collection;
 import java.util.List;
 
@@ -32,8 +21,6 @@ import java.util.List;
  * Binds bean values to a PreparedStatement.
  */
 public final class Binder {
-
-  private static final Logger logger = LoggerFactory.getLogger(Binder.class);
 
   private final TypeManager typeManager;
   private final int asOfBindCount;
@@ -141,7 +128,7 @@ public final class Binder {
       }
 
     } catch (SQLException ex) {
-      logger.warn("error binding parameter [{}][{}]", (dataBind.currentPos() - 1), value);
+      CoreLog.log.warn("error binding parameter [{}][{}]", (dataBind.currentPos() - 1), value);
       throw ex;
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -12,10 +12,7 @@ import io.ebean.bean.EntityBean;
 import io.ebean.bean.PersistenceContext;
 import io.ebean.event.BeanPersistController;
 import io.ebean.meta.MetricVisitor;
-import io.ebeaninternal.api.SpiEbeanServer;
-import io.ebeaninternal.api.SpiSqlUpdate;
-import io.ebeaninternal.api.SpiTransaction;
-import io.ebeaninternal.api.SpiUpdate;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.server.core.PersistRequest;
 import io.ebeaninternal.server.core.PersistRequest.Type;
 import io.ebeaninternal.server.core.PersistRequestBean;
@@ -58,8 +55,7 @@ import java.util.Set;
 public final class DefaultPersister implements Persister {
 
   private static final Logger PUB = LoggerFactory.getLogger("io.ebean.PUB");
-
-  private static final Logger logger = LoggerFactory.getLogger(DefaultPersister.class);
+  private static final Logger log = CoreLog.internal;
 
   /**
    * Actually does the persisting work.
@@ -539,8 +535,8 @@ public final class DefaultPersister implements Persister {
       if (request.isDirty()) {
         request.executeOrQueue();
 
-      } else if (logger.isDebugEnabled()) {
-        logger.debug("Update skipped as bean is unchanged: {}", request.bean());
+      } else if (log.isDebugEnabled()) {
+        log.debug("Update skipped as bean is unchanged: {}", request.bean());
       }
 
       if (request.isPersistCascade()) {
@@ -587,16 +583,14 @@ public final class DefaultPersister implements Persister {
    * A common transaction is used across both requests.
    */
   private int deleteRequest(PersistRequestBean<?> req, PersistRequestBean<?> draftReq) {
-
     if (req.isRegisteredForDeleteBean()) {
       // skip deleting bean. Used where cascade is on
       // both sides of a relationship
-      if (logger.isDebugEnabled()) {
-        logger.debug("skipping delete on alreadyRegistered " + req.bean());
+      if (log.isDebugEnabled()) {
+        log.debug("skipping delete on alreadyRegistered {}", req.bean());
       }
       return 0;
     }
-
     try {
       req.initTransIfRequiredWithBatchCascade();
       int rows = delete(req);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBase.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBase.java
@@ -2,12 +2,11 @@ package io.ebeaninternal.server.persist;
 
 import io.ebean.bean.BeanCollection;
 import io.ebean.bean.EntityBean;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.server.core.PersistRequestBean;
 import io.ebeaninternal.server.deploy.BeanPropertyAssocMany;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -15,8 +14,6 @@ import java.io.IOException;
  * Base for saving entity bean collections and element collections.
  */
 abstract class SaveManyBase implements SaveMany {
-
-  private static final Logger log = LoggerFactory.getLogger(SaveManyBase.class);
 
   final DefaultPersister persister;
   final PersistRequestBean<?> request;
@@ -74,7 +71,7 @@ abstract class SaveManyBase implements SaveMany {
           String asJson = many.jsonWriteCollection(value);
           request.addCollectionChange(many.name(), asJson);
         } catch (IOException e) {
-          log.error("Error build element collection entry for L2 cache", e);
+          CoreLog.log.error("Error build element collection entry for L2 cache", e);
         }
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -3,6 +3,7 @@ package io.ebeaninternal.server.persist;
 import io.ebean.bean.BeanCollection;
 import io.ebean.bean.EntityBean;
 import io.ebean.bean.EntityBeanIntercept;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiSqlUpdate;
 import io.ebeaninternal.server.core.PersistRequestBean;
 import io.ebeaninternal.server.deploy.BeanCollectionUtil;
@@ -10,8 +11,6 @@ import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanProperty;
 import io.ebeaninternal.server.deploy.BeanPropertyAssocMany;
 import io.ebeaninternal.server.deploy.IntersectionRow;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.util.ArrayList;
@@ -26,8 +25,6 @@ import static io.ebeaninternal.server.persist.DmlUtil.isNullOrZero;
  * Saves the details for a OneToMany or ManyToMany relationship (entity beans).
  */
 public final class SaveManyBeans extends SaveManyBase {
-
-  private static final Logger log = LoggerFactory.getLogger(SaveManyBeans.class);
 
   private final boolean cascade;
   private final boolean publish;
@@ -317,7 +314,7 @@ public final class SaveManyBeans extends SaveManyBase {
           if (transaction.isLogSummary()) {
             transaction.logSummary(m);
           }
-          log.warn(m);
+          CoreLog.log.warn(m);
         } else {
           if (!many.hasImportedId(otherBean)) {
             throw new PersistenceException("ManyToMany bean " + otherBean + " does not have an Id value.");

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
@@ -1,15 +1,14 @@
 package io.ebeaninternal.server.persist.dml;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.server.core.PersistRequestBean;
 import io.ebeaninternal.server.deploy.BeanProperty;
-import io.ebeaninternal.server.util.Str;
 import io.ebeaninternal.server.persist.BatchedPstmt;
 import io.ebeaninternal.server.persist.BatchedPstmtHolder;
 import io.ebeaninternal.server.persist.dmlbind.BindableRequest;
 import io.ebeaninternal.server.type.DataBind;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.ebeaninternal.server.util.Str;
 
 import javax.persistence.OptimisticLockException;
 import java.sql.Connection;
@@ -20,8 +19,6 @@ import java.sql.SQLException;
  * Base class for Handler implementations.
  */
 public abstract class DmlHandler implements PersistHandler, BindableRequest {
-
-  private static final Logger logger = LoggerFactory.getLogger(DmlHandler.class);
 
   private static final int[] GENERATED_KEY_COLUMNS = new int[]{1};
   private static final short BATCHED_FIRST = 1;
@@ -126,7 +123,7 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
         dataBind.close();
       }
     } catch (SQLException ex) {
-      logger.error(null, ex);
+      CoreLog.log.error(null, ex);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQuery.java
@@ -7,6 +7,7 @@ import io.ebean.bean.*;
 import io.ebean.core.type.DataReader;
 import io.ebean.event.readaudit.ReadEvent;
 import io.ebean.util.JdbcClose;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiProfileTransactionEvent;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.api.SpiQuery.Mode;
@@ -15,8 +16,6 @@ import io.ebeaninternal.server.autotune.ProfilingListener;
 import io.ebeaninternal.server.core.OrmQueryRequest;
 import io.ebeaninternal.server.core.SpiOrmQueryRequest;
 import io.ebeaninternal.server.deploy.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.lang.ref.WeakReference;
@@ -38,8 +37,6 @@ import java.util.concurrent.locks.ReentrantLock;
  * the key object used in reading the flat resultSet back into Objects.
  */
 public final class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfileTransactionEvent {
-
-  private static final Logger logger = LoggerFactory.getLogger(CQuery.class);
 
   private static final CQueryCollectionAddNoop NOOP_ADD = new CQueryCollectionAddNoop();
 
@@ -351,7 +348,7 @@ public final class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfi
         auditIterateLogMessage();
       }
     } catch (Throwable e) {
-      logger.error("Error logging read audit logs", e);
+      CoreLog.log.error("Error logging read audit logs", e);
     }
     try {
       if (dataReader != null) {
@@ -359,7 +356,7 @@ public final class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfi
         dataReader = null;
       }
     } catch (SQLException e) {
-      logger.error("Error closing dataReader", e);
+      CoreLog.log.error("Error closing dataReader", e);
     }
     JdbcClose.close(pstmt);
     pstmt = null;
@@ -556,7 +553,7 @@ public final class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfi
       }
       getTransaction().profileEvent(this);
     } catch (Exception e) {
-      logger.error("Error updating execution statistics", e);
+      CoreLog.log.error("Error updating execution statistics", e);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -10,6 +10,7 @@ import io.ebean.config.DatabaseConfig;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.util.JdbcClose;
 import io.ebean.util.StringHelper;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.server.core.DiffHelp;
@@ -19,7 +20,6 @@ import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.util.Str;
 import io.ebeaninternal.server.persist.Binder;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.sql.ResultSet;
@@ -35,7 +35,7 @@ import java.util.Map;
  */
 public final class CQueryEngine {
 
-  private static final Logger logger = LoggerFactory.getLogger(CQueryEngine.class);
+  private static final Logger log = CoreLog.log;
 
   private static final String T0 = "t0";
 
@@ -191,7 +191,7 @@ public final class CQueryEngine {
       }
       if (!cquery.prepareBindExecuteQueryForwardOnly(forwardOnlyHintOnFindIterate)) {
         // query has been cancelled already
-        logger.trace("Future fetch already cancelled");
+        log.trace("Future fetch already cancelled");
         return null;
       }
       if (request.logSql()) {
@@ -347,7 +347,7 @@ public final class CQueryEngine {
       }
       if (!cquery.prepareBindExecuteQuery()) {
         // query has been cancelled already
-        logger.trace("Future fetch already cancelled");
+        log.trace("Future fetch already cancelled");
         return null;
       }
       if (request.logSql()) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryFetchSingleAttribute.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryFetchSingleAttribute.java
@@ -4,14 +4,13 @@ import io.ebean.CancelableQuery;
 import io.ebean.CountedValue;
 import io.ebean.core.type.ScalarDataReader;
 import io.ebean.util.JdbcClose;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiProfileTransactionEvent;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.server.core.OrmQueryRequest;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.type.RsetDataReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -25,8 +24,6 @@ import java.util.concurrent.locks.ReentrantLock;
  * Base compiled query request for single attribute queries.
  */
 final class CQueryFetchSingleAttribute implements SpiProfileTransactionEvent, CancelableQuery {
-
-  private static final Logger logger = LoggerFactory.getLogger(CQueryFetchSingleAttribute.class);
 
   private final CQueryPlan queryPlan;
   private final OrmQueryRequest<?> request;
@@ -158,7 +155,7 @@ final class CQueryFetchSingleAttribute implements SpiProfileTransactionEvent, Ca
         dataReader = null;
       }
     } catch (SQLException e) {
-      logger.error("Error closing DataReader", e);
+      CoreLog.log.error("Error closing DataReader", e);
     }
     JdbcClose.close(pstmt);
     pstmt = null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
@@ -6,21 +6,15 @@ import io.ebean.core.type.DataReader;
 import io.ebean.core.type.ScalarDataReader;
 import io.ebean.metric.MetricFactory;
 import io.ebean.metric.TimedMetric;
-import io.ebeaninternal.api.CQueryPlanKey;
-import io.ebeaninternal.api.SpiEbeanServer;
-import io.ebeaninternal.api.SpiQuery;
-import io.ebeaninternal.api.SpiQueryBindCapture;
-import io.ebeaninternal.api.SpiQueryPlan;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.server.core.OrmQueryRequest;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
-import io.ebeaninternal.server.util.Md5;
-import io.ebeaninternal.server.util.Str;
 import io.ebeaninternal.server.query.CQueryPlanStats.Snapshot;
 import io.ebeaninternal.server.type.DataBind;
 import io.ebeaninternal.server.type.DataBindCapture;
 import io.ebeaninternal.server.type.RsetDataReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.ebeaninternal.server.util.Md5;
+import io.ebeaninternal.server.util.Str;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -48,8 +42,6 @@ import java.util.Set;
  * </p>
  */
 public class CQueryPlan implements SpiQueryPlan {
-
-  private static final Logger logger = LoggerFactory.getLogger(CQueryPlan.class);
 
   static final String RESULT_SET_BASED_RAW_SQL = "--ResultSetBasedRawSql";
 
@@ -320,7 +312,7 @@ public class CQueryPlan implements SpiQueryPlan {
       predicates.bind(capture);
       bindCapture.setBind(capture.bindCapture(), executionTimeMicros, startNanos);
     } catch (SQLException e) {
-      logger.error("Error capturing bind values", e);
+      CoreLog.log.error("Error capturing bind values", e);
     }
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlanManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlanManager.java
@@ -3,15 +3,9 @@ package io.ebeaninternal.server.query;
 import io.ebean.meta.MetaQueryPlan;
 import io.ebean.meta.QueryPlanRequest;
 import io.ebean.metric.TimedMetric;
-import io.ebeaninternal.api.ExtraMetrics;
-import io.ebeaninternal.api.QueryPlanManager;
-import io.ebeaninternal.api.SpiDbQueryPlan;
-import io.ebeaninternal.api.SpiQueryBindCapture;
-import io.ebeaninternal.api.SpiQueryPlan;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.server.transaction.TransactionManager;
 import io.ebeaninternal.server.type.bindcapture.BindCapture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -22,20 +16,13 @@ import static java.util.Collections.emptyList;
 
 public final class CQueryPlanManager implements QueryPlanManager {
 
-  private static final Logger log = LoggerFactory.getLogger(CQueryPlanManager.class);
-
   private static final Object dummy = new Object();
 
   private final ConcurrentHashMap<CQueryBindCapture, Object> plans = new ConcurrentHashMap<>();
-
   private final TransactionManager transactionManager;
-
   private final QueryPlanLogger planLogger;
-
   private final TimedMetric timeCollection;
-
   private final TimedMetric timeBindCapture;
-
   private long defaultThreshold;
 
   public CQueryPlanManager(TransactionManager transactionManager, long defaultThreshold, QueryPlanLogger planLogger, ExtraMetrics extraMetrics) {
@@ -77,7 +64,7 @@ public final class CQueryPlanManager implements QueryPlanManager {
       }
       return req.getPlans();
     } catch (SQLException e) {
-      log.error("Error during query plan collection", e);
+      CoreLog.log.error("Error during query plan collection", e);
       return emptyList();
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPredicates.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPredicates.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.query;
 
 import io.ebean.OrderBy;
 import io.ebeaninternal.api.BindParams;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiExpressionList;
 import io.ebeaninternal.api.SpiQuery;
 import io.ebeaninternal.server.core.OrmQueryRequest;
@@ -15,8 +16,6 @@ import io.ebeaninternal.server.querydefn.OrmUpdateProperties;
 import io.ebeaninternal.server.rawsql.SpiRawSql;
 import io.ebeaninternal.server.type.DataBind;
 import io.ebeaninternal.server.util.BindParamsParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -39,8 +38,6 @@ import java.util.Set;
  * </p>
  */
 public final class CQueryPredicates {
-
-  private static final Logger logger = LoggerFactory.getLogger(CQueryPredicates.class);
 
   private final Binder binder;
   private final OrmQueryRequest<?> request;
@@ -375,7 +372,7 @@ public final class CQueryPredicates {
         msg += " must come before the many property [" + manyProp.name() + "] in the orderBy.";
         msg += " Ebean has automatically modified the orderBy clause to do this.";
 
-        logger.warn(msg);
+        CoreLog.log.warn(msg);
       }
 
       // the id needs to come before the manyPropName

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLogger.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLogger.java
@@ -3,16 +3,12 @@ package io.ebeaninternal.server.query;
 import io.ebeaninternal.api.SpiDbQueryPlan;
 import io.ebeaninternal.api.SpiQueryPlan;
 import io.ebeaninternal.server.type.bindcapture.BindCapture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public abstract class QueryPlanLogger {
-
-  static final Logger queryPlanLog = LoggerFactory.getLogger(QueryPlanLogger.class);
 
   abstract SpiDbQueryPlan collectPlan(Connection conn, SpiQueryPlan plan, BindCapture bind);
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerExplain.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerExplain.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.query;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiDbQueryPlan;
 import io.ebeaninternal.api.SpiQueryPlan;
 import io.ebeaninternal.server.type.bindcapture.BindCapture;
@@ -22,7 +23,7 @@ public final class QueryPlanLoggerExplain extends QueryPlanLogger {
         return readQueryPlan(plan, bind, rset);
       }
     } catch (SQLException e) {
-      queryPlanLog.error("Could not log query plan", e);
+      CoreLog.log.warn("Could not log query plan", e);
       return null;
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerOracle.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerOracle.java
@@ -1,6 +1,7 @@
 
 package io.ebeaninternal.server.query;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiDbQueryPlan;
 import io.ebeaninternal.api.SpiQueryPlan;
 import io.ebeaninternal.server.type.bindcapture.BindCapture;
@@ -29,7 +30,7 @@ public final class QueryPlanLoggerOracle extends QueryPlanLogger {
         return readQueryPlan(plan, bind, rset);
       }
     } catch (SQLException e) {
-      queryPlanLog.error("Could not log query plan", e);
+      CoreLog.log.warn("Could not log query plan", e);
       return null;
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerPostgres.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerPostgres.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.query;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiDbQueryPlan;
 import io.ebeaninternal.api.SpiQueryPlan;
 import io.ebeaninternal.server.type.bindcapture.BindCapture;
@@ -23,7 +24,7 @@ public final class QueryPlanLoggerPostgres extends QueryPlanLogger {
         return readQueryPlanBasic(plan, bind, rset);
       }
     } catch (SQLException e) {
-      queryPlanLog.error("Could not log query plan: " + explain, e);
+      CoreLog.log.warn("Could not log query plan: " + explain, e);
       return null;
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerSqlServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryPlanLoggerSqlServer.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.query;
 
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiDbQueryPlan;
 import io.ebeaninternal.api.SpiQueryPlan;
 import io.ebeaninternal.server.type.bindcapture.BindCapture;
@@ -41,13 +42,13 @@ public final class QueryPlanLoggerSqlServer extends QueryPlanLogger {
         return createPlan(plan, bind.toString(), xml);
 
       } catch (SQLException e) {
-        queryPlanLog.error("Could not log query plan", e);
+        CoreLog.log.warn("Could not log query plan", e);
         return null;
       } finally {
         stmt.execute("set statistics xml off");
       }
     } catch (SQLException e) {
-      queryPlanLog.error("Could not log query plan", e);
+      CoreLog.log.warn("Could not log query plan", e);
       return null;
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.query;
 
 import io.ebean.util.SplitName;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.ManyWhereJoins;
 import io.ebeaninternal.api.PropertyJoin;
 import io.ebeaninternal.api.SpiQuery;
@@ -10,9 +11,7 @@ import io.ebeaninternal.server.deploy.InheritInfo;
 import io.ebeaninternal.server.deploy.TableJoin;
 import io.ebeaninternal.server.querydefn.OrmQueryDetail;
 import io.ebeaninternal.server.querydefn.OrmQueryProperties;
-import io.ebeaninternal.server.rawsql.SpiRawSql;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +27,7 @@ import java.util.Set;
  */
 public final class SqlTreeBuilder {
 
-  private static final Logger logger = LoggerFactory.getLogger(SqlTreeBuilder.class);
+  private static final Logger log = CoreLog.internal;
 
   private final SpiQuery<?> query;
   private final STreeType desc;
@@ -384,7 +383,7 @@ public final class SqlTreeBuilder {
   private void addPropertyToSubQuery(SqlTreeProperties selectProps, STreeType desc, String propName, String path) {
     STreeProperty p = desc.findPropertyWithDynamic(propName, path);
     if (p == null) {
-      logger.error("property [" + propName + "]not found on " + desc + " for query - excluding it.");
+      log.error("property [" + propName + "]not found on " + desc + " for query - excluding it.");
       return;
     } else if (p instanceof STreePropertyAssoc && p.isEmbedded()) {
       // if the property is embedded we need to lookup the real column name
@@ -419,13 +418,13 @@ public final class SqlTreeBuilder {
           if (p != null) {
             selectProps.add(p);
           } else {
-            logger.error("property [" + propName + "] not found on " + desc + " for query - excluding it.");
+            log.error("property [" + propName + "] not found on " + desc + " for query - excluding it.");
           }
         } else if (p.isEmbedded() || (p instanceof STreePropertyAssoc && !queryProps.isIncludedBeanJoin(p.name()))) {
           // add the embedded bean or the *ToOne assoc bean.  We skip the check that the *ToOne propName maps to Id property ...
           selectProps.add(p);
         } else {
-          logger.error("property [" + p.fullName() + "] expected to be an embedded or *ToOne bean for query - excluding it.");
+          log.error("property [" + p.fullName() + "] expected to be an embedded or *ToOne bean for query - excluding it.");
         }
       }
 
@@ -434,7 +433,7 @@ public final class SqlTreeBuilder {
       // sub class hierarchy if required
       STreeProperty p = desc.findPropertyWithDynamic(propName, queryProps.getPath());
       if (p == null) {
-        logger.error("property [" + propName + "] not found on " + desc + " for query - excluding it.");
+        log.error("property [" + propName + "] not found on " + desc + " for query - excluding it.");
         p = desc.findProperty("id");
         selectProps.add(p);
 
@@ -534,8 +533,8 @@ public final class SqlTreeBuilder {
     if (queryDetail.includesPath(propName)) {
       if (manyProperty != null) {
         // only one many associated allowed to be included in fetch
-        if (logger.isDebugEnabled()) {
-          logger.debug("Not joining [" + propName + "] as already joined to a Many[" + manyProperty + "].");
+        if (log.isDebugEnabled()) {
+          log.debug("Not joining [" + propName + "] as already joined to a Many[" + manyProperty + "].");
         }
         return false;
       }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/readaudit/DefaultReadAuditLogger.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/readaudit/DefaultReadAuditLogger.java
@@ -6,6 +6,7 @@ import io.ebean.event.readaudit.ReadEvent;
 import io.ebean.text.json.EJson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import io.ebeaninternal.api.CoreLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +19,6 @@ import java.util.Map;
  */
 public class DefaultReadAuditLogger implements ReadAuditLogger {
 
-  private static final Logger appLogger = LoggerFactory.getLogger(DefaultReadAuditLogger.class);
   private static final Logger queryLogger = LoggerFactory.getLogger("io.ebean.ReadAuditQuery");
   private static final Logger auditLogger = LoggerFactory.getLogger("io.ebean.ReadAudit");
 
@@ -50,7 +50,7 @@ public class DefaultReadAuditLogger implements ReadAuditLogger {
       gen.flush();
       queryLogger.info(writer.toString());
     } catch (IOException e) {
-      appLogger.error("Error writing Read audit event", e);
+      CoreLog.log.error("Error writing Read audit event", e);
     }
   }
 
@@ -77,7 +77,7 @@ public class DefaultReadAuditLogger implements ReadAuditLogger {
       writeDetails(gen, event);
       auditLogger.info(writer.toString());
     } catch (IOException e) {
-      appLogger.error("Error writing Read audit event", e);
+      CoreLog.log.error("Error writing Read audit event", e);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -10,8 +10,6 @@ import io.ebeaninternal.server.core.PersistDeferredRelationship;
 import io.ebeaninternal.server.core.PersistRequestBean;
 import io.ebeaninternal.server.persist.BatchControl;
 import io.ebeanservice.docstore.api.DocStoreTransaction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.sql.Connection;
@@ -29,14 +27,10 @@ import java.util.Map;
  */
 final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEventCodes {
 
-  private static final Logger logger = LoggerFactory.getLogger(ImplicitReadOnlyTransaction.class);
-
   private static final String illegalStateMessage = "Transaction is Inactive";
-
   private static final String notExpectedMessage = "Not expected on read only transaction";
 
   private final TransactionManager manager;
-
   private final boolean logSql;
   private final boolean logSummary;
 
@@ -55,13 +49,9 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    * Holder of the objects fetched to ensure unique objects are used.
    */
   private SpiPersistenceContext persistenceContext;
-
   private Object tenantId;
-
   private Map<String, Object> userObjects;
-
   private final long startNanos;
-
   private ProfileLocation profileLocation;
 
   /**
@@ -501,7 +491,7 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
     } catch (Exception ex) {
       // the connection pool will automatically remove the
       // connection if it does not pass the test
-      logger.error("Error closing connection", ex);
+      CoreLog.log.error("Error closing connection", ex);
     }
     connection = null;
     active = false;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -29,10 +29,8 @@ import java.util.function.Consumer;
  */
 class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
 
-  private static final Logger logger = LoggerFactory.getLogger(JdbcTransaction.class);
-
+  private static final Logger log = CoreLog.log;
   private static final Object PLACEHOLDER = new Object();
-
   private static final String illegalStateMessage = "Transaction is Inactive";
 
   /**
@@ -359,7 +357,7 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
         try {
           consumer.accept(callbackList.get(i));
         } catch (Exception e) {
-          logger.error("Error executing transaction callback", e);
+          log.error("Error executing transaction callback", e);
         }
       }
     }
@@ -892,7 +890,7 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
         connection.setReadOnly(false);
       }
     } catch (SQLException e) {
-      logger.error("Error setting to readOnly?", e);
+      log.error("Error setting to readOnly?", e);
     }
     try {
       if (autoCommit) {
@@ -900,14 +898,14 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
         connection.setAutoCommit(true);
       }
     } catch (SQLException e) {
-      logger.error("Error setting to readOnly?", e);
+      log.error("Error setting to readOnly?", e);
     }
     try {
       connection.close();
     } catch (Exception ex) {
       // the connection pool will automatically remove the
       // connection if it does not pass the test
-      logger.error("Error closing connection", ex);
+      log.error("Error closing connection", ex);
     }
     connection = null;
     active = false;
@@ -940,7 +938,7 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
       }
       withEachCallback(TransactionCallback::postCommit);
     } catch (SQLException e) {
-      logger.error("Error when ending a query only transaction via " + onQueryOnly, e);
+      log.error("Error when ending a query only transaction via " + onQueryOnly, e);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
@@ -2,9 +2,9 @@ package io.ebeaninternal.server.transaction;
 
 import io.ebean.config.ExternalTransactionManager;
 import io.ebean.util.JdbcClose;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiTransaction;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -20,15 +20,10 @@ import javax.transaction.UserTransaction;
  */
 public final class JtaTransactionManager implements ExternalTransactionManager {
 
-  private static final Logger logger = LoggerFactory.getLogger(JtaTransactionManager.class);
-
+  private static final Logger log = CoreLog.internal;
   private static final String EBEAN_TXN_RESOURCE = "EBEAN_TXN_RESOURCE";
 
-  /**
-   * The Ebean transaction manager.
-   */
   private TransactionManager transactionManager;
-
   private TransactionScopeManager scope;
 
   /**
@@ -97,16 +92,15 @@ public final class JtaTransactionManager implements ExternalTransactionManager {
     SpiTransaction currentEbeanTransaction = scope.inScope();
     if (currentEbeanTransaction != null) {
       // NOT expecting this so log WARNING
-      String msg = "JTA Transaction - no current txn BUT using current Ebean one " + currentEbeanTransaction.getId();
-      logger.warn(msg);
+      log.warn("JTA Transaction - no current txn BUT using current Ebean one {}", currentEbeanTransaction.getId());
       return currentEbeanTransaction;
     }
 
     UserTransaction ut = getUserTransaction();
     if (ut == null) {
       // no current JTA transaction
-      if (logger.isDebugEnabled()) {
-        logger.debug("JTA Transaction - no current txn");
+      if (log.isDebugEnabled()) {
+        log.debug("JTA Transaction - no current txn");
       }
       return null;
     }
@@ -197,8 +191,8 @@ public final class JtaTransactionManager implements ExternalTransactionManager {
     public void afterCompletion(int status) {
       switch (status) {
         case Status.STATUS_COMMITTED:
-          if (logger.isDebugEnabled()) {
-            logger.debug("Jta Txn [" + transaction.getId() + "] committed");
+          if (log.isDebugEnabled()) {
+            log.debug("Jta Txn [" + transaction.getId() + "] committed");
           }
           transaction.postCommit();
           // Remove this transaction object as it is completed
@@ -206,8 +200,8 @@ public final class JtaTransactionManager implements ExternalTransactionManager {
           break;
 
         case Status.STATUS_ROLLEDBACK:
-          if (logger.isDebugEnabled()) {
-            logger.debug("Jta Txn [" + transaction.getId() + "] rollback");
+          if (log.isDebugEnabled()) {
+            log.debug("Jta Txn [" + transaction.getId() + "] rollback");
           }
           transaction.postRollback(null);
           // Remove this transaction object as it is completed
@@ -215,8 +209,8 @@ public final class JtaTransactionManager implements ExternalTransactionManager {
           break;
 
         default:
-          if (logger.isDebugEnabled()) {
-            logger.debug("Jta Txn [" + transaction.getId() + "] status:" + status);
+          if (log.isDebugEnabled()) {
+            log.debug("Jta Txn [" + transaction.getId() + "] status:" + status);
           }
       }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class TransactionManager implements SpiTransactionManager {
 
-  private static final Logger logger = LoggerFactory.getLogger(TransactionManager.class);
+  private static final Logger log = CoreLog.log;
   private static final Logger clusterLogger = LoggerFactory.getLogger("io.ebean.Cluster");
 
   private final SpiServer server;
@@ -365,7 +365,7 @@ public class TransactionManager implements SpiTransactionManager {
         txnLogger.debug(msg);
       }
     } catch (Exception ex) {
-      logger.error("Error while notifying TransactionEventListener of rollback event", ex);
+      log.error("Error while notifying TransactionEventListener of rollback event", ex);
     }
   }
 
@@ -416,7 +416,7 @@ public class TransactionManager implements SpiTransactionManager {
       postCommit.notifyLocalCache();
       backgroundExecutor.execute(postCommit.backgroundNotify());
     } catch (Exception ex) {
-      logger.error("NotifyOfCommit failed. L2 Cache potentially not notified.", ex);
+      log.error("NotifyOfCommit failed. L2 Cache potentially not notified.", ex);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
@@ -1,9 +1,8 @@
 package io.ebeaninternal.server.type;
 
 import io.ebean.core.type.DataBinder;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,8 +21,6 @@ import java.util.Calendar;
 import java.util.List;
 
 public class DataBind implements DataBinder {
-
-  private static final Logger log = LoggerFactory.getLogger(DataBind.class);
 
   private final DataTimeZone dataTimeZone;
   private final PreparedStatement pstmt;
@@ -112,7 +109,7 @@ public class DataBind implements DataBinder {
         try {
           inputStream.close();
         } catch (IOException e) {
-          log.warn("Error closing InputStream that was bound to PreparedStatement", e);
+          CoreLog.log.warn("Error closing InputStream that was bound to PreparedStatement", e);
         }
       }
       inputStreams = null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -15,6 +15,7 @@ import io.ebean.core.type.ScalarType;
 import io.ebean.types.Cidr;
 import io.ebean.types.Inet;
 import io.ebean.util.AnnotationUtil;
+import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.DbOffline;
 import io.ebeaninternal.api.GeoTypeProvider;
 import io.ebeaninternal.server.core.ServiceUtil;
@@ -25,7 +26,6 @@ import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.joda.time.LocalTime;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.EnumType;
@@ -52,7 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class DefaultTypeManager implements TypeManager {
 
-  private static final Logger logger = LoggerFactory.getLogger(DefaultTypeManager.class);
+  private static final Logger log = CoreLog.internal;
 
   private final ConcurrentHashMap<Class<?>, ScalarType<?>> typeMap;
   private final ConcurrentHashMap<Integer, ScalarType<?>> nativeMap;
@@ -192,7 +192,7 @@ public final class DefaultTypeManager implements TypeManager {
       ExtraTypeFactory plugin = iterator.next();
       List<? extends ScalarType<?>> types = plugin.createTypes(config, objectMapper);
       for (ScalarType<?> type : types) {
-        logger.debug("adding ScalarType {}", type.getClass());
+        log.debug("adding ScalarType {}", type.getClass());
         addCustomType(type);
       }
     }
@@ -231,10 +231,10 @@ public final class DefaultTypeManager implements TypeManager {
   }
 
   private void logAdd(ScalarType<?> scalarType) {
-    if (logger.isTraceEnabled()) {
+    if (log.isTraceEnabled()) {
       String msg = "ScalarType register [" + scalarType.getClass().getName() + "]";
       msg += " for [" + scalarType.getType().getName() + "]";
-      logger.trace(msg);
+      log.trace(msg);
     }
   }
 
@@ -647,7 +647,7 @@ public final class DefaultTypeManager implements TypeManager {
         }
         addCustomType(scalarType);
       } catch (Exception e) {
-        logger.error("Error loading ScalarType [" + cls.getName() + "]", e);
+        log.error("Error loading ScalarType [" + cls.getName() + "]", e);
       }
     }
   }
@@ -681,10 +681,10 @@ public final class DefaultTypeManager implements TypeManager {
         }
         ScalarTypeConverter converter = foundType.getDeclaredConstructor().newInstance();
         ScalarTypeWrapper stw = new ScalarTypeWrapper(logicalType, wrappedType, converter);
-        logger.debug("Register ScalarTypeWrapper from {} -> {} using:{}", logicalType, persistType, foundType);
+        log.debug("Register ScalarTypeWrapper from {} -> {} using:{}", logicalType, persistType, foundType);
         add(stw);
       } catch (Exception e) {
-        logger.error("Error registering ScalarTypeConverter [" + foundType.getName() + "]", e);
+        log.error("Error registering ScalarTypeConverter [" + foundType.getName() + "]", e);
       }
     }
   }
@@ -705,10 +705,10 @@ public final class DefaultTypeManager implements TypeManager {
         }
         AttributeConverter converter = foundType.getDeclaredConstructor().newInstance();
         ScalarTypeWrapper stw = new ScalarTypeWrapper(logicalType, wrappedType, new AttributeConverterAdapter(converter));
-        logger.debug("Register ScalarTypeWrapper from {} -> {} using:{}", logicalType, persistType, foundType);
+        log.debug("Register ScalarTypeWrapper from {} -> {} using:{}", logicalType, persistType, foundType);
         add(stw);
       } catch (Exception e) {
-        logger.error("Error registering AttributeConverter [" + foundType.getName() + "]", e);
+        log.error("Error registering AttributeConverter [" + foundType.getName() + "]", e);
       }
     }
   }
@@ -718,7 +718,7 @@ public final class DefaultTypeManager implements TypeManager {
    */
   private void initialiseJacksonTypes(DatabaseConfig config) {
     if (objectMapper != null) {
-      logger.trace("Registering JsonNode type support");
+      log.trace("Registering JsonNode type support");
       ObjectMapper mapper = (ObjectMapper) objectMapper;
       jsonNodeClob = new ScalarTypeJsonNode.Clob(mapper);
       jsonNodeBlob = new ScalarTypeJsonNode.Blob(mapper);
@@ -777,7 +777,7 @@ public final class DefaultTypeManager implements TypeManager {
     // detect if Joda classes are in the classpath
     if (config.getClassLoadConfig().isJodaTimePresent()) {
       // Joda classes are in the classpath so register the types
-      logger.debug("Registering Joda data types");
+      log.debug("Registering Joda data types");
       addType(LocalDateTime.class, new ScalarTypeJodaLocalDateTime(jsonDateTime));
       addType(DateTime.class, new ScalarTypeJodaDateTime(jsonDateTime));
       addType(LocalDate.class, new ScalarTypeJodaLocalDate(jsonDate));
@@ -788,11 +788,11 @@ public final class DefaultTypeManager implements TypeManager {
       if ("normal".equalsIgnoreCase(jodaLocalTimeMode)) {
         // use the expected/normal local time zone
         addType(LocalTime.class, new ScalarTypeJodaLocalTime());
-        logger.debug("registered ScalarTypeJodaLocalTime");
+        log.debug("registered ScalarTypeJodaLocalTime");
       } else if ("utc".equalsIgnoreCase(jodaLocalTimeMode)) {
         // use the old UTC based
         addType(LocalTime.class, new ScalarTypeJodaLocalTimeUTC());
-        logger.debug("registered ScalarTypeJodaLocalTimeUTC");
+        log.debug("registered ScalarTypeJodaLocalTimeUTC");
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeFile.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeFile.java
@@ -6,19 +6,9 @@ import io.ebean.core.type.DataBinder;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.text.TextException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.ebeaninternal.api.CoreLog;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.sql.SQLException;
 import java.sql.Types;
 
@@ -26,8 +16,6 @@ import java.sql.Types;
  * ScalarType for streaming between a File and the database.
  */
 final class ScalarTypeFile extends ScalarTypeBase<File> {
-
-  private static final Logger logger = LoggerFactory.getLogger(ScalarTypeFile.class);
 
   private final String prefix;
   private final String suffix;
@@ -191,14 +179,14 @@ final class ScalarTypeFile extends ScalarTypeBase<File> {
         try {
           output.close();
         } catch (IOException e) {
-          logger.error("Error when closing outputstream", e);
+          CoreLog.log.error("Error when closing outputstream", e);
         }
       }
       if (input != null) {
         try {
           input.close();
         } catch (IOException e) {
-          logger.error("Error when closing inputstream ", e);
+          CoreLog.log.error("Error when closing inputstream ", e);
         }
       }
     }

--- a/ebean-test/src/main/java/io/ebean/test/config/AutoConfigureForTesting.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/AutoConfigureForTesting.java
@@ -20,7 +20,7 @@ import java.util.Properties;
  */
 public class AutoConfigureForTesting implements AutoConfigure {
 
-  private static final Logger log = LoggerFactory.getLogger(AutoConfigureForTesting.class);
+  private static final Logger log = LoggerFactory.getLogger("io.ebean.test");
 
   /**
    * System property that can override the platform.  mvn clean test -Ddb=sqlserver

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
@@ -13,7 +13,7 @@ import java.util.Properties;
  */
 class Config {
 
-  private static final Logger log = LoggerFactory.getLogger(Config.class);
+  private static final Logger log = LoggerFactory.getLogger("io.ebean.test");
 
   /**
    * Common optional docker parameters that we just transfer to docker properties.

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
@@ -14,7 +14,7 @@ import static java.util.concurrent.CompletableFuture.runAsync;
 
 public class PlatformAutoConfig {
 
-  private static final Logger log = LoggerFactory.getLogger(PlatformAutoConfig.class);
+  private static final Logger log = LoggerFactory.getLogger("io.ebean.test");
 
   /**
    * Known platforms we can setup locally or via docker container.

--- a/ebean-test/src/main/java/io/ebean/test/config/provider/ProviderAutoConfig.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/provider/ProviderAutoConfig.java
@@ -14,7 +14,7 @@ import java.util.Properties;
  */
 public class ProviderAutoConfig {
 
-  private static final Logger log = LoggerFactory.getLogger(ProviderAutoConfig.class);
+  private static final Logger log = LoggerFactory.getLogger("io.ebean.test");
 
   private final DatabaseConfig config;
   private final Properties properties;
@@ -56,23 +56,29 @@ public class ProviderAutoConfig {
   String msg(int providerSetFlag) {
     String msg = msgProvider(providerSetFlag);
     String usage = msgUsage(providerSetFlag);
-    return "for testing purposes "+msg+" has been configured. Use io.ebean.test.UserContext to "+usage+" in tests.";
+    return "For testing purposes " + msg + " has been configured. Use io.ebean.test.UserContext to " + usage + " in tests.";
   }
 
   private String msgProvider(int providerSetFlag) {
     switch (providerSetFlag) {
-      case 1: return "a current user provider";
-      case 2: return "a current tenant provider";
-      case 3: return "a current user and tenant provider";
+      case 1:
+        return "a current user provider";
+      case 2:
+        return "a current tenant provider";
+      case 3:
+        return "a current user and tenant provider";
     }
     return "[unexpected??]";
   }
 
   private String msgUsage(int providerSetFlag) {
     switch (providerSetFlag) {
-      case 1: return "set current user";
-      case 2: return "set current tenant";
-      case 3: return "set current user and tenant";
+      case 1:
+        return "set current user";
+      case 2:
+        return "set current tenant";
+      case 3:
+        return "set current user and tenant";
     }
     return "[unexpected??]";
   }

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <module>ebean-querybean</module>
     <module>ebean-postgis</module>
     <module>ebean-redis</module>
-    <module>tests</module>
+<!--    <module>tests</module>-->
   </modules>
 
 </project>


### PR DESCRIPTION
Largely reduce the non-specific loggers to:
- `io.ebean`
- `io.ebean.core`
- `io.ebean.internal`
- `in.ebean.test`

If people find that the log messages are not even due to the non-specific loggers now used please let me know. This significantly reduces the number of different loggers that ebean uses internally.