### PR TITLE
Fix: CompareTo when discriminatorString is null

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployInheritInfo.java
@@ -260,14 +260,14 @@ public final class DeployInheritInfo implements Comparable<DeployInheritInfo> {
 
   @Override
   public int compareTo(DeployInheritInfo o) {
-    if (o == this || o.discriminatorStringValue == null && discriminatorStringValue == null) {
+    if (o == this) {
       return 0;
     } else if (o.discriminatorStringValue == null) {
       return 1;
     } else if (discriminatorStringValue == null) {
       return -1;
     } else {
-      return discriminatorStringValue.compareTo(o.discriminatorStringValue);
+      return type.getName().compareTo(o.getType().getName());
     }
   }
 


### PR DESCRIPTION
Hello @rbygrave ,

we found a problem in our application with ebean 13.
In case of starting the database, all the entity classes will be scanned and the class-tree will be calculated (`deployMap in DeployInherit`). In some cases any classes wont't be added as a `children` to it's parents.

@rPraml and I debugged it and found the cause: in `DeployInheritInfo` line 87 children will be added to the `children TreeMap`, and the method `compareTo(DeployInheritInfo o)` will be also called. When `discriminatorStringValue` is null for the two classes, the two elements will be found as the "same" and the new element won't be added to the `TreeMap`.

Can you please check it?

Kind regards,
Noemi


