### PR TITLE
DB2 does not support ids in compressed form

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/BaseDB2Platform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/BaseDB2Platform.java
@@ -26,7 +26,7 @@ public abstract class BaseDB2Platform extends DatabasePlatform {
 
     this.dbIdentity.setSupportsGetGeneratedKeys(true);
     this.dbIdentity.setSupportsSequence(true);
-
+    this.idInExpandedForm = true; // Db2 does not support (a,b) in ((?,?),(?,?))
     this.exceptionTranslator =
       new SqlErrorCodes()
         .addAcquireLock("40001","57033") // key -911/-913


### PR DESCRIPTION
Enabled `idInExpandedForm` for DB2

OLD
`Tests run: 3104, Failures: 79, Errors: 97, Skipped: 116`
NEW
`Tests run: 3104, Failures: 79, Errors: 95, Skipped: 116`
Two additional tests are fixed