### PR TITLE
Modify EbeanVersion to check for minimum ebean-agent version

### DIFF
--- a/ebean-api/src/main/java/io/ebean/EbeanVersion.java
+++ b/ebean-api/src/main/java/io/ebean/EbeanVersion.java
@@ -16,21 +16,71 @@ public class EbeanVersion {
 
   private static final Logger log = LoggerFactory.getLogger("io.ebean");
 
+  /**
+   * Maintain the minimum ebean-agent version manually based on required ebean-agent bug fixes.
+   */
+  private static final int MIN_AGENT_MAJOR_VERSION = 12;
+  private static final int MIN_AGENT_MINOR_VERSION = 12;
   private static String version = "unknown";
   static {
+    readVersion();
+    checkAgentVersion();
+  }
+
+  private static void readVersion() {
     try {
-      Properties prop = new Properties();
-      try (InputStream in = DB.class.getResourceAsStream("/META-INF/maven/io.ebean/ebean-api/pom.properties")) {
+      try (InputStream in = ClassLoader.getSystemResourceAsStream("META-INF/maven/io.ebean/ebean-api/pom.properties")) {
         if (in != null) {
-          prop.load(in);
-          in.close();
-          version = prop.getProperty("version");
+          version = readVersion(in);
         }
       }
       log.info("ebean version: {}", version);
     } catch (IOException e) {
       log.warn("Could not determine ebean version: {}", e.getMessage());
     }
+  }
+
+  private static void checkAgentVersion() {
+    try {
+      try (InputStream in = ClassLoader.getSystemResourceAsStream("META-INF/maven/io.ebean/ebean-agent/pom.properties")) {
+        // often we only have ebean-agent during development (with build time enhancement), null is expected
+        if (in != null) {
+          String agentVersion = readVersion(in);
+          if (agentVersion != null) {
+            if (checkMinAgentVersion(agentVersion)) {
+              log.error("Expected minimum ebean-agent version {}.{}.0 but we have {}, please update the ebean-agent", MIN_AGENT_MAJOR_VERSION, MIN_AGENT_MINOR_VERSION, agentVersion);
+            }
+          }
+        }
+      }
+    } catch (IOException e) {
+      log.warn("Could not check minimum ebean-agent version {}.{}.0 required due to - {}", MIN_AGENT_MAJOR_VERSION, MIN_AGENT_MINOR_VERSION, e.getMessage());
+    }
+  }
+
+  /**
+   * Return true if ebean-agent is NOT at our minimum version.
+   */
+  static boolean checkMinAgentVersion(String agentVersion) {
+    String[] versionSegments = agentVersion.split("\\.");
+    if (versionSegments.length != 3) {
+      return true;
+    } else {
+      int major = Integer.parseInt(versionSegments[0]);
+      int minor = Integer.parseInt(versionSegments[1]);
+      if (major < MIN_AGENT_MAJOR_VERSION) {
+        return true;
+      } else {
+        return major == MIN_AGENT_MAJOR_VERSION && minor < MIN_AGENT_MINOR_VERSION;
+      }
+    }
+  }
+
+  private static String readVersion(InputStream in) throws IOException {
+    Properties prop = new Properties();
+    prop.load(in);
+    in.close();
+    return prop.getProperty("version");
   }
 
   private EbeanVersion() {

--- a/ebean-api/src/test/java/io/ebean/EbeanVersionTest.java
+++ b/ebean-api/src/test/java/io/ebean/EbeanVersionTest.java
@@ -1,0 +1,31 @@
+package io.ebean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EbeanVersionTest {
+
+  @Test
+  void checkMinAgentVersion_ok() {
+    assertFalse(EbeanVersion.checkMinAgentVersion("12.12.0"));
+    assertFalse(EbeanVersion.checkMinAgentVersion("12.12.99"));
+    assertFalse(EbeanVersion.checkMinAgentVersion("13.1.0"));
+  }
+
+  @Test
+  void checkMinAgentVersion_agentTooOld() {
+    assertTrue(EbeanVersion.checkMinAgentVersion("11.13.0"));
+    assertTrue(EbeanVersion.checkMinAgentVersion("12.11.0"));
+    assertTrue(EbeanVersion.checkMinAgentVersion("12.11.99"));
+  }
+
+  @Test
+  void checkMinAgentVersion_unexpectedAgentVersion() {
+    assertTrue(EbeanVersion.checkMinAgentVersion("13.13"));
+    assertTrue(EbeanVersion.checkMinAgentVersion("13"));
+    assertTrue(EbeanVersion.checkMinAgentVersion(""));
+  }
+
+}


### PR DESCRIPTION
In EbeanVersion we manually maintain a minimum version of ebean-agent that is expected.  Log an error when an older ebean-agent is being used.