### PR TITLE
DB2: FIX Db2SqlLimiter & tests

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/Db2SqlLimiter.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/Db2SqlLimiter.java
@@ -15,10 +15,13 @@ public class Db2SqlLimiter implements SqlLimiter {
       sb.append("distinct ");
     }
     sb.append(request.getDbSql());
-
+    int firstRow = request.getFirstRow();
+    if (firstRow > 0) {
+      sb.append(" offset ").append(firstRow).append(" rows");
+    }
     int maxRows = request.getMaxRows();
     if (maxRows > 0) {
-      sb.append(" ").append(NEW_LINE).append("FETCH FIRST ").append(maxRows).append(" ROWS ONLY");
+      sb.append(" fetch next ").append(maxRows).append(" rows only");
     }
 
     String sql = request.getDbPlatform().completeSql(sb.toString(), request.getOrmQuery());

--- a/ebean-test/src/test/java/io/ebean/EbeanServer_eqlTest.java
+++ b/ebean-test/src/test/java/io/ebean/EbeanServer_eqlTest.java
@@ -26,7 +26,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
     if (isSqlServer()) {
       assertSql(query).startsWith("select top 100 ");
       assertSql(query).endsWith("order by t0.id");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains(" fetch next 100 rows only");
     } else {
       assertSql(query).endsWith("order by t0.id limit 100");
@@ -44,7 +44,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
     if (isSqlServer()) {
       assertSql(query).startsWith("select top 10 ");
       assertSql(query).endsWith("order by t0.id");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains(" fetch next 10 rows only");
     } else {
       assertSql(query).endsWith("order by t0.id limit 10");
@@ -61,7 +61,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
 
     if (isSqlServer()) {
       assertSql(query).endsWith("order by t0.id offset 3 rows fetch next 10 rows only");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains("offset 3 rows fetch next 10 rows only");
     } else {
       assertSql(query).endsWith("order by t0.id limit 10 offset 3");
@@ -81,7 +81,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
 
     if (isSqlServer()) {
       assertSql(query).endsWith("order by t0.name offset 3 rows fetch next 10 rows only");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains("offset 3 rows fetch next 10 rows only");
     } else {
       assertSql(query).endsWith("order by t0.name limit 10 offset 3");
@@ -107,7 +107,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
 
     if (isSqlServer()) {
       assertSql(query).endsWith("order by t0.name, t0.id offset 3 rows fetch next 10 rows only");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains("offset 3 rows fetch next 10 rows only");
     } else {
       assertSql(query).endsWith("order by t0.name, t0.id limit 10 offset 3");
@@ -136,7 +136,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
 
     if (isSqlServer()) {
       assertSql(query).endsWith("from o_customer t0 order by t0.id offset 3 rows fetch next 10 rows only");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains("offset 3 rows fetch next 10 rows only");
     } else {
       assertSql(query).endsWith("from o_customer t0 limit 10 offset 3");
@@ -154,7 +154,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
 
     if (isSqlServer()) {
       assertSql(query).startsWith("select top 10 ");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains("fetch next 10 rows only");
     } else {
       assertSql(query).endsWith("limit 10");

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
@@ -369,7 +369,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
 
     if (isH2()) {
       assertSql(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ? and concat(t0.sku,'-',t0.code) in (?,?) order by t0.sku desc; --bind(def,Array[2]={2-1000,3-1000})");
-    } else if (isPostgres() || isOracle()) {
+    } else if (isPostgres() || isOracle() || isDb2()) {
       assertSql(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ? and (t0.sku||'-'||t0.code)");
     } else if (isHana()) {
       assertSql(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ? and concat(t0.sku, '-'||t0.code)");
@@ -412,7 +412,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
 
     if (isH2()) {
       assertSql(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ? and concat(t0.sku,':',t0.code,'-foo') in (?,?) order by t0.sku desc; --bind(def,Array[2]={2:1000-foo,3:1000-foo})");
-    } else if (isPostgres() || isOracle()){
+    } else if (isPostgres() || isOracle() || isDb2()){
       assertSql(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ? and (t0.sku||':'||t0.code||'-foo')");
     } else if (isHana()){
       assertSql(sql.get(0)).contains("from o_cached_natkey3 t0 where t0.store = ? and concat(t0.sku, ':'||t0.code||'-foo')");

--- a/ebean-test/src/test/java/org/tests/query/TestQueryOrderById.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryOrderById.java
@@ -18,7 +18,7 @@ public class TestQueryOrderById extends BaseTestCase {
       .setMaxRows(5);
 
     query.findList();
-    if (isSqlServer()) {
+    if (isSqlServer() || isDb2()) {
       assertSql(query).isEqualTo("select t0.id, t0.name from o_customer t0 order by t0.id offset 1 rows fetch next 5 rows only");
     } else if (!isOracle()) {
       assertSql(query).isEqualTo("select t0.id, t0.name from o_customer t0 order by t0.id limit 5 offset 1");
@@ -35,7 +35,7 @@ public class TestQueryOrderById extends BaseTestCase {
       .orderById(true);
 
     query.findList();
-    if (isSqlServer()) {
+    if (isSqlServer() || isDb2()) {
       assertSql(query).isEqualTo("select t0.id, t0.name from o_customer t0 order by t0.id offset 1 rows fetch next 5 rows only");
     } else if (!isOracle()) {
       assertSql(query).isEqualTo("select t0.id, t0.name from o_customer t0 order by t0.id limit 5 offset 1");

--- a/ebean-test/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/ebean-test/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -314,7 +314,7 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     List<String> ids = query.findSingleAttributeList();
     if (isSqlServer()) {
       assertThat(sqlOf(query)).contains("select distinct top 100 t0.id from o_customer t0");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertThat(sqlOf(query)).contains("select distinct t0.id from o_customer t0 fetch next 100 rows only");
     } else {
       assertThat(sqlOf(query)).contains("select distinct t0.id from o_customer t0 limit 100");
@@ -393,7 +393,7 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     List<String> ids = query.findSingleAttributeList();
     if (isSqlServer()) {
       assertThat(sqlOf(query)).contains("select top 100 t0.id from o_customer t0");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertThat(sqlOf(query)).contains("fetch next 100 rows only");
     } else {
       assertThat(sqlOf(query)).contains("select t0.id from o_customer t0 limit 100");
@@ -727,9 +727,7 @@ public class TestQuerySingleAttribute extends BaseTestCase {
     }
     if (isSqlServer()) {
       assertThat(sqlOf(query)).endsWith(" fetch next 2 rows only");
-    } else if (isDb2()) {
-      assertSql(query).endsWith("FETCH FIRST 2 ROWS ONLY");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains(" offset 1 rows fetch next 2 rows only");
     } else {
       assertThat(sqlOf(query)).endsWith(" limit 2 offset 1");

--- a/ebean-test/src/test/java/org/tests/rawsql/TestRawSqlOrmQuery.java
+++ b/ebean-test/src/test/java/org/tests/rawsql/TestRawSqlOrmQuery.java
@@ -147,7 +147,7 @@ public class TestRawSqlOrmQuery extends BaseTestCase {
     if (isSqlServer()) {
       assertSql(query).contains("top 100 ");
       assertSql(query).contains("order by o.ship_date desc");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains("fetch next 100 rows only");
     } else {
       assertSql(query).contains("order by o.ship_date desc limit 100");
@@ -182,7 +182,7 @@ public class TestRawSqlOrmQuery extends BaseTestCase {
     if (isSqlServer()) {
       assertSql(query).contains("top 100 ");
       assertSql(query).contains("order by o.ship_date desc, o.id");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertSql(query).contains("fetch next 100 rows only");
     } else {
       assertSql(query).contains("order by o.ship_date desc, o.id limit 100");
@@ -224,7 +224,11 @@ public class TestRawSqlOrmQuery extends BaseTestCase {
       query.order("coalesce(shipDate, now()) desc");
       query.findList();
 
-      assertSql(query).contains("order by coalesce(o.ship_date, now()) desc limit 100");
+      if (isDb2()) {
+        assertSql(query).contains("order by coalesce(o.ship_date, now()) desc fetch next 100 rows only");
+      } else {
+        assertSql(query).contains("order by coalesce(o.ship_date, now()) desc limit 100");
+      }
     }
   }
 
@@ -257,7 +261,11 @@ public class TestRawSqlOrmQuery extends BaseTestCase {
       query.order("coalesce(shipDate, now()) desc");
       query.findList();
 
-      assertSql(query).contains("order by coalesce(o.ship_date, now()) desc, o.id limit 100");
+      if (isDb2()) {
+        assertSql(query).contains("order by coalesce(o.ship_date, now()) desc, o.id fetch next 100 rows only");
+      } else {
+        assertSql(query).contains("order by coalesce(o.ship_date, now()) desc, o.id limit 100");
+      }
     }
   }
 
@@ -284,7 +292,7 @@ public class TestRawSqlOrmQuery extends BaseTestCase {
     if (isSqlServer()) {
       assertThat(sqlOf(query)).contains("select top 100 ");
       assertThat(sqlOf(query)).contains("order by o.id desc");
-    } else if (isOracle()) {
+    } else if (isOracle() || isDb2()) {
       assertThat(sqlOf(query)).contains("fetch next 100 rows only");
     } else {
       assertThat(sqlOf(query)).contains("order by o.id desc limit 100");


### PR DESCRIPTION
This fixes the SqlLimiter so that it is very similar to the oracle-sql-limiter

it adds offset support and uses the same syntax as oracle now ("fetch next" instead of "FETCH FIRST")
It might introduce breaking changes for elder DB2 versions which only might understand "FETCH FIRST"
At least what I found in avaliable documetation, "fetch next" is recognized by all currently maintained versions.

OLD
`Tests run: 3104, Failures: 79, Errors: 97, Skipped: 116`

NEW
`Tests run: 3104, Failures: 61, Errors: 97, Skipped: 116`
Again 18 tests fixed
