### PR TITLE
Refactor UUID generator. Add uuid-property to serverConfig (#57)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -372,6 +372,33 @@ public class DatabaseConfig {
   private String uuidStateFile;
 
   /**
+   * The node id (=mac address) for Version 1 UUIDs. There are several options:
+   * <ul>
+   * <li><code>null</code> (default) The generator tries to get the hardwarwe MAC
+   * address. If this fails, it will fall back to 'generate' mode.</li>
+   * <li><code>"generate"</code> Hardware detection is skipped. It generates a
+   * random identifier and tries to persist this to the state file. This nodeId
+   * will be reused on next start. If persisting to the state file will fail also,
+   * it will fall back to 'random' mode.<br>
+   * This mode is good, if the MAC address is not reliable, e.g. if you run
+   * multiple ebean instances on the same machine.</li>
+   * <li><code>"random"</code> In this mode, a random node id is generated on each
+   * start. No stateFile is used. it will generate a new nodeId on each
+   * application start.<br>
+   * This mode is good, if you have no write access to save the state file.</li>
+   * <li><code>"xx-xx-xx-xx-xx-xx"</code> When an explicit nodeId is specified,
+   * this one is used.</li>
+   * </ul>
+   * Note: It is possible that multiple servers are sharing the same state file as
+   * long as they are in the <b>same</b> JVM/ClassLoader scope. In this case it is
+   * recommended to use the same uuidNodeId configuration.
+   * 
+   * If you have multiple servers in different JVMs, do <b>not</b> share the state
+   * files!
+   */
+  private String uuidNodeId;
+  
+  /**
    * The clock used for setting the timestamps (e.g. @UpdatedTimestamp) on objects.
    */
   private Clock clock = Clock.systemUTC();
@@ -2019,6 +2046,20 @@ public class DatabaseConfig {
   public void setUuidStateFile(String uuidStateFile) {
     this.uuidStateFile = uuidStateFile;
   }
+  
+  /**
+   * Returns the V1-UUID-NodeId 
+   */
+  public String getUuidNodeId() {
+    return uuidNodeId;
+  }
+  
+  /**
+   * Sets the V1-UUID-NodeId.
+   */
+  public void setUuidNodeId(String uuidNodeId) {
+    this.uuidNodeId = uuidNodeId;
+  }
 
   /**
    * Return true if LocalTime should be persisted with nanos precision.
@@ -2888,6 +2929,7 @@ public class DatabaseConfig {
 
     uuidVersion = p.getEnum(UuidVersion.class, "uuidVersion", uuidVersion);
     uuidStateFile = p.get("uuidStateFile", uuidStateFile);
+    uuidNodeId = p.get("uuidNodeId", uuidNodeId);
 
     localTimeWithNanos = p.getBoolean("localTimeWithNanos", localTimeWithNanos);
     jodaLocalTimeMode = p.get("jodaLocalTimeMode", jodaLocalTimeMode);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -775,7 +775,7 @@ public class DeployBeanDescriptor<T> {
       this.identityMode.setIdType(IdType.EXTERNAL);
       switch (config.getUuidVersion()) {
         case VERSION1:
-          this.idGenerator = UuidV1IdGenerator.getInstance(config.getUuidStateFile());
+          this.idGenerator = UuidV1IdGenerator.getInstance(config.getUuidStateFile(), config.getUuidNodeId());
           break;
         case VERSION1RND:
           this.idGenerator = UuidV1RndIdGenerator.INSTANCE;

--- a/ebean-test/src/test/java/io/ebeaninternal/server/idgen/TestUuidGenerator.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/idgen/TestUuidGenerator.java
@@ -5,14 +5,26 @@
 package io.ebeaninternal.server.idgen;
 
 import io.ebean.config.dbplatform.PlatformIdGenerator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * Run some simple tests for the UUID generator.
@@ -52,12 +64,129 @@ public class TestUuidGenerator {
     }
   }
 
+  private File stateFile;
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    stateFile = new File("target/" + UUID.randomUUID() + ".state");
+  }
+
+  @AfterEach
+  void afterEach() {
+    stateFile.delete();
+  }
+
+  private void writePropertyFile(String nodeId, String clockSeq, String timestamp) throws IOException {
+    Properties prop = new Properties();
+    prop.setProperty("nodeId", nodeId);
+    prop.setProperty("clockSeq", clockSeq);
+    prop.setProperty("timeStamp", timestamp);
+    try (OutputStream os = new FileOutputStream(stateFile)) {
+      prop.store(os, "ebean uuid state file");
+    }
+  }
+  
+  private Properties readPropertyFile() throws IOException {
+    Properties prop = new Properties();
+    try (InputStream is = new FileInputStream(stateFile)) {
+      prop.load(is);
+    }
+    return prop;
+  }
+  /**
+   * Test takes ~0.3 sec
+   */
+  @Test
+  public void testUuidFixedMac() throws Exception {
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance(stateFile, "01-02-03-04-05-06");
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid.node()).isEqualTo(0x010203040506L);
+    Properties props = readPropertyFile();
+    assertThat(props)
+        .containsEntry("nodeId", "01-02-03-04-05-06")
+        .containsEntry("clockSeq", String.valueOf(uuid.clockSequence()));
+    assertThat(Long.parseLong(props.getProperty("timeStamp")))
+        .isCloseTo(uuid.timestamp(), within(2_000_000L));
+  }
+  
+  @Test
+  public void testUuidInvalidMac() throws Exception {
+    assertThatThrownBy(()-> UuidV1IdGenerator.getInstance(stateFile, "01-02-03-04-05"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("01-02-03-04-05 is invalid. Expected format: xx-xx-xx-xx-xx-xx");
+    assertThatThrownBy(()-> UuidV1IdGenerator.getInstance(stateFile, "01-02-03-04-05-GG"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("01-02-03-04-05-gg is invalid.")
+        .hasRootCauseInstanceOf(NumberFormatException.class)
+        .hasRootCauseMessage("For input string: \"gg\"");
+    assertThat(stateFile).doesNotExist();
+  }
+
+  @Test
+  public void testUuidGenerate() throws Exception {
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance(stateFile, "generate");
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid).isNotNull();
+    assertThat(stateFile).exists();
+  }
+
+  @Test
+  public void testUuidRandom() throws Exception {
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance(stateFile, "random");
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid).isNotNull();
+    assertThat(stateFile).doesNotExist();
+  }
+
+  @Test
+  public void testUuidFile() throws Exception {
+    writePropertyFile("12-34-56-78-90-AB", "4252", "0");
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance(stateFile, "generate");
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid.node()).isEqualTo(0x1234567890ABL);
+    assertThat(uuid.clockSequence()).isEqualTo(4252);
+  }
+
+  @Test
+  public void testUuidFileInvalidNodeId() throws Exception {
+    writePropertyFile("AB-CD-EF-GH-IJ-KL", "4252", "0");
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance(stateFile, "generate");
+    // a error message will be printed
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid).isNotNull();
+  }
+
+  @Test
+  public void testInvalidFileName() throws Exception {
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance("/", null);
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid).isNotNull();
+  }
+
+  @Test
+  public void testInvalidStateFile() throws Exception {
+    writePropertyFile("", "", "");
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance(stateFile, null);
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid).isNotNull();
+  }
+  
+  @Test
+  public void testMacChange() throws Exception {
+    writePropertyFile("01-02-03-04-05", "1234", "1234");
+    UuidV1IdGenerator gen = UuidV1IdGenerator.getInstance(stateFile, null);
+    UUID uuid = gen.nextId(null);
+    assertThat(uuid).isNotNull();
+    // MAC must be updated with HW/ID
+    assertThat(readPropertyFile()).doesNotContainEntry("nodeId", "01-02-03-04-05");
+  }
+
   /**
    * Test takes ~0.3 sec
    */
   @Test
   public void testUuidV1SingleThread() throws Exception {
-    testGenerator(1, 500_000, UuidV1IdGenerator.getInstance("ebean-test-uuid.state"));
+    testGenerator(1, 500_000, UuidV1IdGenerator.getInstance(stateFile, null));
   }
 
   /**
@@ -65,7 +194,7 @@ public class TestUuidGenerator {
    */
   @Test
   public void testUuidV1MultiThread() throws Exception {
-    testGenerator(10, 50_000, UuidV1IdGenerator.getInstance("ebean-test-uuid.state"));
+    testGenerator(10, 50_000, UuidV1IdGenerator.getInstance(stateFile, null));
   }
 
   /**


### PR DESCRIPTION
This PR mainly moves the `System.getProperty("ebean.uuid.nodeId")` to the server config.
Now there are also tests, that discovered a parsing bug
(The accepted format was only 5 octets `01-02-03-04-05`and not `01-02-03-04-05-06`)
There are also two more options `generate` and `random` (see javadoc)

The intialization code was refactored a bit and I added more tests (CodeCov of generator is ~92% now)