### PR TITLE
Remove deprecated methods in ebean-api - ServerCacheManager ServerCacheRegion

### DIFF
--- a/ebean-api/src/main/java/io/ebean/cache/ServerCacheManager.java
+++ b/ebean-api/src/main/java/io/ebean/cache/ServerCacheManager.java
@@ -24,14 +24,6 @@ public interface ServerCacheManager {
   boolean localL2Caching();
 
   /**
-   * Deprecated migrate to localL2Caching().
-   */
-  @Deprecated
-  default boolean isLocalL2Caching() {
-    return localL2Caching();
-  }
-
-  /**
    * Return all the cache regions.
    */
   List<ServerCacheRegion> allRegions();
@@ -47,75 +39,34 @@ public interface ServerCacheManager {
   void enabledRegions(String regions);
 
   /**
-   * Deprecated migrate to enabledRegions().
-   */
-  @Deprecated
-  default void setEnabledRegions(String regions) {
-    enabledRegions(regions);
-  }
-
-  /**
    * Enable or disable all the cache regions.
    */
   void allRegionsEnabled(boolean enabled);
-
-  /**
-   * Deprecated migrate to allRegionsEnabled().
-   */
-  @Deprecated
-  default void setAllRegionsEnabled(boolean enabled) {
-    allRegionsEnabled(enabled);
-  }
 
   /**
    * Return the cache region by name. Typically, to enable or disable the region.
    */
   ServerCacheRegion region(String name);
 
-  @Deprecated
-  default ServerCacheRegion getRegion(String name) {
-    return region(name);
-  }
-
   /**
    * Return the cache for mapping natural keys to id values.
    */
   ServerCache naturalKeyCache(Class<?> beanType);
-
-  @Deprecated
-  default ServerCache getNaturalKeyCache(Class<?> beanType) {
-    return naturalKeyCache(beanType);
-  }
 
   /**
    * Return the cache for beans of a particular type.
    */
   ServerCache beanCache(Class<?> beanType);
 
-  @Deprecated
-  default ServerCache getBeanCache(Class<?> beanType) {
-    return beanCache(beanType);
-  }
-
   /**
    * Return the cache for associated many properties of a bean type.
    */
   ServerCache collectionIdsCache(Class<?> beanType, String propertyName);
 
-  @Deprecated
-  default ServerCache getCollectionIdsCache(Class<?> beanType, String propertyName) {
-    return collectionIdsCache(beanType, propertyName);
-  }
-
   /**
    * Return the cache for query results of a particular type of bean.
    */
   ServerCache queryCache(Class<?> beanType);
-
-  @Deprecated
-  default ServerCache getQueryCache(Class<?> beanType) {
-    return queryCache(beanType);
-  }
 
   /**
    * This clears both the bean and query cache for a given type.

--- a/ebean-api/src/main/java/io/ebean/cache/ServerCacheRegion.java
+++ b/ebean-api/src/main/java/io/ebean/cache/ServerCacheRegion.java
@@ -11,14 +11,6 @@ public interface ServerCacheRegion {
   String name();
 
   /**
-   * Deprecated migrate to name().
-   */
-  @Deprecated
-  default String getName() {
-    return name();
-  }
-
-  /**
    * Return true if the cache region is enabled.
    */
   boolean isEnabled();


### PR DESCRIPTION
These methods are deprecated getters, migrate to the associated accessor method.

ServerCacheManager

isLocalL2Caching() -> localL2Caching()
setEnabledRegions() ->  enabledRegions()
setAllRegionsEnabled() -> allRegionsEnabled()
getRegion() -> region()
getNaturalKeyCache() -> naturalKeyCache()
getBeanCache() -> beanCache()
getCollectionIdsCache() -> collectionIdsCache()
getQueryCache() -> queryCache()




ServerCacheRegion

getName() -> name()