### PR TITLE
Path properties query with all props

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryPropertiesParser.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryPropertiesParser.java
@@ -37,7 +37,11 @@ final class OrmQueryPropertiesParser {
     if (rawProperties.equals("*")) {
       return ALL;
     }
-    return new Response(false, splitRawSelect(rawProperties));
+    final Set<String> included = splitRawSelect(rawProperties);
+    if (included.contains("*")) {
+        return ALL;
+      }
+    return new Response(false, included);
   }
 
   /**

--- a/ebean-test/src/test/java/io/ebean/text/PathPropertiesTests.java
+++ b/ebean-test/src/test/java/io/ebean/text/PathPropertiesTests.java
@@ -223,8 +223,8 @@ public class PathPropertiesTests extends BaseTestCase {
     Query<Customer> query = DB.find(Customer.class).apply(root);
     query.findList();
     List<String> sql = LoggedSql.stop();
-	assertThat(sql).hasSize(1);
-	assertThat(sql.get(0)).contains("select t0.status, t0.name, t0.smallnote, t0.anniversary, t0.id, t1.id, t1.line_1 from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id");
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("select t0.id, t0.status, t0.name, t0.smallnote, t0.anniversary, t0.cretime, t0.updtime, t0.version, t0.shipping_address_id, t1.id, t1.line_1 from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id;");
   }
 
 }

--- a/ebean-test/src/test/java/io/ebean/text/PathPropertiesTests.java
+++ b/ebean-test/src/test/java/io/ebean/text/PathPropertiesTests.java
@@ -1,8 +1,11 @@
 package io.ebean.text;
 
+import io.ebean.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.FetchPath;
 import io.ebean.Query;
+import io.ebean.test.LoggedSql;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +17,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PathPropertiesTests {
+public class PathPropertiesTests extends BaseTestCase {
 
   private static final Logger log = LoggerFactory.getLogger(PathPropertiesTests.class);
 
@@ -212,4 +215,16 @@ public class PathPropertiesTests {
     String asJson = DB.json().toJson(list, pathProps);
     log.info("Json: {}", asJson);
   }
+  
+  @Test
+  public void test_withAllPropsQuery() {
+    PathProperties root = PathProperties.parse("*,billingAddress(line1)");
+    LoggedSql.start();
+    Query<Customer> query = DB.find(Customer.class).apply(root);
+    query.findList();
+    List<String> sql = LoggedSql.stop();
+	assertThat(sql).hasSize(1);
+	assertThat(sql.get(0)).contains("select t0.status, t0.name, t0.smallnote, t0.anniversary, t0.id, t1.id, t1.line_1 from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id");
+  }
+
 }


### PR DESCRIPTION
Hi @rbygrave ,

@jonasPoehler and I found a bug with PathProperties.
If you use PathProperty (*, x(y)) and then DB.find(..).apply(PathProperty), a wrong query will be created.
Only the join part with x(y) would be used, without the select * from the original table.

We would have also a fix for this problem.

Kind regards
Noemi