### PR TITLE
findMap() with beanCache should use idPoperty if mapKey = null

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -570,7 +570,12 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   }
 
   private ElPropertyValue mapProperty() {
-    ElPropertyValue property = beanDescriptor.elGetValue(query.getMapKey());
+    ElPropertyValue property;
+    if (query.getMapKey() == null) {
+      property = beanDescriptor.idProperty();
+    } else {
+      property = beanDescriptor.elGetValue(query.getMapKey());
+    }
     if (property == null) {
       throw new IllegalStateException("Unknown map key property " + query.getMapKey());
     }


### PR DESCRIPTION
Hi @rbygrave ,

we found another bug and we would have a solution for it.

If we use an entity with beanCache for a findMap()-call (without mapKey), it works for the first time, when it is loaded from the db.
For the second time the beanCache will be used and we got NPE because mapKey wasn't set. 
In the documentation of Query (ebean12) is written, if no mapKey is set should the idProperty be used.

NPE stack trace:

`java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at io.ebeaninternal.server.deploy.BeanDescriptor.elGetValue(BeanDescriptor.java:2291)
	at io.ebeaninternal.server.core.OrmQueryRequest.mapProperty(OrmQueryRequest.java:586)
	at io.ebeaninternal.server.core.OrmQueryRequest.cacheBeansToMap(OrmQueryRequest.java:564)
	at io.ebeaninternal.server.core.OrmQueryRequest.beanCacheHitsAsMap(OrmQueryRequest.java:559)
	at io.ebeaninternal.server.core.DefaultServer.findMap(DefaultServer.java:1202)
	at io.ebeaninternal.server.querydefn.DefaultOrmQuery.findMap(DefaultOrmQuery.java:1493)
	at io.ebeaninternal.server.expression.DefaultExpressionList.findMap(DefaultExpressionList.java:462)`

Can you please check it?

Kind regards
Noemi