### PR TITLE
Bump avaje classpath scanner to 7.1, ignores module-info, uses System.Logger (not slf4j-api)

### DIFF
--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>classpath-scanner</artifactId>
-      <version>6.2</version>
+      <version>7.1</version>
     </dependency>
 
     <dependency>

--- a/ebean-externalmapping-xml/pom.xml
+++ b/ebean-externalmapping-xml/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>classpath-scanner</artifactId>
-      <version>6.2</version>
+      <version>7.1</version>
     </dependency>
 
     <!-- test dependencies -->


### PR DESCRIPTION
Note that projects with query bean generator don't use classpath scanning (because the query bean generator has found all the entity classes + adapters etc to register and this is generated as code in `_Ebean$ModuleInfo`).

That is, classpath scanner is only used in the fallback case.

Also note, `System.Logger` is part of the JDK and there is some background as to why I am moving various libraries (like avaje classpath scanner, avaje-inject, avaje-jsonb, avaje-config etc) away from using slf4j-api to using System.Logger.  

If we want System.Logger to forward to slf4j-api we can use https://github.com/avaje/slf4j-jdk-platform-logging .  For projects that "do nothing" wrt System.Logger the logs will default to going to JUL (java util logging). It will interesting to see if there is push back against these libraries moving towards System.Logger (but I've had no push back yet).
