### PR TITLE
FIX: When a bean is modified in persistence context and searched again, it will loose the change

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
@@ -268,9 +268,16 @@ class SqlTreeNodeBean implements SqlTreeNode {
         contextBean = localBean;
       } else {
         // bean already exists in persistenceContext
-        if (isLoadContextBeanNeeded(queryMode, contextBean)) {
-          // refresh it anyway (lazy loading for example)
+        
+        if (queryMode.isLoadContextBean()) {
+          // if explicitly set loadContextBean to true, then reload
           localBean = contextBean;
+        } else if (!contextBean._ebean_getIntercept().isFullyLoadedBean()) {
+          // reload if contextBean is partial object
+          localBean = contextBean;
+          // and switch to lazyLoad query mode in order not to overwrite
+          // existing properties in SqlBeanLoad::load
+          queryMode = Mode.LAZYLOAD_BEAN;
         } else {
           // ignore the DB data...
           localBean = null;
@@ -683,14 +690,6 @@ class SqlTreeNodeBean implements SqlTreeNode {
     return "SqlTreeNodeBean: " + desc;
   }
 
-  private boolean isLoadContextBeanNeeded(Mode queryMode, EntityBean contextBean) {
-    // if explicitly set loadContextBean to true, then reload
-    if (queryMode.isLoadContextBean()) {
-      return true;
-    }
-    // reload if contextBean is partial object
-    return !contextBean._ebean_getIntercept().isFullyLoadedBean();
-  }
 
   @Override
   public boolean hasMany() {

--- a/ebean-test/src/test/java/org/tests/basic/TestPersistenceContext.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestPersistenceContext.java
@@ -7,10 +7,12 @@ import io.ebeaninternal.api.SpiPersistenceContext;
 import io.ebeaninternal.api.SpiTransaction;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.tests.model.basic.ContactNote;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
 import org.tests.model.basic.ResetBasicData;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -20,6 +22,19 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class TestPersistenceContext extends BaseTestCase {
 
+  
+  @Test
+  void testReload() {
+    ResetBasicData.reset();
+    try (Transaction txn = DB.beginTransaction()) {
+      List<ContactNote> notes = new ArrayList<>();
+      DB.find(ContactNote.class).findEach(notes::add);
+      notes.get(0).setTitle("FooBar");
+      DB.find(ContactNote.class).findList();
+      assertThat(notes.get(0).getTitle()).isEqualTo("FooBar");
+    }
+  }
+  
   @Test
   void test() {
     ResetBasicData.reset();


### PR DESCRIPTION
When a partial loaded bean is modified during a transaction, the modification may be reset, if the bean is searched again from database.
It is important, that the bean is not fully loaded

**Steps to reproduce**
```java
    try (Transaction txn = DB.beginTransaction()) {
      List<ContactNote> notes = DB.find(ContactNote.class).findList();
      notes.get(0).setTitle("FooBar");
      DB.find(ContactNote.class).findList();
      assertThat(notes.get(0).getTitle()).isEqualTo("FooBar"); // old content is restored
    }
```
This bug was discovered in our app due the changes of the persistenceContext with findEach, but it is not really related to.
