### PR TITLE
Unify JDBC URL for SqlServer (analog to testconfig-files)

### DIFF
--- a/ebean-test/src/main/java/io/ebean/test/config/platform/SqlServerSetup.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/SqlServerSetup.java
@@ -13,7 +13,7 @@ class SqlServerSetup implements PlatformSetup {
     config.setDefaultPort(1433);
     config.setUsernameDefault();
     config.setPassword("SqlS3rv#r");
-    config.setUrl("jdbc:sqlserver://localhost:${port};databaseName=${databaseName}");
+    config.setUrl("jdbc:sqlserver://localhost:${port};databaseName=${databaseName};sendTimeAsDateTime=false");
     config.setDriver("com.microsoft.sqlserver.jdbc.SQLServerDriver");
     config.datasourceDefaults();
 


### PR DESCRIPTION
The config in SqlServerSetup was missing the `sendTimeAsDateTime=false`, which still ist not `true` by default. This is analog to all other sqlserver-jdbc-urls: https://github.com/ebean-orm/ebean/blob/master/ebean-test/testconfig/ebean-sqlserver19.properties