### PR TITLE
Setting different server-wide defaultJsonMutation was not honored

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -269,7 +269,6 @@ public class DeployBeanProperty {
   }
 
   public void setMutationDetection(MutationDetection dirtyDetection) {
-    assert dirtyDetection != MutationDetection.DEFAULT; // This has to be determined beforehand
     this.mutationDetection = dirtyDetection;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -269,6 +269,7 @@ public class DeployBeanProperty {
   }
 
   public void setMutationDetection(MutationDetection dirtyDetection) {
+    assert dirtyDetection != MutationDetection.DEFAULT; // This has to be determined beforehand
     this.mutationDetection = dirtyDetection;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
@@ -48,6 +48,7 @@ public final class DeployUtil {
   private final EncryptKeyManager encryptKeyManager;
   private final Encryptor bytesEncryptor;
   private final boolean useValidationNotNull;
+  private final MutationDetection defaultJsonMutationDetection;
 
   public DeployUtil(TypeManager typeMgr, DatabaseConfig config) {
     this.typeManager = typeMgr;
@@ -58,6 +59,7 @@ public final class DeployUtil {
     Encryptor be = config.getEncryptor();
     this.bytesEncryptor = be != null ? be : new SimpleAesEncryptor();
     this.useValidationNotNull = config.isUseValidationNotNull();
+    this.defaultJsonMutationDetection = config.getJsonMutationDetection();
   }
 
   public TypeManager getTypeManager() {
@@ -203,7 +205,7 @@ public final class DeployUtil {
 
   private void setDbJsonType(DeployBeanProperty prop, int dbType, int dbLength, MutationDetection mutationDetection) {
     prop.setDbType(dbType);
-    prop.setMutationDetection(mutationDetection);
+    prop.setMutationDetection(mutationDetection == MutationDetection.DEFAULT ? defaultJsonMutationDetection : mutationDetection);
     ScalarType<?> scalarType = typeManager.getJsonScalarType(prop, dbType, dbLength);
     if (scalarType == null) {
       throw new RuntimeException("No ScalarType for JSON property [" + prop + "] [" + dbType + "]");

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -123,6 +123,8 @@ public final class DefaultTypeManager implements TypeManager {
   private final PlatformArrayTypeFactory arrayTypeSetFactory;
   private GeoTypeBinder geoTypeBinder;
 
+  private final MutationDetection defaultJsonMutationDetection;
+
   /**
    * Create the DefaultTypeManager.
    */
@@ -141,6 +143,7 @@ public final class DefaultTypeManager implements TypeManager {
     this.arrayTypeSetFactory = arrayTypeSetFactory(config.getDatabasePlatform());
     this.offlineMigrationGeneration = DbOffline.isGenerateMigration();
     this.defaultEnumType = config.getDefaultEnumType();
+    this.defaultJsonMutationDetection = config.getJsonMutationDetection();
 
     initialiseStandard(config);
     initialiseJavaTimeTypes(config);
@@ -361,7 +364,7 @@ public final class DefaultTypeManager implements TypeManager {
         return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT);
       }
     }
-    if (objectMapperPresent && prop.getMutationDetection() == MutationDetection.DEFAULT) {
+    if (objectMapperPresent && prop.getMutationDetection() == MutationDetection.HASH) {
       if (type.equals(JsonNode.class)) {
         switch (dbType) {
           case Types.VARCHAR:

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -364,7 +364,7 @@ public final class DefaultTypeManager implements TypeManager {
         return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT);
       }
     }
-    if (objectMapperPresent && prop.getMutationDetection() == MutationDetection.HASH) {
+    if (objectMapperPresent && prop.getMutationDetection() == defaultJsonMutationDetection) {
       if (type.equals(JsonNode.class)) {
         switch (dbType) {
           case Types.VARCHAR:

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonObjectMapper.java
@@ -33,18 +33,17 @@ final class ScalarTypeJsonObjectMapper {
   static ScalarType<?> createTypeFor(TypeJsonManager jsonManager, DeployBeanProperty prop, int dbType, DocPropertyType docType) {
     AnnotatedField field = (AnnotatedField) prop.getJacksonField();
     MutationDetection mode = prop.getMutationDetection();
-    if (mode == MutationDetection.NONE) {
-      return new NoMutationDetection(jsonManager, field, dbType, docType);
-    } else if (mode != MutationDetection.DEFAULT) {
-      return new GenericObject(jsonManager, field, dbType, docType);
+
+    switch (mode) {
+      case NONE:
+        return new NoMutationDetection(jsonManager, field, dbType, docType);
+      case HASH:
+      case SOURCE:
+        return new GenericObject(jsonManager, field, dbType, docType);
+      case DEFAULT:
+      default:
+        throw new IllegalArgumentException("Could not determine default MutationDetection type");
     }
-    // using the global default MutationDetection mode (defaults to HASH)
-    final MutationDetection defaultMode = jsonManager.mutationDetection();
-    prop.setMutationDetection(defaultMode);
-    if (MutationDetection.NONE == defaultMode) {
-      return new NoMutationDetection(jsonManager, field, dbType, docType);
-    }
-    return new GenericObject(jsonManager, field, dbType, docType);
   }
 
   /**

--- a/ebean-test/src/test/java/org/tests/cache/TestBeanCacheContactLazyLoad.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestBeanCacheContactLazyLoad.java
@@ -3,6 +3,7 @@ package org.tests.cache;
 import io.ebean.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.test.LoggedSql;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
@@ -17,6 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test class testing a wrong behaviour of the bean cache.
  */
 public class TestBeanCacheContactLazyLoad extends BaseTestCase {
+
+  @AfterEach
+  public void afterEach() {
+    DB.find(Customer.class).where().eq("name", "Customer").delete();
+  }
 
   /**
    * This test shows a wrong behaviour of the bean cache up to at least Ebean 12.4.*:

--- a/ebean-test/src/test/java/org/tests/transaction/TestExecuteComplete.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestExecuteComplete.java
@@ -6,6 +6,7 @@ import io.ebean.annotation.PersistBatch;
 import io.ebean.annotation.Platform;
 import io.ebean.annotation.Transactional;
 import io.ebeaninternal.api.SpiTransaction;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.Order;
@@ -15,6 +16,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestExecuteComplete extends BaseTestCase {
 
+  @AfterEach
+  public void afterEach() {
+    DB.find(Customer.class).where().eq("name", "Roland").delete();
+  }
 
   @ForPlatform(Platform.H2)
   @Test


### PR DESCRIPTION
Hello Rob,

we have uncovered a problem with the default for the JsonMutationDetection. By default for a server this is set to `MutationDetection.HASH`, but when we wanted to set it to `MutationDetection.SOURCE`, Ebean didn't hand this information in far enough and the properties were working with hash after all. This PR provides a test and a possible fix for this issue. I tried to determine the **actual** mutation detection for a property when constructing the `DeployProperty`, so I don't have to handle the DatabaseConfig further down in `DeployProperty` or even `Property`. In the end, I'm still unsure if this would be the correct approach for fixing this, so maybe you can put in your two cents on this.

All the best
Jonas