### PR TITLE
Add metaHas and metaFindAll in AnnotationUtil

### DIFF
--- a/ebean-api/src/main/java/io/ebean/util/AnnotationUtil.java
+++ b/ebean-api/src/main/java/io/ebean/util/AnnotationUtil.java
@@ -71,10 +71,16 @@ public class AnnotationUtil {
     return typeGet(clazz, annotation) != null;
   }
 
+  /**
+   * Check if an element is annotated with an annotation of given type searching meta-annotations.
+   */
   public static boolean metaHas(AnnotatedElement element, Class<?> annotationType) {
     return !metaFindAll(element, annotationType).isEmpty();
   }
 
+  /**
+   * Find all the annotations of a given type searching meta-annotations.
+   */
   public static Set<Annotation> metaFindAll(AnnotatedElement element, Class<?> annotationType) {
     return metaFindAllFor(element, Collections.singleton(annotationType));
   }

--- a/ebean-api/src/main/java/io/ebean/util/AnnotationUtil.java
+++ b/ebean-api/src/main/java/io/ebean/util/AnnotationUtil.java
@@ -71,6 +71,14 @@ public class AnnotationUtil {
     return typeGet(clazz, annotation) != null;
   }
 
+  public static boolean metaHas(AnnotatedElement element, Class<?> annotationType) {
+    return !metaFindAll(element, annotationType).isEmpty();
+  }
+
+  public static Set<Annotation> metaFindAll(AnnotatedElement element, Class<?> annotationType) {
+    return metaFindAllFor(element, Collections.singleton(annotationType));
+  }
+
   /**
    * Find all the annotations for the filter searching meta-annotations.
    */


### PR DESCRIPTION
This small addition to the AnnotationUtil allows for simpler checks for annotations on a given element also searching meta-annotations. This would bring the `metaFind*` method in line with the `has*` and `typeGet*` methods.
Note: This is only public API, for external use of the `AnnotationUtil` which is currently unused inside Ebean.