### PR TITLE
FIX: Datasource was not initialized in offline mode.

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InitDataSource.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InitDataSource.java
@@ -99,7 +99,6 @@ final class InitDataSource {
       if (config.getDatabasePlatformName() == null) {
         throw new PersistenceException("You MUST specify a DatabasePlatformName on DatabaseConfig when offline");
       }
-      return null;
     }
 
     attachAlert(dsConfig);


### PR DESCRIPTION
## Expected behavior

when setting datasource offline I would expect, that the datasource is created, but is in offline state

## Actual behavior

no datasource was created, `server.datasource()` was null.

### Steps to reproduce

```java
// create server with
config.getDataSourceConfig().setOffline(true);
// put datasource manually online
((ConnectionPools)(server.dataSource())).online(); // throws NPE
```
