### PR TITLE
Fix javadoc generation

### DIFF
--- a/ebean-api/pom.xml
+++ b/ebean-api/pom.xml
@@ -39,6 +39,12 @@
       <artifactId>avaje-lang</artifactId>
       <version>1.0</version>
     </dependency>
+    
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsr305</artifactId>
+      <version>1.2</version>
+    </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>

--- a/ebean-api/src/main/java/io/ebean/BeanFinder.java
+++ b/ebean-api/src/main/java/io/ebean/BeanFinder.java
@@ -10,11 +10,11 @@ import java.util.Optional;
  * <p>
  * Note that typically users would extend BeanRepository rather than BeanFinder.
  * </p>
- * <pre>{@code
+ * <pre><code>
  *
- * public class CustomerFinder extends BeanFinder<Long,Customer> {
+ * public class CustomerFinder extends BeanFinder&lt;Long,Customergt; {
  *
- *   @Inject
+ *   &#64;Inject
  *   public CustomerFinder(Database database) {
  *     super(Customer.class, database);
  *   }
@@ -22,7 +22,7 @@ import java.util.Optional;
  *   // ... add customer specific finders
  * }
  *
- * }</pre>
+ * </code></pre>
  *
  * @param <I> The ID type
  * @param <T> The Bean type

--- a/ebean-api/src/main/java/io/ebean/BeanRepository.java
+++ b/ebean-api/src/main/java/io/ebean/BeanRepository.java
@@ -8,26 +8,26 @@ import java.util.Collection;
 /**
  * Provides finder functionality for use with "Dependency Injection style" use of Ebean.
  * <p>
- * <pre>{@code
+ * <pre><code>
  *
- * @Repository
- * public class CustomerRepository extends BeanRepository<Long,Customer> {
+ * &#64;Repository
+ * public class CustomerRepository extends BeanRepository&lt;Long,Customer&gt; {
  *
- *   @Inject
+ *   &#64;Inject
  *   public CustomerRepository(Database server) {
  *     super(Customer.class, server);
  *   }
  *
  *   // ... add customer specific finders and persist logic
  *
- *   public List<Customer> findByName(String nameStart) {
+ *   public List&lt;Customer&gt; findByName(String nameStart) {
  *     return query().where()
  *             .istartsWith("name", nameStart)
  *             .findList();
  *   }
  *
  * }
- * }</pre>
+ * </code></pre>
  *
  * @param <I> The ID type
  * @param <T> The Bean type

--- a/ebean-api/src/main/java/io/ebean/Database.java
+++ b/ebean-api/src/main/java/io/ebean/Database.java
@@ -990,14 +990,15 @@ public interface Database {
    * saving an order will also save all its details.
    * </p>
    * <p>
-   * <pre>{@code
-   *   public class Order { ...
+   * <pre><code>
+   * public class Order { ...
    *
-   *     @OneToMany(cascade=CascadeType.ALL, mappedBy="order")
-   * 	   List<OrderDetail> details;
-   * 	   ...
+   *   &#64;OneToMany(cascade=CascadeType.ALL, mappedBy="order")
+   *   List<OrderDetail> details;
+   *     ...
    *   }
-   * }</pre>
+   * }
+   * </code></pre>
    * <p>
    * <p>
    * When a save cascades via a OneToMany or ManyToMany Ebean will automatically

--- a/ebean-api/src/main/java/io/ebean/DocumentStore.java
+++ b/ebean-api/src/main/java/io/ebean/DocumentStore.java
@@ -145,13 +145,13 @@ public interface DocumentStore {
    * <p>
    * Typically this is called indirectly by findEachWhile() on the query that has setUseDocStore(true).
    * </p>
-   * <pre>{@code
+   * <pre><code>
    *
    *  database.find(Order.class)
    *    .setUseDocStore(true)
    *    .where()... // perhaps add predicates
-   *    .findEachWhile(new Predicate<Order>() {
-   *      @Override
+   *    .findEachWhile(new Predicate&lt;Order&gt;() {
+   *      &#64;Override
    *      public void accept(Order bean) {
    *        // process the bean
    *
@@ -161,7 +161,7 @@ public interface DocumentStore {
    *      }
    *    });
    *
-   * }</pre>
+   * </code></pre>
    */
   <T> void findEachWhile(DocQueryContext<T> query, Predicate<T> consumer);
 

--- a/ebean-api/src/main/java/io/ebean/Ebean.java
+++ b/ebean-api/src/main/java/io/ebean/Ebean.java
@@ -342,14 +342,15 @@ public final class Ebean {
    * In this example below the details property has a CascadeType.ALL set so
    * saving an order will also save all its details.
    * </p>
-   * <pre>{@code
-   *   public class Order { ...
+   * <pre><code>
+   * public class Order { ...
    *
-   *     @OneToMany(cascade=CascadeType.ALL, mappedBy="order")
-   * 	   List<OrderDetail> details;
-   * 	   ...
+   *   &#64;OneToMany(cascade=CascadeType.ALL, mappedBy="order")
+   *     List<OrderDetail> details;
+   *     ...
    *   }
-   * }</pre>
+   * }
+   * </code></pre>
    * <p>
    * When a save cascades via a OneToMany or ManyToMany Ebean will automatically
    * set the 'parent' object to the 'detail' object. In the example below in

--- a/ebean-api/src/main/java/io/ebean/Finder.java
+++ b/ebean-api/src/main/java/io/ebean/Finder.java
@@ -15,9 +15,9 @@ import java.util.List;
  * <p>
  * For testing the mocki-ebean project has the ability to replace the finder implementation.
  * </p>
- * <pre>{@code
+ * <pre><code>
  *
- * public class CustomerFinder extends Finder<Long,Customer> {
+ * public class CustomerFinder extends Finder&lt;Long,Customer&gt; {
  *
  *   public CustomerFinder() {
  *     super(Customer.class);
@@ -37,14 +37,14 @@ import java.util.List;
  *   }
  * }
  *
- * @Entity
+ * &#64;Entity
  * public class Customer extends BaseModel {
  *
  *   public static final CustomerFinder find = new CustomerFinder();
  *   ...
  *
  * }
- * }</pre>
+ * </code></pre>
  * <p>
  *  When the Finder is registered as a field on Customer it can then be used like:
  * </p>
@@ -70,9 +70,9 @@ public class Finder<I, T> {
 
   /**
    * Create with the type of the entity bean.
-   * <pre>{@code
+   * <pre><code>
    *
-   * public class CustomerFinder extends Finder<Customer> {
+   * public class CustomerFinder extends Finder&lt;Customer&gt; {
    *
    *   public CustomerFinder() {
    *     super(Customer.class);
@@ -81,14 +81,14 @@ public class Finder<I, T> {
    *   // ... add extra customer specific finder methods
    * }
    *
-   * @Entity
+   * &#64;Entity
    * public class Customer extends BaseModel {
    *
    *   public static final CustomerFinder find = new CustomerFinder();
    *   ...
    *
    * }
-   * }</pre>
+   * </code></pre>
    */
   public Finder(Class<T> type) {
     this.type = type;

--- a/ebean-api/src/main/java/io/ebean/Model.java
+++ b/ebean-api/src/main/java/io/ebean/Model.java
@@ -27,39 +27,39 @@ import io.ebean.bean.EntityBean;
  * relatively nice clean way to write queries.
  * <p>
  * <h3>Typical common @MappedSuperclass</h3>
- * <pre>{@code
+ * <pre><code>
  *
  *     // Typically there is a common base model that has some
  *     // common properties like the ones below
  *
- *   @MappedSuperclass
+ *   &#64;MappedSuperclass
  *   public class BaseModel extends Model {
  *
- *     @Id Long id;
+ *     &#64;Id Long id;
  *
- *     @Version Long version;
+ *     &#64;Version Long version;
  *
- *     @WhenCreated Timestamp whenCreated;
+ *     &#64;WhenCreated Timestamp whenCreated;
  *
- *     @WhenUpdated Timestamp whenUpdated;
+ *     &#64;WhenUpdated Timestamp whenUpdated;
  *
  *     ...
  *   }
- * }</pre>
+ * </code></pre>
  * <p>
  * <h3>Extend the Model</h3>
- * <pre>{@code
+ * <pre><code>
  *
  *     // Extend the mappedSuperclass
  *
- *     @Entity @Table(name="o_account")
+ *     &#64;Entity &#64;Table(name="o_account")
  *     public class Customer extends BaseModel {
  *
  *       String name;
  *       ...
  *     }
  *
- * }</pre>
+ * </code></pre>
  * <p>
  * <h3>Modal: save()</h3>
  * <pre>{@code

--- a/ebean-api/src/main/java/io/ebean/Pairs.java
+++ b/ebean-api/src/main/java/io/ebean/Pairs.java
@@ -15,11 +15,11 @@ import java.util.Objects;
  * These queries can have predicates that can be translated into a list of complex natural keys such that the L2
  * cache can be hit with these keys to obtain some or all of the beans from L2 cache rather than the DB.
  * </p>
- * <pre>{@code
+ * <pre><code>
  *
  *   // where a bean is annotated with a complex
  *   // natural key made of several properties
- *   @Cache(naturalKey = {"store","code","sku"})
+ *   &#64;Cache(naturalKey = {"store","code","sku"})
  *
  *
  *   Pairs pairs = new Pairs("sku", "code");
@@ -38,7 +38,7 @@ import java.util.Objects;
  *   .setUseCache(true)
  *   .findList();
  *
- * }</pre>
+ * </code></pre>
  * <h3>Important implementation Note</h3>
  * <p>
  * When binding many pairs of values we want to be able to utilise a DB index (as this type of query usually means the

--- a/ebean-api/src/main/java/io/ebean/RawSql.java
+++ b/ebean-api/src/main/java/io/ebean/RawSql.java
@@ -39,16 +39,16 @@ package io.ebean;
  * to Order.
  * <p>
  * <h3>Example OrderAggregate</h3>
- * <pre>{@code
- *  ...
- *   // @Sql indicates to that this bean
+ * <pre><code>
+ *   ...
+ *   // &#64;Sql indicates to that this bean
  *   // is based on RawSql rather than a table
  *
- *   @Entity
- *   @Sql
+ *   &#64;Entity
+ *   &#64;Sql
  *   public class OrderAggregate {
  *
- *    @OneToOne
+ *    &#64;OneToOne
  *    Order order;
  *
  *    Double totalAmount;
@@ -58,7 +58,7 @@ package io.ebean;
  *    // getters and setters
  *    ...
  *   }
- * }</pre>
+ * </code></pre>
  *
  * <h3>Example 1:</h3>
  *

--- a/ebean-api/src/main/java/io/ebean/RowMapper.java
+++ b/ebean-api/src/main/java/io/ebean/RowMapper.java
@@ -15,14 +15,14 @@ import java.sql.SQLException;
  * it can automatically map the ResultSet into beans.
  * </p>
  *
- * <pre>{@code
+ * <pre><code>
  *
  *    //
  *    // Map from ResultSet to CustomerDto bean
  *    //
  *    class CustomerMapper implements RowMapper<CustomerDto> {
  *
- *     @Override
+ *     &#64;Override
  *     public CustomerDto map(ResultSet rset, int rowNum) throws SQLException {
  *
  *       long id = rset.getLong(1);
@@ -46,7 +46,7 @@ import java.sql.SQLException;
  *    .findOne();
  *
  *
- * }</pre>
+ * </code></pre>
  *
  * @param <T> The type the row data is mapped into.
  */

--- a/ebean-api/src/main/java/io/ebean/Update.java
+++ b/ebean-api/src/main/java/io/ebean/Update.java
@@ -11,29 +11,29 @@ package io.ebean;
  * <p>
  * The following is an example of named updates on an entity bean.
  * </p>
- * <pre>{@code
+ * <pre><code>
  *    ...
- *   @NamedUpdates(value = {
- *     @NamedUpdate(
+ *   &#64;NamedUpdates(value = {
+ *     &#64;NamedUpdate(
  *       name = "setTitle",
  *       notifyCache = false,
  *       update = "update topic set title = :title, postCount = :count where id = :id"),
- *    @NamedUpdate(
+ *    &#64;NamedUpdate(
  *       name = "setPostCount",
  *       notifyCache = false,
  *       update = "update f_topic set post_count = :postCount where id = :id"),
- *    @NamedUpdate(
+ *    &#64;NamedUpdate(
  *       name = "incrementPostCount",
  *       notifyCache = false,
  *       update = "update Topic set postCount = postCount + 1 where id = :id")
  *       //update = "update f_topic set post_count = post_count + 1 where id = :id")
  *   })
- *   @Entity
- *   @Table(name = "f_topic")
+ *   &#64;Entity
+ *   &#64;Table(name = "f_topic")
  *   public class Topic {
  *     ...
  *   }
- * }</pre>
+ * </code></pre>
  *
  * <p>
  * The following show code that would use a named update on the Topic entity

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfigProvider.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfigProvider.java
@@ -11,11 +11,11 @@ package io.ebean.config;
  * spring specific configuration.  When we are not using a DI container we may use this mechanism to
  * explicitly register the entity beans and avoid classpath scanning.
  * </p>
- * <pre>{@code
+ * <pre><code>
  *
  * public class EbeanConfigProvider implements DatabaseConfigProvider {
  *
- *   @Override
+ *   &#64;Override
  *   public void apply(DatabaseConfig config) {
  *
  *     // register the entity bean classes explicitly
@@ -25,7 +25,7 @@ package io.ebean.config;
  *   }
  * }
  *
- * }</pre>
+ * </code></pre>
  */
 public interface DatabaseConfigProvider {
 

--- a/ebean-api/src/main/java/io/ebean/config/ServerConfigProvider.java
+++ b/ebean-api/src/main/java/io/ebean/config/ServerConfigProvider.java
@@ -12,11 +12,11 @@ package io.ebean.config;
  * spring specific configuration.  When we are not using a DI container we may use this mechanism to
  * explicitly register the entity beans and avoid classpath scanning.
  * </p>
- * <pre>{@code
+ * <pre><code>
  *
  * public class EbeanConfigProvider implements ServerConfigProvider {
  *
- *   @Override
+ *   &#64;Override
  *   public void apply(ServerConfig config) {
  *
  *     // register the entity bean classes explicitly
@@ -26,7 +26,7 @@ package io.ebean.config;
  *   }
  * }
  *
- * }</pre>
+ * <code></pre>
  */
 @Deprecated
 public interface ServerConfigProvider {

--- a/ebean-test/src/main/java/io/ebean/test/ForTests.java
+++ b/ebean-test/src/main/java/io/ebean/test/ForTests.java
@@ -64,16 +64,16 @@ public class ForTests {
    * back all changes made during test execution.
    * </p>
    *
-   * <pre>{@code
+   * <pre><code>
    *
    *   private ForTests.RollbackAll rollbackAll;
    *
-   *   @Before
+   *   &#64;Before
    *   public void before() {
    *     rollbackAll = ForTests.createRollbackAll();
    *   }
    *
-   *   @After
+   *   &#64;After
    *   public void after() {
    *     rollbackAll.close();
    *   }
@@ -81,7 +81,7 @@ public class ForTests {
    *   ... tests execute and everything is rolled back
    *
    *
-   * }</pre>
+   * <code></pre>
    */
   public static RollbackAll createRollbackAll() {
 


### PR DESCRIPTION
Hello Rob,
I noticed, that there are a lot of javadoc warnings during a maven build.
I do some investigation and noted, that it is currently impossible to use an `@` char in an `@{code ...}` block.

This is clearly a Javadoc-Bug, but it seems to exist since a long time, so I think, there will be no fix in the future (See: https://stackoverflow.com/questions/23812761/trying-to-escape-the-symbol-in-a-code-block-within-a-javadoc-comment-with)

To fix invalid javadoc (see https://ebean.io/apidoc/12/io/ebean/RowMapper.html) I changed them to `<code>`
There is also a missing dependency in `avaje-lang`, which causes `unknown enum constant When,MAYBE` warning.

Unfortunately, there are still a lot of files with invalid javadoc (mostly generated by xjc) which are not part of this PR

