### PR TITLE
Bug: Wrong join in query with @Inheritance and @DbForeignKey

### DIFF
--- a/ebean-test/src/test/java/org/tests/model/join/Access.java
+++ b/ebean-test/src/test/java/org/tests/model/join/Access.java
@@ -1,0 +1,70 @@
+package org.tests.model.join;
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.tests.model.basic.Customer;
+
+import io.ebean.annotation.DbForeignKey;
+
+@Inheritance
+@Entity
+public abstract class Access {
+
+  @Id
+  UUID id;
+  
+  @ManyToOne
+  @DbForeignKey(noConstraint = true)
+  @JoinColumn(name = "accessor_id")
+  Customer accessor;
+
+  @ManyToOne
+  @DbForeignKey(noConstraint = true)
+  @JoinColumn(name = "principal_id")
+  Customer principal;
+
+  @ManyToOne
+  @DbForeignKey(noConstraint = true)
+  @JoinColumn(name = "account_account_number")
+  Account account;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public Customer getAccessor() {
+    return accessor;
+  }
+  
+  public void setAccessor(Customer accessor) {
+    this.accessor = accessor;
+  }
+  
+  public Customer getPrincipal() {
+    return principal;
+  }
+
+  public void setPrincipal(Customer principal) {
+    this.principal = principal;
+  }
+  
+  public Account getAccount() {
+    return account;
+  }
+
+  public void setAccount(Account account) {
+    this.account = account;
+    setPrincipal(account.getOwner());
+  }
+  
+}

--- a/ebean-test/src/test/java/org/tests/model/join/Account.java
+++ b/ebean-test/src/test/java/org/tests/model/join/Account.java
@@ -1,0 +1,36 @@
+package org.tests.model.join;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.ManyToOne;
+
+import org.tests.model.basic.Customer;
+
+@Entity
+@Inheritance
+public abstract class Account {
+
+  @Id
+  String accountNumber;
+  
+  @ManyToOne
+  Customer owner;
+
+  public String getAccountNumber() {
+    return accountNumber;
+  }
+
+  public void setAccountNumber(String accountNumber) {
+    this.accountNumber = accountNumber;
+  }
+
+  public Customer getOwner() {
+    return owner;
+  }
+
+  public void setOwner(Customer owner) {
+    this.owner = owner;
+  }
+  
+}

--- a/ebean-test/src/test/java/org/tests/model/join/AccountAccess.java
+++ b/ebean-test/src/test/java/org/tests/model/join/AccountAccess.java
@@ -1,0 +1,10 @@
+package org.tests.model.join;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@DiscriminatorValue("A")
+@Entity
+public class AccountAccess extends Access {
+
+}

--- a/ebean-test/src/test/java/org/tests/model/join/BankAccount.java
+++ b/ebean-test/src/test/java/org/tests/model/join/BankAccount.java
@@ -1,0 +1,10 @@
+package org.tests.model.join;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@DiscriminatorValue("B")
+@Entity
+public class BankAccount extends Account {
+  
+}

--- a/ebean-test/src/test/java/org/tests/model/join/CustomerAccess.java
+++ b/ebean-test/src/test/java/org/tests/model/join/CustomerAccess.java
@@ -1,0 +1,10 @@
+package org.tests.model.join;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@DiscriminatorValue("C")
+@Entity
+public class CustomerAccess extends Access {
+
+}

--- a/ebean-test/src/test/java/org/tests/query/TestQueryMultiJoinFetchPath.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryMultiJoinFetchPath.java
@@ -1,0 +1,80 @@
+package org.tests.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Customer;
+import org.tests.model.basic.Customer.Status;
+import org.tests.model.basic.ResetBasicData;
+import org.tests.model.join.Access;
+import org.tests.model.join.Account;
+import org.tests.model.join.AccountAccess;
+import org.tests.model.join.BankAccount;
+import org.tests.model.join.CustomerAccess;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.Query;
+
+public class TestQueryMultiJoinFetchPath extends BaseTestCase {
+
+  @Test
+  public void test() {
+
+    ResetBasicData.reset();
+
+    Customer c1 = new Customer();
+    c1.setName("c1");
+    c1.setStatus(Status.ACTIVE);
+    DB.save(c1);
+    
+    Customer c2 = new Customer();
+    c2.setName("c2");
+    c2.setStatus(Status.ACTIVE);
+    DB.save(c2);
+    
+    Customer c3 = new Customer();
+    c3.setName("c3");
+    c3.setStatus(Status.ACTIVE);
+    DB.save(c3);
+    
+    Account a1 = new BankAccount();
+    a1.setAccountNumber("a1");
+    a1.setOwner(c1);
+    DB.save(a1);
+    
+    CustomerAccess ca = new CustomerAccess();
+    ca.setAccessor(c3);
+    ca.setPrincipal(c1);
+    DB.save(ca);
+    
+    AccountAccess aa = new AccountAccess();
+    aa.setAccessor(c2);
+    aa.setAccount(a1);
+    DB.save(aa);
+    
+    List<Object> ids = DB.find(Access.class)
+      .where()
+      .eq("principal.status", Status.ACTIVE)
+      .eq("accessor.status", Status.ACTIVE)
+      .findIds();
+    
+    assertThat(ids).hasSize(2);
+   
+    Query<Access> query = DB.find(Access.class)
+      .fetch("account","accountNumber")
+      .fetch("accessor","name")
+      .where()
+      .eq("accessor.status", Status.ACTIVE)
+      .eq("principal.status", Status.ACTIVE)
+      .idIn(ids)
+      .query();
+    
+    List<Access> accesses = query.findList();
+   
+    assertThat(accesses).hasSize(2);
+  }
+  
+}


### PR DESCRIPTION
Bug: Wrong join in query with @ Inheritance and @DbForeignKey

Query was:
select t0.dtype, t0.id, t0.accessor_id, t0.principal_id, t2.dtype, t0.account_account_number, t0.accessor_id, t2.dtype, t0.account_account_number, t1.id, t1.name, t2.dtype, t2.account_number 
from access t0 
left join account t2 on t2.account_number = t0.account_account_number 
left join o_customer t1 on t1.id = t0.accessor_id and t2.dtype = 'B' 
left join o_customer t3 on t3.id = t0.principal_id 
where t1.status = ? and t3.status = ? and t0.id in (?,?,?,?,?)

Problem is that `and t2.dtype = 'B'` is put to the wrong join
