### PR TITLE
Produce deterministic DDL if @Inheritance is used

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
@@ -7,12 +7,14 @@ import javax.persistence.DiscriminatorType;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Represents a node in the Inheritance tree.
  * Holds information regarding Super Subclass support.
  */
-public final class DeployInheritInfo {
+public final class DeployInheritInfo implements Comparable<DeployInheritInfo> {
 
   /**
    * the default discriminator column according to the JPA 1.0 spec.
@@ -27,7 +29,7 @@ public final class DeployInheritInfo {
   private String columnDefn;
   private final Class<?> type;
   private Class<?> parent;
-  private final ArrayList<DeployInheritInfo> children = new ArrayList<>();
+  private final Set<DeployInheritInfo> children = new TreeSet<>();
 
   /**
    * Create for a given type.
@@ -74,7 +76,7 @@ public final class DeployInheritInfo {
   /**
    * Return the child nodes.
    */
-  public List<DeployInheritInfo> children() {
+  public Set<DeployInheritInfo> children() {
     return children;
   }
 
@@ -251,7 +253,22 @@ public final class DeployInheritInfo {
 
   @Override
   public String toString() {
-    return "InheritInfo[" + type.getName() + "]" + " root[" + parent.getName() + "]" + " disValue[" + discriminatorStringValue + "]";
+    String root = parent == null ? null : parent.getName();
+    String name = type == null ? null : type.getName();
+    return "InheritInfo[" + name + "]" + " root[" + root + "]" + " disValue[" + discriminatorStringValue + "]";
+  }
+
+  @Override
+  public int compareTo(DeployInheritInfo o) {
+    if (o == this || o.discriminatorStringValue == null && discriminatorStringValue == null) {
+      return 0;
+    } else if (o.discriminatorStringValue == null) {
+      return 1;
+    } else if (discriminatorStringValue == null) {
+      return -1;
+    } else {
+      return discriminatorStringValue.compareTo(o.discriminatorStringValue);
+    }
   }
 
 }


### PR DESCRIPTION
We had an issue, that the generated DDL scripts will change, if beans are added in a different order to database config.

For example
```java
databaseConfig.addClass(AbstractInheritBase.class)
databaseConfig.addClass(InheritFoo.class)
databaseConfig.addClass(InheritBar.class)
```
will produce a DDL create table with all fields in this order: `fields of base`, `fields of foo`, `fields of bar`

Switching to 
```java
databaseConfig.addClass(InheritBar.class)
databaseConfig.addClass(InheritFoo.class)
```
will change also the generated DDL.

As there is done a lot of effort in logically sorting the fields in DeployCreateProperties, I think it makes sense to keep a deterministic order also for beans that uses `@Inheritance`. I decided to order by the discriminator string value

**Background**

We use ebean in a spring app. As spring already does as class path scan, we use that result for `DatabaseConfig.setClasses`
This saves us from a second class path scan and gives us 2-3 seconds in startup time.
Unfortunately, the class path scanner from spring is not deterministic, so we wondered why the DDL swaps fields from time to time.

Of course, as workaround we can sort the classes from the classpath scan and passes them in a deterministic form to DatabaseConfig

The problem will also not occur when using avaje-classpath scanner as this uses a sorted TreeSet

