### PR TITLE
Improve testing, add DB2 Docker testing support to ebean-test

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/DB2Platform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/DB2Platform.java
@@ -20,8 +20,10 @@ public class DB2Platform extends DatabasePlatform {
   public DB2Platform() {
     super();
     this.platform = Platform.DB2;
-    this.maxTableNameLength = 18;
-    this.maxConstraintNameLength = 18;
+    // Note: DB2 (at least LUW supports length up to 128)
+    // TOOD: Check if we need to introduce a new platform (DB2_LUW_11 ?)
+    this.maxTableNameLength = 128;
+    this.maxConstraintNameLength = 128;
     this.truncateTable = "truncate table %s reuse storage ignore delete triggers immediate";
     this.sqlLimiter = new Db2SqlLimiter();
 

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/sqlite/SQLitePlatform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/sqlite/SQLitePlatform.java
@@ -24,6 +24,7 @@ public class SQLitePlatform extends DatabasePlatform {
     this.dbDefaultValue.setFalse("0");
     this.dbDefaultValue.setTrue("1");
     this.dbDefaultValue.setNow("CURRENT_TIMESTAMP");
+    this.supportsResultSetConcurrencyModeUpdatable = false;
 
     dbTypeMap.put(DbType.BIT, new DbPlatformType("int"));
     dbTypeMap.put(DbType.BOOLEAN, new DbPlatformType("int"));

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/ClickHouseDbArray.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/ClickHouseDbArray.java
@@ -14,6 +14,7 @@ class ClickHouseDbArray {
     mapping.put("varchar[]", "Array(String)");
     mapping.put("integer[]", "Array(UInt32)");
     mapping.put("bigint[]", "Array(UInt64)");
+    mapping.put("float[]", "Array(Float32)");
   }
 
   /**
@@ -21,6 +22,10 @@ class ClickHouseDbArray {
    */
   static String logicalToNative(String logicalArrayType) {
     int colonPos = logicalArrayType.indexOf(':');
+    int bracketPos = logicalArrayType.indexOf('(');
+    if (bracketPos > -1 && (bracketPos < colonPos || colonPos == -1)) {
+      colonPos = bracketPos;
+    }
     if (colonPos > -1) {
       logicalArrayType = logicalArrayType.substring(0, colonPos);
     }

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test-docker</artifactId>
-      <version>4.2</version>
+      <version>4.3</version>
     </dependency>
 
     <dependency>
@@ -187,8 +187,39 @@
 
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc10</artifactId>
+      <!-- Note: Using ojdbc10 here will affect loading other drivers on jdk8, 
+        because the driverManager will stop on first load error and stops loading 
+        other drivers -->
+      <artifactId>ojdbc8</artifactId>
       <version>19.12.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <version>11.5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.36.0.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.nuodb.jdbc</groupId>
+      <artifactId>nuodb-jdbc</artifactId>
+      <version>22.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ru.yandex.clickhouse</groupId>
+      <artifactId>clickhouse-jdbc</artifactId>
+      <version>0.3.1-patch</version>
       <scope>test</scope>
     </dependency>
 
@@ -207,21 +238,6 @@
     </dependency>
 
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>db2</id>
-      <dependencies>
-        <!-- https://mvnrepository.com/artifact/com.ibm.db2/jcc -->
-        <dependency>
-          <groupId>com.ibm.db2</groupId>
-          <artifactId>jcc</artifactId>
-          <version>11.5.5.0</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
   <build>
     <plugins>

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/Db2Setup.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/Db2Setup.java
@@ -1,0 +1,41 @@
+package io.ebean.test.config.platform;
+
+import java.util.Properties;
+
+class Db2Setup implements PlatformSetup {
+
+  @Override
+  public Properties setup(Config config) {
+
+    config.ddlMode("dropCreate");
+    config.setDefaultPort(50000);
+    config.setUsernameDefault();
+    config.setPasswordDefault();
+    config.setUrl("jdbc:db2://localhost:${port}/${databaseName}");
+    config.setDriver("com.ibm.db2.jcc.DB2Driver");
+    config.datasourceDefaults();
+
+    return dockerProperties(config);
+  }
+
+  private Properties dockerProperties(Config dbConfig) {
+
+    if (!dbConfig.isUseDocker()) {
+      return new Properties();
+    }
+
+    dbConfig.setDockerVersion("11.5.6.0a");
+    return dbConfig.getDockerProperties();
+  }
+
+  @Override
+  public void setupExtraDbDataSource(Config config) {
+    // not supported yet
+  }
+
+  @Override
+  public boolean isLocal() {
+    return false;
+  }
+
+}

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
@@ -34,6 +34,7 @@ public class PlatformAutoConfig {
     KNOWN_PLATFORMS.put("clickhouse", new ClickHouseSetup());
     KNOWN_PLATFORMS.put("cockroach", new CockroachSetup());
     KNOWN_PLATFORMS.put("hana", new HanaSetup());
+    KNOWN_PLATFORMS.put("db2", new Db2Setup());
   }
 
   private final DatabaseConfig config;

--- a/ebean-test/src/test/java/main/StartDb2.java
+++ b/ebean-test/src/test/java/main/StartDb2.java
@@ -1,0 +1,22 @@
+package main;
+
+import io.ebean.docker.commands.Db2Config;
+import io.ebean.docker.commands.Db2Container;
+
+public class StartDb2 {
+
+  public static void main(String[] args) {
+
+    Db2Config config = new Db2Config("11.5.6.0a");
+    config.setDbName("unit");
+    config.setUser("unit");
+    config.setPassword("unit");
+
+    // to change collation, charset and other parameters like pagesize:
+    config.setCreateOptions("USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768");
+    config.setConfigOptions("USING STRING_UNITS CODEUNITS32");
+
+    Db2Container container = new Db2Container(config);
+    container.startWithDropCreate();
+  }
+}

--- a/ebean-test/src/test/resources/ebean.properties
+++ b/ebean-test/src/test/resources/ebean.properties
@@ -181,9 +181,9 @@ datasource.nuodb.password=test
 datasource.nuodb.url=jdbc:com.nuodb://localhost/testdb
 #datasource.nuodb.driver=com.nuodb.jdbc.Driver
 
-datasource.db2.username=db2admin
-datasource.db2.password=veryverysecret#1234
-datasource.db2.url=jdbc:db2://127.0.0.1:50000/SAMPLE
+datasource.db2.username=unit
+datasource.db2.password=test
+datasource.db2.url=jdbc:db2://127.0.0.1:50000/unit
 #datasource.db2.driver=com.ibm.db2.jcc.DB2Driver
 
 datasource.hana.username=EBEAN_TEST

--- a/ebean-test/testconfig/ebean-clickhouse.properties
+++ b/ebean-test/testconfig/ebean-clickhouse.properties
@@ -1,0 +1,5 @@
+ebean.test.platform=clickhouse
+ebean.test.dbName=clickhouse
+datasource.default=clickhouse
+datasource.clickhouse.autocommit=true
+

--- a/ebean-test/testconfig/ebean-cockroach.properties
+++ b/ebean-test/testconfig/ebean-cockroach.properties
@@ -1,0 +1,4 @@
+ebean.test.platform=cockroach
+ebean.test.dbName=unit
+datasource.default=cockroach
+

--- a/ebean-test/testconfig/ebean-db2.properties
+++ b/ebean-test/testconfig/ebean-db2.properties
@@ -1,0 +1,4 @@
+ebean.test.platform=db2
+ebean.test.dbName=unit
+ebean.test.dbPassword=unit
+datasource.default=db2-11

--- a/ebean-test/testconfig/ebean-h2.properties
+++ b/ebean-test/testconfig/ebean-h2.properties
@@ -1,0 +1,3 @@
+ebean.test.platform=h2
+datasource.default=h2-local
+ebean.test.dbName=test

--- a/ebean-test/testconfig/ebean-mariadb-10.3.properties
+++ b/ebean-test/testconfig/ebean-mariadb-10.3.properties
@@ -1,0 +1,8 @@
+# This starts an alternative mariadb version on port 7306
+ebean.test.platform=mariadb
+ebean.test.dbName=test_ebean
+ebean.test.dbPassword=unit
+ebean.test.mariadb.version=10.3
+ebean.test.mariadb.containerName=ut_mariadb-10-3
+ebean.test.sqlserver.port = 7306
+datasource.default=mariadb-103

--- a/ebean-test/testconfig/ebean-mariadb.properties
+++ b/ebean-test/testconfig/ebean-mariadb.properties
@@ -1,0 +1,5 @@
+ebean.test.platform=mariadb
+ebean.test.dbName=test_ebean
+ebean.test.mariadb.version=10.6
+ebean.test.mariadb.containerName=ut_mariadb-10-6
+datasource.default=mariadb-106

--- a/ebean-test/testconfig/ebean-mysql.properties
+++ b/ebean-test/testconfig/ebean-mysql.properties
@@ -1,0 +1,6 @@
+# this starts a mysql instance on port 13306
+ebean.test.platform=mysql
+ebean.test.dbName=test_ebean
+# note: do not conflict with mariadb port
+ebean.test.sqlserver.port = 13306
+datasource.default=mysql-docker

--- a/ebean-test/testconfig/ebean-nuodb.properties
+++ b/ebean-test/testconfig/ebean-nuodb.properties
@@ -1,0 +1,3 @@
+ebean.test.platform=nuodb
+ebean.test.dbName=testdb
+ebean.test.nuodb.version=latest

--- a/ebean-test/testconfig/ebean-oracle.properties
+++ b/ebean-test/testconfig/ebean-oracle.properties
@@ -1,0 +1,3 @@
+ebean.test.platform=oracle
+ebean.test.dbName=oracle
+datasource.default=oracle-docker

--- a/ebean-test/testconfig/ebean-postgres.properties
+++ b/ebean-test/testconfig/ebean-postgres.properties
@@ -1,0 +1,3 @@
+ebean.test.platform=postgres
+datasource.default=postgres
+ebean.test.dbName=unit

--- a/ebean-test/testconfig/ebean-sqlite.properties
+++ b/ebean-test/testconfig/ebean-sqlite.properties
@@ -1,0 +1,4 @@
+ebean.test.platform=sqlite
+datasource.default=sqlite-local
+ebean.test.dbName=test.sqlite
+ebean.autoReadOnlyDataSource=false

--- a/ebean-test/testconfig/ebean-sqlserver.properties
+++ b/ebean-test/testconfig/ebean-sqlserver.properties
@@ -1,0 +1,6 @@
+ebean.test.platform=sqlserver
+ebean.test.dbName=test_ebean
+ebean.test.sqlserver.version=2019-latest
+ebean.test.sqlserver.containerName=ut_sqlserver2019
+datasource.default=sqlserver2019
+ebean.sqlserver2019.databasePlatformName=sqlserver17

--- a/ebean-test/testconfig/ebean-sqlserver17.properties
+++ b/ebean-test/testconfig/ebean-sqlserver17.properties
@@ -1,0 +1,7 @@
+ebean.test.platform=sqlserver
+ebean.test.dbName=test_ebean
+ebean.test.sqlserver.version=2017-latest
+ebean.test.sqlserver.containerName=ut_sqlserver2017
+ebean.test.sqlserver.port=1434
+datasource.default=sqlserver2017
+ebean.sqlserver2017.databasePlatformName=sqlserver17

--- a/howto-test.md
+++ b/howto-test.md
@@ -24,145 +24,22 @@ your run configuration:
 Platform Tests
 ==============
 
-By default, the `h2` platform is used. To test a different platform, add 
-`-Ddatasource.default=xxx` to your maven command or JVM arguments.
-
-'h2' platform
--------------
-
-Reqires no setup
-
-run: `mvn clean test`
-
-Current status: PASS
-Tests run: 1986, Failures: 0, Errors: 0, Skipped: 16
-
-'pg' platform
--------------
-
-Reqirements
-- a locally installed PostgreSQL server with PostGis.
-- Create a user "unit" with password "unit" and a database "unit"
-- Give the user all permissions to that db
-
-run: `mvn clean test -Ddatasource.default=pg`
-
-Current status: PASS
-Tests run: 2166, Failures: 0, Errors: 0, Skipped: 25
+By default, the `h2` platform is used. To test a different platform, you can change the 
+`datasource.default` in the `ebean.properties` file.
 
 
+Docker
+------
+Ebean 12 provides preconfigured docker containers now. To start a docker container,
+you can use the starters in  `src/test/java/main` or specify one of the starter 
+properties in the `testconfig` directory with `-Dprops.file=testconfig/ebean-XXX.properties`
 
-'mysql' platform
--------------
+Note: You will have to install docker on your system.
+- For debian, you can use `apt install docker.io`
+- For windows, install docker for windows https://docs.docker.com/desktop/windows/install/
 
-Reqirements
-- a locally installed MySQL server.
-- Create a user "unit" with password "unit" and a database "unit"
-- Give the user all permissions to that db
+Maven
+-----
 
-run: `mvn clean test -Ddatasource.default=mysql`
-
-Current status: PASS
-Tests run: 2166, Failures: 0, Errors: 0, Skipped: 33
-
-
-
-'sqlserver' platform
---------------------
-
-Reqires an installed sqlserver - e.g. https://hub.docker.com/r/microsoft/mssql-server-linux/
-
-- Create a user "ebean" with password "ebean" and a database "ebean_unittest"
-- Adjust the connection string and/or username in ebean.properties
-  
-run: `mvn clean test -Ddatasource.default=mssql`
-
-Current status: PASS
-Tests run: 2166, Failures: 0, Errors: 0, Skipped: 39
-
-
-
-'oracle' platform
------------------
-
-Reqires a locally installed Oracle server.
-- Create a user "unit" with password "unit" with all permissions
-- The test wirtes directly to the "xe" SID - so do not use a productive server!
-- As the Oracle JDBC driver is only available on an oracle repository,
-  you need a special maven setup as described [here](http://docs.oracle.com/middleware/1213/core/MAVEN/config_maven_repo.htm#MAVEN9010)
-  
-run: `mvn clean test -Ddatasource.default=ora -Poracle`
-
-Current status: FAIL
-Tests run: 1986, Failures: 17, Errors: 34, Skipped: 16
-
-
-
-'db2' platform
---------------
-
-Reqires a locally installed DB2 Express-C server.
-- Create a user "unit" with password "unit" with all permissions
-- Install the db2jcc4 driver (see pom.xml)
-
-run: `mvn clean test -Ddatasource.default=db2 -Pdb2`
-
-Current status: FAIL
-Tests run: 2166, Failures: 29, Errors: 58, Skipped: 30
-
-
-'sqlite' platform
------------------
-
-Reqires no setup
-
-run: `mvn clean test -Ddatasource.default=sqlite`
-
-Current status: FAIL
-Tests run: 1986, Failures: 24, Errors: 86, Skipped: 16
-
-After some time, the db locks up, every test takes 3 seconds and fails with 
-"the database file is locked"
-
-
-
-'hsqldb' platform
------------------
-
-Reqires no setup
-
-run: `mvn clean test -Ddatasource.default=hsqldb`
-
-Current status: FAIL
-Tests run: 1980, Failures: 3, Errors: 657, Skipped: 16
-
-
-@Rob FYI
-The problem is https://sourceforge.net/p/hsqldb/bugs/1364/
-In `InsertHandler.getPstmt` the `meta.getIdentityDbColumns()` contains
-'id' in lowercase. Changing that to uppercase gives me this result:
-`Tests run: 1986, Failures: 2, Errors: 18, Skipped: 16`
-(as quick hack I added temporary a toUpperCase to BindableIdScalar.getIdentityColumn)
-
-
-'sqlanywhere' platform
-----------------------
-
-TODO: not yet tested
-
-
-
-'hana' platform
---------------------
-
-Requires an installed SAP HANA server - e.g. https://store.docker.com/images/sap-hana-express-edition
-
-- Create a user `EBEAN_TEST` with password `Eb3an_test` in the tenant database `HXE`
-- Adjust the connection string and/or username in `ebean.properties`
-  
-run: `mvn clean test -Ddatasource.default=hana`
-
-Current status: PASS
-Tests run: 2486, Failures: 0, Errors: 0, Skipped: 84
-
+Use the `-Dprops.file` parameter to start the test cases for a certain platform.
 


### PR DESCRIPTION
Hello @rbygrave, with this PR we tried to use/improve your "ebean-test-docker", so that we can run ebean tests against various database platforms.

Please sse howto-test.md for more infos

cheers
Roland