### PR TITLE
Bug: save with cascade of @OneToOne + @Version model sets version to 1

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -360,7 +360,7 @@ public final class EntityBeanIntercept implements Serializable {
    * Return true if the entity should be updated.
    */
   public boolean isUpdate() {
-    return forceUpdate || state == STATE_LOADED;
+    return forceUpdate || state == STATE_LOADED || state == STATE_REFERENCE;
   }
 
   /**

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoChildVersion.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoChildVersion.java
@@ -1,0 +1,66 @@
+package org.tests.model.onetoone;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Version;
+
+import io.ebean.annotation.Where;
+
+@Entity
+public class OtoChildVersion {
+
+  @Id
+  Integer id;
+
+  String name;
+
+  @OneToOne
+  OtoMasterVersion master;
+
+  @Version
+  int version;
+  
+  @OneToMany(cascade = CascadeType.ALL)
+  @JoinColumn(name = "ref_id")
+  @Where(clause = "${mta}.type=1")
+  List<OtoNotification> notifications;
+  
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public OtoMasterVersion getMaster() {
+    return master;
+  }
+
+  public void setMaster(OtoMasterVersion master) {
+    this.master = master;
+  }
+  
+  public int getVersion() {
+    return version;
+  }
+
+  public void setVersion(int version) {
+    this.version = version;
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoMasterVersion.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoMasterVersion.java
@@ -1,0 +1,66 @@
+package org.tests.model.onetoone;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Version;
+
+import io.ebean.annotation.Where;
+
+@Entity
+public class OtoMasterVersion {
+
+  @Id
+  Long id;
+
+  String name;
+
+  @OneToOne(cascade = CascadeType.ALL, mappedBy = "master")
+  OtoChildVersion child;
+
+  @Version
+  int version;
+  
+  @OneToMany(cascade = CascadeType.ALL)
+  @JoinColumn(name = "ref_id")
+  @Where(clause = "${mta}.type=0")
+  List<OtoNotification> notifications;
+  
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public OtoChildVersion getChild() {
+    return child;
+  }
+
+  public void setChild(OtoChildVersion child) {
+    this.child = child;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public void setVersion(int version) {
+    this.version = version;
+  }
+  
+}

--- a/ebean-test/src/test/java/org/tests/model/onetoone/OtoNotification.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/OtoNotification.java
@@ -1,0 +1,51 @@
+package org.tests.model.onetoone;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class OtoNotification {
+
+  @Id
+  Integer id;
+
+  Integer refId;
+  
+  // 0 = master, 1 = child
+  Integer type;
+
+  String text;
+  
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public Integer getRefId() {
+    return refId;
+  }
+
+  public void setRefId(Integer refId) {
+    this.refId = refId;
+  }
+
+  public Integer getType() {
+    return type;
+  }
+
+  public void setType(Integer type) {
+    this.type = type;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneCascadeSave.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneCascadeSave.java
@@ -34,7 +34,7 @@ public class TestOneToOneCascadeSave extends BaseTestCase {
   }
   
   @Test
-  public void test2() {
+  public void testSaveCascadeWithOneToOne() {
     OtoMasterVersion master = new OtoMasterVersion();
     master.setName("m1");
 
@@ -59,12 +59,12 @@ public class TestOneToOneCascadeSave extends BaseTestCase {
       master.setName("m2");
       DB.save(master);
       child = DB.find(OtoChildVersion.class).findOne();
-      // assertThat(child.getVersion()).isEqualTo(2); but is 1
+      assertThat(child.getVersion()).isEqualTo(2);
       child.setName("c3");
-      DB.save(child); // <-- throws OptimisticLockException
+      DB.save(child); 
       
       txn.commit();
     }
   }
-
+  
 }


### PR DESCRIPTION
When saving a model, that contains a @OneToOne Model with @Version, the child models' version will be set to 1.
Then, when the child model will be saved, a OptimisticLockException occures due to the wrong version.
(see test)

Furthermore the 'child'-model also has to have a xToMany-Relation to another model, so that the flag 'saveRecurseSkippable' in BeanPropertyAssoc is set to false.