### PR TITLE
Allow Line Wrap in JavaMelody

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/platform/MultiValueBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/platform/MultiValueBind.java
@@ -61,7 +61,12 @@ public class MultiValueBind {
     }
     sb.append(" in (?");
     for (int i = 1; i < size; i++) {
-      sb.append(",?");
+      if (i % 100 == 0) {
+        // Fix for JavaMelody to allow line wrap every 100th placeholder
+        sb.append(", ?");
+      } else {
+        sb.append(",?");
+      }
     }
     sb.append(")");
     return sb.toString();


### PR DESCRIPTION
We use Ebean & [JavaMelody](https://github.com/javamelody/javamelody) in our application.

This is a detail pane, that allows to inspect the executed SQLs.
Unfortunately, the pane is unusable, if there is an "IN" query with too many "?,?,?" parameters. As there are no spaces in that string, the browser cannot wrap that properly and you get an extrem long horizontal scroll bar

![grafik](https://user-images.githubusercontent.com/5530228/158537455-1e7df423-ee9d-46db-b653-6e812b89cb38.png)

We use a browser plugin (FoxReplace) to replace "?," by "?,<SPACE>" as workaround. So that the browser can wrap the long queries.

So the result looks like this:
![grafik](https://user-images.githubusercontent.com/5530228/158536275-0fdfb987-fdb6-478f-8bd3-37475d8ed9e6.png)
(Without spaces, this line is very long, causing horizontal scroll bars)

I'm still trying to figure out what the better approach would be 
1. replace `sb.append(",?")` generally by `sb.append(", ?")`,
2. Insert a space every 100th placeholder

Approach 1 will provide better wrappable queries, but would make the query string up to 33% longer. It will also break existing tests.



