### PR TITLE
FIX: typeGetAll did not work with repeated annotations on one class

### DIFF
--- a/ebean-api/src/main/java/io/ebean/util/AnnotationUtil.java
+++ b/ebean-api/src/main/java/io/ebean/util/AnnotationUtil.java
@@ -2,6 +2,7 @@ package io.ebean.util;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -57,10 +58,8 @@ public class AnnotationUtil {
 
   private static <A extends Annotation> void typeGetAllCollect(Class<?> clazz, Class<A> annotationType, Set<A> result) {
     while (clazz != null && clazz != Object.class) {
-      final A val = clazz.getAnnotation(annotationType);
-      if (val != null) {
-        result.add(val);
-      }
+      final A[] annotations = clazz.getAnnotationsByType(annotationType);
+      Collections.addAll(result, annotations);
       clazz = clazz.getSuperclass();
     }
   }

--- a/ebean-api/src/test/java/io/ebean/util/TestAnnotationUtil.java
+++ b/ebean-api/src/test/java/io/ebean/util/TestAnnotationUtil.java
@@ -1,0 +1,28 @@
+package io.ebean.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.ebean.annotation.Formula;
+
+public class TestAnnotationUtil {
+
+  @Formula(select = "x")
+  @Formula(select = "y")
+  private static class TestObject {
+
+  }
+
+  @Test
+  public void testRepeatableAnnotation() {
+
+    Set<Formula> list = AnnotationUtil.typeGetAll(TestObject.class, Formula.class);
+    assertThat(list).hasSize(2);
+
+  }
+
+}


### PR DESCRIPTION
Hello  @rbygrave ,

@jonasPoehler and I wrote a test and made a fix for typeGetAll() with repeated annotations.

Kind regards,
Noemi 