### PR TITLE
Remove deprecated methods in ebean-api - SqlQuery

### DIFF
--- a/ebean-api/src/main/java/io/ebean/SqlQuery.java
+++ b/ebean-api/src/main/java/io/ebean/SqlQuery.java
@@ -75,18 +75,6 @@ public interface SqlQuery extends Serializable, CancelableQuery {
   SqlRow findOne();
 
   /**
-   * Deprecated migrate to use {@link #mapTo(RowMapper)}
-   */
-  @Deprecated
-  <T> T findOne(RowMapper<T> mapper);
-
-  /**
-   * Deprecated migrate to use {@link #mapTo(RowMapper)}
-   */
-  @Deprecated
-  <T> List<T> findList(RowMapper<T> mapper);
-
-  /**
    * Execute the query reading each row from ResultSet using the RowConsumer.
    * <p>
    * This provides a low level option that reads directly from the JDBC ResultSet
@@ -122,50 +110,6 @@ public interface SqlQuery extends Serializable, CancelableQuery {
   Optional<SqlRow> findOneOrEmpty();
 
   /**
-   * Deprecated - migrate to <code>.mapToScalar(attributeType).findOne()</code>.
-   * <pre>{@code
-   *
-   *    .mapToScalar(BigDecimal.class)
-   *    .findOne();
-   * }
-   */
-  @Deprecated
-  <T> T findSingleAttribute(Class<T> attributeType);
-
-  /**
-   * Deprecated - migrate to <code>.mapToScalar(BigDecimal.class).findOne()</code>.
-   * <pre>{@code
-   *
-   *    .mapToScalar(BigDecimal.class)
-   *    .findOne();
-   * }
-   */
-  @Deprecated
-  BigDecimal findSingleDecimal();
-
-  /**
-   * Deprecated - migrate to <code>.mapToScalar(Long.class).findOne()</code>.
-   * <pre>{@code
-   *
-   *    .mapToScalar(Long.class)
-   *    .findOne();
-   * }
-   */
-  @Deprecated
-  Long findSingleLong();
-
-  /**
-   * Deprecated - migrate to <code>.mapToScalar(Long.class).findList()</code>.
-   * <pre>{@code
-   *
-   *    .mapToScalar(Long.class)
-   *    .findList();
-   * }
-   */
-  @Deprecated
-  <T> List<T> findSingleAttributeList(Class<T> attributeType);
-
-  /**
    * Set one of more positioned parameters.
    * <p>
    * This is a convenient alternative to multiple calls to {@link #setParameter(Object)}.
@@ -193,12 +137,6 @@ public interface SqlQuery extends Serializable, CancelableQuery {
    * }</pre>
    */
   SqlQuery setParameters(Object... values);
-
-  /**
-   * Deprecated migrate to setParameters(Object... values)
-   */
-  @Deprecated
-  SqlQuery setParams(Object... values);
 
   /**
    * Set the next bind parameter by position.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
@@ -10,7 +10,6 @@ import io.ebeaninternal.api.BindParams;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiSqlQuery;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -57,36 +56,6 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   }
 
   @Override
-  public BigDecimal findSingleDecimal() {
-    return server.findSingleAttribute(this, BigDecimal.class);
-  }
-
-  @Override
-  public Long findSingleLong() {
-    return server.findSingleAttribute(this, Long.class);
-  }
-
-  @Override
-  public <T> T findSingleAttribute(Class<T> cls) {
-    return server.findSingleAttribute(this, cls);
-  }
-
-  @Override
-  public <T> List<T> findSingleAttributeList(Class<T> cls) {
-    return server.findSingleAttributeList(this, cls);
-  }
-
-  @Override
-  public <T> T findOne(RowMapper<T> mapper) {
-    return server.findOneMapper(this, mapper);
-  }
-
-  @Override
-  public <T> List<T> findList(RowMapper<T> mapper) {
-    return server.findListMapper(this, mapper);
-  }
-
-  @Override
   public void findEachRow(RowConsumer consumer) {
     server.findEachRow(this, consumer);
   }
@@ -99,12 +68,6 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   @Override
   public Optional<SqlRow> findOneOrEmpty() {
     return Optional.ofNullable(findOne());
-  }
-
-  @Override
-  @Deprecated
-  public DefaultRelationalQuery setParams(Object... values) {
-    return setParameters(values);
   }
 
   @Override
@@ -235,6 +198,14 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   @Override
   public <T> TypeQuery<T> mapTo(RowMapper<T> mapper) {
     return new Mapper(mapper);
+  }
+
+  private <T> T findSingleAttribute(Class<T> cls) {
+    return server.findSingleAttribute(this, cls);
+  }
+
+  private <T> List<T> findSingleAttributeList(Class<T> cls) {
+    return server.findSingleAttributeList(this, cls);
   }
 
   private class Scalar<T> implements SqlQuery.TypeQuery<T> {


### PR DESCRIPTION
Migrate as per the comments below:

```java

  /**
   * Deprecated migrate to use {@link #mapTo(RowMapper)}
   */
  @Deprecated
  <T> T findOne(RowMapper<T> mapper);

  /**
   * Deprecated migrate to use {@link #mapTo(RowMapper)}
   */
  @Deprecated
  <T> List<T> findList(RowMapper<T> mapper);

  /**
   * Deprecated - migrate to <code>.mapToScalar(attributeType).findOne()</code>.
   * <pre>{@code
   *
   *    .mapToScalar(BigDecimal.class)
   *    .findOne();
   * }
   */
  @Deprecated
  <T> T findSingleAttribute(Class<T> attributeType);

  /**
   * Deprecated - migrate to <code>.mapToScalar(BigDecimal.class).findOne()</code>.
   * <pre>{@code
   *
   *    .mapToScalar(BigDecimal.class)
   *    .findOne();
   * }
   */
  @Deprecated
  BigDecimal findSingleDecimal();

  /**
   * Deprecated - migrate to <code>.mapToScalar(Long.class).findOne()</code>.
   * <pre>{@code
   *
   *    .mapToScalar(Long.class)
   *    .findOne();
   * }
   */
  @Deprecated
  Long findSingleLong();

  /**
   * Deprecated - migrate to <code>.mapToScalar(Long.class).findList()</code>.
   * <pre>{@code
   *
   *    .mapToScalar(Long.class)
   *    .findList();
   * }
   */
  @Deprecated
  <T> List<T> findSingleAttributeList(Class<T> attributeType);

  /**
   * Deprecated migrate to setParameters(Object... values)
   */
  @Deprecated
  SqlQuery setParams(Object... values);


```