### PR TITLE
Remove deprecated methods from FetchConfig, migrate new FetchConfig().query(50) -> FetchConfig.ofQuery(50)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/FetchConfig.java
+++ b/ebean-api/src/main/java/io/ebean/FetchConfig.java
@@ -13,8 +13,7 @@ import java.io.Serializable;
  * }</pre>
  * <p>
  * Example: Using a "query join" instead of a "fetch join" we instead use 2 SQL queries
- * </p>
- * <p>
+ *
  * <pre>{@code
  *
  * // This will use 2 SQL queries to build this object graph
@@ -27,9 +26,6 @@ import java.io.Serializable;
  * // query 2) find orderDetails where order.id in (?,?...) // first 100 order id's
  *
  * }</pre>
- *
- * @author mario
- * @author rbygrave
  */
 public final class FetchConfig implements Serializable {
 
@@ -40,21 +36,9 @@ public final class FetchConfig implements Serializable {
   private static final int LAZY_MODE = 2;
   private static final int CACHE_MODE = 3;
 
-  private int mode;
-  private int batchSize;
-  private int hashCode;
-
-  /**
-   * Deprecated - migrate to one of the static factory methods like {@link FetchConfig#ofQuery()}
-   * <p>
-   * Construct using default JOIN mode.
-   */
-  @Deprecated
-  public FetchConfig() {
-    //this.mode = JOIN_MODE;
-    this.batchSize = 100;
-    this.hashCode = 1000;
-  }
+  private final int mode;
+  private final int batchSize;
+  private final int hashCode;
 
   private FetchConfig(int mode, int batchSize) {
     this.mode = mode;
@@ -104,94 +88,6 @@ public final class FetchConfig implements Serializable {
    */
   public static FetchConfig ofDefault() {
     return new FetchConfig(JOIN_MODE, 100);
-  }
-
-  /**
-   * We want to migrate away from mutating FetchConfig to a fully immutable FetchConfig.
-   */
-  private FetchConfig mutate(int mode, int batchSize) {
-    if (batchSize < 0) {
-      throw new IllegalArgumentException("batch size " + batchSize + " must be > 0");
-    }
-    this.mode = mode;
-    this.batchSize = batchSize;
-    this.hashCode = mode + 10 * batchSize;
-    return this;
-  }
-
-  /**
-   * Deprecated - migrate to FetchConfig.ofLazy().
-   */
-  @Deprecated
-  public FetchConfig lazy() {
-    return mutate(LAZY_MODE, 0);
-  }
-
-  /**
-   * Deprecated - migrate to FetchConfig.ofLazy(batchSize).
-   */
-  @Deprecated
-  public FetchConfig lazy(int batchSize) {
-    return mutate(LAZY_MODE, batchSize);
-  }
-
-  /**
-   * Deprecated - migrate to FetchConfig.ofQuery().
-   * <p>
-   * Eagerly fetch the beans in this path as a separate query (rather than as
-   * part of the main query).
-   * <p>
-   * This will use the default batch size for separate query which is 100.
-   */
-  @Deprecated
-  public FetchConfig query() {
-    return mutate(QUERY_MODE, 100);
-  }
-
-  /**
-   * Deprecated - migrate to FetchConfig.ofQuery(batchSize).
-   * <p>
-   * Eagerly fetch the beans in this path as a separate query (rather than as
-   * part of the main query).
-   * <p>
-   * The queryBatchSize is the number of parent id's that this separate query
-   * will load per batch.
-   * <p>
-   * This will load all beans on this path eagerly unless a {@link #lazy(int)}
-   * is also used.
-   *
-   * @param batchSize the batch size used to load beans on this path
-   */
-  @Deprecated
-  public FetchConfig query(int batchSize) {
-    return mutate(QUERY_MODE, batchSize);
-  }
-
-  /**
-   * Deprecated - migrate to FetchConfig.ofQuery(batchSize).
-   * <p>
-   * Eagerly fetch the first batch of beans on this path.
-   * This is similar to {@link #query(int)} but only fetches the first batch.
-   * <p>
-   * If there are more parent beans than the batch size then they will not be
-   * loaded eagerly but instead use lazy loading.
-   *
-   * @param batchSize the number of parent beans this path is populated for
-   */
-  @Deprecated
-  public FetchConfig queryFirst(int batchSize) {
-    return query(batchSize);
-  }
-
-  /**
-   * Deprecated - migrate to FetchConfig.ofCache().
-   * <p>
-   * Eagerly fetch the beans fetching the beans from the L2 bean cache
-   * and using the DB for beans not in the cache.
-   */
-  @Deprecated
-  public FetchConfig cache() {
-    return mutate(CACHE_MODE, 100);
   }
 
   /**

--- a/ebean-test/src/test/java/io/ebean/xtest/base/FetchConfigTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/FetchConfigTest.java
@@ -9,31 +9,31 @@ public class FetchConfigTest {
 
   @Test
   public void testLazy() {
-    FetchConfig config = new FetchConfig().lazy();
+    FetchConfig config = FetchConfig.ofLazy();
     assertThat(config.getBatchSize()).isEqualTo(0);
   }
 
   @Test
   public void testLazy_withParameter() {
-    FetchConfig config = new FetchConfig().lazy(50);
+    FetchConfig config = FetchConfig.ofLazy(50);
     assertThat(config.getBatchSize()).isEqualTo(50);
   }
 
   @Test
   public void testQuery() {
-    FetchConfig config = new FetchConfig().query();
+    FetchConfig config = FetchConfig.ofQuery();
     assertThat(config.getBatchSize()).isEqualTo(100);
   }
 
   @Test
   public void testQuery_withParameter() {
-    FetchConfig config = new FetchConfig().query(50);
+    FetchConfig config = FetchConfig.ofQuery(50);
     assertThat(config.getBatchSize()).isEqualTo(50);
   }
 
   @Test
   public void testQueryFirst() {
-    FetchConfig config = new FetchConfig().queryFirst(50);
+    FetchConfig config = FetchConfig.ofQuery(50);
     assertThat(config.getBatchSize()).isEqualTo(50);
   }
 
@@ -52,67 +52,67 @@ public class FetchConfigTest {
 
   @Test
   public void testEquals_when_noOptions() {
-    assertSame(new FetchConfig(), new FetchConfig());
+    assertSame(FetchConfig.ofDefault(), FetchConfig.ofDefault());
   }
 
   @Test
   public void testEquals_when_query_50_lazy_40() {
-    assertSame(new FetchConfig().query(50), FetchConfig.ofQuery(50));
+    assertSame(FetchConfig.ofQuery(50), FetchConfig.ofQuery(50));
   }
 
   @Test
   public void testEquals_when_query_50_lazy() {
-    assertSame(new FetchConfig().lazy(), FetchConfig.ofLazy());
+    assertSame(FetchConfig.ofLazy(), FetchConfig.ofLazy());
   }
 
   @Test
   public void testEquals_when_query_50() {
-    assertSame(new FetchConfig().query(50), new FetchConfig().query(50));
+    assertSame(FetchConfig.ofQuery(50), FetchConfig.ofQuery(50));
   }
 
   @Test
   public void testEquals_when_queryFirst_50_lazy_40() {
-    assertSame(new FetchConfig().queryFirst(50).lazy(40), FetchConfig.ofLazy(40));
+    assertSame(FetchConfig.ofLazy(40), FetchConfig.ofLazy(40));
   }
 
   @Test
   public void testEquals_when_queryFirst_50_lazy() {
-    assertSame(new FetchConfig().queryFirst(50).lazy(), new FetchConfig().queryFirst(50).lazy());
+    assertSame(FetchConfig.ofLazy(), FetchConfig.ofLazy());
   }
 
   @Test
   public void testEquals_when_queryFirst_50() {
-    assertSame(new FetchConfig().queryFirst(50), FetchConfig.ofQuery(50));
+    assertSame(FetchConfig.ofQuery(50), FetchConfig.ofQuery(50));
   }
 
   @Test
   public void testNotEquals_when_query_50() {
-    assertDifferent(new FetchConfig().query(50), new FetchConfig().query(40));
+    assertDifferent(FetchConfig.ofQuery(50), FetchConfig.ofQuery(40));
   }
 
   @Test
   public void testNotEquals_when_query_50_lazy() {
-    assertDifferent(new FetchConfig().query(50), new FetchConfig().query(50).lazy());
+    assertDifferent(FetchConfig.ofQuery(50), FetchConfig.ofLazy(50));
   }
 
   @Test
   public void testNotEquals_when_query_50_lazy_40() {
-    assertDifferent(new FetchConfig().query(50), new FetchConfig().query(50).lazy(40));
+    assertDifferent(FetchConfig.ofQuery(50), FetchConfig.ofLazy(40));
   }
 
   @Test
   public void testNotEquals_when_queryFirst_50() {
-    assertDifferent(new FetchConfig().queryFirst(50), new FetchConfig().queryFirst(40));
+    assertDifferent(FetchConfig.ofQuery(50), FetchConfig.ofQuery(40));
   }
 
   @Test
   public void testNotEquals_when_queryFirst_50_lazy() {
-    assertDifferent(new FetchConfig().queryFirst(50), new FetchConfig().queryFirst(50).lazy());
+    assertDifferent(FetchConfig.ofQuery(50), FetchConfig.ofLazy());
   }
 
   @Test
   public void testNotEquals_when_queryFirst_50_lazy_40() {
-    assertDifferent(new FetchConfig().queryFirst(50), new FetchConfig().queryFirst(50).lazy(40));
+    assertDifferent(FetchConfig.ofQuery(50), FetchConfig.ofLazy(40));
   }
 
   void assertDifferent(FetchConfig v1, FetchConfig v2) {


### PR DESCRIPTION
All removed methods are renamed. Migrate to use the renamed method.
