### PR TITLE
DB2: Fix default values for auto generated ids

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/InsertMeta.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/InsertMeta.java
@@ -181,6 +181,8 @@ final class InsertMeta {
       case MARIADB:
       case ORACLE:
         return " values (default)";
+      case DB2:
+        return " (" + id.getIdentityColumn() + ") values (default)";
       default:
         return " default values";
     }

--- a/ebean-test/src/test/java/org/tests/defaultvalues/TestDefaults.java
+++ b/ebean-test/src/test/java/org/tests/defaultvalues/TestDefaults.java
@@ -28,6 +28,8 @@ public class TestDefaults extends BaseTestCase {
     assertThat(current).isNotEmpty();
     if (isMySql() || isMariaDB() || isOracle()) {
       assertThat(current.get(0)).contains("insert into defaults_model_draft values (default);");
+    } else if (isDb2()) {
+      assertThat(current.get(0)).contains("insert into defaults_model_draft (id) values (default)");
     } else if (isSqlServer()) {
       assertThat(current.get(0)).contains("insert into defaults_model_draft (id) values (?)");
     } else {


### PR DESCRIPTION
DB2 requires different syntax for inserting default values

while other DBMS accept a syntax like: `insert into my_table values (default)`, 
you must specify each column for DB2: `insert into my_table (id) values (default)`, 

https://www.ibm.com/docs/en/i/7.1?topic=language-inserting-rows-using-insert-statement
https://www.ibm.com/docs/en/db2/11.5?topic=statements-insert#sdx-synid_values

Note: This fix does not support composed keys, yet. It may be improved later

OLD
`Error:  Tests run: 3104, Failures: 79, Errors: 97, Skipped: 116`

NEW
`Tests run: 3104, Failures: 82, Errors: 90, Skipped: 116`

Fixes 4 tests (-7 errors, +3 failures)