### PR TITLE
Fix maven warning

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
+    <relativePath>/</relativePath>
     <groupId>org.avaje</groupId>
     <artifactId>java8-oss</artifactId>
     <version>2.3</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <relativePath>/</relativePath>
+    <relativePath>../../</relativePath>
     <groupId>org.avaje</groupId>
     <artifactId>java8-oss</artifactId>
     <version>2.3</version>

--- a/tests/test-kotlin/pom.xml
+++ b/tests/test-kotlin/pom.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
+    <relativePath>../../../</relativePath>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
     <version>2.3</version>


### PR DESCRIPTION
Fixes
```
Warning:  
Warning:  Some problems were encountered while building the effective model for org.avaje:test-kotlin:jar:1.0
Warning:  'parent.relativePath' of POM org.avaje:test-kotlin:1.0 (/home/runner/work/ebean/ebean/tests/test-kotlin/pom.xml) points at io.ebean:tests instead of org.avaje:java11-oss, please verify your project structure @ line 6, column 11
Warning:  
Warning:  Some problems were encountered while building the effective model for io.ebean:tests:pom:1.0
Warning:  'parent.relativePath' of POM io.ebean:tests:1.0 (/home/runner/work/ebean/ebean/tests/pom.xml) points at io.ebean:ebean-parent instead of org.avaje:java8-oss, please verify your project structure @ line 4, column 11
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
Warning:
```
during build. See https://github.com/ebean-orm/ebean/runs/4376912993?check_suite_focus=true