### PR TITLE
Remove deprecated methods from Transaction, migrate setBatchGetGeneratedKeys() -> setGetGeneratedKeys() etc

### DIFF
--- a/ebean-api/src/main/java/io/ebean/Transaction.java
+++ b/ebean-api/src/main/java/io/ebean/Transaction.java
@@ -441,14 +441,6 @@ public interface Transaction extends AutoCloseable {
   void setGetGeneratedKeys(boolean getGeneratedKeys);
 
   /**
-   * Deprecated renamed to setGetGeneratedKeys().
-   */
-  @Deprecated
-  default void setBatchGetGeneratedKeys(boolean getGeneratedKeys) {
-    setGetGeneratedKeys(getGeneratedKeys);
-  }
-
-  /**
    * By default when mixing UpdateSql (or CallableSql) with Beans the batch is
    * automatically flushed when you change (between persisting beans and
    * executing UpdateSql or CallableSql).
@@ -464,14 +456,6 @@ public interface Transaction extends AutoCloseable {
   void setFlushOnMixed(boolean batchFlushOnMixed);
 
   /**
-   * Deprecated renamed to setFlushOnMixed().
-   */
-  @Deprecated
-  default void setBatchFlushOnMixed(boolean batchFlushOnMixed) {
-    setFlushOnMixed(batchFlushOnMixed);
-  }
-
-  /**
    * By default executing a query will automatically flush any batched
    * statements (persisted beans, executed UpdateSql etc).
    * <p>
@@ -481,28 +465,12 @@ public interface Transaction extends AutoCloseable {
   void setFlushOnQuery(boolean batchFlushOnQuery);
 
   /**
-   * Deprecated renamed to setFlushOnQuery().
-   */
-  @Deprecated
-  default void setBatchFlushOnQuery(boolean batchFlushOnQuery) {
-    setFlushOnQuery(batchFlushOnQuery);
-  }
-
-  /**
    * Return true if the batch (of persisted beans or executed UpdateSql etc)
    * should be flushed prior to executing a query.
    * <p>
    * The default is for this to be true.
    */
   boolean isFlushOnQuery();
-
-  /**
-   * Deprecated renamed to isFlushOnQuery().
-   */
-  @Deprecated
-  default boolean isBatchFlushOnQuery() {
-    return isFlushOnQuery();
-  }
 
   /**
    * The batch will be flushing automatically but you can use this to explicitly
@@ -520,14 +488,6 @@ public interface Transaction extends AutoCloseable {
   void flush() throws PersistenceException;
 
   /**
-   * Deprecated - migrate to flush().
-   * <p>
-   * flush() is preferred as it matches the JPA flush() method.
-   */
-  @Deprecated
-  void flushBatch() throws PersistenceException;
-
-  /**
    * Return the underlying Connection object.
    * <p>
    * Useful where a Developer wishes to use the JDBC API directly. Note that the
@@ -539,14 +499,6 @@ public interface Transaction extends AutoCloseable {
    * Savepoints, advanced CLOB BLOB use and advanced stored procedure calls.
    */
   Connection connection();
-
-  /**
-   * Deprecated migrate to connection().
-   */
-  @Deprecated
-  default Connection getConnection() {
-    return connection();
-  }
 
   /**
    * Add table modification information to the TransactionEvent.

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
@@ -313,11 +313,6 @@ public abstract class SpiTransactionProxy implements SpiTransaction {
   }
 
   @Override
-  public void flushBatch() throws PersistenceException {
-    flush();
-  }
-
-  @Override
   public Connection connection() {
     return transaction.connection();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -378,17 +378,10 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
   /**
    * Flush any queued persist requests.
    * <p>
-   * This is general will result in a number of batched PreparedStatements
-   * executing.
-   * </p>
+   * This is general will result in a number of batched PreparedStatements executing.
    */
   @Override
   public void flush() {
-  }
-
-  @Override
-  public void flushBatch() {
-    flush();
   }
 
   /**
@@ -405,7 +398,6 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    * This could be considered similar to EJB3 Extended PersistanceContext. In
    * that you get the PersistanceContext from a transaction, hold onto it, and
    * then set it back later to a second transaction.
-   * </p>
    */
   @Override
   public void setPersistenceContext(SpiPersistenceContext context) {
@@ -503,7 +495,6 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    * <p>
    * This leaves the transaction active and expects another commit
    * to occur later (which closes the underlying connection etc).
-   * </p>
    */
   @Override
   public void commitAndContinue() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -758,11 +758,6 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
     internalBatchFlush();
   }
 
-  @Override
-  public final void flushBatch() {
-    flush();
-  }
-
   /**
    * Flush the JDBC batch and execute derived relationship statements if necessary.
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
@@ -284,10 +284,6 @@ final class NoTransaction implements SpiTransaction {
   }
 
   @Override
-  public void flushBatch() throws PersistenceException {
-  }
-
-  @Override
   public Connection connection() {
     return null;
   }


### PR DESCRIPTION
All removed methods are renamed. Migrate to use the renamed method.

```java
  /**
   * Deprecated renamed to setGetGeneratedKeys().
   */
  @Deprecated
  default void setBatchGetGeneratedKeys(boolean getGeneratedKeys) {
    setGetGeneratedKeys(getGeneratedKeys);
  }

  /**
   * Deprecated renamed to setFlushOnMixed().
   */
  @Deprecated
  default void setBatchFlushOnMixed(boolean batchFlushOnMixed) {
    setFlushOnMixed(batchFlushOnMixed);
  }

  /**
   * Deprecated renamed to setFlushOnQuery().
   */
  @Deprecated
  default void setBatchFlushOnQuery(boolean batchFlushOnQuery) {
    setFlushOnQuery(batchFlushOnQuery);
  }

  /**
   * Deprecated renamed to isFlushOnQuery().
   */
  @Deprecated
  default boolean isBatchFlushOnQuery() {
    return isFlushOnQuery();
  }

  /**
   * Deprecated - migrate to flush().
   * <p>
   * flush() is preferred as it matches the JPA flush() method.
   */
  @Deprecated
  void flushBatch() throws PersistenceException;

  /**
   * Deprecated migrate to connection().
   */
  @Deprecated
  default Connection getConnection() {
    return connection();
  }


```