### PR TITLE
Investigate allowing an entity to extend entity ( ~"Customization" )

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployBeanInfo.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployBeanInfo.java
@@ -77,4 +77,16 @@ public final class DeployBeanInfo<T> {
   public boolean isEmbedded() {
     return descriptor.isEmbedded();
   }
+
+  public Class<?> getOriginalType() {
+    return descriptor.getOriginalType();
+  }
+
+  public void markAsCustomized() {
+    descriptor.markAsCustomized();
+  }
+
+  public boolean isCustomized() {
+    return descriptor.isCustomized();
+  }
 }

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/OCachedApp.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/OCachedApp.java
@@ -3,10 +3,12 @@ package org.tests.model.basic.cache;
 import io.ebean.annotation.Cache;
 
 import javax.persistence.Entity;
+import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 @Cache(naturalKey = "appName")
 @Entity
+@Table(name="ocached_app")
 @UniqueConstraint(name="uq_ocached_app", columnNames = "app_name")
 public class OCachedApp extends OCacheBase {
 

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/OCachedAppCustom.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/OCachedAppCustom.java
@@ -1,0 +1,28 @@
+package org.tests.model.basic.cache;
+
+import io.ebean.annotation.Cache;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Cache(naturalKey = "appName")
+@Entity
+@Table(name = "ocached_app")
+@UniqueConstraint(name = "uq_ocached_app", columnNames = "app_name")
+public class OCachedAppCustom extends OCachedApp {
+
+  String custom;
+
+  public OCachedAppCustom(String appName) {
+    super(appName);
+  }
+
+  public String getCustom() {
+    return custom;
+  }
+
+  public void setCustom(String custom) {
+    this.custom = custom;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/TestCustomExtends.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/TestCustomExtends.java
@@ -1,0 +1,35 @@
+package org.tests.model.basic.cache;
+
+import io.ebean.DB;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestCustomExtends {
+
+  @Test
+  void insert_find() {
+    OCachedApp orig = new OCachedApp("orig");
+    DB.save(orig);
+
+    OCachedAppCustom custom = new OCachedAppCustom("custom");
+    custom.setCustom("someCustomValue");
+    DB.save(custom);
+
+    OCachedAppCustom c1 = DB.find(OCachedAppCustom.class, custom.getId());
+    OCachedApp c2 = DB.find(OCachedApp.class, custom.getId());
+
+    OCachedAppCustom o1 = DB.find(OCachedAppCustom.class, orig.getId());
+    OCachedApp o2 = DB.find(OCachedApp.class, orig.getId());
+
+    assertThat(c1).isNotNull();
+    assertThat(c2).isNotNull();
+    assertThat(c2.getAppName()).isEqualTo(c1.getAppName());
+    assertThat(c2).isNotNull().isInstanceOf(OCachedAppCustom.class);
+
+    assertThat(o1).isNotNull();
+    assertThat(o2).isNotNull();
+    assertThat(o2.getAppName()).isEqualTo(o1.getAppName());
+    assertThat(o2).isNotNull().isInstanceOf(OCachedAppCustom.class);
+  }
+}


### PR DESCRIPTION
Normally `@Entity` beans can not extend another `@Entity` bean without using the inheritance annotations and discriminator column.

What this is about is allowing an `@Entity` bean to extend another `@Entity`. There are 2 use cases that I have in mind that I think this could be useful for.

1. Customisation
2. Logical replication

## Customisation

With this, we have existing models (entity beans) and we can't or don't want to modify those entity beans. Either we didn't author them ourselves or they represent some common or core functionality that can be extended.

We are authoring an extension that uses the common entity beans but for the purposes of this extension we desire additional columns on an entity. With this we can create a new entity that extends another and adds properties/columns.  

Under the hood:
- The custom extension entity becomes the actual entity that drives DDL generation, and is the actual entity that the other entity beans joins to.
- The existing/common/core entity ... actually turns into a "view based entity" which means it doesn't create DDL.
- We can use both entity types for queries ... but they result in fetching back the extended entity
- We can persist both entity types


## Logical replication

The other potential use case is where we are using logical replication. We have a common/central table (say product) and this is logically replicated to a few other databases. Logical typically replication requires that the destination table has at LEAST the columns of the source table but it can have ADDITIONAL columns.  This exactly matches what this feature allows.  For example, a service extends Product to have its own ProductCustom entity with additional columns specific to that service.

