### PR TITLE
DB2: Fix Concat operator

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/Db2DbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/Db2DbExpression.java
@@ -1,0 +1,13 @@
+package io.ebeaninternal.server.expression.platform;
+
+/**
+ * DB2 handling of platform specific expressions. ARRAY expressions not supported.
+ */
+final class Db2DbExpression extends BasicDbExpression {
+
+  @Override
+  public String concat(String property0, String separator, String property1, String suffix) {
+    return concatOperator(property0, separator, property1, suffix);
+  }
+
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandlerFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandlerFactory.java
@@ -24,6 +24,8 @@ public final class DbExpressionHandlerFactory {
         return new MySqlDbExpression();
       case ORACLE:
         return new OracleDbExpression();
+      case DB2:
+        return new Db2DbExpression();
       case SQLSERVER:
         return new SqlServerDbExpression();
       case HANA:


### PR DESCRIPTION
DB2 uses the concat operator `prop1 || prop2` instead of `concat(prop1, prop2)`

OLD
`Error:  Tests run: 3104, Failures: 79, Errors: 97, Skipped: 116`

NEW
`Tests run: 3104, Failures: 81, Errors: 87, Skipped: 116`

Fixes 8 tests in total (-10 errors, +2 faiures)

@rbygrave FYI: I've to execute the DB2 LUW workflow in my branch ([BuildResult](https://github.com/FOCONIS/ebean/runs/4978069110?check_suite_focus=true))