### PR TITLE
Set persistBatchOnCascade to ALL for newer DB2 versions

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/BaseDB2Platform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/BaseDB2Platform.java
@@ -43,7 +43,6 @@ public abstract class BaseDB2Platform extends DatabasePlatform {
     dbTypeMap.put(DbType.BIGINT, new DbPlatformType("bigint", false));
     dbTypeMap.put(DbType.REAL, new DbPlatformType("real"));
     dbTypeMap.put(DbType.DECIMAL, new DbPlatformType("decimal", 16, 3));
-    persistBatchOnCascade = PersistBatch.NONE;
   }
 
   /**

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/DB2LegacyPlatform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/db2/DB2LegacyPlatform.java
@@ -1,5 +1,6 @@
 package io.ebean.config.dbplatform.db2;
 
+import io.ebean.annotation.PersistBatch;
 import io.ebean.annotation.Platform;
 
 /**
@@ -16,5 +17,6 @@ public class DB2LegacyPlatform extends BaseDB2Platform {
     // TOOD: Check if we need to introduce a new platform (DB2_LUW_11 ?)
     this.maxTableNameLength = 18;
     this.maxConstraintNameLength = 18;
+    this.persistBatchOnCascade = PersistBatch.NONE;
   }
 }


### PR DESCRIPTION
Hello Rob,

here is another fix for DB2. Unfortunately it currently depends on #2521, because ony with that the fix really works. When the generated keys would work correctly, depending inserts in one batch can be done referencing previously inserted entries with the returned ids. Otherwise, this would result in 684 errors, because ResetTestData can not insert contactNotes, because the id of the contact it belongs to does not exist. With that as a requirement, the failing test would improve as follows:
Before:
`Tests run: 3107, Failures: 55, Errors: 19, Skipped: 123`
After:
`Tests run: 3107, Failures: 7, Errors: 1, Skipped: 123`
In total, this would fix 66 testacases and leave the DB2 support with just 8 failing tests remaining.
I guess for now it would be fine to leave this "on hold" until it is clear, how the solution for #2521 will look like.

All the best
Jonas