### PR TITLE
generate mysql StoredProcs for column deletion also for mariadb

### DIFF
--- a/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl.xml
+++ b/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl.xml
@@ -112,7 +112,7 @@ BEGIN
 END
 GO
 </ddl-script>
-<ddl-script name="create procs" platforms="mysql" init="true">-- Inital script to create stored procedures etc for mysql platform
+<ddl-script name="create procs" platforms="mysql mariadb" init="true">-- Inital script to create stored procedures etc for mysql platform
 DROP PROCEDURE IF EXISTS usp_ebean_drop_foreign_keys;
 
 delimiter $$


### PR DESCRIPTION
The StoredProcedures required for #2494 are also required for mariadb (discovered with #2551)