### PR TITLE
FIX: Assume InfoInherit infoType  when it has no children

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/AssocOneHelpRefInherit.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/AssocOneHelpRefInherit.java
@@ -31,10 +31,17 @@ final class AssocOneHelpRefInherit extends AssocOneHelp {
   Object read(DbReadContext ctx) throws SQLException {
     // read discriminator to determine the type
     InheritInfo rowInheritInfo = inherit.readType(ctx);
+    BeanDescriptor<?> desc;
     if (rowInheritInfo == null) {
-      // ignore the id property
-      property.targetIdBinder.loadIgnore(ctx);
-      return null;
+      if(!inherit.hasChildren()) {
+        desc = inherit.desc();
+      } else {
+        // ignore the id property
+        property.targetIdBinder.loadIgnore(ctx);
+        return null;
+      }
+    } else {
+      desc = rowInheritInfo.desc();
     }
     Object id = property.targetIdBinder.read(ctx);
     if (id == null) {
@@ -42,7 +49,6 @@ final class AssocOneHelpRefInherit extends AssocOneHelp {
     }
     // check transaction context to see if it already exists
     PersistenceContext pc = ctx.getPersistenceContext();
-    BeanDescriptor<?> desc = rowInheritInfo.desc();
     Object existing = desc.contextGet(pc, id);
     if (existing != null) {
       return existing;

--- a/ebean-test/src/test/java/org/tests/inheritance/bothsides/Target1.java
+++ b/ebean-test/src/test/java/org/tests/inheritance/bothsides/Target1.java
@@ -4,7 +4,6 @@ import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 
 @Entity
-@Inheritance
 public class Target1 extends TargetBase {
 
   public Target1(String name) {

--- a/ebean-test/src/test/java/org/tests/lazyforeignkeys/MainEntityRelation.java
+++ b/ebean-test/src/test/java/org/tests/lazyforeignkeys/MainEntityRelation.java
@@ -3,6 +3,9 @@ package org.tests.lazyforeignkeys;
 import io.ebean.annotation.DbForeignKey;
 
 import javax.persistence.*;
+
+import org.tests.model.basic.Cat;
+
 import java.util.UUID;
 
 
@@ -22,6 +25,11 @@ public class MainEntityRelation {
   @JoinColumn(name = "id2")
   @DbForeignKey(noConstraint = true)
   private MainEntity entity2;
+  
+  @ManyToOne
+  @JoinColumn(name = "cat_id")
+  @DbForeignKey(noConstraint = true)
+  private Cat cat;
 
   private String attr1;
 
@@ -39,6 +47,14 @@ public class MainEntityRelation {
 
   public void setEntity2(MainEntity entity2) {
     this.entity2 = entity2;
+  }
+
+  public Cat getCat() {
+    return cat;
+  }
+
+  public void setCat(Cat cat) {
+    this.cat = cat;
   }
 
   public String getAttr1() {

--- a/ebean-test/src/test/java/org/tests/lazyforeignkeys/TestLazyForeignKeys.java
+++ b/ebean-test/src/test/java/org/tests/lazyforeignkeys/TestLazyForeignKeys.java
@@ -8,6 +8,7 @@ import io.ebean.text.PathProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Cat;
 
 import java.util.List;
 
@@ -56,7 +57,7 @@ public class TestLazyForeignKeys extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(3);
-    assertSql(sql.get(0)).contains("select t0.id, t0.attr1, t0.id1, t0.id2 from main_entity_relation");
+    assertSql(sql.get(0)).contains("select t0.id, t0.attr1, t0.id1, t0.id2, t1.species, t0.cat_id from main_entity_relation t0 left join animal t1 on t1.id = t0.cat_id");
     if (isSqlServer() || isOracle()) {
       assertSql(sql.get(1)).contains("select t0.id, t0.attr1, t0.attr2, CASE WHEN t0.id is null THEN 1 ELSE 0 END from main_entity t0");
     } else {
@@ -85,5 +86,18 @@ public class TestLazyForeignKeys extends BaseTestCase {
     assertEquals("attr1", rel1.getEntity1().getAttr1());
     assertFalse(rel1.getEntity1().isDeleted());
     assertTrue(rel1.getEntity2().isDeleted());
+  }
+  
+  @Test
+  public void testGetWithDbForeignKey() {
+    MainEntityRelation relation = DB.find(MainEntityRelation.class).findOne();
+    Cat cat = new Cat();
+    cat.setId(123L);
+    relation.setCat(cat);
+    DB.save(relation);
+    
+    relation = DB.find(MainEntityRelation.class).findOne();
+    
+    assertNotNull(relation.getCat());
   }
 }


### PR DESCRIPTION
Hi @rbygrave ,

in our application we implemented object-relations with @DbForeignKey(noConstraint = true), because at the moment of the data-import of the "main" entity (MainEntityRelation) it is not sure, if the related entity (Cat) already exists. The related entity type is a derived class, without children.
In case of a call from mainEntity.getRelatedEntity() we got NPE.

In our test we used MainEntityRelation as "main" object and Cat (extends Animal) as the related entity.
A fix suggestion we also implemented with @jonasPoehler .

Kind regards
Noemi

