### PR TITLE
Remove deprecated methods from BeanPersistRequest, BeanQueryRequest, BeanDeleteIdRequest

### DIFF
--- a/ebean-api/src/main/java/io/ebean/event/BeanDeleteIdRequest.java
+++ b/ebean-api/src/main/java/io/ebean/event/BeanDeleteIdRequest.java
@@ -1,7 +1,6 @@
 package io.ebean.event;
 
 import io.ebean.Database;
-import io.ebean.EbeanServer;
 import io.ebean.Transaction;
 
 /**
@@ -10,25 +9,9 @@ import io.ebean.Transaction;
 public interface BeanDeleteIdRequest {
 
   /**
-   * Deprecated migrate to database().
-   */
-  @Deprecated
-  EbeanServer getEbeanServer();
-
-  /**
-   * Deprecated migrate to database().
-   */
-  @Deprecated
-  default Database getDatabase() {
-    return getEbeanServer();
-  }
-
-  /**
    * Return the DB processing the request.
    */
-  default Database database() {
-    return getEbeanServer();
-  }
+  Database database();
 
   /**
    * Return the Transaction associated with this request.
@@ -36,36 +19,13 @@ public interface BeanDeleteIdRequest {
   Transaction transaction();
 
   /**
-   * Deprecated migrate to transaction().
-   */
-  @Deprecated
-  default Transaction getTransaction() {
-    return transaction();
-  }
-
-  /**
    * Returns the bean type of the bean being deleted.
    */
   Class<?> beanType();
-
-  /**
-   * Deprecated migrate to beanType().
-   */
-  @Deprecated
-  default Class<?> getBeanType() {
-    return beanType();
-  }
 
   /**
    * Returns the Id value of the bean being deleted.
    */
   Object id();
 
-  /**
-   * Deprecated migrate to id().
-   */
-  @Deprecated
-  default Object getId() {
-    return id();
-  }
 }

--- a/ebean-api/src/main/java/io/ebean/event/BeanPersistRequest.java
+++ b/ebean-api/src/main/java/io/ebean/event/BeanPersistRequest.java
@@ -1,7 +1,6 @@
 package io.ebean.event;
 
 import io.ebean.Database;
-import io.ebean.EbeanServer;
 import io.ebean.Transaction;
 import io.ebean.ValuePair;
 
@@ -20,28 +19,12 @@ public interface BeanPersistRequest<T> {
   /**
    * Return the DB processing the request.
    */
-  default Database database() {
-    return getEbeanServer();
-  }
-
-  /**
-   * Deprecated migrate to database().
-   */
-  @Deprecated
-  EbeanServer getEbeanServer();
+  Database database();
 
   /**
    * Return the Transaction associated with this request.
    */
   Transaction transaction();
-
-  /**
-   * Deprecated migrate to transaction().
-   */
-  @Deprecated
-  default Transaction getTransaction() {
-    return transaction();
-  }
 
   /**
    * Return true if this request is due to cascading persist.
@@ -56,14 +39,6 @@ public interface BeanPersistRequest<T> {
   Set<String> loadedProperties();
 
   /**
-   * Deprecated migrate to loadedProperties().
-   */
-  @Deprecated
-  default Set<String> getLoadedProperties() {
-    return loadedProperties();
-  }
-
-  /**
    * For an update this is the set of properties that where updated.
    * <p>
    * Note that hasDirtyProperty() is a more efficient check than this method and
@@ -73,25 +48,9 @@ public interface BeanPersistRequest<T> {
   Set<String> updatedProperties();
 
   /**
-   * Deprecated migrate to updatedProperties().
-   */
-  @Deprecated
-  default Set<String> getUpdatedProperties() {
-    return updatedProperties();
-  }
-
-  /**
    * Flags set for dirty properties (used by ElasticSearch integration).
    */
   boolean[] dirtyProperties();
-
-  /**
-   * Deprecated migrate to updatedProperties().
-   */
-  @Deprecated
-  default boolean[] getDirtyProperties() {
-    return dirtyProperties();
-  }
 
   /**
    * Return true for an update request if at least one of dirty properties is contained
@@ -114,14 +73,6 @@ public interface BeanPersistRequest<T> {
    * Returns the bean being inserted updated or deleted.
    */
   T bean();
-
-  /**
-   * Deprecated migrate to bean().
-   */
-  @Deprecated
-  default T getBean() {
-    return bean();
-  }
 
   /**
    * Returns a map of the properties that have changed and their new and old values.

--- a/ebean-api/src/main/java/io/ebean/event/BeanQueryRequest.java
+++ b/ebean-api/src/main/java/io/ebean/event/BeanQueryRequest.java
@@ -1,7 +1,6 @@
 package io.ebean.event;
 
 import io.ebean.Database;
-import io.ebean.EbeanServer;
 import io.ebean.Query;
 import io.ebean.Transaction;
 
@@ -13,15 +12,7 @@ public interface BeanQueryRequest<T> {
   /**
    * Return the DB processing the request.
    */
-  default Database database() {
-    return getEbeanServer();
-  }
-
-  /**
-   * Deprecated migrate to database().
-   */
-  @Deprecated
-  EbeanServer getEbeanServer();
+  Database database();
 
   /**
    * Return the Transaction associated with this request.
@@ -29,25 +20,9 @@ public interface BeanQueryRequest<T> {
   Transaction transaction();
 
   /**
-   * Deprecated migrate to transaction().
-   */
-  @Deprecated
-  default Transaction getTransaction() {
-    return transaction();
-  }
-
-  /**
    * Returns the query.
    */
   Query<T> query();
-
-  /**
-   * Deprecated migrate to query().
-   */
-  @Deprecated
-  default Query<T> getQuery() {
-    return query();
-  }
 
   /**
    * Return true if an Id IN expression should have the bind parameters padded.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.server.core;
 
-import io.ebean.EbeanServer;
+import io.ebean.Database;
 import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiTransaction;
@@ -79,7 +79,7 @@ public abstract class BeanRequest {
    * Return the server processing the request. Made available for
    * BeanController and BeanFinder.
    */
-  public EbeanServer getEbeanServer() {
+  public Database database() {
     return server;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DeleteIdRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DeleteIdRequest.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.persist;
 
+import io.ebean.Database;
 import io.ebean.EbeanServer;
 import io.ebean.Transaction;
 import io.ebean.event.BeanDeleteIdRequest;
@@ -7,9 +8,9 @@ import io.ebeaninternal.api.SpiEbeanServer;
 
 final class DeleteIdRequest implements BeanDeleteIdRequest {
 
-  private final EbeanServer server;
+  private final SpiEbeanServer server;
   private final Transaction transaction;
-  private Class<?> beanType;
+  private final Class<?> beanType;
   private Object id;
 
   DeleteIdRequest(SpiEbeanServer server, Transaction transaction, Class<?> beanType, Object id) {
@@ -24,7 +25,7 @@ final class DeleteIdRequest implements BeanDeleteIdRequest {
   }
 
   @Override
-  public EbeanServer getEbeanServer() {
+  public Database database() {
     return server;
   }
 

--- a/ebean-core/src/test/java/io/ebeaninternal/server/expression/BaseExpressionTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/expression/BaseExpressionTest.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.server.expression;
 
-import io.ebean.EbeanServer;
+import io.ebean.Database;
 import io.ebean.Query;
 import io.ebean.Transaction;
 import io.ebean.event.BeanQueryRequest;
@@ -62,7 +62,7 @@ public abstract class BaseExpressionTest extends BaseTest {
     }
 
     @Override
-    public EbeanServer getEbeanServer() {
+    public Database database() {
       return null;
     }
 


### PR DESCRIPTION
All removed methods are renamed. Migrate to use the renamed method.