### PR TITLE
Remove deprecated methods from SpiServer, migrate getServerConfig() -> config() etc

### DIFF
--- a/ebean-api/src/main/java/io/ebean/event/BulkTableEvent.java
+++ b/ebean-api/src/main/java/io/ebean/event/BulkTableEvent.java
@@ -11,14 +11,6 @@ public interface BulkTableEvent {
   String tableName();
 
   /**
-   * Deprecated migrate to tableName().
-   */
-  @Deprecated
-  default String getTableName() {
-    return tableName();
-  }
-
-  /**
    * Return true if rows were inserted.
    */
   boolean isInsert();

--- a/ebean-api/src/main/java/io/ebean/plugin/SpiServer.java
+++ b/ebean-api/src/main/java/io/ebean/plugin/SpiServer.java
@@ -19,25 +19,9 @@ public interface SpiServer extends Database {
   DatabaseConfig config();
 
   /**
-   * Migrate to config().
-   */
-  @Deprecated
-  default DatabaseConfig getServerConfig() {
-    return config();
-  }
-
-  /**
    * Return the DatabasePlatform for this database.
    */
   DatabasePlatform databasePlatform();
-
-  /**
-   * Migrate to config().
-   */
-  @Deprecated
-  default DatabasePlatform getDatabasePlatform() {
-    return databasePlatform();
-  }
 
   /**
    * Return all the bean types registered on this server instance.
@@ -45,25 +29,9 @@ public interface SpiServer extends Database {
   List<? extends BeanType<?>> beanTypes();
 
   /**
-   * Migrate to beanTypes().
-   */
-  @Deprecated
-  default List<? extends BeanType<?>> getBeanTypes() {
-    return beanTypes();
-  }
-
-  /**
    * Return the bean type for a given entity bean class.
    */
   <T> BeanType<T> beanType(Class<T> beanClass);
-
-  /**
-   * Migrate to beanType().
-   */
-  @Deprecated
-  default <T> BeanType<T> getBeanType(Class<T> beanClass) {
-    return beanType(beanClass);
-  }
 
   /**
    * Return the bean types mapped to the given base table.
@@ -71,25 +39,9 @@ public interface SpiServer extends Database {
   List<? extends BeanType<?>> beanTypes(String baseTableName);
 
   /**
-   * Migrate to beanTypes().
-   */
-  @Deprecated
-  default List<? extends BeanType<?>> getBeanTypes(String baseTableName) {
-    return beanTypes(baseTableName);
-  }
-
-  /**
    * Return the bean type for a given doc store queueId.
    */
   BeanType<?> beanTypeForQueueId(String queueId);
-
-  /**
-   * Migrate to beanTypes().
-   */
-  @Deprecated
-  default BeanType<?> getBeanTypeForQueueId(String queueId) {
-    return beanTypeForQueueId(queueId);
-  }
 
   /**
    * Return a BeanLoader.


### PR DESCRIPTION
All removed methods are renamed. Migrate to use the renamed method.