### PR TITLE
Using TCK Tested JDK builds of OpenJDK Making the switch to Zulu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java_version }}
-        distribution: 'adopt'
+        distribution: 'zulu'
     - name: Maven cache
       uses: actions/cache@v2
       env:

--- a/.github/workflows/multi-jdk-build.yml
+++ b/.github/workflows/multi-jdk-build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [8, 11, 17]
+        java_version: [8.0.192, 8, 11.0.3, 11, 17]
         os: [ubuntu-latest]
 
     steps:
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java_version }}
-        distribution: 'adopt'
+        distribution: 'zulu'
     - name: Maven cache
       uses: actions/cache@v2
       env:


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/