### PR TITLE
Big refactor and bug fixing of date time handling

### DIFF
--- a/ebean-core-type/src/main/java/io/ebean/core/type/DataBinder.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/DataBinder.java
@@ -117,7 +117,7 @@ public interface DataBinder {
   /**
    * Bind a timestamp value.
    */
-  void setTimestamp(Timestamp value) throws SQLException;
+  void setTimestamp(Timestamp value, boolean isLocal) throws SQLException;
 
   /**
    * Bind a time value.

--- a/ebean-core-type/src/main/java/io/ebean/core/type/DataReader.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/DataReader.java
@@ -39,7 +39,7 @@ public interface DataReader {
 
   java.sql.Time getTime() throws SQLException;
 
-  java.sql.Timestamp getTimestamp() throws SQLException;
+  java.sql.Timestamp getTimestamp(boolean isLocal) throws SQLException;
 
   BigDecimal getBigDecimal() throws SQLException;
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
@@ -451,7 +451,9 @@ public final class InternalConfiguration {
       }
       return new NoDataTimeZone();
     }
-    if (getPlatform().base() == Platform.ORACLE) {
+    if (isMySql(getPlatform())) {
+      return new MySqlDataTimeZone(tz);
+    } else if (getPlatform().base() == Platform.ORACLE) {
       return new OracleDataTimeZone(tz);
     } else {
       return new SimpleDataTimeZone(tz);
@@ -459,7 +461,7 @@ public final class InternalConfiguration {
   }
 
   private boolean isMySql(Platform platform) {
-    return platform.base() == Platform.MYSQL;
+    return platform.base() == Platform.MYSQL || platform.base() == Platform.MARIADB ;
   }
 
   public DataTimeZone getDataTimeZone() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/DataTimeZone.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/DataTimeZone.java
@@ -8,16 +8,18 @@ import java.util.Calendar;
 public interface DataTimeZone {
 
   /**
-   * Return the Calendar to use for Timezone information when reading/writing timestamps.
+   * Return the Calendar to use for Timezone information when reading/writing
+   * timestamps/Instants
    */
   Calendar getTimeZone();
 
   /**
-   * Return the Calendar to use for Timezone information when reading/writing date.
-   * A 'date' only value has normally no timezone information, but some platforms (like MySQL)
-   * reqire this.
+   * Return the Calendar to use for Timezone information when reading/writing
+   * LocalDate / LocalTime / LocalDateTime. A local date only value has normally
+   * no timezone information - and no conversion will occur. but some platforms
+   * (like MySQL) require this.
    */
-  default Calendar getDateTimeZone() {
+  default Calendar getLocalTimeZone() {
     return null;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/MySqlDataTimeZone.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/MySqlDataTimeZone.java
@@ -19,7 +19,7 @@ public class MySqlDataTimeZone implements DataTimeZone {
   }
 
   @Override
-  public Calendar getDateTimeZone() {
+  public Calendar getLocalTimeZone() {
     return zone;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/MySqlDataTimeZone.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/MySqlDataTimeZone.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.core.timezone;
 
 import java.util.Calendar;
+import java.util.TimeZone;
 
 /**
  * Implementation of DataTimeZone when single Calendar instance is used with local timezone.
@@ -8,9 +9,15 @@ import java.util.Calendar;
 public class MySqlDataTimeZone implements DataTimeZone {
 
   protected final Calendar zone;
+  protected final Calendar localZone;
 
+  public MySqlDataTimeZone(String zoneId) {
+    this.zone = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
+    this.localZone = Calendar.getInstance();
+  }
   public MySqlDataTimeZone() {
     this.zone = Calendar.getInstance();
+    this.localZone = zone;
   }
 
   @Override
@@ -20,6 +27,6 @@ public class MySqlDataTimeZone implements DataTimeZone {
 
   @Override
   public Calendar getLocalTimeZone() {
-    return zone;
+    return localZone;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/Binder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/Binder.java
@@ -294,8 +294,11 @@ public final class Binder {
           break;
 
         case java.sql.Types.TIMESTAMP:
+          b.setTimestamp((java.sql.Timestamp) data, false);
+          break;
+          
         case DbPlatformType.LOCALDATETIME:
-          b.setTimestamp((java.sql.Timestamp) data);
+          b.setTimestamp((java.sql.Timestamp) data, true);
           break;
 
         case java.sql.Types.BINARY:

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeRoot.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeRoot.java
@@ -51,8 +51,8 @@ final class SqlTreeNodeRoot extends SqlTreeNodeBean implements SqlTreeRoot {
   public <T> Version<T> loadVersion(DbReadContext ctx) throws SQLException {
     // read the sys period lower and upper bounds
     // these are always the first 2 columns in the resultSet
-    Timestamp start = ctx.getDataReader().getTimestamp();
-    Timestamp end = ctx.getDataReader().getTimestamp();
+    Timestamp start = ctx.getDataReader().getTimestamp(false);
+    Timestamp end = ctx.getDataReader().getTimestamp(false);
     T bean = (T) load(ctx, null, null);
     return new Version<>(bean, start, end);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
@@ -158,7 +158,7 @@ public class DataBind implements DataBinder {
 
   @Override
   public final void setDate(java.sql.Date v) throws SQLException {
-    Calendar timeZone = dataTimeZone.getDateTimeZone();
+    Calendar timeZone = dataTimeZone.getLocalTimeZone();
     if (timeZone != null) {
       pstmt.setDate(++pos, v, timeZone);
     } else {
@@ -167,8 +167,8 @@ public class DataBind implements DataBinder {
   }
 
   @Override
-  public final void setTimestamp(Timestamp v) throws SQLException {
-    Calendar timeZone = dataTimeZone.getTimeZone();
+  public final void setTimestamp(Timestamp v, boolean isLocal) throws SQLException {
+    Calendar timeZone = isLocal ? dataTimeZone.getLocalTimeZone() : dataTimeZone.getTimeZone();
     if (timeZone != null) {
       pstmt.setTimestamp(++pos, v, timeZone);
     } else {
@@ -178,7 +178,7 @@ public class DataBind implements DataBinder {
 
   @Override
   public final void setTime(Time v) throws SQLException {
-    Calendar timeZone = dataTimeZone.getTimeZone();
+    Calendar timeZone = dataTimeZone.getLocalTimeZone();
     if (timeZone != null) {
       pstmt.setTime(++pos, v, timeZone);
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DecimalUtils.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DecimalUtils.java
@@ -72,10 +72,20 @@ final class DecimalUtils {
   }
 
   static String toDecimal(long seconds, int nanoseconds) {
+    assert nanoseconds >= 0;
+    boolean negative = seconds < 0;
+    if (nanoseconds > 0 && negative) {
+      seconds++; // to support dates < 1970-01-01
+      nanoseconds = 1_000_000_000 - nanoseconds;
+    }
     StringBuilder string = new StringBuilder(Integer.toString(nanoseconds));
     if (string.length() < 9)
       string.insert(0, ZEROES, 0, 9 - string.length());
-    return seconds + "." + string;
+    if (negative && seconds == 0) {
+      return "-0." + string;
+    } else {
+      return seconds + "." + string;
+    }
   }
 
   static int extractNanosecondDecimal(BigDecimal value, long integer) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -591,8 +591,7 @@ public final class DefaultTypeManager implements TypeManager {
    */
   private ScalarTypeEnum<?> createEnumScalarTypeDbValue(Class<? extends Enum<?>> enumType, Method method, boolean integerType, int length, boolean withConstraint) {
     Map<String, String> nameValueMap = new LinkedHashMap<>();
-    Enum<?>[] enumConstants = enumType.getEnumConstants();
-    for (Enum<?> enumConstant : enumConstants) {
+    for (Enum<?> enumConstant : enumType.getEnumConstants()) {
       try {
         Object value = method.invoke(enumConstant);
         nameValueMap.put(enumConstant.name(), value.toString());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -43,6 +43,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.*;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -269,8 +270,11 @@ public final class DefaultTypeManager implements TypeManager {
   }
 
   private ScalarType<?> checkInterfaceTypes(Class<?> type) {
-    if (java.nio.file.Path.class.isAssignableFrom(type)) {
-      return typeMap.get(java.nio.file.Path.class);
+    for (Entry<Class<?>, ScalarType<?>> entry : typeMap.entrySet()) {
+      if (entry.getKey().isAssignableFrom(type)) {
+        typeMap.put(type, entry.getValue());
+        return entry.getValue();
+      }
     }
     return null;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/IsoJsonDateTimeParser.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/IsoJsonDateTimeParser.java
@@ -15,6 +15,9 @@ final class IsoJsonDateTimeParser {
     return Instant.parse(jsonDateTime);
   }
 
+  /**
+   * Formats the instant with milliseconds precision.
+   */
   static String formatIso(Instant value) {
     return ISO_MILLIS.format(value);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
@@ -102,7 +102,7 @@ public class RsetDataReader implements DataReader {
 
   @Override
   public Date getDate() throws SQLException {
-    Calendar cal = dataTimeZone.getDateTimeZone();
+    Calendar cal = dataTimeZone.getLocalTimeZone();
     if (cal != null) {
       return rset.getDate(pos(), cal);
     } else {
@@ -151,7 +151,7 @@ public class RsetDataReader implements DataReader {
 
   @Override
   public Time getTime() throws SQLException {
-    Calendar cal = dataTimeZone.getTimeZone();
+    Calendar cal = dataTimeZone.getLocalTimeZone();
     if (cal != null) {
       return rset.getTime(pos(), cal);
     } else {
@@ -160,8 +160,8 @@ public class RsetDataReader implements DataReader {
   }
 
   @Override
-  public Timestamp getTimestamp() throws SQLException {
-    Calendar cal = dataTimeZone.getTimeZone();
+  public Timestamp getTimestamp(boolean isLocal) throws SQLException {
+    Calendar cal = isLocal ? dataTimeZone.getLocalTimeZone() : dataTimeZone.getTimeZone();
     if (cal != null) {
       return rset.getTimestamp(pos(), cal);
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDate.java
@@ -59,9 +59,8 @@ abstract class ScalarTypeBaseDate<T> extends ScalarTypeBase<T> {
 
   @Override
   public String formatValue(T t) {
-    Date date = convertToDate(t);
     // format all dates into epoch millis
-    long epochMillis = date.getTime();
+    long epochMillis = convertToMillis(t);
     return Long.toString(epochMillis);
   }
 
@@ -69,7 +68,7 @@ abstract class ScalarTypeBaseDate<T> extends ScalarTypeBase<T> {
   public T parse(String value) {
     try {
       long epochMillis = Long.parseLong(value);
-      return convertFromDate(new Date(epochMillis));
+      return convertFromMillis(epochMillis);
     } catch (NumberFormatException e) {
       Date date = Date.valueOf(value);
       return convertFromDate(date);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
@@ -113,6 +113,10 @@ abstract class ScalarTypeBaseDateTime<T> extends ScalarTypeBase<T> {
   protected String toJsonNanos(long epochSecs, int nanos) {
     return DecimalUtils.toDecimal(epochSecs, nanos);
   }
+  
+  protected String toJsonNanos(long millis) {
+    return DecimalUtils.toDecimal(millis / 1000, (int) (millis % 1000) * 1_000_000);
+  }
 
   @Override
   public final T jsonRead(JsonParser parser) throws IOException {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
@@ -24,10 +24,12 @@ import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.parseIso;
 abstract class ScalarTypeBaseDateTime<T> extends ScalarTypeBase<T> {
 
   protected final JsonConfig.DateTime mode;
+  protected final boolean isLocal;
 
-  ScalarTypeBaseDateTime(JsonConfig.DateTime mode, Class<T> type, boolean jdbcNative, int jdbcType) {
+  ScalarTypeBaseDateTime(JsonConfig.DateTime mode, Class<T> type, boolean jdbcNative, int jdbcType, boolean isLocal) {
     super(type, jdbcNative, jdbcType);
     this.mode = mode;
+    this.isLocal = isLocal;
   }
 
   @Override
@@ -77,19 +79,21 @@ abstract class ScalarTypeBaseDateTime<T> extends ScalarTypeBase<T> {
   protected T fromJsonISO8601(String value) {
     return convertFromInstant(parseIso(value));
   }
+  
+
 
   @Override
   public void bind(DataBinder binder, T value) throws SQLException {
     if (value == null) {
       binder.setNull(Types.TIMESTAMP);
     } else {
-      binder.setTimestamp(convertToTimestamp(value));
+      binder.setTimestamp(convertToTimestamp(value), isLocal);
     }
   }
 
   @Override
   public T read(DataReader reader) throws SQLException {
-    Timestamp ts = reader.getTimestamp();
+    Timestamp ts = reader.getTimestamp(isLocal);
     if (ts == null) {
       return null;
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeCalendar.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeCalendar.java
@@ -12,7 +12,6 @@ import java.time.Instant;
 import java.util.Calendar;
 
 import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.formatIso;
-import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.parseIso;
 
 /**
  * ScalarType for java.util.Calendar.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeCalendar.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeCalendar.java
@@ -19,7 +19,7 @@ import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.formatIso;
 final class ScalarTypeCalendar extends ScalarTypeBaseDateTime<Calendar> {
 
   ScalarTypeCalendar(JsonConfig.DateTime mode, int jdbcType) {
-    super(mode, Calendar.class, false, jdbcType);
+    super(mode, Calendar.class, false, jdbcType, false);
   }
 
   @Override
@@ -29,7 +29,7 @@ final class ScalarTypeCalendar extends ScalarTypeBaseDateTime<Calendar> {
     } else {
       if (jdbcType == Types.TIMESTAMP) {
         Timestamp timestamp = new Timestamp(value.getTimeInMillis());
-        binder.setTimestamp(timestamp);
+        binder.setTimestamp(timestamp, isLocal);
       } else {
         Date d = new Date(value.getTimeInMillis());
         binder.setDate(d);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeCalendar.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeCalendar.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.Calendar;
 
 import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.formatIso;
+import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.parseIso;
 
 /**
  * ScalarType for java.util.Calendar.
@@ -60,7 +61,8 @@ final class ScalarTypeCalendar extends ScalarTypeBaseDateTime<Calendar> {
 
   @Override
   protected String toJsonNanos(Calendar value) {
-    return String.valueOf(value.getTime());
+    Instant i = value.toInstant();
+    return toJsonNanos(i.getEpochSecond(), i.getNano());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDate.java
@@ -8,6 +8,10 @@ import io.ebeaninternal.server.core.BasicTypeConverter;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 /**
  * ScalarType for java.sql.Date.
@@ -25,7 +29,12 @@ final class ScalarTypeDate extends ScalarTypeBaseDate<java.sql.Date> {
 
   @Override
   public long convertToMillis(Date value) {
-    return value.getTime();
+    return value.toLocalDate().toEpochDay() * 86400000L; // return a GMT aligned millis value
+  }
+  @Override
+  public Date convertFromMillis(long systemTimeMillis) {
+    LocalDate ld = LocalDate.ofEpochDay(systemTimeMillis / 86400000L);
+    return Date.valueOf(ld);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInstant.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInstant.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 final class ScalarTypeInstant extends ScalarTypeBaseDateTime<Instant> {
 
   ScalarTypeInstant(JsonConfig.DateTime mode) {
-    super(mode, Instant.class, false, Types.TIMESTAMP);
+    super(mode, Instant.class, false, Types.TIMESTAMP, false);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateMidnight.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateMidnight.java
@@ -22,7 +22,7 @@ final class ScalarTypeJodaDateMidnight extends ScalarTypeBaseDate<org.joda.time.
 
   @Override
   protected String toIsoFormat(DateMidnight value) {
-    return value.toString();
+    return value.toLocalDate().toString();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateTime.java
@@ -14,7 +14,7 @@ import java.time.Instant;
 final class ScalarTypeJodaDateTime extends ScalarTypeBaseDateTime<DateTime> {
 
   ScalarTypeJodaDateTime(JsonConfig.DateTime mode) {
-    super(mode, DateTime.class, false, Types.TIMESTAMP);
+    super(mode, DateTime.class, false, Types.TIMESTAMP, false);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaDateTime.java
@@ -29,7 +29,7 @@ final class ScalarTypeJodaDateTime extends ScalarTypeBaseDateTime<DateTime> {
 
   @Override
   protected String toJsonISO8601(DateTime value) {
-    return value.toString();
+    return value.toInstant().toString();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDate.java
@@ -24,7 +24,7 @@ final class ScalarTypeJodaLocalDate extends ScalarTypeBaseDate<LocalDate> {
 
   @Override
   public LocalDate convertFromMillis(long systemTimeMillis) {
-    return new LocalDate(systemTimeMillis);
+    return new LocalDate(systemTimeMillis, DateTimeZone.UTC);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
@@ -26,6 +26,11 @@ final class ScalarTypeJodaLocalDateTime extends ScalarTypeBaseDateTime<LocalDate
   protected String toJsonISO8601(LocalDateTime value) {
     return value.toString();
   }
+  
+  @Override
+  protected LocalDateTime fromJsonISO8601(String value) {
+    return LocalDateTime.parse(value);
+  }
 
   @Override
   public long convertToMillis(LocalDateTime value) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
@@ -8,7 +8,6 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 
 import java.sql.Timestamp;
-import java.sql.Types;
 import java.time.Instant;
 
 /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
@@ -3,6 +3,8 @@ package io.ebeaninternal.server.type;
 import io.ebean.config.JsonConfig;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebeaninternal.server.core.BasicTypeConverter;
+
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 
 import java.sql.Timestamp;
@@ -20,9 +22,14 @@ final class ScalarTypeJodaLocalDateTime extends ScalarTypeBaseDateTime<LocalDate
 
   @Override
   protected String toJsonNanos(LocalDateTime value) {
-    return String.valueOf(value.toDateTime().getMillis());
+    return toJsonNanos(value.toDateTime(DateTimeZone.UTC).getMillis());
   }
 
+  @Override
+  protected LocalDateTime fromJsonNanos(long seconds, int nanoseconds) {
+    return new LocalDateTime(seconds * 1000 + nanoseconds / 1_000_000, DateTimeZone.UTC);
+  }
+  
   @Override
   protected String toJsonISO8601(LocalDateTime value) {
     return value.toString();
@@ -35,12 +42,12 @@ final class ScalarTypeJodaLocalDateTime extends ScalarTypeBaseDateTime<LocalDate
 
   @Override
   public long convertToMillis(LocalDateTime value) {
-    return value.toDateTime().getMillis();
+    return value.toDateTime(DateTimeZone.UTC).getMillis();
   }
 
   @Override
   public LocalDateTime convertFromMillis(long systemTimeMillis) {
-    return new LocalDateTime(systemTimeMillis);
+    return new LocalDateTime(systemTimeMillis, DateTimeZone.UTC);
   }
 
   @Override
@@ -50,7 +57,7 @@ final class ScalarTypeJodaLocalDateTime extends ScalarTypeBaseDateTime<LocalDate
 
   @Override
   public LocalDateTime convertFromInstant(Instant ts) {
-    return new LocalDateTime(ts.toEpochMilli());
+    return new LocalDateTime(ts.toEpochMilli(), DateTimeZone.UTC);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalDateTime.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.type;
 
 import io.ebean.config.JsonConfig;
+import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebeaninternal.server.core.BasicTypeConverter;
 import org.joda.time.LocalDateTime;
 
@@ -14,7 +15,7 @@ import java.time.Instant;
 final class ScalarTypeJodaLocalDateTime extends ScalarTypeBaseDateTime<LocalDateTime> {
 
   ScalarTypeJodaLocalDateTime(JsonConfig.DateTime mode) {
-    super(mode, LocalDateTime.class, false, Types.TIMESTAMP);
+    super(mode, LocalDateTime.class, false, DbPlatformType.LOCALDATETIME, true);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDate.java
@@ -4,8 +4,8 @@ import io.ebean.config.JsonConfig;
 import io.ebeaninternal.server.core.BasicTypeConverter;
 
 import java.sql.Date;
-import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -26,7 +26,15 @@ final class ScalarTypeLocalDate extends ScalarTypeBaseDate<LocalDate> {
 
   @Override
   public LocalDate convertFromMillis(long systemTimeMillis) {
-    return new Timestamp(systemTimeMillis).toLocalDateTime().toLocalDate();
+    // java 9: 
+    // return LocalDate.ofInstant(Instant.ofEpochMilli(systemTimeMillis), ZoneOffset.UTC);
+    
+    // java 8:
+    Instant instant = Instant.ofEpochMilli(systemTimeMillis);
+    ZoneOffset offset = ZoneOffset.UTC.getRules().getOffset(instant);
+    long localSecond = instant.getEpochSecond() + offset.getTotalSeconds();
+    long localEpochDay = Math.floorDiv(localSecond, 86400);
+    return LocalDate.ofEpochDay(localEpochDay);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
@@ -1,15 +1,11 @@
 package io.ebeaninternal.server.type;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
 import io.ebean.config.JsonConfig;
 import io.ebean.config.dbplatform.ExtraDbTypes;
 
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 
 /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
@@ -17,7 +17,7 @@ import java.time.ZoneId;
 final class ScalarTypeLocalDateTime extends ScalarTypeBaseDateTime<LocalDateTime> {
 
   ScalarTypeLocalDateTime(JsonConfig.DateTime mode) {
-    super(mode, LocalDateTime.class, false, ExtraDbTypes.LOCALDATETIME);
+    super(mode, LocalDateTime.class, false, ExtraDbTypes.LOCALDATETIME, true);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTime.java
@@ -10,6 +10,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 
 /**
  * ScalarType for java.sql.Timestamp.
@@ -22,17 +23,22 @@ final class ScalarTypeLocalDateTime extends ScalarTypeBaseDateTime<LocalDateTime
 
   @Override
   public LocalDateTime convertFromMillis(long systemTimeMillis) {
-    return new Timestamp(systemTimeMillis).toLocalDateTime();
+    return LocalDateTime.ofEpochSecond(systemTimeMillis / 1000, (int) (systemTimeMillis % 1000) * 1_000_000, ZoneOffset.UTC);
   }
 
   @Override
   public long convertToMillis(LocalDateTime value) {
-    return Timestamp.valueOf(value).getTime();
+    return value.toEpochSecond(ZoneOffset.UTC) * 1000 + value.getNano() / 1_000_000;
   }
 
   @Override
   protected String toJsonNanos(LocalDateTime value) {
-    return value.toString();
+    return toJsonNanos(value.toEpochSecond(ZoneOffset.UTC), value.getNano());
+  }
+  
+  @Override
+  protected LocalDateTime fromJsonNanos(long seconds, int nanoseconds) {
+    return LocalDateTime.ofEpochSecond(seconds, nanoseconds, ZoneOffset.UTC);
   }
 
   @Override
@@ -43,16 +49,6 @@ final class ScalarTypeLocalDateTime extends ScalarTypeBaseDateTime<LocalDateTime
   @Override
   protected LocalDateTime fromJsonISO8601(String value) {
     return LocalDateTime.parse(value);
-  }
-
-  @Override
-  public LocalDateTime jsonRead(JsonParser parser) throws IOException {
-    return LocalDateTime.parse(parser.getText());
-  }
-
-  @Override
-  public void jsonWrite(JsonGenerator writer, LocalDateTime value) throws IOException {
-    writer.writeString(value.toString());
   }
 
   @Override
@@ -72,7 +68,7 @@ final class ScalarTypeLocalDateTime extends ScalarTypeBaseDateTime<LocalDateTime
 
   @Override
   public LocalDateTime convertFromInstant(Instant ts) {
-    return LocalDateTime.ofInstant(ts, ZoneId.systemDefault());
+    return LocalDateTime.ofInstant(ts, ZoneOffset.UTC);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTime.java
@@ -18,7 +18,7 @@ final class ScalarTypeOffsetDateTime extends ScalarTypeBaseDateTime<OffsetDateTi
   private final ZoneId zoneId;
 
   ScalarTypeOffsetDateTime(JsonConfig.DateTime mode, ZoneId zoneId) {
-    super(mode, OffsetDateTime.class, false, Types.TIMESTAMP);
+    super(mode, OffsetDateTime.class, false, Types.TIMESTAMP, false);
     this.zoneId = zoneId;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeOffsetDateTime.java
@@ -8,8 +8,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 
-import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.formatIso;
-
 /**
  * ScalarType for java.sql.Timestamp.
  */
@@ -29,7 +27,7 @@ final class ScalarTypeOffsetDateTime extends ScalarTypeBaseDateTime<OffsetDateTi
 
   @Override
   protected String toJsonISO8601(OffsetDateTime value) {
-    return formatIso(value.toInstant());
+    return value.toInstant().toString();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTimestamp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTimestamp.java
@@ -21,7 +21,7 @@ final class ScalarTypeTimestamp extends ScalarTypeBaseDateTime<Timestamp> {
 
   @Override
   protected String toJsonNanos(Timestamp value) {
-    return String.valueOf(value.getTime());
+    return toJsonNanos(value.getTime()/1000, value.getNanos());
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTimestamp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTimestamp.java
@@ -10,8 +10,6 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
 
-import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.formatIso;
-
 /**
  * ScalarType for java.sql.Timestamp.
  */
@@ -28,7 +26,7 @@ final class ScalarTypeTimestamp extends ScalarTypeBaseDateTime<Timestamp> {
 
   @Override
   protected String toJsonISO8601(Timestamp value) {
-    return formatIso(value.toInstant());
+    return value.toInstant().toString();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTimestamp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTimestamp.java
@@ -18,7 +18,7 @@ import static io.ebeaninternal.server.type.IsoJsonDateTimeParser.formatIso;
 final class ScalarTypeTimestamp extends ScalarTypeBaseDateTime<Timestamp> {
 
   ScalarTypeTimestamp(JsonConfig.DateTime mode) {
-    super(mode, Timestamp.class, true, Types.TIMESTAMP);
+    super(mode, Timestamp.class, true, Types.TIMESTAMP, false);
   }
 
   @Override
@@ -61,13 +61,13 @@ final class ScalarTypeTimestamp extends ScalarTypeBaseDateTime<Timestamp> {
     if (value == null) {
       binder.setNull(Types.TIMESTAMP);
     } else {
-      binder.setTimestamp(value);
+      binder.setTimestamp(value, isLocal);
     }
   }
 
   @Override
   public Timestamp read(DataReader reader) throws SQLException {
-    return reader.getTimestamp();
+    return reader.getTimestamp(isLocal);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeUtilDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeUtilDate.java
@@ -21,7 +21,7 @@ final class ScalarTypeUtilDate {
   static final class TimestampType extends ScalarTypeBaseDateTime<java.util.Date> {
 
     TimestampType(JsonConfig.DateTime mode) {
-      super(mode, java.util.Date.class, false, Types.TIMESTAMP);
+      super(mode, java.util.Date.class, false, Types.TIMESTAMP, false);
     }
 
     @Override
@@ -41,7 +41,7 @@ final class ScalarTypeUtilDate {
 
     @Override
     public java.util.Date read(DataReader reader) throws SQLException {
-      Timestamp timestamp = reader.getTimestamp();
+      Timestamp timestamp = reader.getTimestamp(isLocal);
       if (timestamp == null) {
         return null;
       } else {
@@ -54,7 +54,7 @@ final class ScalarTypeUtilDate {
       if (value == null) {
         binder.setNull(Types.TIMESTAMP);
       } else {
-        binder.setTimestamp(new Timestamp(value.getTime()));
+        binder.setTimestamp(new Timestamp(value.getTime()), isLocal);
       }
     }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeUtilDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeUtilDate.java
@@ -26,13 +26,17 @@ final class ScalarTypeUtilDate {
 
     @Override
     protected String toJsonNanos(Date value) {
-      return String.valueOf(value.getTime());
+      return toJsonNanos(value.getTime()); 
     }
 
     @Override
     protected String toJsonISO8601(Date value) {
       return formatIso(value.toInstant());
     }
+    
+    protected Date fromJsonISO8601(String value) {
+      return convertFromInstant(Instant.parse(value));
+    };
 
     @Override
     public long convertToMillis(Date value) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTime.java
@@ -31,6 +31,11 @@ final class ScalarTypeZonedDateTime extends ScalarTypeBaseDateTime<ZonedDateTime
   }
 
   @Override
+  protected ZonedDateTime fromJsonISO8601(String value) {
+    return convertFromInstant(Instant.parse(value));
+  }
+
+  @Override
   public long convertToMillis(ZonedDateTime value) {
     return value.toInstant().toEpochMilli();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeZonedDateTime.java
@@ -16,7 +16,7 @@ final class ScalarTypeZonedDateTime extends ScalarTypeBaseDateTime<ZonedDateTime
   private final ZoneId zoneId;
 
   ScalarTypeZonedDateTime(JsonConfig.DateTime mode, ZoneId zoneId) {
-    super(mode, ZonedDateTime.class, false, Types.TIMESTAMP);
+    super(mode, ZonedDateTime.class, false, Types.TIMESTAMP, false);
     this.zoneId = zoneId;
   }
 

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -187,7 +187,10 @@
 
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc10</artifactId>
+      <!-- Note: Using ojdbc10 here will affect loading other drivers on jdk8, 
+        because the driverManager will stop on first load error and stops loading 
+        other drivers -->
+      <artifactId>ojdbc8</artifactId>
       <version>19.12.0.0</version>
       <scope>test</scope>
     </dependency>

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test-docker</artifactId>
-      <version>4.2</version>
+      <version>4.3</version>
     </dependency>
 
     <dependency>

--- a/ebean-test/src/test/java/io/ebeaninternal/server/cache/CachedBeanDataFromBeanTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/cache/CachedBeanDataFromBeanTest.java
@@ -12,6 +12,7 @@ import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
 
 import java.sql.Date;
+import java.time.LocalDate;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +27,8 @@ public class CachedBeanDataFromBeanTest extends BaseTestCase {
 
     BeanDescriptor<Customer> desc = server.descriptor(Customer.class);
 
-    Date largeDate = new Date(9223372036825200000L);
+    
+    Date largeDate = Date.valueOf(LocalDate.of(292278994, 8, 17));
 
     Customer customer = new Customer();
     customer.setId(42);
@@ -44,7 +46,8 @@ public class CachedBeanDataFromBeanTest extends BaseTestCase {
     assertEquals(cacheData.getData("id"), "42");
     assertEquals(cacheData.getData("name"), "Rob");
     assertEquals(cacheData.getData("billingAddress"), "12");
-    assertEquals(cacheData.getData("anniversary"), "9223372036825200000");
+    assertEquals(cacheData.getData("anniversary"), "9223372036828800000");
+    assertEquals(9223372036828800000L % 86400000, 0); // is gmt based millis
   }
 
 

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesTest.java
@@ -1,0 +1,700 @@
+package io.ebeaninternal.server.type;
+
+import static java.lang.String.format;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.List;
+import java.util.TimeZone;
+
+import javax.sql.DataSource;
+
+import org.assertj.core.api.SoftAssertions;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.tests.model.basic.MDateTime;
+
+import io.ebean.Database;
+import io.ebean.DatabaseFactory;
+import io.ebean.config.DatabaseConfig;
+import io.ebean.core.type.ScalarType;
+import io.ebean.plugin.ExpressionPath;
+import io.ebean.plugin.Property;
+import io.ebean.text.PathProperties;
+import io.ebean.text.json.JsonWriteOptions;
+import io.ebean.util.CamelCaseHelper;
+import io.ebeaninternal.server.deploy.BeanProperty;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class DatesAndTimesTest {
+ 
+
+  String platform="h2";
+  
+  private Database db;
+  private TimeZone tz;
+  private DatabaseConfig config;
+  private SoftAssertions softly;
+
+  private String json;
+  private String formatted;
+  private long millis;
+
+  @BeforeEach
+  public void startTest() {
+    softly = new SoftAssertions();
+    tz = TimeZone.getDefault();
+    if (db == null) {
+      db = createServer("GMT", null, null); // test uses GMT database
+    } else {
+      restartServer(null, "GMT");
+    }
+    json = null;
+    formatted = null;
+    millis = 0;
+  }
+  
+  @AfterEach
+  public void stopTest() {
+    setJavaTimeZone(tz);
+    softly.assertAll();
+  }
+
+  @AfterAll
+  public void shutdown() {
+    if (db != null) {
+      db.find(MDateTime.class).delete();
+      db.shutdown();
+    }
+  }
+  
+  private void restartServer(String javaTimeZone, String dbTimeZone) {
+    DataSource existingDs = db.dataSource();
+    DataSource existingRoDs = db.readOnlyDataSource();
+    db.shutdown(false, false);
+    if (javaTimeZone != null) {
+      setJavaTimeZone(TimeZone.getTimeZone(javaTimeZone));
+    }
+    db = createServer(dbTimeZone, existingDs, existingRoDs);
+  }
+
+  private void setJavaTimeZone(TimeZone newTz) {
+    TimeZone.setDefault(newTz);
+    DateTimeZone.setDefault(DateTimeZone.forTimeZone(newTz));
+    org.h2.util.DateTimeUtils.resetCalendar();
+  }
+  
+  private Database createServer(String dbTimeZone, DataSource existingDs, DataSource existingRoDs) {
+
+    config = new DatabaseConfig();
+    config.setName(platform);
+    config.loadFromProperties();
+    config.setDdlGenerate(existingDs == null );
+    config.setDdlRun(existingDs == null);
+    config.setReadOnlyDataSource(existingDs);
+    config.setDdlExtra(false);
+    config.setDefaultServer(false);
+    config.setRegister(false);
+    config.setChangeLogAsync(false);
+    config.addClass(MDateTime.class);
+    
+    config.setDumpMetricsOnShutdown(false);
+    config.setDataTimeZone(dbTimeZone);
+    config.setDataSource(existingDs);
+    reconfigure(config);
+
+    return DatabaseFactory.create(config);
+  }
+
+  protected void reconfigure(DatabaseConfig config) {
+    
+  }
+
+  @Test
+  public void testLocalTime() {
+    if (config.isLocalTimeWithNanos()) {
+      LocalTime lt = LocalTime.of(5, 15, 15,123456789);
+      doTest("localTime", lt, String.valueOf(lt.toNanoOfDay())); 
+      softly.assertThat(json).isEqualTo("{\"localTime\":\"05:15:15.123456789\"}");
+      softly.assertThat(formatted).isEqualTo("05:15:15.123456789");
+      return;
+    }
+    // localTimes are never converted, when read or written to database
+    doTest("localTime", LocalTime.of(5, 15, 15), "05:15:15");
+    softly.assertThat(json).isEqualTo("{\"localTime\":\"05:15:15\"}");
+    softly.assertThat(formatted).isEqualTo("05:15:15");
+    
+    doTest("localTime", LocalTime.of(0, 0, 0), "00:00:00");
+    doTest("localTime", LocalTime.of(23, 59, 59), "23:59:59");
+
+    // it does not matter in which timezone the server or java is!
+    restartServer("PST", "Europe/Berlin");
+    doTest("localTime", LocalTime.of(5, 15, 15), "05:15:15");
+    doTest("localTime", LocalTime.of(0, 0, 0), "00:00:00");
+    doTest("localTime", LocalTime.of(23, 59, 59), "23:59:59");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("localTime", LocalTime.of(5, 15, 15), "05:15:15");
+    doTest("localTime", LocalTime.of(0, 0, 0), "00:00:00");
+    doTest("localTime", LocalTime.of(23, 59, 59), "23:59:59");
+
+  }
+
+  @Test
+  public void testJodaLocalTime() {
+    // localTimes are never converted, when read or written to database
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("05:15:15"), "05:15:15");
+    softly.assertThat(json).isEqualTo("{\"jodaLocalTime\":\"05:15:15.000\"}");
+    softly.assertThat(formatted).isEqualTo("05:15:15.000");
+    
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("00:00:00"), "00:00:00");
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("23:59:59"), "23:59:59");
+
+    // it does not matter in which timezone the server or java is!
+    restartServer("PST", "Europe/Berlin");
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("05:15:15"), "05:15:15");
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("00:00:00"), "00:00:00");
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("23:59:59"), "23:59:59");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("05:15:15"), "05:15:15");
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("00:00:00"), "00:00:00");
+    doTest("jodaLocalTime", org.joda.time.LocalTime.parse("23:59:59"), "23:59:59");
+
+  }
+
+  @Test
+  public void testLocalDate() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("localDate", LocalDate.parse("2021-11-21"), "2021-11-21");
+    softly.assertThat(formatted).isEqualTo("1637452800000");
+    softly.assertThat(millis).isEqualTo(1637452800000L); // 00:00 in GMT
+    
+    if (config.getJsonDate() == io.ebean.config.JsonConfig.Date.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"localDate\":\"2021-11-21\"}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"localDate\":1637452800000}"); // 21-nov 00:00 GMT
+    }
+  
+    doTest("localDate", LocalDate.parse("1970-01-01"), "1970-01-01");
+    softly.assertThat(formatted).isEqualTo("0");
+    softly.assertThat(millis).isEqualTo(0L); 
+    
+    doTest("localDate", LocalDate.parse("1969-12-31"), "1969-12-31");
+    softly.assertThat(formatted).isEqualTo("-86400000");
+    softly.assertThat(millis).isEqualTo(-86400000L); 
+    if (config.getJsonDate() == io.ebean.config.JsonConfig.Date.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"localDate\":\"1969-12-31\"}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"localDate\":-86400000}");
+    }
+
+    doTest("localDate", LocalDate.parse("2021-08-21"), "2021-08-21");
+
+    restartServer("PST", "Europe/Berlin");
+    doTest("localDate", LocalDate.parse("2021-11-21"), "2021-11-21");
+    doTest("localDate", LocalDate.parse("2021-08-21"), "2021-08-21");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("localDate", LocalDate.parse("2021-11-21"), "2021-11-21");
+    doTest("localDate", LocalDate.parse("2021-08-21"), "2021-08-21");
+
+  }
+
+  @Test
+  public void testJodaLocalDate() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("2021-11-21"), "2021-11-21");
+    if (config.getJsonDate() == io.ebean.config.JsonConfig.Date.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"jodaLocalDate\":\"2021-11-21\"}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"jodaLocalDate\":1637452800000}"); // GMT: 00:00
+    }
+
+    
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("2021-08-21"), "2021-08-21");
+
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("1970-01-01"), "1970-01-01");
+    softly.assertThat(formatted).isEqualTo("0");
+    softly.assertThat(millis).isEqualTo(0L); 
+    
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("1969-12-31"), "1969-12-31");
+    softly.assertThat(formatted).isEqualTo("-86400000");
+    softly.assertThat(millis).isEqualTo(-86400000L); 
+    
+    restartServer("PST", "Europe/Berlin");
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("2021-11-21"), "2021-11-21");
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("2021-08-21"), "2021-08-21");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("2021-11-21"), "2021-11-21");
+    doTest("jodaLocalDate", org.joda.time.LocalDate.parse("2021-08-21"), "2021-08-21");
+
+  }
+
+  @Test
+  public void testCalendar() {
+
+    restartServer("GMT", "GMT");
+    Calendar cal = Calendar.getInstance();
+    cal.clear();
+    cal.set(2021, 8 - 1, 21, 5, 15, 15); // month 0-based!
+
+    softly.assertThat(cal.toInstant()).isEqualTo(Instant.parse("2021-08-21T05:15:15Z"));
+
+    doTest("propCalendar", cal, "2021-08-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":\"2021-08-21T05:15:15.000Z\"}");
+    } else if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":1629522915000}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":1629522915.000000000}"); // 05:15 GMT
+    }
+    
+    cal.clear();
+    cal.setTimeInMillis(-1);
+    doTest("propCalendar", cal, "1969-12-31 23:59:59.999");
+    softly.assertThat(formatted).isEqualTo("-1");
+    softly.assertThat(millis).isEqualTo(-1L); 
+    
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":\"1969-12-31T23:59:59.999Z\"}");
+    } else if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":-1}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":-0.001000000}");
+    }
+    
+    // test in PST time zone
+    restartServer("PST", "GMT");
+    cal = Calendar.getInstance();
+    cal.setTimeInMillis(0); // clear
+    cal.set(2021, 8 - 1, 20, 22, 15, 15); // month 0-based!
+
+    softly.assertThat(cal.toInstant()).isEqualTo(Instant.parse("2021-08-21T05:15:15Z"));
+
+    doTest("propCalendar", cal, "2021-08-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":\"2021-08-21T05:15:15.000Z\"}");
+    } else if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":1629522915000}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"propCalendar\":1629522915.000000000}");
+    }
+  }
+
+  @Test
+  public void testInstant() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("propInstant", Instant.parse("2021-11-21T05:15:15Z"), "2021-11-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"propInstant\":\"2021-11-21T05:15:15Z\"}");
+    } else if (config.getJsonDateTime()  == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"propInstant\":1637471715000}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"propInstant\":1637471715.000000000}"); // 05:15 GMT
+    }
+
+    doTest("propInstant", Instant.parse("1970-01-01T00:00:00Z"), "1970-01-01 00:00:00");
+    softly.assertThat(formatted).isEqualTo("0");
+    softly.assertThat(millis).isEqualTo(0L); 
+    
+    doTest("propInstant", Instant.parse("2021-08-21T05:15:15Z"), "2021-08-21 05:15:15");
+
+    restartServer("PST", "GMT");
+
+    doTest("propInstant", Instant.parse("2021-11-21T05:15:15Z"), "2021-11-21 05:15:15");
+    doTest("propInstant", Instant.parse("2021-08-21T05:15:15Z"), "2021-08-21 05:15:15");
+  }
+
+  @Test
+  public void testJodaDateTime() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("jodaDateTime", org.joda.time.DateTime.parse("2021-11-21T05:15:15Z"), "2021-11-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"jodaDateTime\":\"2021-11-21T05:15:15.000Z\"}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"jodaDateTime\":1637471715000}");
+    }
+    
+    doTest("jodaDateTime", org.joda.time.DateTime.parse("1970-01-01T00:00:00Z"), "1970-01-01 00:00:00");
+    softly.assertThat(formatted).isEqualTo("0");
+    softly.assertThat(millis).isEqualTo(0L); 
+
+    restartServer("PST", "GMT");
+
+    doTest("jodaDateTime", org.joda.time.DateTime.parse("2021-11-21T05:15:15Z"), "2021-11-21 05:15:15");
+    doTest("jodaDateTime", org.joda.time.DateTime.parse("2021-08-21T05:15:15Z"), "2021-08-21 05:15:15");
+  }
+
+  @Test
+  public void testLocalDateTime() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("localDateTime", LocalDateTime.parse("2021-11-21T05:15:15"), "2021-11-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"localDateTime\":\"2021-11-21T05:15:15\"}");
+    } else if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"localDateTime\":1637471715000}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"localDateTime\":1637471715.000000000}");
+    }
+    softly.assertThat(formatted).isEqualTo("2021-11-21T05:15:15"); // WHY is this not formatted in millis
+    softly.assertThat(millis).isEqualTo(1637471715000L); 
+    
+    doTest("localDateTime", LocalDateTime.parse("1970-01-01T00:00:00"), "1970-01-01 00:00:00");
+    softly.assertThat(formatted).isEqualTo("1970-01-01T00:00");
+    softly.assertThat(millis).isEqualTo(0L); 
+
+    restartServer("PST", "Europe/Berlin");
+    doTest("localDateTime", LocalDateTime.parse("2021-11-21T05:15:15"), "2021-11-21 05:15:15");
+    doTest("localDateTime", LocalDateTime.parse("2021-08-21T05:15:15"), "2021-08-21 05:15:15");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("localDateTime", LocalDateTime.parse("2021-11-21T05:15:15"), "2021-11-21 05:15:15");
+    doTest("localDateTime", LocalDateTime.parse("2021-08-21T05:15:15"), "2021-08-21 05:15:15");
+
+  }
+
+  @Test
+  public void testJodaLocalDateTime() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("jodaLocalDateTime", org.joda.time.LocalDateTime.parse("2021-11-21T05:15:15"), "2021-11-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"jodaLocalDateTime\":\"2021-11-21T05:15:15.000\"}");
+    } else if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"jodaLocalDateTime\":1637471715000}"); // 05:15:15 GMT
+    } else {
+      softly.assertThat(json).isEqualTo("{\"jodaLocalDateTime\":1637471715.000000000}"); // 05:15:15 GMT
+    }
+    
+    doTest("jodaLocalDateTime", org.joda.time.LocalDateTime.parse("2021-08-21T05:15:15"), "2021-08-21 05:15:15");
+
+    restartServer("PST", "Europe/Berlin");
+    doTest("jodaLocalDateTime", org.joda.time.LocalDateTime.parse("2021-11-21T05:15:15"), "2021-11-21 05:15:15");
+    doTest("jodaLocalDateTime", org.joda.time.LocalDateTime.parse("2021-08-21T05:15:15"), "2021-08-21 05:15:15");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("jodaLocalDateTime", org.joda.time.LocalDateTime.parse("2021-11-21T05:15:15"), "2021-11-21 05:15:15");
+    doTest("jodaLocalDateTime", org.joda.time.LocalDateTime.parse("2021-08-21T05:15:15"), "2021-08-21 05:15:15");
+
+  }
+
+  @Test
+  public void testJodaDateMidnight() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("jodaDateMidnight", org.joda.time.DateMidnight.parse("2021-11-21"), "2021-11-21");
+    if (config.getJsonDate() == io.ebean.config.JsonConfig.Date.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"jodaDateMidnight\":\"2021-11-21\"}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"jodaDateMidnight\":1637449200000}");
+    }
+    
+    doTest("jodaDateMidnight", org.joda.time.DateMidnight.parse("2021-08-21"), "2021-08-21");
+
+    restartServer("PST", "Europe/Berlin");
+    doTest("jodaDateMidnight", org.joda.time.DateMidnight.parse("2021-11-21"), "2021-11-21");
+    doTest("jodaDateMidnight", org.joda.time.DateMidnight.parse("2021-08-21"), "2021-08-21");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("jodaDateMidnight", org.joda.time.DateMidnight.parse("2021-11-21"), "2021-11-21");
+    doTest("jodaDateMidnight", org.joda.time.DateMidnight.parse("2021-08-21"), "2021-08-21");
+  }
+
+  @Test
+  public void testYearMonth() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("propYearMonth", YearMonth.of(2020, 2), "2020-02-01");
+    if (config.getJsonDate() == io.ebean.config.JsonConfig.Date.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"propYearMonth\":\"2020-02-01\"}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"propYearMonth\":1580515200000}"); // 00:00 GMT
+    }
+    doTest("propYearMonth", YearMonth.of(2020, 3), "2020-03-01");
+    doTest("propYearMonth", YearMonth.of(2020, 4), "2020-04-01");
+
+  }
+  @Test
+  public void testYear() {
+
+    doTest("propYear", Year.of(2020), "2020");
+
+  }
+  
+  @Test
+  public void testMonthDay() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("propMonthDay", MonthDay.of(11, 21), "2000-11-21");
+    softly.assertThat(json).isEqualTo("{\"propMonthDay\":\"--11-21\"}");
+    doTest("propMonthDay", MonthDay.of(8, 21), "2000-08-21");
+    doTest("propMonthDay", MonthDay.of(2, 29), "2000-02-29"); // leap year check
+
+    restartServer("PST", "Europe/Berlin");
+    doTest("propMonthDay", MonthDay.of(11, 21), "2000-11-21");
+    doTest("propMonthDay", MonthDay.of(8, 21), "2000-08-21");
+    doTest("propMonthDay", MonthDay.of(2, 29), "2000-02-29"); // leap year check
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("propMonthDay", MonthDay.of(11, 21), "2000-11-21");
+    doTest("propMonthDay", MonthDay.of(8, 21), "2000-08-21");
+    doTest("propMonthDay", MonthDay.of(2, 29), "2000-02-29"); // leap year check
+  }
+
+  @Test
+  public void testSqlDate() {
+    // localTimes are never converted, when read or written to database
+    doTest("sqlDate", new java.sql.Date(2021 - 1900, 11 - 1, 21), "2021-11-21");
+    if (config.getJsonDate() == io.ebean.config.JsonConfig.Date.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"sqlDate\":\"2021-11-21\"}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"sqlDate\":1637452800000}"); // 00:00 GMT
+    }
+
+    doTest("sqlDate", new java.sql.Date(2021 - 1900, 8 - 1, 21), "2021-08-21");
+
+    // it does not matter in which timezone the server or java is!
+    restartServer("PST", "Europe/Berlin");
+    doTest("sqlDate", new java.sql.Date(2021 - 1900, 11 - 1, 21), "2021-11-21");
+    doTest("sqlDate", new java.sql.Date(2021 - 1900, 8 - 1, 21), "2021-08-21");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("sqlDate", new java.sql.Date(2021 - 1900, 11 - 1, 21), "2021-11-21");
+    doTest("sqlDate", new java.sql.Date(2021 - 1900, 8 - 1, 21), "2021-08-21");
+
+  }
+
+  @Test
+  public void testSqlTime() {
+
+    // Test with DST and no DST date (in germany)
+    doTest("sqlTime", new java.sql.Time(5, 15, 15), "05:15:15");
+    softly.assertThat(json).isEqualTo("{\"sqlTime\":\"05:15:15\"}");
+    
+    doTest("sqlTime", new java.sql.Time(0, 0, 0), "00:00:00");
+    doTest("sqlTime", new java.sql.Time(23, 59, 59), "23:59:59");
+
+    restartServer("PST", "Europe/Berlin");
+    doTest("sqlTime", new java.sql.Time(5, 15, 15), "05:15:15");
+    doTest("sqlTime", new java.sql.Time(0, 0, 0), "00:00:00");
+    doTest("sqlTime", new java.sql.Time(23, 59, 59), "23:59:59");
+
+    restartServer("Europe/Berlin", "PST");
+    doTest("sqlTime", new java.sql.Time(5, 15, 15), "05:15:15");
+    doTest("sqlTime", new java.sql.Time(0, 0, 0), "00:00:00");
+    doTest("sqlTime", new java.sql.Time(23, 59, 59), "23:59:59");
+  }
+  
+  @Test
+  public void testTimestamp() {
+    restartServer("PST", "PST"); // java & db in same TZ
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 11 - 1, 21, 5, 15, 15, 0), "2021-11-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"propTimestamp\":\"2021-11-21T13:15:15Z\"}");
+    } else if (config.getJsonDateTime()  == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"propTimestamp\":1637500515000}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"propTimestamp\":1637500515.000000000}");
+    }
+
+    
+    restartServer("Europe/Berlin", "GMT"); // go to germany
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 11 - 1, 21, 6, 15, 15, 0), "2021-11-21 05:15:15");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 8 - 1, 21, 7, 15, 15, 0), "2021-08-21 05:15:15"); // Check DST
+    
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 27, 23, 0, 0, 0), "2021-03-27 22:00:00");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 28, 0, 0, 0, 0), "2021-03-27 23:00:00");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 28, 1, 0, 0, 0), "2021-03-28 00:00:00");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 28, 2, 0, 0, 0), "2021-03-28 01:00:00");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 28, 3, 0, 1, 0), "2021-03-28 01:00:01");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 28, 4, 0, 0, 0), "2021-03-28 02:00:00");
+
+    restartServer("GMT", "Europe/Berlin"); 
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 11 - 1, 21, 4, 15, 15, 0), "2021-11-21 05:15:15");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 8 - 1, 21, 3, 15, 15, 0), "2021-08-21 05:15:15"); // Check DST
+    
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 27, 1, 0, 0, 0), "2021-03-27 02:00:00");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 27, 23, 0, 0, 0), "2021-03-28 00:00:00");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 28, 0, 0, 0, 0), "2021-03-28 01:00:00");
+    doTest("propTimestamp", new Timestamp(2021 - 1900, 3 - 1, 28, 1, 0, 0, 0), "2021-03-28 03:00:00");
+  }
+
+  @Test
+  public void testUtilDate() {
+    restartServer("PST", "PST"); // java & db in same TZ
+    doTest("utilDate", new java.util.Date(2021 - 1900, 11 - 1, 21, 5, 15, 15), "2021-11-21 05:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"utilDate\":\"2021-11-21T13:15:15.000Z\"}");
+    } else if (config.getJsonDateTime()  == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"utilDate\":1637500515000}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"utilDate\":1637500515.000000000}");
+    }
+
+    
+    restartServer("Europe/Berlin", "GMT"); // go to germany
+    doTest("utilDate", new java.util.Date(2021 - 1900, 11 - 1, 21, 6, 15, 15), "2021-11-21 05:15:15");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 8 - 1, 21, 7, 15, 15), "2021-08-21 05:15:15");
+    
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 27, 23, 0, 0), "2021-03-27 22:00:00");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 28, 0, 0, 0), "2021-03-27 23:00:00");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 28, 1, 0, 0), "2021-03-28 00:00:00");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 28, 2, 0, 0), "2021-03-28 01:00:00");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 28, 3, 0, 1), "2021-03-28 01:00:01");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 28, 4, 0, 0), "2021-03-28 02:00:00");
+
+    restartServer("GMT", "Europe/Berlin"); 
+    doTest("utilDate", new java.util.Date(2021 - 1900, 11 - 1, 21, 4, 15, 15), "2021-11-21 05:15:15");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 8 - 1, 21, 3, 15, 15), "2021-08-21 05:15:15");
+    
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 27, 1, 0, 0), "2021-03-27 02:00:00");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 27, 23, 0, 0), "2021-03-28 00:00:00");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 28, 0, 0, 0), "2021-03-28 01:00:00");
+    doTest("utilDate", new java.util.Date(2021 - 1900, 3 - 1, 28, 1, 0, 0), "2021-03-28 03:00:00");
+  }
+  
+  @Test
+  public void testOffsetDateTime() {
+
+    restartServer("PST", "PST"); // be in the same TZ
+    doTest("offsetDateTime", OffsetDateTime.parse("2021-11-20T21:15:15-08:00"), "2021-11-20 21:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"offsetDateTime\":\"2021-11-21T05:15:15Z\"}");
+    } else if (config.getJsonDateTime()  == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"offsetDateTime\":1637471715000}");
+    } else {
+      softly.assertThat(json).isEqualTo("{\"offsetDateTime\":1637471715.000000000}");
+    }
+    
+    restartServer("PST", "GMT"); // pass PST offsetDateTime to GMT DB
+    doTest("offsetDateTime", OffsetDateTime.parse("2021-11-20T21:15:15-08:00"), "2021-11-21 05:15:15");
+    
+  }
+
+  @Test
+  public void testZonedDateTime() {
+
+    restartServer("PST", "PST"); // be in the same TZ
+    doTest("zonedDateTime", ZonedDateTime.parse("2021-11-20T21:15:15-08:00"), "2021-11-20 21:15:15");
+    if (config.getJsonDateTime() == io.ebean.config.JsonConfig.DateTime.ISO8601) {
+      softly.assertThat(json).isEqualTo("{\"zonedDateTime\":\"2021-11-21T05:15:15Z\"}");
+    } else if (config.getJsonDateTime()  == io.ebean.config.JsonConfig.DateTime.MILLIS) {
+      softly.assertThat(json).isEqualTo("{\"zonedDateTime\":1637471715000}"); // 05:15 GMT
+    } else {
+      softly.assertThat(json).isEqualTo("{\"zonedDateTime\":1637471715.000000000}");
+    }
+    
+    restartServer("PST", "GMT"); // pass PST offsetDateTime to GMT DB
+    doTest("zonedDateTime", ZonedDateTime.parse("2021-11-20T21:15:15-08:00"), "2021-11-21 05:15:15");
+    
+  }
+//  offsetDateTime : OffsetDateTime
+//  zonedDateTime : ZonedDateTime
+  private String simpleClassNameOf(StackTraceElement testStackTraceElement) {
+    String className = testStackTraceElement.getClassName();
+    return className.substring(className.lastIndexOf('.') + 1);
+  }
+
+  private <T extends Comparable<? super T>> void doTest(String property, T javaValue, String sqlValue) {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    String testClassName = simpleClassNameOf(stackTrace[2]);
+    String testName = stackTrace[2].getMethodName();
+    int lineNumber = stackTrace[2].getLineNumber();
+    String testLoc = format("at %s.%s(%s.java:%s)", testClassName, testName, testClassName, lineNumber);
+
+    db.find(MDateTime.class).delete(); // clear database
+    String sqlColumn = CamelCaseHelper.toUnderscoreFromCamel(property);
+    // insert with raw sql
+    db.sqlUpdate("insert into mdate_time (id, " + sqlColumn + ") values (1, '" + sqlValue + "')").execute();
+
+    // check findSingleAttributeList
+    List<T> list = db.find(MDateTime.class).select(property).findSingleAttributeList();
+    softly.assertThat(list).as("find " + testLoc).hasSize(1);
+    T attr = list.get(0);
+    assertTimeEquals("find attribute " + testLoc, attr, javaValue);
+
+    // check find model
+    MDateTime model = db.find(MDateTime.class).where().eq(property, javaValue).findOne();
+    Property beanProp = db.pluginApi().beanType(MDateTime.class).property(property);
+    softly.assertThat(model).as("find model " + testLoc).isNotNull();
+    if (model != null) {
+      @SuppressWarnings("unchecked")
+      T beanValue = (T) beanProp.value(model);
+      assertTimeEquals("read from model " + testLoc, beanValue, javaValue);
+    }
+    // insert with "save"
+    model = new MDateTime();
+    model.setId(2);
+    ((ExpressionPath) beanProp).pathSet(model, javaValue);
+    db.save(model);
+
+    // check findCount
+    int count = db.find(MDateTime.class).where().eq(property, javaValue).findCount();
+    softly.assertThat(count).as("find count " + testLoc).isEqualTo(2);
+
+    JsonWriteOptions opts = new JsonWriteOptions();
+    opts.setPathProperties(PathProperties.parse(property));
+    // check json roundtrip
+    json = db.json().toJson(model, opts);
+    model = db.json().toBean(MDateTime.class, json);
+    T beanValue = (T) beanProp.value(model);
+    assertTimeEquals("json roundtrip " + testLoc, beanValue, javaValue);
+
+    ScalarType<T> st = (ScalarType) ((BeanProperty) beanProp).scalarType();
+    formatted = st.formatValue(javaValue);
+    assertTimeEquals("parse/format symmetry " + testLoc, st.parse(formatted), javaValue);
+    if (st instanceof ScalarTypeBaseDate) {
+      ScalarTypeBaseDate<T> st2 = (ScalarTypeBaseDate<T>) st;
+      Date date = st2.convertToDate(javaValue);
+      assertTimeEquals("date convert symmetry " + testLoc, st2.convertFromDate(date), javaValue);
+      millis = st2.convertToMillis(javaValue);
+      assertTimeEquals("millis convert symmetry " + testLoc, st2.convertFromMillis(millis), javaValue);
+    }
+    if (st instanceof ScalarTypeBaseDateTime) {
+      ScalarTypeBaseDateTime<T> st2 = (ScalarTypeBaseDateTime<T>) st;
+      Timestamp ts = st2.convertToTimestamp(javaValue);
+      assertTimeEquals("timestamp convert symmetry " + testLoc, st2.convertFromTimestamp(ts), javaValue);
+       millis = st2.convertToMillis(javaValue);
+      assertTimeEquals("millis convert symmetry " + testLoc, st2.convertFromMillis(millis), javaValue);
+      assertTimeEquals("instant convert symmetry " + testLoc, st2.convertFromInstant(Instant.ofEpochMilli(millis)),
+          javaValue);
+    }
+  }
+
+  private <T extends Comparable<? super T>> void assertTimeEquals(String msg, T value, T expected) {
+    if (value instanceof java.sql.Date) {
+      // SQL Dates may not be aligned at 00:00 - so compare toString representation
+      softly.assertThat(value.toString()).as(msg).isEqualTo(expected.toString());
+    } else if (value instanceof OffsetDateTime) {
+      softly.assertThat((OffsetDateTime) value).as(msg).isAtSameInstantAs((OffsetDateTime) expected);
+    } else if (value instanceof ZonedDateTime) {
+      softly.assertThat(((ZonedDateTime) value).toInstant()).as(msg).isEqualTo(((ZonedDateTime) expected).toInstant());
+    } else {
+      softly.assertThat(value).as(msg).isEqualByComparingTo(expected);
+    }
+  }
+
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -42,6 +43,7 @@ import io.ebean.util.CamelCaseHelper;
 import io.ebeaninternal.server.deploy.BeanProperty;
 
 @TestInstance(Lifecycle.PER_CLASS)
+@Disabled
 public class DatesAndTimesTest {
  
 

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesTest.java
@@ -43,7 +43,7 @@ import io.ebean.util.CamelCaseHelper;
 import io.ebeaninternal.server.deploy.BeanProperty;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@Disabled
+//@Disabled
 public class DatesAndTimesTest {
  
 

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithDb2Test.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithDb2Test.java
@@ -1,0 +1,7 @@
+package io.ebeaninternal.server.type;
+
+public class DatesAndTimesWithDb2Test extends DatesAndTimesTest {
+  public DatesAndTimesWithDb2Test() {
+    platform = "db2";
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithJsonMillisTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithJsonMillisTest.java
@@ -1,0 +1,11 @@
+package io.ebeaninternal.server.type;
+
+import io.ebean.config.DatabaseConfig;
+
+public class DatesAndTimesWithJsonMillisTest extends DatesAndTimesTest {
+  @Override
+  protected void reconfigure(DatabaseConfig config) {
+    config.setJsonDate(io.ebean.config.JsonConfig.Date.MILLIS);
+    config.setJsonDateTime(io.ebean.config.JsonConfig.DateTime.MILLIS);
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithJsonNanosTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithJsonNanosTest.java
@@ -1,0 +1,10 @@
+package io.ebeaninternal.server.type;
+
+import io.ebean.config.DatabaseConfig;
+
+public class DatesAndTimesWithJsonNanosTest extends DatesAndTimesTest {
+  @Override
+  protected void reconfigure(DatabaseConfig config) {
+    config.setJsonDateTime(io.ebean.config.JsonConfig.DateTime.NANOS);
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithMariaDbTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithMariaDbTest.java
@@ -1,0 +1,7 @@
+package io.ebeaninternal.server.type;
+
+public class DatesAndTimesWithMariaDbTest extends DatesAndTimesTest {
+  public DatesAndTimesWithMariaDbTest() {
+    platform = "mariadb";
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithMysqlTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithMysqlTest.java
@@ -1,0 +1,10 @@
+package io.ebeaninternal.server.type;
+
+import org.junit.jupiter.api.Disabled;
+
+@Disabled
+public class DatesAndTimesWithMysqlTest extends DatesAndTimesTest {
+  public DatesAndTimesWithMysqlTest() {
+    platform = "mysql";
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithNanosTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithNanosTest.java
@@ -1,0 +1,10 @@
+package io.ebeaninternal.server.type;
+
+import io.ebean.config.DatabaseConfig;
+
+public class DatesAndTimesWithNanosTest extends DatesAndTimesTest {
+  @Override
+  protected void reconfigure(DatabaseConfig config) {
+    config.setLocalTimeWithNanos(true);
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithPgTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithPgTest.java
@@ -1,0 +1,10 @@
+package io.ebeaninternal.server.type;
+
+import org.junit.jupiter.api.Disabled;
+
+@Disabled
+public class DatesAndTimesWithPgTest extends DatesAndTimesTest {
+  public DatesAndTimesWithPgTest() {
+    platform = "pg";
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithSqlServerTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/DatesAndTimesWithSqlServerTest.java
@@ -1,0 +1,7 @@
+package io.ebeaninternal.server.type;
+
+public class DatesAndTimesWithSqlServerTest extends DatesAndTimesTest {
+  public DatesAndTimesWithSqlServerTest() {
+    platform = "sqlserver";
+  }
+}

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/ScalarTypeDateTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/ScalarTypeDateTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.sql.Date;
+import java.time.LocalDate;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,6 +18,8 @@ public class ScalarTypeDateTest {
   @Test
   public void formatParse_PG_DATE_POSITIVE_INFINITY() {
 
+    // Note: This test does not pass if 
+    // TimeZone.setDefault(TimeZone.getTimeZone("PST"));
     Date postgresInfinityDate = new Date(9223372036825200000L);
 
     String format = type.formatValue(postgresInfinityDate);
@@ -26,8 +30,9 @@ public class ScalarTypeDateTest {
   @Test
   public void json() throws IOException {
 
-
-    Date val = new Date(1557360000000L);
+    // Date val = new Date(1557360000000L); does not work if
+    // TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+    Date val = Date.valueOf(LocalDate.of(2019,5,9)); // erase tz dependent fraction.
 
     JsonTester<Date> jsonMillis = new JsonTester<>(type);
     assertThat(jsonMillis.test(val)).isEqualTo("{\"key\":1557360000000}");

--- a/ebean-test/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTimeTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalDateTimeTest.java
@@ -8,8 +8,11 @@ import org.junit.jupiter.api.Test;
 import java.io.StringWriter;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ScalarTypeLocalDateTimeTest {
@@ -28,7 +31,8 @@ public class ScalarTypeLocalDateTimeTest {
 
     long now = System.currentTimeMillis();
     long toMillis = type.convertToMillis(LocalDateTime.now());
-    assertTrue(toMillis - now < 30);
+    now += TimeZone.getDefault().getOffset(now);
+    assertThat(toMillis).isCloseTo(now, within(30L));
   }
 
   @Test

--- a/ebean-test/src/test/java/main/StartDb2.java
+++ b/ebean-test/src/test/java/main/StartDb2.java
@@ -1,0 +1,22 @@
+package main;
+
+import io.ebean.docker.commands.Db2Config;
+import io.ebean.docker.commands.Db2Container;
+
+public class StartDb2 {
+
+  public static void main(String[] args) {
+
+    Db2Config config = new Db2Config("11.5.6.0a");
+    config.setDbName("unit");
+    config.setUser("unit");
+    config.setPassword("unit");
+
+    // to change collation, charset and other parameters like pagesize:
+    config.setCreateOptions("USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768");
+    config.setConfigOptions("USING STRING_UNITS CODEUNITS32");
+
+    Db2Container container = new Db2Container(config);
+    container.startWithDropCreate();
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/basic/MDateTime.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/MDateTime.java
@@ -1,0 +1,90 @@
+package org.tests.model.basic;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+
+import javax.annotation.Nullable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.joda.time.DateTime;
+
+@Entity
+public class MDateTime {
+
+  @Id
+  private Integer id;
+
+  @Nullable
+  private LocalTime localTime;
+
+  @Nullable
+  private LocalDateTime localDateTime;
+
+  @Nullable
+  private LocalDate localDate;
+
+  @Nullable
+  private OffsetDateTime offsetDateTime;
+
+  @Nullable
+  private ZonedDateTime zonedDateTime;
+  
+  @Nullable
+  private YearMonth propYearMonth;
+  
+  @Nullable
+  private MonthDay propMonthDay;
+  
+  @Nullable
+  private Year propYear;
+
+  @Nullable
+  private Instant propInstant;
+
+  @Nullable
+  private Calendar propCalendar;
+
+  @Nullable
+  private Timestamp propTimestamp;
+  
+  @Nullable
+  private java.sql.Date sqlDate;
+
+  @Nullable
+  private java.sql.Time sqlTime;
+
+  @Nullable
+  private java.util.Date utilDate;
+
+  @Nullable
+  private org.joda.time.DateTime jodaDateTime;
+
+  @Nullable
+  private org.joda.time.LocalDateTime jodaLocalDateTime;
+
+  @Nullable
+  private org.joda.time.LocalDate jodaLocalDate;
+
+  @Nullable
+  private org.joda.time.LocalTime jodaLocalTime;
+
+  @Nullable
+  private org.joda.time.DateMidnight jodaDateMidnight;
+
+  public Integer getId() {
+    return id;
+  }
+  public void setId(Integer id) {
+    this.id = id;
+  }
+}

--- a/ebean-test/src/test/resources/ebean.properties
+++ b/ebean-test/src/test/resources/ebean.properties
@@ -181,9 +181,9 @@ datasource.nuodb.password=test
 datasource.nuodb.url=jdbc:com.nuodb://localhost/testdb
 #datasource.nuodb.driver=com.nuodb.jdbc.Driver
 
-datasource.db2.username=db2admin
-datasource.db2.password=veryverysecret#1234
-datasource.db2.url=jdbc:db2://127.0.0.1:50000/SAMPLE
+datasource.db2.username=unit
+datasource.db2.password=unit
+datasource.db2.url=jdbc:db2://127.0.0.1:50000/unit
 #datasource.db2.driver=com.ibm.db2.jcc.DB2Driver
 
 datasource.hana.username=EBEAN_TEST


### PR DESCRIPTION
Hello Rob, this is a very big PR and @NSzemenyei and I tried to split it up in several commits.

It adressess the problem of date time handling in ebean and I found several bugs or detected inconsistencies
I think not all in this PR is correct, so feel free to give me feedback
(I recommend watching this [video ](https://youtu.be/-5wpm-gesOY) to relax before your head explodes)

I imagine the following scenario:
- distributed database around the world (one replica in germany, an other in USA)
- multiple application servers around the world
all of them are in different local timezones

*Assumptions*
1. A time only value (LocalTime / java.sql.Time) is never converted. So if `05:15:15` is stored in the database, you will get this value in USA and in germany
2. A time only value is serialized as ISO string (like `05:15:00`) or as GMT based millis value in JSON. So `00:00:00` is equivalent to 0 ms
3. A date only value (LocalDate / java.sql.Date) is never converted. So if `25.11.2021` is stored in the database, you will get this value in USA and in germany
4. A date only value is serialized as ISO string (like `2021-11-25`) or as GMT based millis value in JSON. So `1970-01-01` is equivalent to 0 ms
5. A LocalDateTime is never converted ( see 1 & 3)
6. A LocalDateTime is serialized as ISO String (see 2 & 4)
7. A Timestamp/Instant/ZonedDateTime is stored as relative offset to your current data timezone - so if you set your dataTimeZone to GMT - the offset is 0. It's up to the user (e.g. for Instant) or to the datatype (e.g. for Calendar) to convert the value to your local jvm timezone (e.g. Calendar.toString will return different values in USA and Germany, while Instant.toString will return the same)
8. A Timestamp/Instant/ZonedDateTime/Calendar is serialized as ISO String (Instant.toString() / Instant.parse) and as GMT based millis value in JSON. The value 0 ms represents the 1970-01-01 00:00 GMT timestamp. 

We have written a test an extensive [DateAndTimesTest](https://github.com/ebean-orm/ebean/commit/2f853c11df1c5a9b88cd9477fd39ef984f5045ff#diff-9e37d94c940992598d4a8374c37f5f06c6c27f21b7208780f4b6bce85f86e125) that tries to check the following things for all date/time datatypes:
- how does it read a value stored in the database
- can I find a model with `where().eq("someTimeProperty", timeValue)
- Is the scalarType.convertToMillis/convertFromMillis, toInstant/fromInstant and so on symmetric
- Is the JSON roundtrip symmetric

Especially in the JSON roundtrip, we found a lot of bugs. This seems to be untested for the different JSON variations like ISO/Millis/Nanos.

We also tested different database engines and found annomalities in the driver. It was a nightmare as you've already mentioned here: https://jira.mariadb.org/browse/CONJ-433

All in all, we have a bunch of fixes, which work on most database systems now.
I am also aware, that this type of change may introduce breaking changes. So we tried to split up into some non dangerous commits:

https://github.com/ebean-orm/ebean/commit/8945833d912502a2a54ecbd62b5c28e23e5f43c2 (non danger)
This commit fixes a bug when the test tries to find the bean with `where().eq("calendar", value)` because calendar was not a `java.util.Calendar` but a subtype (GregorianCalendar). If a ScalarType was not found, all scalar types have to be checked, if one of them is able to handle this datatype. I'm aware, that this check may be improved, so that we do not get collisions.

https://github.com/ebean-orm/ebean/commit/5e700fa2f9701f77a387ae88e26cc637241b012a, https://github.com/ebean-orm/ebean/commit/4ff3c7868d6311f61fb95d07fbd79b6605e4b822, https://github.com/ebean-orm/ebean/commit/4fcd3be6c5cbf76ad309ae2efc2cb336a2a44d3c https://github.com/ebean-orm/ebean/commit/1b5ce51ab165374334f890b76931e8ba2b1d0187 https://github.com/ebean-orm/ebean/commit/1d9ba5b4b40541f95ee9f2516799d4966325f25f (non danger)
Fixes ISO-Format of some scalar types

https://github.com/ebean-orm/ebean/commit/00a7a0d88d136f88aaf7058ddfd75fb056ed2f85 (danger)
This introduces a flag in DataBinder and RsetDataReader, that controls, if the read type is a localType or not.
Note, that we tried to disable conversion for date only and time only values (see assumption 1 & 3)

https://github.com/ebean-orm/ebean/commit/ce706ad36220f179f853edc2ca669fd0b83a4c6f (mid danger)
DataTypes from the java.time package should not use `IsoJsonDateTimeParser.formatIso` as it will truncate nanoseconds

https://github.com/ebean-orm/ebean/commit/45b90dc1345336dc9b211219b4556a82d87d2511 (mid danger)
This fixes some conversion problems in json datatypes and it addresses a **severe bug** : We cannot handle dates before 1970-01-01 in Json-Mode NANOS

https://github.com/ebean-orm/ebean/commit/540f15ac51e0300872e25d9908d408f5538d78a5 (danger)
This will change the millis conversion of localDate to a GMT based value, so 1970-01-01 is alway 0, no matter in which timezone we are. See also https://github.com/ebean-orm/ebean/commit/b4899fb9a8274db57d5f21834a93dde8539a64ff and https://github.com/ebean-orm/ebean/commit/a3b6090def2867560624a02ea807aa1245ca297a for joda

https://github.com/ebean-orm/ebean/commit/168709119308c09d95c3d44fef2d6fb200e627bf (breaking change, but bug)
Timestamp and Util.date had returned millis value in NANO Json mode

https://github.com/ebean-orm/ebean/commit/9ab33427e4ffe64ed76d2c0b4fe85d223171fb2d (bug)
Problem with negative dates (< 1970-01-01) fixed

https://github.com/ebean-orm/ebean/commit/98ae7d43a5148b726d3afee9fec6fea6f35e29c0 (danger)
Fixes for MariaDB

https://github.com/ebean-orm/ebean/commit/25ad2426ac7222997e5c37580acdd6b03700b28b (java 8 incompat)
Returned to jdk8 compatible oracle driver. Unfortunately, the drivermanager stops loading drivers, if there is one that is in wrong class format. This prevents drivers, that are in order after the oracle driver from being loaded.

https://github.com/ebean-orm/ebean/commit/ea415e1f75041882c1dd437202bf9466393c3325 (addon)
add starter for the new DB2 container

https://github.com/ebean-orm/ebean/commit/4369de4a2393edf093b808d58e6d92a5896e5041 (bug)
Fix a test, introduced trough the changes. 

We tried to work here test driven and wrote a test, that verifies the assumptions.

Maybe you can take a look at this big PR and cherry pick the one or other uncritical change.
Feel also free to call the assumptions into question.

cheers
Noemi & Roland

