### PR TITLE
Tidy up ddl generation (no effective code change)

### DIFF
--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
@@ -582,9 +582,9 @@ public class DefaultDbMigration implements DbMigration {
         // writer needs the current model to provide table/column details for
         // history ddl generation (triggers, history tables etc)
         DdlOptions options = new DdlOptions(addForeignKeySkipCheck);
-        DdlWrite write = new DdlWrite(new MConfiguration(), request.current, options);
-        PlatformDdlWriter writer = createDdlWriter(databasePlatform);
-        writer.processMigration(dbMigration, write, request.migrationDir, fullVersion);
+        DdlWrite writer = new DdlWrite(new MConfiguration(), request.current, options);
+        PlatformDdlWriter platformWriter = createDdlWriter(databasePlatform);
+        platformWriter.processMigration(dbMigration, writer, request.migrationDir, fullVersion);
       }
       return fullVersion;
     }
@@ -651,10 +651,10 @@ public class DefaultDbMigration implements DbMigration {
   private void writeExtraPlatformDdl(String fullVersion, CurrentModel currentModel, Migration dbMigration, File writePath) throws IOException {
     DdlOptions options = new DdlOptions(addForeignKeySkipCheck);
     for (Pair pair : platforms) {
-      DdlWrite platformBuffer = new DdlWrite(new MConfiguration(), currentModel.read(), options);
+      DdlWrite writer = new DdlWrite(new MConfiguration(), currentModel.read(), options);
       PlatformDdlWriter platformWriter = createDdlWriter(pair.platform);
       File subPath = platformWriter.subPath(writePath, pair.prefix);
-      platformWriter.processMigration(dbMigration, platformBuffer, subPath, fullVersion);
+      platformWriter.processMigration(dbMigration, writer, subPath, fullVersion);
     }
   }
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/BaseDdlHandler.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/BaseDdlHandler.java
@@ -75,13 +75,13 @@ public class BaseDdlHandler implements DdlHandler {
   }
 
   @Override
-  public void generateProlog(DdlWrite write) {
-    tableDdl.generateProlog(write);
+  public void generateProlog(DdlWrite writer) {
+    tableDdl.generateProlog(writer);
   }
 
   @Override
-  public void generateEpilog(DdlWrite write) {
-    tableDdl.generateEpilog(write);
+  public void generateEpilog(DdlWrite writer) {
+    tableDdl.generateEpilog(writer);
   }
 
   @Override

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/DdlHandler.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/DdlHandler.java
@@ -45,7 +45,7 @@ public interface DdlHandler {
 
   void generate(DdlWrite writer, AlterForeignKey alterForeignKey);
 
-  void generateProlog(DdlWrite write);
+  void generateProlog(DdlWrite writer);
 
-  void generateEpilog(DdlWrite write);
+  void generateEpilog(DdlWrite writer);
 }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/TableDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/TableDdl.java
@@ -81,10 +81,10 @@ public interface TableDdl {
   /**
    * Generate any extra DDL such as stored procedures or TableValueParameters.
    */
-  void generateProlog(DdlWrite write);
+  void generateProlog(DdlWrite writer);
 
   /**
    * Generate any extra DDL such as regeneration of history triggers.
    */
-  void generateEpilog(DdlWrite write);
+  void generateEpilog(DdlWrite writer);
 }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
@@ -350,7 +350,7 @@ public class BaseTableDdl implements TableDdl {
    * Specific handling of OneToOne unique constraints for MsSqlServer.
    * For all other DB platforms these unique constraints are done inline as per normal.
    */
-  protected void writeUniqueOneToOneConstraints(DdlWrite write, CreateTable createTable) {
+  protected void writeUniqueOneToOneConstraints(DdlWrite writer, CreateTable createTable) {
     String tableName = createTable.getName();
     for (Column col : externalUnique) {
       String uqName = col.getUniqueOneToOne();
@@ -358,8 +358,8 @@ public class BaseTableDdl implements TableDdl {
         uqName = col.getUnique();
       }
       String[] columnNames = {col.getName()};
-      write.apply().appendStatement(platformDdl.alterTableAddUniqueConstraint(tableName, uqName, columnNames, Boolean.TRUE.equals(col.isNotnull()) ? null : columnNames));
-      write.dropAllForeignKeys().appendStatement(platformDdl.dropIndex(uqName, tableName));
+      writer.apply().appendStatement(platformDdl.alterTableAddUniqueConstraint(tableName, uqName, columnNames, Boolean.TRUE.equals(col.isNotnull()) ? null : columnNames));
+      writer.dropAllForeignKeys().appendStatement(platformDdl.dropIndex(uqName, tableName));
     }
 
     for (UniqueConstraint constraint : externalCompoundUnique) {
@@ -367,8 +367,8 @@ public class BaseTableDdl implements TableDdl {
       String[] columnNames = split(constraint.getColumnNames());
       String[] nullableColumns = split(constraint.getNullableColumns());
 
-      write.apply().appendStatement(platformDdl.alterTableAddUniqueConstraint(tableName, uqName, columnNames, nullableColumns));
-      write.dropAllForeignKeys().appendStatement(platformDdl.dropIndex(uqName, tableName));
+      writer.apply().appendStatement(platformDdl.alterTableAddUniqueConstraint(tableName, uqName, columnNames, nullableColumns));
+      writer.dropAllForeignKeys().appendStatement(platformDdl.dropIndex(uqName, tableName));
     }
   }
 
@@ -386,63 +386,63 @@ public class BaseTableDdl implements TableDdl {
     platformDdl.createWithHistory(writer, table);
   }
 
-  protected void writeInlineForeignKeys(DdlWrite write, CreateTable createTable) {
+  protected void writeInlineForeignKeys(DdlWrite writer, CreateTable createTable) {
     for (Column column : createTable.getColumn()) {
       String references = column.getReferences();
       if (hasValue(references)) {
-        writeInlineForeignKey(write, column);
+        writeInlineForeignKey(writer, column);
       }
     }
-    writeInlineCompoundForeignKeys(write, createTable);
+    writeInlineCompoundForeignKeys(writer, createTable);
   }
 
-  protected void writeInlineForeignKey(DdlWrite write, Column column) {
+  protected void writeInlineForeignKey(DdlWrite writer, Column column) {
     String fkConstraint = platformDdl.tableInlineForeignKey(new WriteForeignKey(null, column));
-    write.apply().append(",").newLine().append("  ").append(fkConstraint);
+    writer.apply().append(",").newLine().append("  ").append(fkConstraint);
   }
 
-  protected void writeInlineCompoundForeignKeys(DdlWrite write, CreateTable createTable) {
+  protected void writeInlineCompoundForeignKeys(DdlWrite writer, CreateTable createTable) {
     for (ForeignKey key : createTable.getForeignKey()) {
       String fkConstraint = platformDdl.tableInlineForeignKey(new WriteForeignKey(null, key));
-      write.apply().append(",").newLine().append("  ").append(fkConstraint);
+      writer.apply().append(",").newLine().append("  ").append(fkConstraint);
     }
   }
 
-  protected void writeAddForeignKeys(DdlWrite write, CreateTable createTable) {
+  protected void writeAddForeignKeys(DdlWrite writer, CreateTable createTable) {
     for (Column column : createTable.getColumn()) {
       String references = column.getReferences();
       if (hasValue(references)) {
-        writeForeignKey(write, createTable.getName(), column);
+        writeForeignKey(writer, createTable.getName(), column);
       }
     }
-    writeAddCompoundForeignKeys(write, createTable);
+    writeAddCompoundForeignKeys(writer, createTable);
   }
 
-  protected void writeAddCompoundForeignKeys(DdlWrite write, CreateTable createTable) {
+  protected void writeAddCompoundForeignKeys(DdlWrite writer, CreateTable createTable) {
     for (ForeignKey key : createTable.getForeignKey()) {
-      writeForeignKey(write, new WriteForeignKey(createTable.getName(), key));
+      writeForeignKey(writer, new WriteForeignKey(createTable.getName(), key));
     }
   }
 
-  protected void writeForeignKey(DdlWrite write, String tableName, Column column) {
-    writeForeignKey(write, new WriteForeignKey(tableName, column));
+  protected void writeForeignKey(DdlWrite writer, String tableName, Column column) {
+    writeForeignKey(writer, new WriteForeignKey(tableName, column));
   }
 
-  protected void writeForeignKey(DdlWrite write, WriteForeignKey request) {
-    DdlBuffer fkeyBuffer = write.applyForeignKeys();
+  protected void writeForeignKey(DdlWrite writer, WriteForeignKey request) {
+    DdlBuffer fkeyBuffer = writer.applyForeignKeys();
     String tableName = lowerTableName(request.table());
     if (request.indexName() != null) {
       // no matching unique constraint so add the index
       fkeyBuffer.appendStatement(platformDdl.createIndex(new WriteCreateIndex(request.indexName(), tableName, request.cols(), false)));
     }
-    alterTableAddForeignKey(write.getOptions(), fkeyBuffer, request);
+    alterTableAddForeignKey(writer.getOptions(), fkeyBuffer, request);
     fkeyBuffer.end();
 
-    write.dropAllForeignKeys().appendStatement(platformDdl.alterTableDropForeignKey(tableName, request.fkName()));
+    writer.dropAllForeignKeys().appendStatement(platformDdl.alterTableDropForeignKey(tableName, request.fkName()));
     if (hasValue(request.indexName())) {
-      write.dropAllForeignKeys().appendStatement(platformDdl.dropIndex(request.indexName(), tableName));
+      writer.dropAllForeignKeys().appendStatement(platformDdl.dropIndex(request.indexName(), tableName));
     }
-    write.dropAllForeignKeys().end();
+    writer.dropAllForeignKeys().end();
   }
 
   protected void alterTableAddForeignKey(DdlOptions options, DdlBuffer buffer, WriteForeignKey request) {
@@ -628,25 +628,25 @@ public class BaseTableDdl implements TableDdl {
   }
 
   @Override
-  public void generateProlog(DdlWrite write) {
-    platformDdl.generateProlog(write);
+  public void generateProlog(DdlWrite writer) {
+    platformDdl.generateProlog(writer);
   }
 
   /**
    * Called at the end to generate additional ddl such as regenerate history triggers.
    */
   @Override
-  public void generateEpilog(DdlWrite write) {
+  public void generateEpilog(DdlWrite writer) {
     if (!regenerateHistoryTriggers.isEmpty()) {
-      platformDdl.lockTables(write.applyHistoryTrigger(), regenerateHistoryTriggers.keySet());
+      platformDdl.lockTables(writer.applyHistoryTrigger(), regenerateHistoryTriggers.keySet());
 
       for (HistoryTableUpdate update : this.regenerateHistoryTriggers.values()) {
-        platformDdl.regenerateHistoryTriggers(write, update);
+        platformDdl.regenerateHistoryTriggers(writer, update);
       }
 
-      platformDdl.unlockTables(write.applyHistoryTrigger(), regenerateHistoryTriggers.keySet());
+      platformDdl.unlockTables(writer.applyHistoryTrigger(), regenerateHistoryTriggers.keySet());
     }
-    platformDdl.generateEpilog(write);
+    platformDdl.generateEpilog(writer);
   }
 
   @Override

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
@@ -62,24 +62,11 @@ public class BaseTableDdl implements TableDdl {
   protected final String historyTableSuffix;
 
   /**
-   * Used to check that indexes on foreign keys should be skipped as a unique index on the columns
-   * already exists.
-   */
-  protected final IndexSet indexSet = new IndexSet();
-
-  /**
    * Used when unique constraints specifically for OneToOne can't be created normally (MsSqlServer).
    */
   protected final List<Column> externalUnique = new ArrayList<>();
 
   protected final List<UniqueConstraint> externalCompoundUnique = new ArrayList<>();
-
-  // counters used when constraint names are truncated due to maximum length
-  // and these counters are used to keep the constraint name unique
-  protected int countCheck;
-  protected int countUnique;
-  protected int countForeignKey;
-  protected int countIndex;
 
   /**
    * Base tables that have associated history tables that need their triggers/functions regenerated as
@@ -220,13 +207,8 @@ public class BaseTableDdl implements TableDdl {
    * Reset counters and index set for each table processed.
    */
   protected void reset() {
-    indexSet.clear();
     externalUnique.clear();
     externalCompoundUnique.clear();
-    countCheck = 0;
-    countUnique = 0;
-    countForeignKey = 0;
-    countIndex = 0;
   }
 
   /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/HanaHistoryDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/HanaHistoryDdl.java
@@ -101,7 +101,7 @@ public class HanaHistoryDdl implements PlatformHistoryDdl {
   }
 
   @Override
-  public void updateTriggers(DdlWrite write, HistoryTableUpdate baseTable) {
+  public void updateTriggers(DdlWrite writer, HistoryTableUpdate baseTable) {
     // nothing to do
   }
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/NoHistorySupportDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/NoHistorySupportDdl.java
@@ -33,7 +33,7 @@ public class NoHistorySupportDdl implements PlatformHistoryDdl {
   }
 
   @Override
-  public void updateTriggers(DdlWrite write, HistoryTableUpdate update) {
+  public void updateTriggers(DdlWrite writer, HistoryTableUpdate update) {
     // does nothing
   }
 }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
@@ -375,8 +375,8 @@ public class PlatformDdl {
   /**
    * Regenerate the history triggers (or function) due to a column being added/dropped/excluded or included.
    */
-  public void regenerateHistoryTriggers(DdlWrite write, HistoryTableUpdate update) {
-    historyDdl.updateTriggers(write, update);
+  public void regenerateHistoryTriggers(DdlWrite writer, HistoryTableUpdate update) {
+    historyDdl.updateTriggers(writer, update);
   }
 
   /**
@@ -727,14 +727,14 @@ public class PlatformDdl {
   /**
    * Use this to generate a prolog for each script (stored procedures)
    */
-  public void generateProlog(DdlWrite write) {
+  public void generateProlog(DdlWrite writer) {
 
   }
 
   /**
    * Use this to generate an epilog. Will be added at the end of script
    */
-  public void generateEpilog(DdlWrite write) {
+  public void generateEpilog(DdlWrite writer) {
 
   }
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformHistoryDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformHistoryDdl.java
@@ -34,5 +34,5 @@ public interface PlatformHistoryDdl {
   /**
    * Regenerate the history triggers/stored function due to column added/dropped/included or excluded.
    */
-  void updateTriggers(DdlWrite write, HistoryTableUpdate baseTable);
+  void updateTriggers(DdlWrite writer, HistoryTableUpdate baseTable);
 }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/SqlServerDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/SqlServerDdl.java
@@ -211,25 +211,25 @@ public class SqlServerDdl extends PlatformDdl {
    * This writes the multi value datatypes needed for MultiValueBind.
    */
   @Override
-  public void generateProlog(DdlWrite write) {
-    super.generateProlog(write);
+  public void generateProlog(DdlWrite writer) {
+    super.generateProlog(writer);
 
-    generateTVPDefinitions(write, "bigint");
-    generateTVPDefinitions(write, "float");
-    generateTVPDefinitions(write, "bit");
-    generateTVPDefinitions(write, "date");
-    generateTVPDefinitions(write, "time");
+    generateTVPDefinitions(writer, "bigint");
+    generateTVPDefinitions(writer, "float");
+    generateTVPDefinitions(writer, "bit");
+    generateTVPDefinitions(writer, "date");
+    generateTVPDefinitions(writer, "time");
     //generateTVPDefinitions(write, "datetime2");
-    generateTVPDefinitions(write, "uniqueidentifier");
-    generateTVPDefinitions(write, "nvarchar(max)");
+    generateTVPDefinitions(writer, "uniqueidentifier");
+    generateTVPDefinitions(writer, "nvarchar(max)");
 
   }
 
-  private void generateTVPDefinitions(DdlWrite write, String definition) {
+  private void generateTVPDefinitions(DdlWrite writer, String definition) {
     int pos = definition.indexOf('(');
     String name = pos == -1 ? definition : definition.substring(0, pos);
 
-    dropTVP(write.dropAll(), name);
+    dropTVP(writer.dropAll(), name);
     //TVPs are included in "I__create_procs.sql"
     //createTVP(write.apply(), name, definition);
   }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/CurrentModel.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/CurrentModel.java
@@ -35,7 +35,7 @@ public class CurrentModel {
 
   private ModelContainer model;
   private ChangeSet changeSet;
-  private DdlWrite write;
+  private DdlWrite writer;
 
   /**
    * Construct with a given EbeanServer instance for DDL create all generation, not migration.
@@ -127,10 +127,10 @@ public class CurrentModel {
     if (jaxbPresent) {
       addExtraDdl(ddl, ExtraDdlXmlReader.readBuiltin(), "-- init script ");
     }
-    ddl.append(write.apply().getBuffer());
-    ddl.append(write.applyForeignKeys().getBuffer());
-    ddl.append(write.applyHistoryView().getBuffer());
-    ddl.append(write.applyHistoryTrigger().getBuffer());
+    ddl.append(writer.apply().getBuffer());
+    ddl.append(writer.applyForeignKeys().getBuffer());
+    ddl.append(writer.applyHistoryView().getBuffer());
+    ddl.append(writer.applyHistoryTrigger().getBuffer());
     return ddl.toString();
   }
 
@@ -157,8 +157,8 @@ public class CurrentModel {
     if (ddlHeader != null && !ddlHeader.isEmpty()) {
       ddl.append(ddlHeader).append('\n');
     }
-    ddl.append(write.dropAllForeignKeys().getBuffer());
-    ddl.append(write.dropAll().getBuffer());
+    ddl.append(writer.dropAllForeignKeys().getBuffer());
+    ddl.append(writer.dropAll().getBuffer());
     return ddl.toString();
   }
 
@@ -166,13 +166,13 @@ public class CurrentModel {
    * Create all the DDL based on the changeSet.
    */
   private void createDdl() {
-    if (write == null) {
+    if (writer == null) {
       ChangeSet createChangeSet = getChangeSet();
-      write = new DdlWrite(new MConfiguration(), model, ddlOptions);
+      writer = new DdlWrite(new MConfiguration(), model, ddlOptions);
       DdlHandler handler = handler();
-      handler.generateProlog(write);
-      handler.generate(write, createChangeSet);
-      handler.generateEpilog(write);
+      handler.generateProlog(writer);
+      handler.generate(writer, createChangeSet);
+      handler.generateEpilog(writer);
     }
   }
 

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/BaseDdlHandlerTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/BaseDdlHandlerTest.java
@@ -45,30 +45,30 @@ public class BaseDdlHandlerTest extends BaseTestCase {
   @Test
   public void addColumn_nullable_noConstraint() throws Exception {
 
-    DdlWrite write = new DdlWrite();
-    h2Handler().generate(write, Helper.getAddColumn());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column added_to_foo varchar(20);\n\n");
+    DdlWrite writer = new DdlWrite();
+    h2Handler().generate(writer, Helper.getAddColumn());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column added_to_foo varchar(20);\n\n");
 
-    write = new DdlWrite();
-    sqlserverHandler().generate(write, Helper.getAddColumn());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add added_to_foo nvarchar(20);\n\n");
+    writer = new DdlWrite();
+    sqlserverHandler().generate(writer, Helper.getAddColumn());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add added_to_foo nvarchar(20);\n\n");
 
-    write = new DdlWrite();
-    hanaHandler().generate(write, Helper.getAddColumn());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add ( added_to_foo nvarchar(20));\n\n");
+    writer = new DdlWrite();
+    hanaHandler().generate(writer, Helper.getAddColumn());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add ( added_to_foo nvarchar(20));\n\n");
   }
 
   @Test
   public void addColumn_withCheckConstraint() throws Exception {
 
-    DdlWrite write = new DdlWrite();
-    h2Handler().generate(write, Helper.getAlterTableAddColumnWithCheckConstraint());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column status integer;\n"
+    DdlWrite writer = new DdlWrite();
+    h2Handler().generate(writer, Helper.getAlterTableAddColumnWithCheckConstraint());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column status integer;\n"
         + "alter table foo add constraint ck_ordering_status check ( status in (0,1));\n\n");
 
-    write = new DdlWrite();
-    hanaHandler().generate(write, Helper.getAlterTableAddColumnWithCheckConstraint());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add ( status integer);\n"
+    writer = new DdlWrite();
+    hanaHandler().generate(writer, Helper.getAlterTableAddColumnWithCheckConstraint());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add ( status integer);\n"
         + "alter table foo add constraint ck_ordering_status check ( status in (0,1));\n\n");
   }
 
@@ -79,158 +79,160 @@ public class BaseDdlHandlerTest extends BaseTestCase {
   @Test
   public void addColumn_dbarray() throws Exception {
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     DdlHandler postgresHandler = postgresHandler();
-    postgresHandler.generate(write, Helper.getAlterTableAddDbArrayColumn());
+    postgresHandler.generate(writer, Helper.getAlterTableAddDbArrayColumn());
 
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_added_to_foo varchar[];\n\n");
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_added_to_foo varchar[];\n\n");
 
-    write = new DdlWrite();
+    writer = new DdlWrite();
 
     DdlHandler sqlserverHandler = sqlserverHandler();
-    sqlserverHandler.generate(write, Helper.getAlterTableAddDbArrayColumn());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add dbarray_added_to_foo varchar(1000);\n\n");
+    sqlserverHandler.generate(writer, Helper.getAlterTableAddDbArrayColumn());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add dbarray_added_to_foo varchar(1000);\n\n");
 
-    write = new DdlWrite();
+    writer = new DdlWrite();
 
     DdlHandler hanaHandler = hanaHandler();
-    hanaHandler.generate(write, Helper.getAlterTableAddDbArrayColumn());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add ( dbarray_added_to_foo nvarchar(255) array);\n\n");
+    hanaHandler.generate(writer, Helper.getAlterTableAddDbArrayColumn());
+    assertThat(writer.apply().getBuffer())
+      .isEqualTo("alter table foo add ( dbarray_added_to_foo nvarchar(255) array);\n\n");
   }
 
   @Test
   public void addColumn_dbarray_withLength() throws Exception {
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
-    postgresHandler().generate(write, Helper.getAlterTableAddDbArrayColumnWithLength());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_ninety varchar[];\n\n");
+    postgresHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnWithLength());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_ninety varchar[];\n\n");
 
-    write = new DdlWrite();
-    h2Handler().generate(write, Helper.getAlterTableAddDbArrayColumnWithLength());
+    writer = new DdlWrite();
+    h2Handler().generate(writer, Helper.getAlterTableAddDbArrayColumnWithLength());
     if (useV1Syntax) {
-      assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_ninety array;\n\n");
+      assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_ninety array;\n\n");
     } else {
-      assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_ninety varchar array;\n\n");
+      assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_ninety varchar array;\n\n");
     }
 
-    write = new DdlWrite();
-    sqlserverHandler().generate(write, Helper.getAlterTableAddDbArrayColumnWithLength());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add dbarray_ninety varchar(90);\n\n");
+    writer = new DdlWrite();
+    sqlserverHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnWithLength());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add dbarray_ninety varchar(90);\n\n");
 
-    write = new DdlWrite();
-    hanaHandler().generate(write, Helper.getAlterTableAddDbArrayColumnWithLength());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add ( dbarray_ninety nvarchar(255) array(90));\n\n");
+    writer = new DdlWrite();
+    hanaHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnWithLength());
+    assertThat(writer.apply().getBuffer())
+      .isEqualTo("alter table foo add ( dbarray_ninety nvarchar(255) array(90));\n\n");
   }
 
   @Test
   public void addColumn_dbarray_integer_withLength() throws Exception {
 
-    DdlWrite write = new DdlWrite();
-    postgresHandler().generate(write, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_integer integer[];\n\n");
+    DdlWrite writer = new DdlWrite();
+    postgresHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_integer integer[];\n\n");
 
-    write = new DdlWrite();
-    h2Handler().generate(write, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
+    writer = new DdlWrite();
+    h2Handler().generate(writer, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
     if (useV1Syntax) {
-      assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_integer array;\n\n");
+      assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_integer array;\n\n");
     } else {
-      assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_integer integer array;\n\n");
+      assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add column dbarray_integer integer array;\n\n");
     }
 
-    write = new DdlWrite();
-    sqlserverHandler().generate(write, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add dbarray_integer varchar(90);\n\n");
+    writer = new DdlWrite();
+    sqlserverHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add dbarray_integer varchar(90);\n\n");
 
-    write = new DdlWrite();
-    sqlserverHandler().generate(write, Helper.getAlterTableAddDbArrayColumnInteger());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add dbarray_integer varchar(1000);\n\n");
+    writer = new DdlWrite();
+    sqlserverHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnInteger());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add dbarray_integer varchar(1000);\n\n");
 
-    write = new DdlWrite();
-    hanaHandler().generate(write, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add ( dbarray_integer integer array(90));\n\n");
+    writer = new DdlWrite();
+    hanaHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnIntegerWithLength());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add ( dbarray_integer integer array(90));\n\n");
 
-    write = new DdlWrite();
-    hanaHandler().generate(write, Helper.getAlterTableAddDbArrayColumnInteger());
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo add ( dbarray_integer integer array);\n\n");
+    writer = new DdlWrite();
+    hanaHandler().generate(writer, Helper.getAlterTableAddDbArrayColumnInteger());
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo add ( dbarray_integer integer array);\n\n");
   }
 
   @Test
   public void addColumn_withForeignKey() throws Exception {
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     DdlHandler handler = h2Handler();
-    handler.generate(write, Helper.getAlterTableAddColumn());
+    handler.generate(writer, Helper.getAlterTableAddColumn());
 
-    String buffer = write.apply().getBuffer();
+    String buffer = writer.apply().getBuffer();
     assertThat(buffer).contains("alter table foo add column some_id integer;");
 
-    String fkBuffer = write.applyForeignKeys().getBuffer();
+    String fkBuffer = writer.applyForeignKeys().getBuffer();
     assertThat(fkBuffer).contains(
         "alter table foo add constraint fk_foo_some_id foreign key (some_id) references bar (id) on delete restrict on update restrict;");
     assertThat(fkBuffer).contains("create index idx_foo_some_id on foo (some_id);");
-    assertThat(write.dropAll().getBuffer()).isEqualTo("");
+    assertThat(writer.dropAll().getBuffer()).isEqualTo("");
   }
 
   @Test
   public void dropColumn() throws Exception {
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
     DdlHandler handler = h2Handler();
 
-    handler.generate(write, Helper.getDropColumn());
+    handler.generate(writer, Helper.getDropColumn());
 
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table foo drop column col2;\n\n");
-    assertThat(write.dropAll().getBuffer()).isEqualTo("");
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table foo drop column col2;\n\n");
+    assertThat(writer.dropAll().getBuffer()).isEqualTo("");
 
-    write = new DdlWrite();
+    writer = new DdlWrite();
     DdlHandler hanaHandler = hanaHandler();
 
-    hanaHandler.generate(write, Helper.getDropColumn());
+    hanaHandler.generate(writer, Helper.getDropColumn());
 
-    assertThat(write.apply().getBuffer()).isEqualTo("CALL usp_ebean_drop_column('foo', 'col2');\n\n");
-    assertThat(write.dropAll().getBuffer()).isEqualTo("");
+    assertThat(writer.apply().getBuffer()).isEqualTo("CALL usp_ebean_drop_column('foo', 'col2');\n\n");
+    assertThat(writer.dropAll().getBuffer()).isEqualTo("");
   }
 
   @Test
   public void createTable() throws Exception {
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
     DdlHandler handler = h2Handler();
 
-    handler.generate(write, Helper.getCreateTable());
+    handler.generate(writer, Helper.getCreateTable());
 
     String createTableDDL = Helper.asText(this, "/assert/create-table.txt");
 
-    assertThat(write.apply().getBuffer()).isEqualTo(createTableDDL);
-    assertThat(write.dropAll().getBuffer().trim()).isEqualTo("drop table if exists foo;");
+    assertThat(writer.apply().getBuffer()).isEqualTo(createTableDDL);
+    assertThat(writer.dropAll().getBuffer().trim()).isEqualTo("drop table if exists foo;");
 
-    write = new DdlWrite();
+    writer = new DdlWrite();
     DdlHandler hanaHandler = hanaHandler();
 
-    hanaHandler.generate(write, Helper.getCreateTable());
+    hanaHandler.generate(writer, Helper.getCreateTable());
 
     String createColumnTableDDL = Helper.asText(this, "/assert/create-column-table.txt");
 
-    assertThat(write.apply().getBuffer()).isEqualTo(createColumnTableDDL);
-    assertThat(write.dropAll().getBuffer().trim()).isEqualTo("drop table foo cascade;");
+    assertThat(writer.apply().getBuffer()).isEqualTo(createColumnTableDDL);
+    assertThat(writer.dropAll().getBuffer().trim()).isEqualTo("drop table foo cascade;");
   }
 
   @Test
   public void generateChangeSet() throws Exception {
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
     DdlHandler handler = h2Handler();
 
-    handler.generate(write, Helper.getChangeSet());
+    handler.generate(writer, Helper.getChangeSet());
 
     String apply = Helper.asText(this, "/assert/BaseDdlHandlerTest/baseApply.sql");
     String rollbackLast = Helper.asText(this, "/assert/BaseDdlHandlerTest/baseDropAll.sql");
 
-    assertThat(write.apply().getBuffer()).isEqualTo(apply);
-    assertThat(write.dropAll().getBuffer()).isEqualTo(rollbackLast);
+    assertThat(writer.apply().getBuffer()).isEqualTo(apply);
+    assertThat(writer.dropAll().getBuffer()).isEqualTo(rollbackLast);
   }
 
   @Disabled
@@ -241,16 +243,16 @@ public class BaseDdlHandlerTest extends BaseTestCase {
 
     ChangeSet createChangeSet = new CurrentModel(defaultServer).getChangeSet();
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     DdlHandler handler = h2Handler();
-    handler.generate(write, createChangeSet);
+    handler.generate(writer, createChangeSet);
 
     String apply = Helper.asText(this, "/assert/changeset-apply.txt");
     String rollbackLast = Helper.asText(this, "/assert/changeset-dropAll.txt");
 
-    assertThat(write.apply().getBuffer()).isEqualTo(apply);
-    assertThat(write.dropAll().getBuffer()).isEqualTo(rollbackLast);
+    assertThat(writer.apply().getBuffer()).isEqualTo(apply);
+    assertThat(writer.dropAll().getBuffer()).isEqualTo(rollbackLast);
   }
 
   @Disabled
@@ -260,20 +262,20 @@ public class BaseDdlHandlerTest extends BaseTestCase {
 
     ChangeSet createChangeSet = new CurrentModel(defaultServer).getChangeSet();
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     DdlHandler handler = postgresHandler();
-    handler.generate(write, createChangeSet);
+    handler.generate(writer, createChangeSet);
 
     String apply = Helper.asText(this, "/assert/changeset-pg-apply.sql");
     String applyLast = Helper.asText(this, "/assert/changeset-pg-applyLast.sql");
     String rollbackFirst = Helper.asText(this, "/assert/changeset-pg-rollbackFirst.sql");
     String rollbackLast = Helper.asText(this, "/assert/changeset-pg-rollbackLast.sql");
 
-    assertThat(write.apply().getBuffer()).isEqualTo(apply);
-    assertThat(write.applyForeignKeys().getBuffer()).isEqualTo(applyLast);
-    assertThat(write.dropAllForeignKeys().getBuffer()).isEqualTo(rollbackFirst);
-    assertThat(write.dropAll().getBuffer()).isEqualTo(rollbackLast);
+    assertThat(writer.apply().getBuffer()).isEqualTo(apply);
+    assertThat(writer.applyForeignKeys().getBuffer()).isEqualTo(applyLast);
+    assertThat(writer.dropAllForeignKeys().getBuffer()).isEqualTo(rollbackFirst);
+    assertThat(writer.dropAll().getBuffer()).isEqualTo(rollbackLast);
   }
 
 }

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdlTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdlTest.java
@@ -30,16 +30,16 @@ public class BaseTableDdlTest {
   public void testAlterColumn() {
     BaseTableDdl ddlGen = new BaseTableDdl(serverConfig, h2ddl);
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     AlterColumn alterColumn = new AlterColumn();
     alterColumn.setTableName("mytab");
     alterColumn.setCheckConstraint("check (acol in ('A','B'))");
     alterColumn.setCheckConstraintName("ck_mytab_acol");
 
-    ddlGen.generate(write, alterColumn);
+    ddlGen.generate(writer, alterColumn);
 
-    String ddl = write.apply().getBuffer();
+    String ddl = writer.apply().getBuffer();
     assertThat(ddl).contains("alter table mytab drop constraint if exists ck_mytab_acol");
     assertThat(ddl).contains("alter table mytab add constraint ck_mytab_acol check (acol in ('A','B'))");
   }
@@ -49,15 +49,15 @@ public class BaseTableDdlTest {
 
     BaseTableDdl ddlGen = new BaseTableDdl(serverConfig, PlatformDdlBuilder.create(new OraclePlatform()));
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     Column column = new Column();
     column.setName("col_name");
     column.setType("varchar(20)");
 
-    ddlGen.alterTableAddColumn(write.apply(), "mytable", column, false, false);
+    ddlGen.alterTableAddColumn(writer.apply(), "mytable", column, false, false);
 
-    String ddl = write.apply().getBuffer();
+    String ddl = writer.apply().getBuffer();
     assertThat(ddl).contains("alter table mytable add col_name varchar2(20)");
   }
 
@@ -66,15 +66,15 @@ public class BaseTableDdlTest {
 
     ClickHouseTableDdl ddlGen = new ClickHouseTableDdl(serverConfig, PlatformDdlBuilder.create(new ClickHousePlatform()));
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     Column column = new Column();
     column.setName("col_name");
     column.setType("varchar(20)");
 
-    ddlGen.alterTableAddColumn(write.apply(), "mytable", column, false, false);
+    ddlGen.alterTableAddColumn(writer.apply(), "mytable", column, false, false);
 
-    String ddl = write.apply().getBuffer();
+    String ddl = writer.apply().getBuffer();
     assertThat(ddl).contains("alter table mytable add column col_name String");
   }
 
@@ -83,32 +83,33 @@ public class BaseTableDdlTest {
 
     BaseTableDdl ddlGen = new BaseTableDdl(serverConfig, h2ddl);
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     AlterColumn alterColumn = new AlterColumn();
     alterColumn.setTableName("mytab");
     alterColumn.setColumnName("acol");
     alterColumn.setComment("my comment");
 
-    ddlGen.generate(write, alterColumn);
+    ddlGen.generate(writer, alterColumn);
 
-    String ddl = write.apply().getBuffer();
+    String ddl = writer.apply().getBuffer();
     assertThat(ddl).contains("comment on column mytab.acol is 'my comment'");
   }
 
   @Test
   public void alterTableAddColumnWithComment() {
     BaseTableDdl ddl = new BaseTableDdl(serverConfig, h2ddl);
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
     Column column = new Column();
     column.setName("my_column");
     column.setComment("some comment");
     column.setType("int");
 
-    ddl.alterTableAddColumn(write.apply(), "my_table", column, false, false);
+    ddl.alterTableAddColumn(writer.apply(), "my_table", column, false, false);
     assertEquals(
       "alter table my_table add column my_column int;\n" +
-      "comment on column my_table.my_column is 'some comment';\n", write.apply().getBuffer());
+        "comment on column my_table.my_column is 'some comment';\n",
+      writer.apply().getBuffer());
   }
 
   @Test
@@ -116,15 +117,15 @@ public class BaseTableDdlTest {
 
     BaseTableDdl ddlGen = new BaseTableDdl(serverConfig, h2ddl);
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     AddTableComment addTableComment = new AddTableComment();
     addTableComment.setName("mytab");
     addTableComment.setComment("my comment");
 
-    ddlGen.generate(write, addTableComment);
+    ddlGen.generate(writer, addTableComment);
 
-    String ddl = write.apply().getBuffer();
+    String ddl = writer.apply().getBuffer();
     assertThat(ddl).contains("comment on table mytab is 'my comment'");
   }
 
@@ -133,15 +134,15 @@ public class BaseTableDdlTest {
 
     BaseTableDdl ddlGen = new BaseTableDdl(serverConfig, PlatformDdlBuilder.create(new MySqlPlatform()));
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
     AddTableComment addTableComment = new AddTableComment();
     addTableComment.setName("mytab");
     addTableComment.setComment("my comment");
 
-    ddlGen.generate(write, addTableComment);
+    ddlGen.generate(writer, addTableComment);
 
-    String ddl = write.apply().getBuffer();
+    String ddl = writer.apply().getBuffer();
     assertThat(ddl).contains("alter table mytab comment = 'my comment'");
   }
 
@@ -150,14 +151,14 @@ public class BaseTableDdlTest {
 
     BaseTableDdl ddlGen = new BaseTableDdl(serverConfig, h2ddl);
 
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
 
-    ddlGen.generate(write, createTable());
-    String apply = write.apply().getBuffer();
-    String applyLast = write.applyForeignKeys().getBuffer();
+    ddlGen.generate(writer, createTable());
+    String apply = writer.apply().getBuffer();
+    String applyLast = writer.applyForeignKeys().getBuffer();
 
-    String rollbackFirst = write.dropAllForeignKeys().getBuffer();
-    String rollbackLast = write.dropAll().getBuffer();
+    String rollbackFirst = writer.dropAllForeignKeys().getBuffer();
+    String rollbackLast = writer.dropAll().getBuffer();
 
     assertThat(apply).isEqualTo(Helper.asText(this, "/assert/BaseTableDdlTest/createTable-apply.txt"));
     assertThat(applyLast).isEqualTo(Helper.asText(this, "/assert/BaseTableDdlTest/createTable-applyLast.txt"));

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/H2HistoryDdlTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/H2HistoryDdlTest.java
@@ -28,23 +28,23 @@ public class H2HistoryDdlTest {
 
     CurrentModel currentModel = new CurrentModel(ebeanServer);
     ModelContainer modelContainer = currentModel.read();
-    DdlWrite write = new DdlWrite(new MConfiguration(), modelContainer, new DdlOptions());
+    DdlWrite writer = new DdlWrite(new MConfiguration(), modelContainer, new DdlOptions());
 
     H2Platform h2Platform = new H2Platform();
     PlatformDdl h2Ddl = PlatformDdlBuilder.create(h2Platform);
     h2Ddl.configure(ebeanServer.config());
-    h2Ddl.regenerateHistoryTriggers(write, update);
+    h2Ddl.regenerateHistoryTriggers(writer, update);
 
-    assertThat(write.applyHistoryView().isEmpty()).isFalse();
-    assertThat(write.applyHistoryTrigger().isEmpty()).isFalse();
-    assertThat(write.applyHistoryView().getBuffer())
+    assertThat(writer.applyHistoryView().isEmpty()).isFalse();
+    assertThat(writer.applyHistoryTrigger().isEmpty()).isFalse();
+    assertThat(writer.applyHistoryView().getBuffer())
       .contains("create view")
       .doesNotContain("create trigger");
-    assertThat(write.applyHistoryTrigger().getBuffer())
+    assertThat(writer.applyHistoryTrigger().getBuffer())
       .contains("add one")
       .contains("create trigger")
       .doesNotContain("create view");
-    assertThat(write.dropAll().isEmpty()).isTrue();
+    assertThat(writer.dropAll().isEmpty()).isTrue();
 
   }
 }

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/HanaDdlTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/HanaDdlTest.java
@@ -12,15 +12,15 @@ public class HanaDdlTest {
   @Test
   public void alterTableDropColumn() {
     HanaColumnStoreDdl ddl = new HanaColumnStoreDdl(new HanaPlatform());
-    DdlWrite write = new DdlWrite();
-    ddl.alterTableDropColumn(write.apply(), "my_table", "my_column");
-    assertEquals("CALL usp_ebean_drop_column('my_table', 'my_column');\n", write.apply().getBuffer());
+    DdlWrite writer = new DdlWrite();
+    ddl.alterTableDropColumn(writer.apply(), "my_table", "my_column");
+    assertEquals("CALL usp_ebean_drop_column('my_table', 'my_column');\n", writer.apply().getBuffer());
   }
 
   @Test
   public void alterTableAddColumn() {
     HanaColumnStoreDdl ddl = new HanaColumnStoreDdl(new HanaPlatform());
-    DdlWrite write = new DdlWrite();
+    DdlWrite writer = new DdlWrite();
     Column column = new Column();
     column.setName("my_column");
     column.setComment("comment");
@@ -33,7 +33,7 @@ public class HanaDdlTest {
     column.setCheckConstraintName("check_constraint");
     column.setHistoryExclude(Boolean.TRUE);
     column.setIdentity(Boolean.TRUE);
-    ddl.alterTableAddColumn(write.apply(), "my_table", column, false, "1");
-    assertEquals("alter table my_table add ( my_column int default 1 not null);\nalter table my_table add constraint check_constraint CHECK(my_column > 0);\n", write.apply().getBuffer());
+    ddl.alterTableAddColumn(writer.apply(), "my_table", column, false, "1");
+    assertEquals("alter table my_table add ( my_column int default 1 not null);\nalter table my_table add constraint check_constraint CHECK(my_column > 0);\n", writer.apply().getBuffer());
   }
 }

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl_AlterColumnTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl_AlterColumnTest.java
@@ -251,9 +251,9 @@ public class PlatformDdl_AlterColumnTest {
 
   @Test
   public void oracle_alterTableAddColumn() {
-    DdlWrite write = new DdlWrite();
-    oraDdl.alterTableAddColumn(write.apply(), "my_table", simpleColumn(), false, "1");
-    assertThat(write.apply().getBuffer()).isEqualTo("alter table my_table add my_column int default 1 not null;\n");
+    DdlWrite writer = new DdlWrite();
+    oraDdl.alterTableAddColumn(writer.apply(), "my_table", simpleColumn(), false, "1");
+    assertThat(writer.apply().getBuffer()).isEqualTo("alter table my_table add my_column int default 1 not null;\n");
   }
 
   private Column simpleColumn() {


### PR DESCRIPTION
These are the first two commits of #2566 and they contain no effective code change.

I decided to replace all `DdlWrite write` by `DdlWrite writer`, because the later one was already used more often in existing code.