### PR TITLE
Remove deprecated methods in ebean-api - SqlUpdate

### DIFF
--- a/ebean-api/src/main/java/io/ebean/SqlUpdate.java
+++ b/ebean-api/src/main/java/io/ebean/SqlUpdate.java
@@ -288,23 +288,11 @@ public interface SqlUpdate {
   SqlUpdate setParameters(Object... values);
 
   /**
-   * Deprecated migrate to setParameters(Object... values).
-   */
-  @Deprecated
-  SqlUpdate setParams(Object... values);
-
-  /**
    * Set the next bind parameter by position.
    *
    * @param value The value to bind
    */
   SqlUpdate setParameter(Object value);
-
-  /**
-   * Deprecated migrate to setParameter(value).
-   */
-  @Deprecated
-  SqlUpdate setNextParameter(Object value);
 
   /**
    * Set a parameter via its index position.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultSqlUpdate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultSqlUpdate.java
@@ -262,16 +262,6 @@ public final class DefaultSqlUpdate implements Serializable, SpiSqlUpdate {
   }
 
   @Override
-  public SqlUpdate setParams(Object... values) {
-    return setParameters(values);
-  }
-
-  @Override
-  public SqlUpdate setNextParameter(Object value) {
-    return setParameter(value);
-  }
-
-  @Override
   public SqlUpdate setParameters(Object... values) {
     for (Object value : values) {
       setParameter(++addPos, value);


### PR DESCRIPTION
migrate from -> to
setParams() -> setParameters()
setNextParameter() -> setParameter()

```java
  /**
   * Deprecated migrate to setParameters(Object... values).
   */
  @Deprecated
  SqlUpdate setParams(Object... values);

  /**
   * Deprecated migrate to setParameter(value).
   */
  @Deprecated
  SqlUpdate setNextParameter(Object value);
```