### PR TITLE
Remove deprecated methods from BackgroundExecutor, migrate executePeriodically() -> scheduleWithFixedDelay()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/BackgroundExecutor.java
+++ b/ebean-api/src/main/java/io/ebean/BackgroundExecutor.java
@@ -40,26 +40,6 @@ public interface BackgroundExecutor {
   void execute(Runnable task);
 
   /**
-   * Deprecated - migrate to scheduleWithFixedDelay().
-   * Execute a task periodically with a fixed delay between each execution.
-   * <p>
-   * For example, execute a runnable every minute.
-   * <p>
-   * The delay is the time between executions no matter how long the task took.
-   * That is, this method has the same behaviour characteristics as
-   * {@link ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}
-   */
-  @Deprecated
-  void executePeriodically(Runnable task, long delay, TimeUnit unit);
-
-  /**
-   * Deprecated - migrate to scheduleWithFixedDelay().
-   * Execute a task periodically additionally with an initial delay different from delay.
-   */
-  @Deprecated
-  void executePeriodically(Runnable task, long initialDelay, long delay, TimeUnit unit);
-
-  /**
    * Execute a task periodically with a given delay.
    *
    * @param task         the task to execute

--- a/ebean-core/src/main/java/io/ebeaninternal/server/executor/DefaultBackgroundExecutor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/executor/DefaultBackgroundExecutor.java
@@ -100,20 +100,9 @@ public final class DefaultBackgroundExecutor implements SpiBackgroundExecutor {
     return pool.submit(wrap(task));
   }
 
-
   @Override
   public void execute(Runnable task) {
     submit(logExceptions(task));
-  }
-
-  @Override
-  public void executePeriodically(Runnable task, long delay, TimeUnit unit) {
-    schedulePool.scheduleWithFixedDelay(wrap(logExceptions(task)), delay, delay, unit);
-  }
-
-  @Override
-  public void executePeriodically(Runnable task, long initialDelay, long delay, TimeUnit unit) {
-    schedulePool.scheduleWithFixedDelay(wrap(logExceptions(task)), initialDelay, delay, unit);
   }
 
   @Override


### PR DESCRIPTION
All removed methods are renamed. Migrate to use the renamed method.

```java

  /**
   * Deprecated - migrate to scheduleWithFixedDelay().
   * Execute a task periodically with a fixed delay between each execution.
   * <p>
   * For example, execute a runnable every minute.
   * <p>
   * The delay is the time between executions no matter how long the task took.
   * That is, this method has the same behaviour characteristics as
   * {@link ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}
   */
  @Deprecated
  void executePeriodically(Runnable task, long delay, TimeUnit unit);

  /**
   * Deprecated - migrate to scheduleWithFixedDelay().
   * Execute a task periodically additionally with an initial delay different from delay.
   */
  @Deprecated
  void executePeriodically(Runnable task, long initialDelay, long delay, TimeUnit unit);

```