### PR TITLE
DB2: Do not try to update deferred null values (Discovered by TestPrinterStateIssue)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/BindParams.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/BindParams.java
@@ -167,6 +167,7 @@ public final class BindParams implements Serializable {
    */
   @SuppressWarnings("rawtypes")
   public void setParameter(int position, Object value) {
+    assert value != null : "use setNullParameter";
     Param p = getParam(position);
     if (value instanceof Collection) {
       // use of postgres ANY with positioned parameter
@@ -218,6 +219,7 @@ public final class BindParams implements Serializable {
    * Set a named In parameter that is not null.
    */
   public Param setParameter(String name, Object value) {
+    assert value != null : "use setNullParameter";
     Param p = getParam(name);
     p.setInValue(value);
     return p;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistDeferredRelationship.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistDeferredRelationship.java
@@ -40,6 +40,9 @@ public final class PersistDeferredRelationship {
 
     // bind the set clause for the importedId
     int pos = importedId.bind(1, sqlUpdate, assocBean);
+    if (pos == -1) {
+      return; // could not bind: TODO: should we log/throw an error?
+    }
     // bind the where clause for the bean
     Object[] idValues = beanDescriptor.idBinder().getIdValues(bean);
     for (int j = 0; j < idValues.length; j++) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/ImportedIdEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/ImportedIdEmbedded.java
@@ -85,6 +85,9 @@ public final class ImportedIdEmbedded implements ImportedId {
     for (ImportedIdSimple anImported : imported) {
       if (anImported.owner.isUpdateable()) {
         Object scalarValue = anImported.foreignProperty.getValue(embedded);
+        if (scalarValue == null) {
+          return -1; // could not bind
+        }
         update.setParameter(pos++, scalarValue);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/ImportedIdSimple.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/ImportedIdSimple.java
@@ -151,6 +151,9 @@ public final class ImportedIdSimple implements ImportedId, Comparable<ImportedId
   @Override
   public int bind(int position, SqlUpdate update, EntityBean bean) {
     Object value = getIdValue(bean);
+    if (value == null) {
+      return -1; // could not bind
+    }
     update.setParameter(position, value);
     return ++position;
   }


### PR DESCRIPTION
DB2 does not support "setParameter(null)" without specifying the type.

See also PreparedStatement.setObject
>**Note** Not all databases allow for a non-typed Null to be sent to the backend. For maximum portability, the `setNull` or the `setObject(int parameterIndex, Object x, int sqlType)` method should be used instead of `setObject(int parameterIndex, Object x)`

This PR adds some asserts in the "setParameter" to enforce correct usage. 
**This may break existing apps, that have used setParameter the wrong way**

OLD
Tests run: 3104, Failures: 79, Errors: 97, Skipped: 116

NEW
Tests run: 3104, Failures: 80, Errors: 95, Skipped: 116

Effectively only one test fixed