### PR TITLE
Provide custom BackgroundExecutorWrapper to pass thread locals

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/BackgroundExecutorWrapper.java
+++ b/ebean-api/src/main/java/io/ebean/config/BackgroundExecutorWrapper.java
@@ -1,0 +1,23 @@
+package io.ebean.config;
+
+import java.util.concurrent.Callable;
+
+/**
+ * BackgroundExecutorWrapper that can be used to wrap tasks that are sent to background (i.e. an other thread).
+ * It should copy all neccessary thread-local variables. See {@link MdcBackgroundExecutorWrapper} for implementation details.
+ * 
+ * @author Roland Praml, FOCONIS AG
+ */
+public interface BackgroundExecutorWrapper {
+
+  /**
+   * Wrap the task with MDC context if defined.
+   */
+  <T> Callable<T> wrap(Callable<T> task);
+
+  /**
+   * Wrap the task with MDC context if defined.
+   */
+  Runnable wrap(Runnable task);
+
+}

--- a/ebean-api/src/main/java/io/ebean/config/BackgroundExecutorWrapper.java
+++ b/ebean-api/src/main/java/io/ebean/config/BackgroundExecutorWrapper.java
@@ -20,4 +20,23 @@ public interface BackgroundExecutorWrapper {
    */
   Runnable wrap(Runnable task);
 
+  /**
+   * Combines two wrappers by joining them.
+   */
+  default BackgroundExecutorWrapper with(BackgroundExecutorWrapper inner) {
+    return new BackgroundExecutorWrapper() {
+      
+      @Override
+      public Runnable wrap(Runnable task) {
+        return BackgroundExecutorWrapper.this.wrap(inner.wrap(task));
+      }
+      
+      @Override
+      public <T> Callable<T> wrap(Callable<T> task) {
+        return BackgroundExecutorWrapper.this.wrap(inner.wrap(task));
+      }
+    };
+   
+  }
+
 }

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -445,6 +445,7 @@ public class DatabaseConfig {
 
   private int backgroundExecutorSchedulePoolSize = 1;
   private int backgroundExecutorShutdownSecs = 30;
+  private BackgroundExecutorWrapper backgroundExecutorWrapper = new MdcBackgroundExecutorWrapper();
 
   // defaults for the L2 bean caching
 
@@ -1461,6 +1462,20 @@ public class DatabaseConfig {
    */
   public void setBackgroundExecutorShutdownSecs(int backgroundExecutorShutdownSecs) {
     this.backgroundExecutorShutdownSecs = backgroundExecutorShutdownSecs;
+  }
+
+  /**
+   * Return the background executor wrapper.
+   */
+  public BackgroundExecutorWrapper getBackgroundExecutorWrapper() {
+    return backgroundExecutorWrapper;
+  }
+
+  /**
+   * Sets the background executor wrapper. The wrapper is used when a task is sent to background and should copy the thread-locals.
+   */
+  public void setBackgroundExecutorWrapper(BackgroundExecutorWrapper backgroundExecutorWrapper) {
+    this.backgroundExecutorWrapper = backgroundExecutorWrapper;
   }
 
   /**
@@ -2884,6 +2899,7 @@ public class DatabaseConfig {
 
     backgroundExecutorSchedulePoolSize = p.getInt("backgroundExecutorSchedulePoolSize", backgroundExecutorSchedulePoolSize);
     backgroundExecutorShutdownSecs = p.getInt("backgroundExecutorShutdownSecs", backgroundExecutorShutdownSecs);
+    backgroundExecutorWrapper = p.createInstance(BackgroundExecutorWrapper.class, "backgroundExecutorWrapper", backgroundExecutorWrapper);
     disableClasspathSearch = p.getBoolean("disableClasspathSearch", disableClasspathSearch);
     currentUserProvider = p.createInstance(CurrentUserProvider.class, "currentUserProvider", currentUserProvider);
     databasePlatform = p.createInstance(DatabasePlatform.class, "databasePlatform", databasePlatform);

--- a/ebean-api/src/main/java/io/ebean/config/MdcBackgroundExecutorWrapper.java
+++ b/ebean-api/src/main/java/io/ebean/config/MdcBackgroundExecutorWrapper.java
@@ -1,0 +1,50 @@
+package io.ebean.config;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.slf4j.MDC;
+
+public class MdcBackgroundExecutorWrapper implements BackgroundExecutorWrapper {
+
+  
+  /**
+   * Wrap the task with MDC context if defined.
+   */
+  @Override
+  public <T> Callable<T> wrap(Callable<T> task) {
+    final Map<String, String> map = MDC.getCopyOfContextMap();
+    if (map == null) {
+      return task;
+    } else {
+      return () -> {
+        MDC.setContextMap(map);
+        try {
+          return task.call();
+        } finally {
+          MDC.clear();
+        }
+      };
+    }
+  }
+
+  /**
+   * Wrap the task with MDC context if defined.
+   */
+  @Override
+  public Runnable wrap(Runnable task) {
+    final Map<String, String> map = MDC.getCopyOfContextMap();
+    if (map == null) {
+      return task;
+    } else {
+      return () -> {
+        MDC.setContextMap(map);
+        try {
+          task.run();
+        } finally {
+          MDC.clear();
+        }
+      };
+    }
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.core;
 
+import io.ebean.config.BackgroundExecutorWrapper;
 import io.ebean.config.ContainerConfig;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.config.DatabaseConfigProvider;
@@ -67,7 +68,8 @@ public final class DefaultContainer implements SpiContainer {
     String namePrefix = "ebean-" + config.getName();
     int schedulePoolSize = config.getBackgroundExecutorSchedulePoolSize();
     int shutdownSecs = config.getBackgroundExecutorShutdownSecs();
-    return new DefaultBackgroundExecutor(schedulePoolSize, shutdownSecs, namePrefix);
+    BackgroundExecutorWrapper wrapper = config.getBackgroundExecutorWrapper();
+    return new DefaultBackgroundExecutor(schedulePoolSize, shutdownSecs, namePrefix, wrapper);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/executor/DefaultBackgroundExecutor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/executor/DefaultBackgroundExecutor.java
@@ -1,11 +1,13 @@
 package io.ebeaninternal.server.executor;
 
 import io.avaje.lang.NonNullApi;
+import io.ebean.config.BackgroundExecutorWrapper;
 import io.ebeaninternal.api.SpiBackgroundExecutor;
-import org.slf4j.MDC;
 
-import java.util.Map;
 import java.util.concurrent.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The default implementation of the BackgroundExecutor.
@@ -13,58 +15,78 @@ import java.util.concurrent.*;
 @NonNullApi
 public final class DefaultBackgroundExecutor implements SpiBackgroundExecutor {
 
+  protected static final Logger logger = LoggerFactory.getLogger("io.ebean.BackgroundExecutor");
+  
   private final ScheduledExecutorService schedulePool;
   private final DaemonExecutorService pool;
+  private final BackgroundExecutorWrapper wrapper;
 
   /**
    * Construct the default implementation of BackgroundExecutor.
    */
-  public DefaultBackgroundExecutor(int schedulePoolSize, int shutdownWaitSeconds, String namePrefix) {
+  public DefaultBackgroundExecutor(int schedulePoolSize, int shutdownWaitSeconds, String namePrefix, BackgroundExecutorWrapper wrapper) {
     this.schedulePool = new DaemonScheduleThreadPool(schedulePoolSize, shutdownWaitSeconds, namePrefix + "-periodic-");
     this.pool = new DaemonExecutorService(shutdownWaitSeconds, namePrefix);
+    this.wrapper = wrapper;
+    logger.debug("Created backgroundExecutor {} (schedulePoolSize={}, shutdownWaitSeconds={})", namePrefix, schedulePoolSize, shutdownWaitSeconds);
   }
 
   /**
    * Wrap the task with MDC context if defined.
    */
-  <T> Callable<T> wrapMDC(Callable<T> task) {
-    final Map<String, String> map = MDC.getCopyOfContextMap();
-    if (map == null) {
-      return task;
+  <T> Callable<T> wrap(Callable<T> task) {
+    if (wrapper == null) {
+      return clock(task);
     } else {
-      return () -> {
-        MDC.setContextMap(map);
-        try {
-          return task.call();
-        } finally {
-          MDC.clear();
-        }
-      };
+      return wrapper.wrap(clock(task));
     }
   }
 
   /**
    * Wrap the task with MDC context if defined.
    */
-  Runnable wrapMDC(Runnable task) {
-    final Map<String, String> map = MDC.getCopyOfContextMap();
-    if (map == null) {
-      return task;
+  Runnable wrap(Runnable task) {
+    if (wrapper == null) {
+      return clock(task);
     } else {
+      return wrapper.wrap(clock(task));
+    }
+  }
+  
+  private <T> Callable<T> clock(Callable<T> task) {
+    if (logger.isTraceEnabled()) {
+      long queued = System.nanoTime();
+      logger.trace("Queued {}", task);
       return () -> {
-        MDC.setContextMap(map);
-        try {
-          task.run();
-        } finally {
-          MDC.clear();
-        }
+        long start = System.nanoTime();
+        logger.trace("Start {} (delay time {} us)", task, (start - queued) / 1000L);
+        T ret = task.call();
+        logger.trace("Stop {} (exec time {} us)", task, (System.nanoTime() - start) / 1000L);
+        return ret;
       };
+    } else {
+      return task;
+    }
+  }
+  
+  private Runnable clock(Runnable task) {
+    if (logger.isTraceEnabled()) {
+      long queued = System.nanoTime();
+      logger.trace("Queued {}", task);
+      return () -> {
+        long start = System.nanoTime();
+        logger.trace("Start {} (delay time {} us)", task, (start - queued) / 1000L);
+        task.run();
+        logger.trace("Stop {} (exec time {} us)", task, (System.nanoTime() - start) / 1000L);
+      };
+    } else {
+      return task;
     }
   }
 
   @Override
   public <T> Future<T> submit(Callable<T> task) {
-    return pool.submit(wrapMDC(task));
+    return pool.submit(wrap(task));
   }
 
   /**
@@ -72,48 +94,56 @@ public final class DefaultBackgroundExecutor implements SpiBackgroundExecutor {
    */
   @Override
   public Future<?> submit(Runnable task) {
-    return pool.submit(wrapMDC(task));
+    return pool.submit(wrap(task));
   }
 
   @Override
   public void execute(Runnable task) {
-    submit(task);
+    submit(() -> {
+      try {
+        task.run();
+      } catch (Throwable t) {
+        logger.error("Error while executing the task {}", task, t);
+      }
+    });
   }
 
   @Override
   public void executePeriodically(Runnable task, long delay, TimeUnit unit) {
-    schedulePool.scheduleWithFixedDelay(wrapMDC(task), delay, delay, unit);
+    schedulePool.scheduleWithFixedDelay(wrap(task), delay, delay, unit);
   }
 
   @Override
   public void executePeriodically(Runnable task, long initialDelay, long delay, TimeUnit unit) {
-    schedulePool.scheduleWithFixedDelay(wrapMDC(task), initialDelay, delay, unit);
+    schedulePool.scheduleWithFixedDelay(wrap(task), initialDelay, delay, unit);
   }
 
   @Override
   public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long initialDelay, long delay, TimeUnit unit) {
-    return schedulePool.scheduleWithFixedDelay(wrapMDC(task), initialDelay, delay, unit);
+    return schedulePool.scheduleWithFixedDelay(wrap(task), initialDelay, delay, unit);
   }
 
   @Override
   public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long initialDelay, long delay, TimeUnit unit) {
-    return schedulePool.scheduleAtFixedRate(wrapMDC(task), initialDelay, delay, unit);
+    return schedulePool.scheduleAtFixedRate(wrap(task), initialDelay, delay, unit);
   }
 
   @Override
   public ScheduledFuture<?> schedule(Runnable task, long delay, TimeUnit unit) {
-    return schedulePool.schedule(wrapMDC(task), delay, unit);
+    return schedulePool.schedule(wrap(task), delay, unit);
   }
 
   @Override
   public <V> ScheduledFuture<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
-    return schedulePool.schedule(wrapMDC(task), delay, unit);
+    return schedulePool.schedule(wrap(task), delay, unit);
   }
 
   @Override
   public void shutdown() {
+    logger.trace("Shutting down backgroundExecutor");
     schedulePool.shutdown();
     pool.shutdown();
+    logger.debug("BackgroundExecutor stopped");
   }
 
 }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/executor/DaemonExecutorServiceTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/executor/DaemonExecutorServiceTest.java
@@ -31,7 +31,7 @@ class DaemonExecutorServiceTest {
 
   @Test
   void submit_via_DefaultBackgroundExecutor() throws Exception {
-    DefaultBackgroundExecutor des = new DefaultBackgroundExecutor(1, 5, "junk");
+    DefaultBackgroundExecutor des = new DefaultBackgroundExecutor(1, 5, "junk", null);
     long start = System.currentTimeMillis();
     List<Future<?>> futures = new ArrayList<>();
     for (int i = 0; i < count; i++) {

--- a/ebean-test/src/test/java/org/tests/cache/TestBeanCacheAsync.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestBeanCacheAsync.java
@@ -1,0 +1,113 @@
+package org.tests.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.OCachedBean;
+
+import io.ebean.BaseTestCase;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.DatabaseFactory;
+import io.ebean.config.CurrentTenantProvider;
+import io.ebean.config.DatabaseConfig;
+import io.ebean.config.MdcBackgroundExecutorWrapper;
+import io.ebeaninternal.server.cache.DefaultServerCachePlugin;
+
+/**
+ * Test class testing async/background cache updates in a multi-tenant environment. 
+ */
+public class TestBeanCacheAsync extends BaseTestCase {
+
+  private final ThreadLocal<String> tenantId = new ThreadLocal<>();
+
+  class ThreadLocalTenantProvider implements CurrentTenantProvider {
+
+    @Override
+    public Object currentId() {
+      return tenantId.get();
+    }
+  }
+  /**
+   * Copy tenant info to the background thread.
+   */
+  class TenantCopyBackgroundExecutorWrapper extends MdcBackgroundExecutorWrapper {
+    @Override
+    public <T> Callable<T> wrap(Callable<T> task) {
+      String tenant = tenantId.get();
+      if (tenant == null) {
+        return super.wrap(task);
+      } else {
+        return () -> {
+          tenantId.set(tenant);
+          try {
+            return super.wrap(task).call();
+          } finally {
+            tenantId.remove();
+          }
+        };
+      }
+    }
+    
+    @Override
+    public Runnable wrap(Runnable task) {
+      String tenant = tenantId.get();
+      if (tenant == null) {
+        return super.wrap(task);
+      } else {
+        return () -> {
+          tenantId.set(tenant);
+          try {
+            super.wrap(task).run();
+          } finally {
+            tenantId.remove();
+          }
+        };
+      }
+    }
+  }
+  
+  @Test
+  public void findById_with_tenant() throws InterruptedException {
+    DatabaseConfig config = new DatabaseConfig();
+    config.setName(DB.getDefault().name());
+    config.loadFromProperties();
+    config.setDataSource(DB.getDefault().dataSource());
+    config.setReadOnlyDataSource(DB.getDefault().readOnlyDataSource());
+    config.setDdlExtra(false);
+    config.setDdlGenerate(false);
+    config.setDdlRun(false);
+    config.setDefaultServer(false);
+    config.setRegister(false);
+    config.setServerCachePlugin(new DefaultServerCachePlugin()); // disables foreground local caching (as it is done in Hz/Ignite)
+    config.setCurrentTenantProvider(new ThreadLocalTenantProvider());
+    config.setBackgroundExecutorWrapper(new TenantCopyBackgroundExecutorWrapper());
+    tenantId.set("4711");
+    
+    Database db = DatabaseFactory.create(config);
+    try {
+      OCachedBean bean = new OCachedBean();
+      bean.setName("findById");
+      db.save(bean);
+
+      OCachedBean bean0 = db.find(OCachedBean.class, bean.getId());
+      assertNotNull(bean0);
+      assertThat(bean0.getName()).isEqualTo("findById");
+      bean0.setName("findById2");
+      db.save(bean0);
+
+      Thread.sleep(100); // TODO: can we block finds on that ID if a pending cache update is present?
+      
+      bean0 = db.find(OCachedBean.class, bean.getId());
+      assertNotNull(bean0);
+      assertThat(bean0.getName()).isEqualTo("findById2");
+
+    } finally {
+      db.shutdown();
+    }
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/cache/TestBeanCacheAsync.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestBeanCacheAsync.java
@@ -101,7 +101,7 @@ public class TestBeanCacheAsync extends BaseTestCase {
       assertThat(bean0.getName()).isEqualTo("findById2");
 
     } finally {
-      db.shutdown();
+      db.shutdown(false, false);
     }
   }
 


### PR DESCRIPTION
Hi @rbygrave ,

we might have found a bug with l2 cache updates if the update runs in background.

Our use case:
we are working on the hazelcast integration in our application. We have the ebean-hazelcast dependency in our pom.xml. We only want to use hazelcast if there is a hazelcast xml config file in the classpath --> in this case we would set `ebean.serverCachePlugin=io.ebean.hazelcast.HzCachePlugin` .

For our unittests with h2 we set `ebean.serverCachePlugin=io.ebeaninternal.server.cache.DefaultServerCachePlugin` .
We have now problems with the tests that are handling data in different tenants.

@rPraml and I created a unittest for this: `TestBeanCacheAsync`.

The problem is: in `InternalConfiguration.initServerCachePlugin()`, If we use `ebean.serverCachePlugin=io.ebeaninternal.server.cache.DefaultServerCachePlugin` , the variable `localL2Caching` won't be set to `true`. Afterwards if we call `db.save(bean)` in `PostCommitProcessing` the cache won't be updated in foreground, it will call `backgroundExecutor.execute(postCommit.backgroundNotify()` async. These does not "copy" the tenant infos to the thread of `backgroundExecutor`, it will run in the "wrong tenant".

To solve this problem we introduced the `BackgroundExecutorWrapper`. It can be defined in the `DatabaseConfig`.

We also have a second problem, which can theoretically also occur by hazelcast-cache: if the update of the cache happens async in a `backgroundExecutor`, it isn't guaranteed that it would be done before the next `DB.find()` will be called. That's why we had to add a `Thread.sleep(100)` in our `TestBeanCacheAsync`.

Can you please check the first problem with `BackgroundExecutorWrapper` if the fix would be ok?

Kind regards
Noemi