### PR TITLE
Allow startup without working DB

### DIFF
--- a/ebean-api/src/main/java/io/ebean/Database.java
+++ b/ebean-api/src/main/java/io/ebean/Database.java
@@ -1715,6 +1715,12 @@ public interface Database {
   <T> Set<String> validateQuery(Query<T> query);
 
   /**
+   * Runs the DbMigration or DDL manually. This is normally executed on startup, as long as
+   * serverConfig.initDatabase is set to true.
+   */
+  void initDatabase(boolean online);
+
+  /**
    * Load and lock the bean using {@code select for update}.
    * <p>
    * This should be executed inside a transaction and results in the bean being loaded or

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -2,30 +2,15 @@ package io.ebean.config;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import io.avaje.config.Config;
-import io.ebean.DatabaseFactory;
-import io.ebean.EbeanVersion;
-import io.ebean.PersistenceContextScope;
-import io.ebean.Query;
-import io.ebean.Transaction;
-import io.ebean.annotation.DbJson;
-import io.ebean.annotation.Encrypted;
-import io.ebean.annotation.MutationDetection;
-import io.ebean.annotation.PersistBatch;
-import io.ebean.annotation.Platform;
+import io.ebean.*;
+import io.ebean.annotation.*;
 import io.ebean.cache.ServerCachePlugin;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.DbEncrypt;
 import io.ebean.config.dbplatform.DbType;
 import io.ebean.config.dbplatform.IdType;
 import io.ebean.datasource.DataSourceConfig;
-import io.ebean.event.BeanFindController;
-import io.ebean.event.BeanPersistController;
-import io.ebean.event.BeanPersistListener;
-import io.ebean.event.BeanPostConstructListener;
-import io.ebean.event.BeanPostLoad;
-import io.ebean.event.BeanQueryAdapter;
-import io.ebean.event.BulkTableEventListener;
-import io.ebean.event.ServerConfigStartup;
+import io.ebean.event.*;
 import io.ebean.event.changelog.ChangeLogListener;
 import io.ebean.event.changelog.ChangeLogPrepare;
 import io.ebean.event.changelog.ChangeLogRegister;
@@ -38,13 +23,7 @@ import javax.sql.DataSource;
 import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.ServiceLoader;
+import java.util.*;
 
 /**
  * The configuration used for creating a Database.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DatabasePlatformFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DatabasePlatformFactory.java
@@ -56,6 +56,10 @@ public class DatabasePlatformFactory {
       if (config.getDataSourceConfig().isOffline()) {
         throw new PersistenceException("DatabasePlatformName must be specified with offline mode");
       }
+      if (config.getTenantMode().isDynamicDataSource()) {
+        throw new IllegalStateException("DatabasePlatform must be explicitly set on ServerConfig for TenantMode "
+          + config.getTenantMode());
+      }
       // guess using meta data from driver
       return byDataSource(config.getDataSource());
 

--- a/ebean-test/src/test/java/io/ebean/EbeanServerFactory_MultiTenancy_Test.java
+++ b/ebean-test/src/test/java/io/ebean/EbeanServerFactory_MultiTenancy_Test.java
@@ -71,10 +71,6 @@ public class EbeanServerFactory_MultiTenancy_Test extends BaseTestCase {
 
     Mockito.doReturn(config.getDataSource()).when(dataSourceProvider).dataSource(tenant);
 
-    // When TenantMode.DB we don't really want to run DDL
-    // and we want to explicitly specify the Database platform
-    //config.setDdlGenerate(false);
-    //config.setDdlRun(false);
     config.setDatabasePlatform(new PostgresPlatform());
 
     final Database database = DatabaseFactory.create(config);

--- a/ebean-test/src/test/java/io/ebean/EbeanServerFactory_MultiTenancy_Test.java
+++ b/ebean-test/src/test/java/io/ebean/EbeanServerFactory_MultiTenancy_Test.java
@@ -44,7 +44,42 @@ public class EbeanServerFactory_MultiTenancy_Test extends BaseTestCase {
     database.shutdown();
   }
 
+  /**
+   *  Tests using multi tenancy per database
+   */
+  @Test
+  public void create_new_server_with_multi_tenancy_db_with_master() {
 
+    String tenant = "customer";
+    CurrentTenantProvider tenantProvider = Mockito.mock(CurrentTenantProvider.class);
+    Mockito.doReturn(tenant).when(tenantProvider).currentId();
+
+    TenantDataSourceProvider dataSourceProvider = Mockito.mock(TenantDataSourceProvider.class);
+
+    DatabaseConfig config = new DatabaseConfig();
+
+    config.setName("h2");
+    config.loadFromProperties();
+    config.setRegister(false);
+    config.setDefaultServer(false);
+    config.setDdlGenerate(false);
+    config.setDdlRun(false);
+
+    config.setTenantMode(TenantMode.DB_WITH_MASTER);
+    config.setCurrentTenantProvider(tenantProvider);
+    config.setTenantDataSourceProvider(dataSourceProvider);
+
+    Mockito.doReturn(config.getDataSource()).when(dataSourceProvider).dataSource(tenant);
+
+    // When TenantMode.DB we don't really want to run DDL
+    // and we want to explicitly specify the Database platform
+    //config.setDdlGenerate(false);
+    //config.setDdlRun(false);
+    config.setDatabasePlatform(new PostgresPlatform());
+
+    final Database database = DatabaseFactory.create(config);
+    database.shutdown();
+  }
 
   /**
    *  Tests using multi tenancy per schema

--- a/ebean-test/src/test/java/io/ebean/config/TestServerOffline.java
+++ b/ebean-test/src/test/java/io/ebean/config/TestServerOffline.java
@@ -1,0 +1,163 @@
+package io.ebean.config;
+
+
+import io.ebean.Database;
+import io.ebean.DatabaseFactory;
+import io.ebean.annotation.ForPlatform;
+import io.ebean.annotation.Platform;
+import io.ebean.datasource.DataSourceAlert;
+import io.ebean.datasource.DataSourceInitialiseException;
+
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.EBasicVer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import javax.persistence.PersistenceException;
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestServerOffline {
+
+  @Test
+  @ForPlatform({Platform.H2})
+  public void testOffline_with_failOnStart() throws SQLException {
+
+    String url = "jdbc:h2:mem:testoffline1";
+    try (Connection bootup = DriverManager.getConnection(url, "sa", "secret")) {
+      Properties props = props(url);
+      props.setProperty("datasource.h2_offline.failOnStart", "true");
+      DatabaseConfig config = config(props);
+      assertThatThrownBy(() -> DatabaseFactory.create(config))
+        .isInstanceOf(DataSourceInitialiseException.class);
+   }
+
+  }
+
+  @Test
+  @ForPlatform({Platform.H2})
+  public void testOffline_no_failOnStart() throws SQLException {
+
+    String url = "jdbc:h2:mem:testoffline2";
+    try (Connection bootup = DriverManager.getConnection(url, "sa", "secret")) {
+      Properties props = props(url);
+
+      DatabaseConfig config = config(props);
+      config.setSkipDataSourceCheck(true);
+      config.setSkipInitDatabase(true);
+      Database h2Offline = DatabaseFactory.create(config);
+      assertThat(h2Offline).isNotNull();
+    }
+  }
+
+  private static class LazyDatasourceInitializer implements DataSourceAlert {
+
+    public Database server;
+
+    private boolean initialized;
+
+    @Override
+    public void dataSourceUp(DataSource dataSource) {
+      if (!initialized) {
+        initDatabase();
+      }
+    }
+
+    public synchronized void initDatabase() {
+      if (!initialized) {
+        server.initDatabase(true);
+        initialized = true;
+      }
+    }
+
+    @Override
+    public void dataSourceDown(DataSource dataSource, SQLException reason) {}
+
+    @Override
+    public void dataSourceWarning(DataSource dataSource, String msg) {}
+
+  }
+
+  @Test
+  @ForPlatform({Platform.H2})
+  public void testOffline_recovery() throws SQLException {
+
+    String url = "jdbc:h2:mem:testoffline3";
+    try (Connection bootup = DriverManager.getConnection(url, "sa", "secret")) {
+
+      Properties props = props(url);
+      LazyDatasourceInitializer alert = new LazyDatasourceInitializer() ;
+
+      DatabaseConfig config = config(props);
+
+      config.getDataSourceConfig().setAlert(alert);
+      config.getDataSourceConfig().setHeartbeatFreqSecs(1);
+      config.setSkipDataSourceCheck(true);
+      config.setSkipInitDatabase(true);
+
+      Database h2Offline = DatabaseFactory.create(config);
+      alert.server = h2Offline;
+      assertThat(h2Offline).isNotNull();
+
+      assertThatThrownBy(() -> alert.initDatabase())
+        .isInstanceOf(PersistenceException.class)
+        .hasMessageContaining("Failed to obtain connection to run DDL");
+
+      assertThatThrownBy(() -> h2Offline.find(EBasicVer.class).findCount()).isInstanceOf(PersistenceException.class);
+
+      // so - reset the password so that the server can reconnect
+      try (Statement stmt = bootup.createStatement()) {
+        stmt.execute("alter user sa set password 'sa'");
+      }
+
+      assertThat(alert.initialized).isFalse();
+      // next access to ebean should bring DS online
+      h2Offline.find(EBasicVer.class).findCount();
+      assertThat(alert.initialized).isTrue();
+
+      // check if server is working (ie ddl was run)
+      EBasicVer bean = new EBasicVer("foo");
+      h2Offline.save(bean);
+      assertThat(h2Offline.find(EBasicVer.class).findCount()).isEqualTo(1);
+      h2Offline.delete(bean);
+    }
+  }
+
+  private Properties props(String url) {
+
+    Properties props = new Properties();
+
+    props.setProperty("datasource.h2_offline.username", "sa");
+    props.setProperty("datasource.h2_offline.password", "sa");
+    props.setProperty("datasource.h2_offline.url", url);
+    props.setProperty("datasource.h2_offline.driver", "org.h2.Driver");
+
+    // ensures, that the datasource will come up when DB is not available
+    props.setProperty("datasource.h2_offline.failOnStart", "false");
+
+    props.setProperty("ebean.h2_offline.databasePlatformName", "h2");
+    props.setProperty("ebean.h2_offline.ddl.extra", "false");
+
+    props.setProperty("ebean.h2_offline.ddl.generate", "true");
+    props.setProperty("ebean.h2_offline.ddl.run", "true");
+
+    return props;
+  }
+
+  private DatabaseConfig config(Properties props) {
+    DatabaseConfig config = new DatabaseConfig();
+    config.setName("h2_offline");
+    config.loadFromProperties(props);
+    config.setDefaultServer(false);
+    config.setRegister(false);
+    config.getClasses().add(EBasicVer.class);
+    return config;
+  }
+
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/api/TDSpiServer.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/api/TDSpiServer.java
@@ -586,6 +586,11 @@ public class TDSpiServer implements SpiServer {
   }
 
   @Override
+  public void initDatabase(final boolean online) {
+
+  }
+
+  @Override
   public void truncate(String... tables) {
 
   }


### PR DESCRIPTION
As a follow-up to #2291, this PR adds the ability to startup the server without running migrations in case the DB is not yet up and run DDL once the datasource is ready. The fix that was done in #2291 only omits the datasource check on Ebean startup, but if this is skipped and the datasource is not yet up, Ebean tries to run DDL anyway and thus fails hard. With this change it is possible to also skip the running of DDL and explicitely running it when the datasource comes up, using `DataSourceAlert.dataSourceUp` (see tests for examples). This allows e.g. user-facing applications using Ebean to start up and possibly showing an error, instead of just not coming up at all.
I have left the `skipDataSourceCheck` flag in the config in case somebody doesn't run DDL but still might want Ebean to come up despite the DB not being available yet. I'm not entirely sure, if this is a real usecase, so maybe we could also merge the two flags into one, but for now I have left it as is.
Should that be desired, I would also offer to write a bit of documentation for the website on how to build such a lazy DB initialization with Ebean just like it is done in the test in this PR.