### PR TITLE
Unselect LOBs when making a distinct select

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -1160,7 +1160,26 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
   public boolean isLob() {
     return lob;
   }
-
+  
+  /**
+   * Returns true if this <code>isLob()</code> or the type will effectively map to a lob. 
+   */
+  public boolean isDbLob() {
+    if (lob) {
+      return true;
+    }
+    switch (dbType) {
+    case DbPlatformType.JSON:
+    case DbPlatformType.JSONB:
+      return dbLength == 0; // must be analog to DbPlatformTypeMapping.lookup
+    case DbPlatformType.JSONBlob:
+    case DbPlatformType.JSONClob:
+      return true;
+    default:
+      return false;
+    }
+  }
+  
   public static boolean isLobType(int type) {
     switch (type) {
       case Types.CLOB:

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/DynamicPropertyAggregationFormula.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/DynamicPropertyAggregationFormula.java
@@ -62,4 +62,9 @@ class DynamicPropertyAggregationFormula extends DynamicPropertyBase {
     ctx.appendParseSelect(parsedFormula, alias);
   }
 
+  @Override
+  public boolean isDbLob() {
+    return false;
+  }
+
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -760,6 +760,10 @@ final class CQueryBuilder {
     return dbPlatform.isPlatform(Platform.POSTGRES);
   }
 
+  boolean isPlatformDistinctNoLobs() {
+    return dbPlatform.isPlatform(Platform.DB2); // CHECKME: Also oracle?
+  }
+
   /**
    * Return the 'for update' FROM hint (sql server).
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/STreeProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/STreeProperty.java
@@ -28,6 +28,11 @@ public interface STreeProperty extends ScalarDataReader<Object> {
    * Return true if the property is the Id.
    */
   boolean isId();
+  
+  /**
+   * Returns true, if this is a lob property from db-perspective.
+   */
+  boolean isDbLob();
 
   /**
    * Return true if the property is an embedded type.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -53,6 +53,7 @@ public final class SqlTreeBuilder {
   private final SpiQuery.TemporalMode temporalMode;
   private SqlTreeNode rootNode;
   private boolean sqlDistinct;
+  private final boolean distinctNoLobs;
 
   /**
    * Construct for RawSql query.
@@ -65,6 +66,7 @@ public final class SqlTreeBuilder {
     this.query = null;
     this.subQuery = false;
     this.distinctOnPlatform = false;
+    this.distinctNoLobs = false;
     this.queryDetail = queryDetail;
     this.predicates = predicates;
     this.temporalMode = SpiQuery.TemporalMode.CURRENT;
@@ -97,6 +99,7 @@ public final class SqlTreeBuilder {
     this.predicates = predicates;
     this.alias = new SqlTreeAlias(request.baseTableAlias(), temporalMode);
     this.distinctOnPlatform = builder.isPlatformDistinctOn();
+    this.distinctNoLobs = builder.isPlatformDistinctNoLobs();
     String fromForUpdate = builder.fromForUpdate(query);
     CQueryHistorySupport historySupport = builder.getHistorySupport(query);
     CQueryDraftSupport draftSupport = builder.getDraftSupport(query);
@@ -265,6 +268,9 @@ public final class SqlTreeBuilder {
     SqlTreeNode selectNode = buildNode(prefix, prop, desc, myJoinList, props);
     if (joinList != null) {
       joinList.add(selectNode);
+    }
+    if (sqlDistinct && distinctNoLobs) {
+      selectNode.unselectLobs();
     }
     return selectNode;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNode.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNode.java
@@ -78,6 +78,10 @@ interface SqlTreeNode {
    * Create the loader for this node.
    */
   SqlTreeLoad createLoad();
-  
-  default void unselectLobs() {};
+
+  /**
+   * Unselect lobs (for distinct queries on DB2 and Oracle).
+   */
+  default void unselectLobs() {
+  };
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNode.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNode.java
@@ -78,4 +78,6 @@ interface SqlTreeNode {
    * Create the loader for this node.
    */
   SqlTreeLoad createLoad();
+  
+  default void unselectLobs() {};
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
@@ -26,8 +26,8 @@ class SqlTreeNodeBean implements SqlTreeNode {
   /**
    * Set to true if this is a partial object fetch.
    */
-  final boolean partialObject;
-  final STreeProperty[] properties;
+  boolean partialObject;
+  STreeProperty[] properties;
   /**
    * Extra where clause added by Where annotation on associated many.
    */
@@ -394,6 +394,35 @@ class SqlTreeNodeBean implements SqlTreeNode {
   public boolean hasMany() {
     for (SqlTreeNode child : children) {
       if (child.hasMany()) {
+        return true;
+      }
+    }
+    return false;
+  }
+  
+
+  @Override
+  public void unselectLobs() {
+    if (children != null) {
+      for (SqlTreeNode child : children) {
+        child.unselectLobs();
+      }
+    }
+    if (hasLob()) {
+      List<STreeProperty> lst = new ArrayList<>();
+      for (STreeProperty prop : properties) {
+        if (!prop.isDbLob()) {
+          lst.add(prop);
+        }
+      }
+      properties = lst.toArray(new STreeProperty[0]);
+      partialObject = true;
+    }
+  }
+
+  private boolean hasLob() {
+    for (STreeProperty prop : properties) {
+      if (prop.isDbLob()) {
         return true;
       }
     }


### PR DESCRIPTION
Some platforms like DB2, Oracle and also Postgres do not allow to perform a `select distinct` when LOB columns are used.

There was a related issue #900 for postgres, but DB2 does not support `select distinct on (id)`
Workarounds like `cast(lob_column as varchar(32000))` or `DBMS_LOB.substr(lob_column , 32000)` would be not reliable enough. So for these platforms we must not select lobs, when performing a distinct query.

Ebean automatically unselect these columns and rely on lazy load of the properties.

Note: There are some edge cases, when that will not work:
- Ebean unselects the lobs and lazy load is disabled
- the lob is part of a findSingleAttribute-query and distinct is used.
  In this case you can use `select("cast(lobProp as varchar(32000))")` or `fetch("el.path", "cast(lobProp as varchar(32000))")` in your application

This fixes #2495 


