### PR TITLE
Fix: composite id in select distinct queries

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -568,8 +568,16 @@ final class CQueryBuilder {
         if (countSingleAttribute) {
           sb.append("r1.attribute_, count(*) from (select ");
           if (distinct) {
-            sb.append("distinct t0.");
-            sb.append(request.descriptor().idProperty().dbColumn()).append(", ");
+            sb.append("distinct ");
+            BeanProperty idProp = request.descriptor().idProperty();
+            if (idProp.isEmbedded()) {
+              BeanProperty[] props = ((BeanPropertyAssocOne<?>) idProp).properties();
+              for (BeanProperty prop : props) {
+                sb.append("t0.").append(prop.dbColumn()).append(", ");
+              }
+            } else {
+              sb.append("t0.").append(idProp.dbColumn()).append(", ");
+            }
           }
           sb.append(select.getSelectSql()).append(" as attribute_");
         } else {

--- a/ebean-test/src/test/java/org/tests/compositekeys/TestOnCascadeDeleteChildrenWithCompositeKeys.java
+++ b/ebean-test/src/test/java/org/tests/compositekeys/TestOnCascadeDeleteChildrenWithCompositeKeys.java
@@ -1,7 +1,9 @@
 package org.tests.compositekeys;
 
 import io.ebean.BaseTestCase;
+import io.ebean.CountDistinctOrder;
 import io.ebean.DB;
+import io.ebean.Query;
 import io.ebean.annotation.Identity;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 import static io.ebean.annotation.IdentityGenerated.BY_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -81,6 +84,31 @@ public class TestOnCascadeDeleteChildrenWithCompositeKeys extends BaseTestCase {
 
     beanProperty.findIdsByParentId(null, ids, null, null, true);
     beanProperty.findIdsByParentId(1L, null, null, null, true);
+  }
+  
+  /**
+   * Test makes select and a select distinct of entities with composite keys.
+   */
+  @Test
+  public void testSelectDistinctCountWithCompositeKey() {
+
+    // first query with a simple findList
+    Query<UserRole> query1 = DB.find(UserRole.class);
+    query1.findList();
+
+    assertThat(query1.getGeneratedSql()).contains("select t0.user_id, t0.role_id, t0.user_id, t0.role_id from em_user_role t0");
+
+    // second query with count distinct
+    query1 = DB.find(UserRole.class);
+    query1.select("");
+    query1.fetch("user", "name");
+    query1.setDistinct(true).setCountDistinct(CountDistinctOrder.COUNT_DESC_ATTR_ASC).setMaxRows(20);
+    query1.findSingleAttributeList();
+
+    assertThat(query1.getGeneratedSql()).contains("select distinct r1.attribute_, count(*) from "
+        + "(select distinct t0.user_id, t0.role_id, t1.name as attribute_ "
+        + "from em_user_role t0 join em_user t1 on t1.id = t0.user_id) r1 "
+        + "group by r1.attribute_ order by count(*) desc, r1.attribute_ limit 20");
   }
 
   @Identity(generated = BY_DEFAULT)


### PR DESCRIPTION
Hello @rbygrave ,

I found a bug with composite ids. If you construct a select distint query for the main entity, the id (the dbColumn of the idProperty) would not be found (embedded query: select t0.null).

@rPraml and I had a solution for this problem.

Kind regards
Noemi