### PR TITLE
Change the PersistenceContext default resetLimit for iteration queries to 100 (from 1000)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DefaultPersistenceContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DefaultPersistenceContext.java
@@ -273,10 +273,10 @@ public final class DefaultPersistenceContext implements SpiPersistenceContext {
     }
 
     /**
-     * Return true if grown above the reset limit size of 1000.
+     * Return true if grown above the reset limit size of 100.
      */
     private boolean resetLimit() {
-      return map.size() > 1000;
+      return map.size() >= 100;
     }
 
     @Override

--- a/ebean-test/src/test/java/io/ebeaninternal/server/transaction/DefaultPersistenceContextTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/transaction/DefaultPersistenceContextTest.java
@@ -199,23 +199,23 @@ public class DefaultPersistenceContextTest {
     final PersistenceContext pcIterate = initialPc.forIterate();
     assertFalse(pcIterate.resetLimit());
 
-    // added 900 NEW contact beans
-    addContacts(pcIterate, 2000, 900);
-    assertThat(pcIterate.size(Contact.class)).isEqualTo(1910);
+    // added 90 NEW contact beans
+    addContacts(pcIterate, 2000, 90);
+    assertThat(pcIterate.size(Contact.class)).isEqualTo(1100);
     assertFalse(pcIterate.resetLimit());
 
-    // boundary, added 1000 NEW contact beans (still false)
-    addContacts(pcIterate, 3000, 100);
+    // boundary, added 9 NEW contact beans (still false)
+    addContacts(pcIterate, 3000, 9);
     assertFalse(pcIterate.resetLimit());
 
     addContacts(pcIterate, 4000, 1);
-    addProducts(pcIterate, 1, 100);
-    // ACT - over 1000 added beans boundary for contacts so returns true
+    addProducts(pcIterate, 1, 10);
+    // ACT - over 100 added beans boundary for contacts so returns true
     assertTrue(pcIterate.resetLimit());
 
-    assertThat(pcIterate.size(Contact.class)).isEqualTo(2011);
+    assertThat(pcIterate.size(Contact.class)).isEqualTo(1110);
     assertThat(pcIterate.size(Customer.class)).isEqualTo(100);
-    assertThat(pcIterate.size(Product.class)).isEqualTo(100);
+    assertThat(pcIterate.size(Product.class)).isEqualTo(10);
 
     // ACT - obtain new PC forIterateReset
     PersistenceContext pcReset = pcIterate.forIterateReset();


### PR DESCRIPTION
FYI @rPraml 

Changes the resetLimit from 1000 to 100 for iteration queries (findEach, findIterate, findStream).

Then with `TestPersistenceContext.findWithGcTest()` we see


```
Total instances: 500, instances left in memory: 99
Total instances: 1000, instances left in memory: 99
Total instances: 1500, instances left in memory: 99
Total instances: 2000, instances left in memory: 99
Total instances: 2500, instances left in memory: 99
Total instances: 3000, instances left in memory: 99
Total instances: 3500, instances left in memory: 99
Total instances: 4000, instances left in memory: 99
Total instances: 4500, instances left in memory: 99
Total instances: 5000, instances left in memory: 99
Total instances: 5500, instances left in memory: 99
Total instances: 6000, instances left in memory: 99
Total instances: 6500, instances left in memory: 99
Total instances: 7000, instances left in memory: 99
Total instances: 7500, instances left in memory: 99
Total instances: 8000, instances left in memory: 99
Total instances: 8500, instances left in memory: 99
Total instances: 9000, instances left in memory: 99
Total instances: 9500, instances left in memory: 99
Total instances: 10000, instances left in memory: 99
```