### PR TITLE
DTimedMetricTest fails sometimes (flaky test)

### DIFF
--- a/ebean-test/src/test/java/io/ebeaninternal/server/profile/DTimedMetricTest.java
+++ b/ebean-test/src/test/java/io/ebeaninternal/server/profile/DTimedMetricTest.java
@@ -12,7 +12,7 @@ public class DTimedMetricTest {
     DTimedMetric metric = new DTimedMetric("addSinceNanos");
 
     long start = System.nanoTime();
-    Thread.sleep(10);
+    Thread.sleep(11);
 
     metric.addSinceNanos(start);
 
@@ -35,7 +35,7 @@ public class DTimedMetricTest {
     DTimedMetric metric = new DTimedMetric("addSinceNanos");
 
     long start = System.nanoTime();
-    Thread.sleep(10);
+    Thread.sleep(11);
 
     metric.addBatchSince(start, 5);
 


### PR DESCRIPTION
This test fails sometimes (~10%) on my machine in this line
```
assertThat(stats.total()).isGreaterThan(10000);
```
with "expecting actual: 9876L to be grater than 10000L" 

The value is very close to 10000, but not greater.

I think this may happen, because `Thread.sleep(10)` will wait approx 10ms (9.5-10.5) - and if you have a fast machine, the wait time may not be at least 10ms.
Can also be a problem of windows-os (it never happened on build server)

cheers
Roland

