### PR TITLE
beanCache order by & clear did not work

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -524,7 +524,7 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
     }
     if (result instanceof BeanList) {
       OrderBy<T> orderBy = query.getOrderBy();
-      if (orderBy != null) {
+      if (orderBy != null && !orderBy.isEmpty()) {
         // in memory sort after merging the cache hits with the DB hits
         beanDescriptor.sort(((BeanList<T>) result).getActualList(), orderBy.toStringFormat());
       }
@@ -543,7 +543,7 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   @Override
   public List<T> beanCacheHits() {
     OrderBy<T> orderBy = query.getOrderBy();
-    if (orderBy != null) {
+    if (orderBy != null && !orderBy.isEmpty()) {
       beanDescriptor.sort(cacheBeans, orderBy.toStringFormat());
     }
     return cacheBeans;
@@ -552,7 +552,7 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   @Override
   public <K> Map<K, T> beanCacheHitsAsMap() {
     OrderBy<T> orderBy = query.getOrderBy();
-    if (orderBy != null) {
+    if (orderBy != null && !orderBy.isEmpty()) {
       beanDescriptor.sort(cacheBeans, orderBy.toStringFormat());
     }
     return cacheBeansToMap();

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByClear.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByClear.java
@@ -6,6 +6,7 @@ import io.ebean.OrderBy;
 import io.ebean.Query;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Order;
+import org.tests.model.basic.OrderDetail;
 import org.tests.model.basic.ResetBasicData;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,6 +37,19 @@ public class TestOrderByClear extends BaseTestCase {
 
     assertTrue(sql.contains("order by t0.ship_date"));
 
+  }
+  
+  @Test
+  public void testWithCache() {
+    ResetBasicData.reset();
+
+    Query<OrderDetail> query = DB.find(OrderDetail.class).where().idIn(1,2,3).query();
+    query.setUseCache(true);
+    query.findList();
+    query.order().asc("cretime").findList(); // hit cache
+    query.order().clear();
+    query.findList(); // hit cache again
+    
   }
 
 }


### PR DESCRIPTION
We noticed this bug, when `orderBy.clear()` was used and result comes from BeanCache.

Without this fix, `orderBy.toStringFormat()` returns null and this value is put into the ConcurrentHashMap

Stack trace
{code}
java.lang.NullPointerException
    at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1690)
    at io.ebeaninternal.server.deploy.BeanDescriptor.elComparator(BeanDescriptor.java:2185)
    at io.ebeaninternal.server.deploy.BeanDescriptor.sort(BeanDescriptor.java:2181)
    at io.ebeaninternal.server.core.OrmQueryRequest.beanCacheHits(OrmQueryRequest.java:547)
    at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1447)
    at io.ebeaninternal.server.core.DefaultServer.findList(DefaultServer.java:1438)
    at io.ebeaninternal.server.querydefn.DefaultOrmQuery.findList(DefaultOrmQuery.java:1483)
{code}

I added a test for "findList", but the problem may also occur in "findMap" or "mergeCacheHitsToList"