### PR TITLE
#2677 - Fix for trim failing on mutation of lastAccessTime

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCache.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCache.java
@@ -49,6 +49,7 @@ public class DefaultServerCache implements ServerCache {
   protected final int trimFrequency;
   protected final int maxIdleSecs;
   protected final int maxSecsToLive;
+  protected final long trimOnPut;
   protected final ReentrantLock lock = new ReentrantLock();
   protected final AtomicLong mutationCounter = new AtomicLong();
 
@@ -60,6 +61,7 @@ public class DefaultServerCache implements ServerCache {
     this.maxIdleSecs = config.getMaxIdleSecs();
     this.maxSecsToLive = config.getMaxSecsToLive();
     this.trimFrequency = config.determineTrimFrequency();
+    this.trimOnPut = config.determineTrimOnPut();
 
     MetricFactory factory = MetricFactory.get();
     String prefix = "l2n.";
@@ -191,7 +193,7 @@ public class DefaultServerCache implements ServerCache {
   public void put(Object key, Object value) {
     map.put(key, new SoftReference<>(new CacheEntry(key, value)));
     putCount.increment();
-    if (mutationCounter.incrementAndGet() > 1000) {
+    if (mutationCounter.incrementAndGet() > trimOnPut) {
       runEviction();
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheConfig.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheConfig.java
@@ -76,4 +76,14 @@ public final class DefaultServerCacheConfig {
     }
     return 0;
   }
+
+  /**
+   * Determine the number of mutations/puts required to trigger a runEviction() in the foreground.
+   */
+  public long determineTrimOnPut() {
+    if (maxSize > 0) {
+      return maxSize / 10;
+    }
+    return 1000;
+  }
 }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultServerCacheConfigTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultServerCacheConfigTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DefaultServerCacheConfigTest {
-
+class DefaultServerCacheConfigTest {
 
   private DefaultServerCacheConfig create(int maxSize, int maxIdleSecs, int maxSecsToLive, int trimFreq) {
     ServerCacheOptions options = new ServerCacheOptions();
@@ -20,33 +19,45 @@ public class DefaultServerCacheConfigTest {
   }
 
   @Test
-  public void trimFreq_halfIdle() {
-
+  void trimFreq_halfIdle() {
     assertEquals(create(10000,10,20, 0).determineTrimFrequency(), 4);
   }
 
-
   @Test
-  public void trimFreq_halfIdle_withRounding() {
-
+  void trimFreq_halfIdle_withRounding() {
     assertEquals(create(10000,11,20, 0).determineTrimFrequency(), 4);
   }
 
   @Test
-  public void trimFreq_halfTTL() {
-
+  void trimFreq_halfTTL() {
     assertEquals(create(10000,0,20, 0).determineTrimFrequency(), 9);
   }
 
   @Test
-  public void trimFreq_halfTTL_withRounding() {
-
+  void trimFreq_halfTTL_withRounding() {
     assertEquals(create(10000,0,21, 0).determineTrimFrequency(), 9);
   }
 
   @Test
-  public void trimFreq_explicit() {
-
+  void trimFreq_explicit() {
     assertEquals(create(10000,10,20, 42).determineTrimFrequency(), 42);
+  }
+
+  @Test
+  void trimOnPut_default() {
+    assertEquals(create(0,0,0, 0).determineTrimOnPut(), 1_000);
+  }
+
+  @Test
+  void trimOnPut_tenPercent() {
+    assertEquals(create(10_000,0,0, 0).determineTrimOnPut(), 1_000);
+    assertEquals(create(9_000,0,0, 0).determineTrimOnPut(), 900);
+    assertEquals(create(100,0,0, 0).determineTrimOnPut(), 10);
+  }
+
+  @Test
+  void trimOnPut_roundDown() {
+    assertEquals(create(9010,0,0, 0).determineTrimOnPut(), 901);
+    assertEquals(create(9009,0,0, 0).determineTrimOnPut(), 900);
   }
 }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultServerCache_RunEvictionTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultServerCache_RunEvictionTest.java
@@ -17,7 +17,7 @@ class DefaultServerCache_RunEvictionTest {
     cacheOptions.setMaxSize(300);
     cacheOptions.setMaxIdleSecs(1);
     cacheOptions.setMaxSecsToLive(2);
-    cacheOptions.setTrimFrequency(1);
+    cacheOptions.setTrimFrequency(5);
 
     ServerCacheConfig con = new ServerCacheConfig(ServerCacheType.BEAN, "foo", "foo", cacheOptions, null, null);
     return new DefaultServerCache(new DefaultServerCacheConfig(con));
@@ -44,10 +44,10 @@ class DefaultServerCache_RunEvictionTest {
   }
 
   private void doStuff() {
-    for (int i = 0; i < 500; i++) {
+    for (int i = 0; i < 5000; i++) {
       String key = "" + random.nextInt(20000);
       int mode = random.nextInt(10);
-      if (mode < 8) {
+      if (mode < 7) {
         cache.get(key);
       } else {
         cache.put(key, key + "-" + System.currentTimeMillis());

--- a/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultServerCache_RunEvictionTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/cache/DefaultServerCache_RunEvictionTest.java
@@ -10,13 +10,11 @@ import org.junit.jupiter.api.Test;
 import java.util.Random;
 
 
-public class DefaultServerCache_RunEvictionTest {
-
+class DefaultServerCache_RunEvictionTest {
 
   private DefaultServerCache createCache() {
-
     ServerCacheOptions cacheOptions = new ServerCacheOptions();
-    cacheOptions.setMaxSize(10000);
+    cacheOptions.setMaxSize(300);
     cacheOptions.setMaxIdleSecs(1);
     cacheOptions.setMaxSecsToLive(2);
     cacheOptions.setTrimFrequency(1);
@@ -35,8 +33,7 @@ public class DefaultServerCache_RunEvictionTest {
 
   @Disabled("test takes long time")
   @Test
-  public void runEvict() throws InterruptedException {
-
+  void runEvict() throws InterruptedException {
     for (int i = 0; i < 15; i++) {
       doStuff();
       cache.runEviction();
@@ -47,10 +44,8 @@ public class DefaultServerCache_RunEvictionTest {
   }
 
   private void doStuff() {
-
     for (int i = 0; i < 500; i++) {
       String key = "" + random.nextInt(20000);
-
       int mode = random.nextInt(10);
       if (mode < 8) {
         cache.get(key);


### PR DESCRIPTION
Currently, lastAccessTime can mutate during cache trim processing. This fixes this issue by taking a copy of the lastAccessTime storing as lastAccessSort and using that for sorting for cache trim.

This also adds a foreground trigger of the runEviction() to occur based on `trimOnPut` which is either 10% of max size or 1_000.