### PR TITLE
Remove deprecated findLargeStream(), migrate to findStream()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/ExtendedServer.java
+++ b/ebean-api/src/main/java/io/ebean/ExtendedServer.java
@@ -113,19 +113,6 @@ public interface ExtendedServer {
   <T> Stream<T> findStream(Query<T> query, Transaction transaction);
 
   /**
-   * Deprecated - migrate to findStream().
-   * <p>
-   * Execute the query returning the result as a Stream.
-   * <p>
-   * Note that this can support very large queries iterating any number of results.
-   * To do so internally it can use multiple persistence contexts.
-   * <p>
-   * Note that the stream needs to be closed so use with try with resources.
-   */
-  @Deprecated
-  <T> Stream<T> findLargeStream(Query<T> query, Transaction transaction);
-
-  /**
    * Execute the query visiting the each bean one at a time.
    * <p>
    * Unlike findList() this is suitable for processing a query that will return

--- a/ebean-api/src/main/java/io/ebean/Query.java
+++ b/ebean-api/src/main/java/io/ebean/Query.java
@@ -751,29 +751,6 @@ public interface Query<T> extends CancelableQuery {
   Stream<T> findStream();
 
   /**
-   * Deprecated - migrate to findStream.
-   * <p>
-   * Execute the query returning the result as a Stream.
-   * <p>
-   * Note that this uses multiple persistence contexts such that we can use
-   * it with a large number of results.
-   * </p>
-   * <pre>{@code
-   *
-   *  // use try with resources to ensure Stream is closed
-   *
-   *  try (Stream<Customer> stream = query.findLargeStream()) {
-   *    stream
-   *    .map(...)
-   *    .collect(...);
-   *  }
-   *
-   * }</pre>
-   */
-  @Deprecated
-  Stream<T> findLargeStream();
-
-  /**
    * Execute the query processing the beans one at a time.
    * <p>
    * This method is appropriate to process very large query results as the

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1377,11 +1377,6 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> Stream<T> findLargeStream(Query<T> query, Transaction transaction) {
-    return findStream(query, transaction);
-  }
-
-  @Override
   public <T> Stream<T> findStream(Query<T> query, Transaction transaction) {
     return toStream(findIterate(query, transaction));
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
@@ -252,11 +252,6 @@ final class DefaultFetchGroupQuery<T> implements SpiFetchGroupQuery<T>, SpiQuery
   }
 
   @Override
-  public Stream<T> findLargeStream() {
-    throw new RuntimeException("EB102: Only select() and fetch() clause is allowed on FetchGroup");
-  }
-
-  @Override
   public void findEach(Consumer<T> consumer) {
     throw new RuntimeException("EB102: Only select() and fetch() clause is allowed on FetchGroup");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1457,11 +1457,6 @@ public final class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<
   }
 
   @Override
-  public Stream<T> findLargeStream() {
-    return server.findLargeStream(this, transaction);
-  }
-
-  @Override
   public List<Version<T>> findVersions() {
     this.temporalMode = TemporalMode.VERSIONS;
     return server.findVersions(this, transaction);

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
@@ -1647,14 +1647,6 @@ public abstract class TQRootBean<T, R> {
   }
 
   /**
-   * Deprecated - migrate to findStream().
-   */
-  @Deprecated
-  public Stream<T> findLargeStream() {
-    return query.findLargeStream();
-  }
-
-  /**
    * Execute the query returning the set of objects.
    * <p>
    * This query will execute against the EbeanServer that was used to create it.

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -388,24 +388,6 @@ public class QCustomerTest {
   }
 
   @Test
-  public void testFindLargeStream() {
-    insertCustomer("largeStream1");
-    insertCustomer("largeStream2");
-    insertCustomer("largeStream3");
-
-    StringJoiner sb = new StringJoiner("|");
-    try (Stream<Customer> stream = new QCustomer()
-      .name.startsWith("largeStream")
-      .id.asc()
-      .findLargeStream()) {
-
-      stream.forEach(it -> sb.add(it.getName()));
-    }
-
-    assertThat(sb.toString()).isEqualTo("largeStream1|largeStream2|largeStream3");
-  }
-
-  @Test
   public void testFilterMany() {
 
     Customer cust = new Customer();

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
@@ -654,11 +654,6 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public <T> Stream<T> findLargeStream(Query<T> query, Transaction transaction) {
-    return null;
-  }
-
-  @Override
   public <T> void findEach(Query<T> query, Consumer<T> consumer, Transaction transaction) {
   }
 

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindStream.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindStream.java
@@ -38,27 +38,6 @@ public class TestQueryFindStream extends BaseTestCase {
   }
 
   @Test
-  public void findLargeStream_basic() {
-    ResetBasicData.reset();
-    try (Stream<Customer> stream = DB.find(Customer.class)
-      .findLargeStream()) {
-
-      // bad example, don't use a stream like this when we can
-      // use findSingleAttributeList() instead
-      final List<String> namesStream = stream
-        .map(Customer::getName)
-        .collect(toList());
-
-      final List<String> namesQuery = DB.find(Customer.class)
-        .select("name")
-        .findSingleAttributeList();
-
-      assertThat(namesStream).hasSize(namesQuery.size());
-      assertThat(namesStream).containsAll(namesQuery);
-    }
-  }
-
-  @Test
   public void manualTest_findSteam_when_closeWithResources() {
     // confirm manually the stream is closed via try with resources block
     try (Stream<Customer> stream = DB.find(Customer.class).findStream()) {


### PR DESCRIPTION
findLargeStream() became no longer become needed due to improvements in the persistence context. Migrate to just use findStream() instead.