### PR TITLE
DB2 Support for unique indices with null columns

### DIFF
--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/DB2Ddl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/DB2Ddl.java
@@ -24,10 +24,22 @@ public class DB2Ddl extends PlatformDdl {
   public String alterTableAddUniqueConstraint(String tableName, String uqName, String[] columns, String[] nullableColumns) {
     if (nullableColumns == null || nullableColumns.length == 0) {
       return super.alterTableAddUniqueConstraint(tableName, uqName, columns, nullableColumns);
-    } else {
-      // Hmm: Complex workaround: https://www.ibm.com/developerworks/mydeveloperworks/blogs/SQLTips4DB2LUW/entry/unique_where_not_null_indexes26?lang=en
-      return "-- NOT SUPPORTED " + super.alterTableAddUniqueConstraint(tableName, uqName, columns, nullableColumns);
+    }     
+
+    if (uqName == null) {
+      throw new NullPointerException();
     }
+    StringBuilder sb = new StringBuilder("create unique index ");
+    sb.append(uqName).append(" on ").append(tableName).append('(');
+
+    for (int i = 0; i < columns.length; i++) {
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append(columns[i]);
+    }
+    sb.append(") exclude null keys");
+    return sb.toString();
   }
 
   @Override


### PR DESCRIPTION
The creation of unique inidices on columns which might be null is now supported in DB2 (https://www.ibm.com/docs/en/db2/11.5?topic=statements-create-index). This fixes 7 additional tests for DB2