### PR TITLE
Small code change for Hazelcast 4.1.5

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
@@ -716,7 +716,6 @@ final class BeanDescriptorCacheHelp<T> {
         if (beanLog.isTraceEnabled()) {
           beanLog.trace("   load {}({}) - cache miss on property({})", cacheName, key, propertyName);
         }
-        iterator.remove();
       } else {
         CachedBeanDataToBean.load(desc, ebi.getOwner(), cacheData, context);
         loaded.add(ebi);


### PR DESCRIPTION
Hello @rbygrave ,

this code change is needed for Hazelcast 4.1.5 (https://github.com/ebean-orm/ebean-hazelcast/pull/10) because the hazelcast cache map is since 4.X an UnmodifiableMap.
As we analysed, the iterator will only used for iterating over the collection and it won't be used in any code block after.

Can you please check it, if we can remove this line?

Kind regards
Noemi