### PR TITLE
DB2: Fix Sequence generator

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/DB2SequenceIdGenerator.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/DB2SequenceIdGenerator.java
@@ -19,7 +19,7 @@ public class DB2SequenceIdGenerator extends SequenceBatchIdGenerator {
   public DB2SequenceIdGenerator(BackgroundExecutor be, DataSource ds, String seqName, int batchSize) {
     super(be, ds, seqName, batchSize);
     this.baseSql = "values nextval for " + seqName;
-    this.unionBaseSql = " union " + baseSql;
+    this.unionBaseSql = ", nextval for " + seqName;
   }
 
   @Override


### PR DESCRIPTION
This changes the Sequence generator syntax for batch mode and may introduce breaking change for elder DB2 platforms (or did it ever work?)

OLD
`Tests run: 3104, Failures: 79, Errors: 97, Skipped: 116`

NEW
`Tests run: 3104, Failures: 80, Errors: 82, Skipped: 116`

14 tests fixed