### PR TITLE
Test case for lazy @OneToOne beans with @History

### DIFF
--- a/ebean-test/src/test/java/org/tests/model/history/HistoryOneToOne.java
+++ b/ebean-test/src/test/java/org/tests/model/history/HistoryOneToOne.java
@@ -1,0 +1,32 @@
+package org.tests.model.history;
+
+import io.ebean.annotation.History;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+import org.tests.model.draftable.BaseDomain;
+
+@History
+@Entity
+public class HistoryOneToOne extends BaseDomain {
+
+  String name;
+
+  @OneToOne(cascade = {CascadeType.REFRESH, CascadeType.REFRESH})
+  HistorylessOneToOne historylessOneToOne;
+
+  public HistoryOneToOne(String name) {
+    this.name = name;
+  }
+
+  public HistoryOneToOne() {
+  }
+
+  public HistorylessOneToOne getHistorylessOneToOne() {
+    return historylessOneToOne;
+  }
+
+  public void setHistorylessOneToOne(final HistorylessOneToOne historylessOneToOne) {
+    this.historylessOneToOne = historylessOneToOne;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/history/HistorylessOneToOne.java
+++ b/ebean-test/src/test/java/org/tests/model/history/HistorylessOneToOne.java
@@ -1,0 +1,28 @@
+package org.tests.model.history;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+import org.tests.model.draftable.BaseDomain;
+
+@Entity
+public class HistorylessOneToOne extends BaseDomain {
+  private String name;
+
+  public HistorylessOneToOne() {}
+
+  public HistorylessOneToOne(final String name) {
+    this.name = name;
+  }
+
+  @OneToOne(mappedBy = "historylessOneToOne", cascade = CascadeType.ALL, orphanRemoval = true)
+  HistoryOneToOne historyOneToOne;
+
+  public HistoryOneToOne getHistoryOneToOne() {
+    return historyOneToOne;
+  }
+
+  public void setHistoryOneToOne(final HistoryOneToOne historyOneToOne) {
+    this.historyOneToOne = historyOneToOne;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/history/TestHistoryOneToOne.java
+++ b/ebean-test/src/test/java/org/tests/model/history/TestHistoryOneToOne.java
@@ -1,0 +1,33 @@
+package org.tests.model.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.ebean.DB;
+import io.ebean.annotation.Platform;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import io.ebean.xtest.IgnorePlatform;
+import java.sql.Timestamp;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class TestHistoryOneToOne extends BaseTestCase {
+
+  @IgnorePlatform({Platform.ORACLE, Platform.COCKROACH})
+  @Test
+  public void test() throws InterruptedException {
+    HistorylessOneToOne historylessOneToOne = new HistorylessOneToOne();
+    historylessOneToOne.setHistoryOneToOne(new HistoryOneToOne("one"));
+    DB.save(historylessOneToOne);
+    Thread.sleep(20);
+    LoggedSql.start();
+
+    HistoryOneToOne oneFetched = DB.find(HistoryOneToOne.class)
+                          .asOf(new Timestamp(System.currentTimeMillis()))
+                          .findOne();
+
+    assertThat(oneFetched.getHistorylessOneToOne().getHistoryOneToOne().getId()).isEqualTo(historylessOneToOne.getHistoryOneToOne().getId());
+
+    List<String> sql = LoggedSql.stop();
+  }
+}


### PR DESCRIPTION
Ebean produces an invalid query when trying to lazy load @OneToOne
from a historical bean. This test asserts working behaviour.