### PR TITLE
NPE by lazy loading a cached bean

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanBuffer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanBuffer.java
@@ -4,7 +4,7 @@ import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.bean.PersistenceContext;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * A buffer of beans for batch lazy loading and secondary query loading.
@@ -13,7 +13,7 @@ public interface LoadBeanBuffer {
 
   int batchSize();
 
-  List<EntityBeanIntercept> batch();
+  Set<EntityBeanIntercept> batch();
 
   BeanDescriptor<?> descriptor();
 

--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanRequest.java
@@ -16,7 +16,7 @@ import java.util.Set;
  */
 public final class LoadBeanRequest extends LoadRequest {
 
-  private final List<EntityBeanIntercept> batch;
+  private final Set<EntityBeanIntercept> batch;
   private final LoadBeanBuffer loadBuffer;
   private final String lazyLoadProperty;
   private final boolean loadCache;
@@ -58,7 +58,7 @@ public final class LoadBeanRequest extends LoadRequest {
   /**
    * Return the batch of beans to actually load.
    */
-  public List<EntityBeanIntercept> batch() {
+  public Set<EntityBeanIntercept> batch() {
     return batch;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Helper to handle lazy loading and refreshing of beans.
@@ -121,7 +122,7 @@ final class DefaultBeanLoader {
    * Load a batch of beans for +query or +lazy loading.
    */
   void loadBean(LoadBeanRequest loadRequest) {
-    List<EntityBeanIntercept> batch = loadRequest.batch();
+    Set<EntityBeanIntercept> batch = loadRequest.batch();
     if (batch.isEmpty()) {
       throw new RuntimeException("Nothing in batch?");
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1310,8 +1310,8 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * Hit the bean cache trying to load a list/batch of entities.
    * Return the set of entities that were successfully loaded from L2 cache.
    */
-  public Set<EntityBeanIntercept> cacheBeanLoadAll(List<EntityBeanIntercept> list, PersistenceContext persistenceContext, int lazyLoadProperty, String propertyName) {
-    return cacheHelp.beanCacheLoadAll(list, persistenceContext, lazyLoadProperty, propertyName);
+  public Set<EntityBeanIntercept> cacheBeanLoadAll(Set<EntityBeanIntercept> batch, PersistenceContext persistenceContext, int lazyLoadProperty, String propertyName) {
+    return cacheHelp.beanCacheLoadAll(batch, persistenceContext, lazyLoadProperty, propertyName);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
@@ -693,9 +693,9 @@ final class BeanDescriptorCacheHelp<T> {
   /**
    * Load a batch of entities from L2 bean cache checking the lazy loaded property is loaded.
    */
-  Set<EntityBeanIntercept> beanCacheLoadAll(List<EntityBeanIntercept> list, PersistenceContext context, int lazyLoadProperty, String propertyName) {
+  Set<EntityBeanIntercept> beanCacheLoadAll(Set<EntityBeanIntercept> batch, PersistenceContext context, int lazyLoadProperty, String propertyName) {
     Map<Object, EntityBeanIntercept> ebis = new HashMap<>();
-    for (EntityBeanIntercept ebi : list) {
+    for (EntityBeanIntercept ebi : batch) {
       ebis.put(desc.cacheKeyForBean(ebi.getOwner()), ebi);
     }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadBeanContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadBeanContext.java
@@ -190,7 +190,7 @@ final class DLoadBeanContext extends DLoadBaseContext implements LoadBeanContext
         // lazy load property was a Many
         return;
       }
-      if (list.isEmpty()) {
+      if (!list.contains(ebi)) {
         // re-add to the batch and lazy load from DB skipping l2 cache
         list.add(ebi);
       } else if (context.hitCache) {


### PR DESCRIPTION
Hi @rbygrave 

we were hunting an NPE for several months. It didn't occured in our test enviroments only by some of our customers in production, we were not able to reproduce it with unit or UI tests. We analyzed several logs, the database of the customer but in the end we had to create a heap dump after the NPE happened.

In the heap dump we checked EntityBeanIntercept:
![image](https://user-images.githubusercontent.com/63635801/158378368-a3bbb3a9-625f-463d-af2d-f042a4d6b2b9.png)

This is the state after the getPropertyX() call. This helped us to understand and reproduce the NPE in a unit test: `loadedFromCache = true`, `state=2` and `lazyLoadedProperty = 34` --> it was not resetted to -1.

In `TestWithCacheAndLazyLoad.testBatch()` two cached entities & parents will be created. After that with a `DB.findById` the entity will be loaded from the database and put into the cache.

In a separate transaction we are searching for a list of the parent entities and we load an entity `temp` with `DB.findById` . By calling `temp.getChild().getName()` the cache will be used at `line 198 - DLoadBeanContext.loadBean(ebi)` and the `hit` will be removed from the `list`. The next call in the test (`list.get(0).getChild().getAddress()`) refers to the bean which was removed in the last iteration from the cache (`list.removeAll(hits)`) but the other entity is still in `list`.  That's why `list.isEmpty() = false` at line 194 --> `else if (context.hitCache) = true` and `if (list.isEmpty() || hits.contains(ebi)) = true`  --> the method returns and the bean won't be loaded.

Our suggestion would be at line 194: `if (list.isEmpty())` --> `if (!list.contains(ebi))`

In a third commit we changed the List to a Set to get better performance.

Can you please check it?

Kind regards
Noemi