### PR TITLE
Postgres DDL - With Postgres table partitioning, add partition column to primary key

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PartitionMeta.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/PartitionMeta.java
@@ -16,11 +16,17 @@ public final class PartitionMeta {
     return mode;
   }
 
+  /**
+   * Originally the property name but replaced with the db column.
+   */
   public String getProperty() {
     return property;
   }
 
-  public void setProperty(String dbColumn) {
+  /**
+   * Set the db column being partitioned on.
+   */
+  public void setColumn(String dbColumn) {
     this.property = dbColumn;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -249,12 +249,12 @@ public class DeployBeanDescriptor<T> {
     if (partitionMeta != null) {
       DeployBeanProperty beanProperty = getBeanProperty(partitionMeta.getProperty());
       if (beanProperty != null) {
-        partitionMeta.setProperty(beanProperty.getDbColumn());
+        partitionMeta.setColumn(beanProperty.getDbColumn());
       }
     }
     return partitionMeta;
   }
-  
+
   public void setTablespaceMeta(TablespaceMeta tablespaceMeta) {
     this.tablespaceMeta = tablespaceMeta;
   }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableIdentity.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableIdentity.java
@@ -1,0 +1,78 @@
+package io.ebeaninternal.dbmigration.ddlgeneration.platform;
+
+import io.ebean.config.NamingConvention;
+import io.ebean.config.dbplatform.IdType;
+import io.ebeaninternal.dbmigration.migration.Column;
+import io.ebeaninternal.dbmigration.migration.CreateTable;
+import io.ebeaninternal.dbmigration.model.MTableIdentity;
+import io.ebeaninternal.server.deploy.IdentityMode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class BaseTableIdentity {
+
+  private final PlatformDdl platformDdl;
+  private final NamingConvention namingConvention;
+  private final CreateTable createTable;
+  private final List<Column> pk = new ArrayList<>(3);
+
+  BaseTableIdentity(CreateTable createTable, PlatformDdl platformDdl, NamingConvention namingConvention) {
+    this.platformDdl = platformDdl;
+    this.namingConvention = namingConvention;
+    this.createTable = createTable;
+    init(createTable.getColumn());
+  }
+
+  private void init(List<Column> columns) {
+    for (Column column : columns) {
+      if (Boolean.TRUE.equals(column.isPrimaryKey())) {
+        pk.add(column);
+      }
+    }
+  }
+
+  DdlIdentity identity() {
+    if (pk.size() != 1) {
+      return DdlIdentity.NONE;
+    }
+    final IdentityMode identityMode = MTableIdentity.fromCreateTable(createTable);
+    final IdType idType = platformDdl.useIdentityType(identityMode.getIdType());
+    String sequenceName = identityMode.getSequenceName();
+    if (IdType.SEQUENCE == idType && (sequenceName == null || sequenceName.isEmpty())) {
+      sequenceName = deriveSequenceName();
+    }
+    return new DdlIdentity(idType, identityMode, sequenceName);
+  }
+
+  private String deriveSequenceName() {
+    String columnName = pk.size() == 1 ? pk.get(0).getName() : "";
+    return namingConvention.getSequenceName(createTable.getName(), columnName);
+  }
+
+  boolean hasPrimaryKey() {
+    return !pk.isEmpty();
+  }
+
+  List<Column> pkColumns() {
+    if (createTable.getPartitionMode() != null && platformDdl.addPartitionColumnToPrimaryKey()) {
+      String partitionColumn = createTable.getPartitionColumn();
+      if (!pkContains(partitionColumn)) {
+        Column pc = new Column();
+        pc.setName(partitionColumn);
+        // future, could consider prefix option rather than suffix
+        pk.add(pc);
+      }
+    }
+    return pk;
+  }
+
+  private boolean pkContains(String partitionColumn) {
+    for (Column column : pk) {
+      if (column.getName().equals(partitionColumn)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
@@ -772,4 +772,12 @@ public class PlatformDdl {
     }
     apply.append(createSchema).append(" ").append(quote(request.getName())).endOfStatement();
   }
+
+  /**
+   * Override to return true for Postgres / platforms that want the partition column to be
+   * part of the primary key when using table partitioning.
+   */
+  public boolean addPartitionColumnToPrimaryKey() {
+    return false;
+  }
 }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresDdl.java
@@ -26,6 +26,11 @@ public class PostgresDdl extends PlatformDdl {
   }
 
   @Override
+  public boolean addPartitionColumnToPrimaryKey() {
+    return true;
+  }
+
+  @Override
   public String setLockTimeout(int lockTimeoutSeconds) {
     return "set lock_timeout = " + (lockTimeoutSeconds * 1000);
   }

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableIdentityTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableIdentityTest.java
@@ -1,0 +1,127 @@
+package io.ebeaninternal.dbmigration.ddlgeneration.platform;
+
+import io.ebean.config.NamingConvention;
+import io.ebean.config.UnderscoreNamingConvention;
+import io.ebean.platform.postgres.PostgresPlatform;
+import io.ebeaninternal.dbmigration.migration.Column;
+import io.ebeaninternal.dbmigration.migration.CreateTable;
+import io.ebeaninternal.dbmigration.migration.IdentityType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BaseTableIdentityTest {
+
+  static final PlatformDdl postgresDdl = new PostgresDdl(new PostgresPlatform());
+  static final NamingConvention namingConvention = new UnderscoreNamingConvention();
+  static {
+    namingConvention.setDatabasePlatform(new PostgresPlatform());
+  }
+
+  @Test
+  void identity_noPk() {
+    CreateTable createTable = table(column("c0"), column("c1"));
+    BaseTableIdentity bti = new BaseTableIdentity(createTable, postgresDdl, namingConvention);
+    DdlIdentity identity = bti.identity();
+
+    assertFalse(identity.useIdentity());
+    assertFalse(bti.hasPrimaryKey());
+    assertThat(bti.pkColumns()).isEmpty();
+  }
+
+  @Test
+  void identity_singlePk() {
+    CreateTable createTable = table(column("c0", true), column("c1"));
+    BaseTableIdentity bti = new BaseTableIdentity(createTable, postgresDdl, namingConvention);
+    DdlIdentity identity = bti.identity();
+
+    assertTrue(identity.useIdentity());
+    assertTrue(bti.hasPrimaryKey());
+    assertThat(bti.pkColumns()).hasSize(1);
+  }
+
+  @Test
+  void identity_singlePk_useSequence_deriveName() {
+
+    BaseTableIdentity bti = new BaseTableIdentity(createTableWithSequence(null), postgresDdl, namingConvention);
+    DdlIdentity identity = bti.identity();
+
+    assertThat(identity.getSequenceName()).isEqualTo("tab0_seq");
+    assertFalse(identity.useIdentity());
+    assertTrue(bti.hasPrimaryKey());
+    assertThat(bti.pkColumns()).hasSize(1);
+  }
+
+  @Test
+  void identity_singlePk_useSequence_explicitName() {
+    CreateTable createTable = createTableWithSequence("myseq");
+    BaseTableIdentity bti = new BaseTableIdentity(createTable, postgresDdl, namingConvention);
+    DdlIdentity identity = bti.identity();
+
+    assertThat(identity.getSequenceName()).isEqualTo("myseq");
+    assertFalse(identity.useIdentity());
+    assertTrue(bti.hasPrimaryKey());
+    assertThat(bti.pkColumns()).hasSize(1);
+  }
+
+  private CreateTable createTableWithSequence(String seqName) {
+    CreateTable createTable = table(column("c0", true), column("c1"));
+    createTable.setIdentityType(IdentityType.SEQUENCE);
+    createTable.setName("tab0");
+    createTable.setSequenceName(seqName);
+    return createTable;
+  }
+
+  @Test
+  void identity_singlePk_withPartitionColumn() {
+    CreateTable createTable = table(column("c0", true), column("c1"), column("pc"));
+    createTable.setPartitionMode("DAY");
+    createTable.setPartitionColumn("pc");
+
+    BaseTableIdentity bti = new BaseTableIdentity(createTable, postgresDdl, namingConvention);
+    DdlIdentity identity = bti.identity();
+
+    assertTrue(identity.useIdentity());
+    assertTrue(bti.hasPrimaryKey());
+    assertThat(bti.pkColumns()).hasSize(2);
+    assertThat(bti.pkColumns().get(0).getName()).isEqualTo("c0");
+    assertThat(bti.pkColumns().get(1).getName()).isEqualTo("pc");
+  }
+
+  @Test
+  void identity_singlePk_withPartitionColumnAlreadyInPk() {
+    CreateTable createTable = table(column("c0", true), column("c1"), column("pc", true));
+    createTable.setPartitionMode("DAY");
+    createTable.setPartitionColumn("pc");
+
+    BaseTableIdentity bti = new BaseTableIdentity(createTable, postgresDdl, namingConvention);
+    DdlIdentity identity = bti.identity();
+
+    assertFalse(identity.useIdentity());
+    assertTrue(bti.hasPrimaryKey());
+    assertThat(bti.pkColumns()).hasSize(2);
+    assertThat(bti.pkColumns().get(0).getName()).isEqualTo("c0");
+    assertThat(bti.pkColumns().get(1).getName()).isEqualTo("pc");
+  }
+
+
+  CreateTable table(Column... cols) {
+    CreateTable createTable = new CreateTable();
+    for (Column col : cols) {
+      createTable.getColumn().add(col);
+    }
+    return createTable;
+  }
+
+  Column column(String name) {
+    return column(name, null);
+  }
+
+  Column column(String name, Boolean primaryKey) {
+    Column col = new Column();
+    col.setName(name);
+    col.setPrimaryKey(primaryKey);
+    return col;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/generated/MyPart.java
+++ b/ebean-test/src/test/java/org/tests/model/generated/MyPart.java
@@ -1,0 +1,48 @@
+package org.tests.model.generated;
+
+import io.ebean.annotation.DbPartition;
+import io.ebean.annotation.PartitionMode;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.Instant;
+
+@DbPartition(mode = PartitionMode.MONTH, property = "eventTime")
+@Entity
+@Table(name="mypart_combo")
+public class MyPart {
+
+  @Id @GeneratedValue
+  long id;
+
+  final Instant eventTime;
+
+  String metaInfo;
+
+  public MyPart(Instant eventTime) {
+    this.eventTime = eventTime;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public Instant getEventTime() {
+    return eventTime;
+  }
+
+  public String getMetaInfo() {
+    return metaInfo;
+  }
+
+  public void setMetaInfo(String metaInfo) {
+    this.metaInfo = metaInfo;
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/model/generated/MyPartTest.java
+++ b/ebean-test/src/test/java/org/tests/model/generated/MyPartTest.java
@@ -1,0 +1,24 @@
+package org.tests.model.generated;
+
+import io.ebean.DB;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MyPartTest {
+
+  @Test
+  void insert_find() {
+    Instant now = Instant.now();
+    MyPart part = new MyPart(now);
+    part.setMetaInfo("meta");
+
+    DB.save(part);
+    assertThat(part.getId()).isGreaterThan(0);
+
+    MyPart found = DB.find(MyPart.class, part.getId());
+    assertThat(found).isNotNull();
+  }
+}


### PR DESCRIPTION
- Postgres DDL generation
- Using table partitioning
- There is a primary key defined that doesn't contain the partition column

In DDL generation, automatically add the partition column to the DB primary key.


```java
@DbPartition(mode = PartitionMode.MONTH, property = "eventTime")
@Entity
@Table(name="mypart_combo")
public class MyPart {

  @Id 
  @GeneratedValue
  long id;

  final Instant eventTime;
  ...
```

The DDL generation includes `event_time` in the database primary key (as the table is partitioned by that column).

```sql
create table mypart_combo (
  id                            bigint generated by default as identity not null,
  event_time                    timestamptz,
  meta_info                     varchar(255),
  constraint pk_mypart_combo primary key (id,event_time)
) partition by range (event_time);
```