### PR TITLE
Refactor L2 cache tenant awareness - add TenantAwareCache

### DIFF
--- a/ebean-api/src/main/java/io/ebean/cache/ServerCache.java
+++ b/ebean-api/src/main/java/io/ebean/cache/ServerCache.java
@@ -104,4 +104,11 @@ public interface ServerCache {
   default void visit(MetricVisitor visitor) {
     // do nothing by default
   }
+
+  /**
+   * Unwrap the underlying ServerCache.
+   */
+  default <T> T unwrap(Class<T> cls) {
+    return (T) this;
+  }
 }

--- a/ebean-api/src/main/java/io/ebean/cache/ServerCacheConfig.java
+++ b/ebean-api/src/main/java/io/ebean/cache/ServerCacheConfig.java
@@ -13,6 +13,7 @@ public class ServerCacheConfig {
   private final ServerCacheOptions cacheOptions;
   private final CurrentTenantProvider tenantProvider;
   private final QueryCacheEntryValidate queryCacheEntryValidate;
+  private final TenantAwareKey tenantAwareKey;
 
   public ServerCacheConfig(ServerCacheType type, String cacheKey, String shortName, ServerCacheOptions cacheOptions, CurrentTenantProvider tenantProvider, QueryCacheEntryValidate queryCacheEntryValidate) {
     this.type = type;
@@ -21,6 +22,14 @@ public class ServerCacheConfig {
     this.cacheOptions = cacheOptions;
     this.tenantProvider = tenantProvider;
     this.queryCacheEntryValidate = queryCacheEntryValidate;
+    this.tenantAwareKey = (tenantProvider == null) ? null : new TenantAwareKey(tenantProvider);
+  }
+
+  /**
+   * Return the ServerCache taking into account if multi-tenant is used.
+   */
+  public ServerCache tenantAware(ServerCache cache) {
+    return tenantAwareKey == null ? cache : new TenantAwareCache(cache, tenantAwareKey);
   }
 
   /**

--- a/ebean-api/src/main/java/io/ebean/cache/TenantAwareCache.java
+++ b/ebean-api/src/main/java/io/ebean/cache/TenantAwareCache.java
@@ -1,0 +1,104 @@
+package io.ebean.cache;
+
+import io.ebean.meta.MetricVisitor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A ServerCache proxy that is tenant aware.
+ */
+public final class TenantAwareCache implements ServerCache {
+
+  private final ServerCache delegate;
+  private final TenantAwareKey tenantAwareKey;
+
+  /**
+   * Create given the TenantAwareKey and delegate cache to proxy to.
+   *
+   * @param delegate       The cache to proxy to
+   * @param tenantAwareKey Provides tenant aware keys to use in the cache
+   */
+  public TenantAwareCache(ServerCache delegate, TenantAwareKey tenantAwareKey) {
+    this.delegate = delegate;
+    this.tenantAwareKey = tenantAwareKey;
+  }
+
+  /**
+   * Return the underlying ServerCache that is being delegated to.
+   */
+  @Override
+  public <T> T unwrap(Class<T> cls) {
+    return (T)delegate;
+  }
+
+  @Override
+  public void visit(MetricVisitor visitor) {
+    delegate.visit(visitor);
+  }
+
+  private Object key(Object key) {
+    return tenantAwareKey.key(key);
+  }
+
+  @Override
+  public Object get(Object id) {
+    return delegate.get(key(id));
+  }
+
+  @Override
+  public void put(Object id, Object value) {
+    delegate.put(key(id), value);
+  }
+
+  @Override
+  public void remove(Object id) {
+    delegate.remove(key(id));
+  }
+
+  @Override
+  public void clear() {
+    delegate.clear();
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public int getHitRatio() {
+    return delegate.getHitRatio();
+  }
+
+  @Override
+  public ServerCacheStatistics getStatistics(boolean reset) {
+    return delegate.getStatistics(reset);
+  }
+
+  @Override
+  public Map<Object, Object> getAll(Set<Object> keys) {
+    Map<Object, Object> keyMapping = new HashMap<>(keys.size());
+    keys.forEach(k -> keyMapping.put(key(k), k));
+    Map<Object, Object> tmp = delegate.getAll(keyMapping.keySet());
+    Map<Object, Object> ret = new HashMap<>(keys.size());
+    // unwrap tenant info here
+    tmp.forEach((k,v)-> ret.put(((TenantAwareKey.CacheKey) k).key, v));
+    return ret;
+  }
+
+  @Override
+  public void putAll(Map<Object, Object> keyValues) {
+    Map<Object, Object> tmp = new HashMap<>();
+    keyValues.forEach((k, v) -> tmp.put(key(k), v));
+    delegate.putAll(tmp);
+  }
+
+  @Override
+  public void removeAll(Set<Object> keys) {
+    delegate.removeAll(keys.stream().map(this::key).collect(Collectors.toSet()));
+  }
+
+}

--- a/ebean-api/src/test/java/io/ebean/cache/TenantAwareCacheTest.java
+++ b/ebean-api/src/test/java/io/ebean/cache/TenantAwareCacheTest.java
@@ -1,0 +1,122 @@
+package io.ebean.cache;
+
+import io.ebean.cache.TenantAwareKey.CacheKey;
+import io.ebean.config.CurrentTenantProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TenantAwareCacheTest {
+
+  ServerCache serverCache;
+  TenantAwareCache cache;
+
+  TenantAwareCacheTest() {
+    TenantAwareKey key = new TenantAwareKey(new TenantProv());
+    this.serverCache = new Cache();
+    this.cache = new TenantAwareCache(serverCache, key);
+  }
+
+  @Test
+  void put_get_remove() {
+    cache.put("A", "a");
+    Object val = cache.get("A");
+    assertThat(val).isEqualTo("a");
+
+    CacheKey cacheKey = new CacheKey("A", 42);
+    Object val2 = serverCache.get(cacheKey);
+    assertThat(val2).isEqualTo("a");
+
+    cache.put("B", "bb");
+    assertThat(cache.size()).isEqualTo(2);
+    cache.remove("A");
+    assertThat(cache.get("A")).isNull();
+    assertThat(cache.size()).isEqualTo(1);
+
+    cache.clear();
+    assertThat(cache.size()).isEqualTo(0);
+    assertThat(cache.get("B")).isNull();
+  }
+
+  @Test
+  void putAll_getAll_removeAll() {
+    Map<Object,Object> map = new HashMap<>();
+    map.put("A", "a");
+    map.put("B", "b");
+    map.put("C", "c");
+
+    cache.putAll(map);
+    assertThat(cache.size()).isEqualTo(3);
+    assertThat(cache.get("A")).isEqualTo("a");
+    assertThat(serverCache.get(new CacheKey("A", 42))).isEqualTo("a");
+
+
+    Map<Object, Object> result = cache.getAll(Set.of("A", "B", "C", "D"));
+    assertThat(result).hasSize(3);
+    assertThat(result).containsOnlyKeys("A", "B", "C");
+    assertThat(result.values()).containsOnly("a", "b", "c");
+
+    cache.removeAll(Set.of("A", "C", "D"));
+    assertThat(cache.size()).isEqualTo(1);
+
+    assertThat(cache.get("B")).isEqualTo("b");
+    assertThat(serverCache.get(new CacheKey("B", 42))).isEqualTo("b");
+
+    cache.remove("B");
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+
+  static class TenantProv implements CurrentTenantProvider {
+
+    @Override
+    public Object currentId() {
+      return 42;
+    }
+  }
+
+  static class Cache implements ServerCache {
+
+    Map<Object, Object> map = new ConcurrentHashMap<>();
+
+    @Override
+    public Object get(Object id) {
+      return map.get(id);
+    }
+
+    @Override
+    public void put(Object id, Object value) {
+      map.put(id, value);
+    }
+
+    @Override
+    public void remove(Object id) {
+      map.remove(id);
+    }
+
+    @Override
+    public void clear() {
+      map.clear();
+    }
+
+    @Override
+    public int size() {
+      return map.size();
+    }
+
+    @Override
+    public int getHitRatio() {
+      return 0;
+    }
+
+    @Override
+    public ServerCacheStatistics getStatistics(boolean reset) {
+      return null;
+    }
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheConfig.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheConfig.java
@@ -3,7 +3,6 @@ package io.ebeaninternal.server.cache;
 import io.ebean.cache.QueryCacheEntryValidate;
 import io.ebean.cache.ServerCacheConfig;
 import io.ebean.cache.ServerCacheOptions;
-import io.ebean.config.CurrentTenantProvider;
 import io.ebeaninternal.server.cache.DefaultServerCache.CacheEntry;
 
 import java.lang.ref.SoftReference;
@@ -32,10 +31,6 @@ public final class DefaultServerCacheConfig {
     this.maxSecsToLive = options.getMaxSecsToLive();
     this.trimFrequency = options.getTrimFrequency();
     this.maxSize = options.getMaxSize();
-  }
-
-  public CurrentTenantProvider getTenantProvider() {
-    return config.getTenantProvider();
   }
 
   public QueryCacheEntryValidate getQueryCacheEntryValidate() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheFactory.java
@@ -41,7 +41,7 @@ final class DefaultServerCacheFactory implements ServerCacheFactory {
     if (executor != null) {
       cache.periodicTrim(executor);
     }
-    return cache;
+    return config.tenantAware(cache);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerQueryCache.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerQueryCache.java
@@ -27,8 +27,7 @@ public class DefaultServerQueryCache extends DefaultServerCache {
   }
 
   @Override
-  protected CacheEntry getCacheEntry(Object id) {
-    Object key = key(id);
+  protected CacheEntry getCacheEntry(Object key) {
     final SoftReference<CacheEntry> ref = map.get(key);
     CacheEntry entry = ref != null ? ref.get() : null;
     if (entry == null) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/profile/DCountMetric.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/profile/DCountMetric.java
@@ -48,7 +48,6 @@ final class DCountMetric implements CountMetric {
 
   @Override
   public void visit(MetricVisitor visitor) {
-
     long val = visitor.reset() ? count.sumThenReset() : count.sum();
     if (val > 0) {
       visitor.visitCount(new DCountMetricStats(name, val));

--- a/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultCacheHolderTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultCacheHolderTest.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.cache;
 
+import io.ebean.cache.ServerCache;
 import io.ebean.cache.ServerCacheFactory;
 import io.ebean.cache.ServerCacheOptions;
 import io.ebean.cache.ServerCacheType;
@@ -12,7 +13,7 @@ import org.tests.model.basic.Customer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class DefaultCacheHolderTest {
+class DefaultCacheHolderTest {
 
   private final ThreadLocal<String> tenantId = new ThreadLocal<>();
 
@@ -25,42 +26,30 @@ public class DefaultCacheHolderTest {
       .with(cacheFactory, new TableModState());
   }
 
-
   @Test
-  public void getCache_normal() {
-
+  void getCache_normal() {
     DefaultCacheHolder holder = new DefaultCacheHolder(options());
 
-    DefaultServerCache cache = cache(holder, Customer.class);
-    assertThat(cache.getName()).isEqualTo("org.tests.model.basic.Customer_B");
-    assertThat(cache.getShortName()).isEqualTo("Customer_B");
-
-    DefaultServerCache cache1 = cache(holder, Customer.class);
+    ServerCache cache = cache(holder, Customer.class);
+    ServerCache cache1 = cache(holder, Customer.class);
     assertThat(cache1).isSameAs(cache);
 
-    DefaultServerCache cache2 = cache(holder, Contact.class);
+    ServerCache cache2 = cache(holder, Contact.class);
     assertThat(cache1).isNotSameAs(cache2);
-    assertThat(cache2.getName()).isEqualTo("org.tests.model.basic.Contact_B");
-    assertThat(cache2.getShortName()).isEqualTo("Contact_B");
-
   }
 
-  private DefaultServerCache cache(DefaultCacheHolder holder, Class<?> type) {
-    return (DefaultServerCache) holder.getCache(type, ServerCacheType.BEAN);
+  private ServerCache cache(DefaultCacheHolder holder, Class<?> type) {
+    return holder.getCache(type, ServerCacheType.BEAN);
   }
 
   @Test
-  public void getCache_multiTenant() throws Exception {
-
+  void getCache_multiTenant() throws Exception {
     CacheManagerOptions builder = options().with(tenantId::get);
 
     DefaultCacheHolder holder = new DefaultCacheHolder(builder);
 
     tenantId.set("ten_1");
-    DefaultServerCache cache = cache(holder, Customer.class);
-    assertThat(cache.getName()).isEqualTo("org.tests.model.basic.Customer_B");
-    assertThat(cache.getShortName()).isEqualTo("Customer_B");
-
+    ServerCache cache = cache(holder, Customer.class);
     cache.put("1", "value-for-tenant1");
     cache.put("2", "an other value-for-tenant1");
 
@@ -109,10 +98,9 @@ public class DefaultCacheHolderTest {
   }
 
   @Test
-  public void clearAll() {
-
+  void clearAll() {
     DefaultCacheHolder holder = new DefaultCacheHolder(options());
-    DefaultServerCache cache = cache(holder, Customer.class);
+    ServerCache cache = cache(holder, Customer.class);
     cache.put("foo", "foo");
     assertThat(cache.size()).isEqualTo(1);
     holder.clearAll();
@@ -121,12 +109,11 @@ public class DefaultCacheHolderTest {
   }
 
   @Test
-  public void clearAll_multiTenant() {
-
+  void clearAll_multiTenant() {
     CacheManagerOptions options = options().with(tenantId::get);
 
     DefaultCacheHolder holder = new DefaultCacheHolder(options);
-    DefaultServerCache cache = cache(holder, Customer.class);
+    ServerCache cache = cache(holder, Customer.class);
     cache.put("foo", "foo");
     assertThat(cache.size()).isEqualTo(1);
 

--- a/ebean-redis/src/main/java/io/ebean/redis/RedisCacheFactory.java
+++ b/ebean-redis/src/main/java/io/ebean/redis/RedisCacheFactory.java
@@ -139,7 +139,7 @@ final class RedisCacheFactory implements ServerCacheFactory {
     RedisCache redisCache = createRedisCache(config);
     boolean nearCache = config.getCacheOptions().isNearCache();
     if (!nearCache) {
-      return redisCache;
+      return config.tenantAware(redisCache);
     }
 
     String cacheKey = config.getCacheKey();
@@ -147,7 +147,7 @@ final class RedisCacheFactory implements ServerCacheFactory {
     near.periodicTrim(executor);
     DuelCache duelCache = new DuelCache(near, redisCache, cacheKey, nearCacheNotify);
     nearCacheMap.put(cacheKey, duelCache);
-    return duelCache;
+    return config.tenantAware(duelCache);
   }
 
   private RedisCache createRedisCache(ServerCacheConfig config) {
@@ -173,7 +173,7 @@ final class RedisCacheFactory implements ServerCacheFactory {
         cache.periodicTrim(executor);
         queryCaches.put(config.getCacheKey(), cache);
       }
-      return cache;
+      return config.tenantAware(cache);
     } finally {
       lock.unlock();
     }

--- a/ebean-redis/src/test/java/org/integration/ClusterTest.java
+++ b/ebean-redis/src/test/java/org/integration/ClusterTest.java
@@ -40,14 +40,14 @@ public class ClusterTest {
     foo.save();
 
     DB.cacheManager().clearAll();
-    DB.getDefault().metaInfo().resetAllMetrics();
+    db.metaInfo().resetAllMetrics();
     other.metaInfo().resetAllMetrics();
 
     Person fooA = DB.find(Person.class, foo.getId());
     allowAsyncMessaging(); // allow time for background cache load
     Person fooB = other.find(Person.class, foo.getId());
 
-    DuelCache dualCacheA = (DuelCache) DB.cacheManager().beanCache(Person.class);
+    DuelCache dualCacheA = db.cacheManager().beanCache(Person.class).unwrap(DuelCache.class);
     assertCounts(dualCacheA, 0, 1, 0, 1);
     fooA = DB.find(Person.class, foo.getId());
     assertCounts(dualCacheA, 1, 1, 0, 1);
@@ -55,7 +55,7 @@ public class ClusterTest {
     fooA = DB.find(Person.class, foo.getId());
     assertCounts(dualCacheA, 2, 1, 0, 1);
     fooB = other.find(Person.class, foo.getId());
-    DuelCache dualCacheB = (DuelCache) other.cacheManager().beanCache(Person.class);
+    DuelCache dualCacheB = other.cacheManager().beanCache(Person.class).unwrap(DuelCache.class);
     assertCounts(dualCacheB, 2, 1, 1, 0);
   }
 
@@ -73,7 +73,7 @@ public class ClusterTest {
     other.cacheManager().clearAll();
     other.metaInfo().resetAllMetrics();
 
-    DuelCache dualCache = (DuelCache) other.cacheManager().beanCache(Person.class);
+    DuelCache dualCache = other.cacheManager().beanCache(Person.class).unwrap(DuelCache.class);
 
     Person foo0 = other.find(Person.class, 1);
     assertCounts(dualCache, 0, 1, 0, 1);

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/TestNatKeyCacheWithForeignKey.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/TestNatKeyCacheWithForeignKey.java
@@ -117,9 +117,9 @@ public class TestNatKeyCacheWithForeignKey extends BaseTestCase {
 
   @Test
   public void findSimple() {
-
     setupData();
     clearAllL2Cache();
+    appStats();
 
     OCachedApp app0 = findAppByName("app0");
     assertThat(app0).isNotNull();


### PR DESCRIPTION
The design change is to use TenantAwareCache to deal with wrap/unwrap of tenant aware keys, removing any tenant awareness from the underlying cache implementations (DefaultServerCache, redis, hazelcast etc).