### PR TITLE
#2582 - Fix for regression, BackgroundExecutor is bounded (since 12.6.2)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/executor/DaemonExecutorService.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/executor/DaemonExecutorService.java
@@ -1,0 +1,67 @@
+package io.ebeaninternal.server.executor;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.*;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A "CachedThreadPool" based on Daemon threads.
+ * <p>
+ * The Threads are created as needed and once idle live for 60 seconds.
+ */
+final class DaemonExecutorService {
+
+  private static final Logger logger = LoggerFactory.getLogger(DaemonExecutorService.class);
+
+  private final ReentrantLock lock = new ReentrantLock(false);
+  private final String namePrefix;
+  private final int shutdownWaitSeconds;
+  private final ExecutorService service;
+
+  DaemonExecutorService(int shutdownWaitSeconds, String namePrefix) {
+    this.service = Executors.newCachedThreadPool(new DaemonThreadFactory(namePrefix));
+    this.shutdownWaitSeconds = shutdownWaitSeconds;
+    this.namePrefix = namePrefix;
+  }
+
+  <T> Future<T> submit(Callable<T> task) {
+    return service.submit(task);
+  }
+
+  Future<?> submit(Runnable task) {
+    return service.submit(task);
+  }
+
+  /**
+   * Shutdown this thread pool nicely if possible.
+   * <p>
+   * This will wait a maximum of 20 seconds before terminating any threads still working.
+   */
+  void shutdown() {
+    lock.lock();
+    try {
+      if (service.isShutdown()) {
+        logger.debug("DaemonExecutorService[{}] already shut down", namePrefix);
+        return;
+      }
+      try {
+        logger.debug("DaemonExecutorService[{}] shutting down...", namePrefix);
+        service.shutdown();
+        if (!service.awaitTermination(shutdownWaitSeconds, TimeUnit.SECONDS)) {
+          logger.info("DaemonExecutorService[{}] shut down timeout exceeded. Terminating running threads.", namePrefix);
+          service.shutdownNow();
+        }
+
+      } catch (Exception e) {
+        logger.error("Error during shutdown of DaemonThreadPool[" + namePrefix + "]", e);
+        e.printStackTrace();
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+}

--- a/ebean-core/src/test/java/io/ebeaninternal/server/executor/DaemonExecutorServiceTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/executor/DaemonExecutorServiceTest.java
@@ -1,0 +1,56 @@
+package io.ebeaninternal.server.executor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DaemonExecutorServiceTest {
+
+  private final int count = 10;
+  private final int waitMillis = 100;
+
+  @Test
+  void submit() throws Exception {
+    DaemonExecutorService des = new DaemonExecutorService(5, "junk");
+    long start = System.currentTimeMillis();
+    List<Future<?>> futures = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      futures.add(des.submit(this::doStuff));
+    }
+    for (Future<?> f: futures) {
+      f.get();
+    }
+    long exeMillis = System.currentTimeMillis() - start;
+    assertThat(exeMillis).isLessThan(count * waitMillis);
+    des.shutdown();
+  }
+
+  @Test
+  void submit_via_DefaultBackgroundExecutor() throws Exception {
+    DefaultBackgroundExecutor des = new DefaultBackgroundExecutor(1, 5, "junk");
+    long start = System.currentTimeMillis();
+    List<Future<?>> futures = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      futures.add(des.submit(this::doStuff));
+    }
+    for (Future<?> f: futures) {
+      f.get();
+    }
+    long exeMillis = System.currentTimeMillis() - start;
+    assertThat(exeMillis).isLessThan(count * waitMillis);
+    des.shutdown();
+  }
+
+  private void doStuff() {
+    try {
+      Thread.sleep(waitMillis);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
The change for #2121 brought in a regression where the scheduledExecutorService was used for processing ALL submitted tasks (not just scheduled ones) and is a bounded executor service.  Previously non-scheduled tasks went to a "newCachedThreadPool" based executor service and with this change we are moving back to that (via restoring and using the DaemonExecutorService for those tasks).