### PR TITLE
#2647 - When Postgres + isAllQuotedIdentifiers true + using DataSourceConfig THEN `datasourceConfig.addProperty("quoteReturningIdentifiers", false);`

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InitDataSource.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InitDataSource.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.core;
 
+import io.ebean.annotation.Platform;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.datasource.DataSourceAlertFactory;
 import io.ebean.datasource.DataSourceConfig;
@@ -97,8 +98,14 @@ final class InitDataSource {
       dsConfig.setReadOnly(true);
       dsConfig.setDefaults(config.getDataSourceConfig());
       dsConfig.setIsolationLevel(config.getDataSourceConfig().getIsolationLevel());
+    } else if (isPostgresAllQuotedIdentifiers()) {
+      dsConfig.addProperty("quoteReturningIdentifiers", false);
     }
     return create(dsConfig, readOnly);
+  }
+
+  boolean isPostgresAllQuotedIdentifiers() {
+    return config.isAllQuotedIdentifiers() && Platform.POSTGRES == config.getDatabasePlatform().getPlatform().base();
   }
 
   private DataSource create(DataSourceConfig dsConfig, boolean readOnly) {

--- a/ebean-core/src/test/java/io/ebeaninternal/server/core/InitDataSourceTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/core/InitDataSourceTest.java
@@ -4,6 +4,9 @@ import io.ebean.config.DatabaseConfig;
 import io.ebean.datasource.DataSourceAlert;
 import io.ebean.datasource.DataSourceConfig;
 import io.ebean.datasource.DataSourcePool;
+import io.ebean.platform.h2.H2Platform;
+import io.ebean.platform.postgres.Postgres9Platform;
+import io.ebean.platform.postgres.PostgresPlatform;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
@@ -128,6 +131,41 @@ public class InitDataSourceTest {
     assertEquals("foo", roConfig.getUrl());
   }
 
+  @Test
+  void isPostgresAllQuotedIdentifiers_true_when_postgres() {
+    DatabaseConfig config = new DatabaseConfig();
+    config.setAllQuotedIdentifiers(true);
+    config.setDatabasePlatform(new PostgresPlatform());
+
+    assertTrue(new InitDataSource(config).isPostgresAllQuotedIdentifiers());
+  }
+
+  @Test
+  void isPostgresAllQuotedIdentifiers_true_when_postgres9() {
+    DatabaseConfig config = new DatabaseConfig();
+    config.setAllQuotedIdentifiers(true);
+    config.setDatabasePlatform(new Postgres9Platform());
+
+    assertTrue(new InitDataSource(config).isPostgresAllQuotedIdentifiers());
+  }
+
+  @Test
+  void isPostgresAllQuotedIdentifiers_false() {
+    DatabaseConfig config = new DatabaseConfig();
+    config.setAllQuotedIdentifiers(false);
+    config.setDatabasePlatform(new PostgresPlatform());
+
+    assertFalse(new InitDataSource(config).isPostgresAllQuotedIdentifiers());
+  }
+
+  @Test
+  void isPostgresAllQuotedIdentifiers_false_when_notPostgres() {
+    DatabaseConfig config = new DatabaseConfig();
+    config.setAllQuotedIdentifiers(true);
+    config.setDatabasePlatform(new H2Platform());
+
+    assertFalse(new InitDataSource(config).isPostgresAllQuotedIdentifiers());
+  }
 
   @Test
   public void online() {


### PR DESCRIPTION
I think there is not a case where we do NOT want to do this. allQuotedIdentifiers + Postgres is almost not usable without this.