### PR TITLE
ebean-test-docker was renamed to ebean-test-containers

### DIFF
--- a/ebean-bom/pom.xml
+++ b/ebean-bom/pom.xml
@@ -62,8 +62,8 @@
 
       <dependency>
         <groupId>io.ebean</groupId>
-        <artifactId>ebean-test-docker</artifactId>
-        <version>${ebean-test-docker.version}</version>
+        <artifactId>ebean-test-containers</artifactId>
+        <version>${ebean-test-containers.version}</version>
       </dependency>
 
       <!-- modules -->

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -61,8 +61,8 @@
 
     <dependency>
       <groupId>io.ebean</groupId>
-      <artifactId>ebean-test-docker</artifactId>
-      <version>${ebean-test-docker.version}</version>
+      <artifactId>ebean-test-containers</artifactId>
+      <version>${ebean-test-containers.version}</version>
     </dependency>
 
     <dependency>

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/ElasticSearchSetup.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/ElasticSearchSetup.java
@@ -1,6 +1,6 @@
 package io.ebean.test.config.platform;
 
-import io.ebean.docker.commands.ElasticContainer;
+import io.ebean.test.containers.ElasticContainer;
 
 import java.util.Properties;
 

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
@@ -1,7 +1,7 @@
 package io.ebean.test.config.platform;
 
 import io.ebean.config.DatabaseConfig;
-import io.ebean.docker.container.ContainerFactory;
+import io.ebean.test.containers.ContainerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/RedisSetup.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/RedisSetup.java
@@ -1,6 +1,6 @@
 package io.ebean.test.config.platform;
 
-import io.ebean.docker.commands.RedisContainer;
+import io.ebean.test.containers.RedisContainer;
 
 import java.util.Properties;
 

--- a/ebean-test/src/main/java/module-info.java
+++ b/ebean-test/src/main/java/module-info.java
@@ -18,7 +18,7 @@ module io.ebean.test {
   requires com.fasterxml.jackson.databind;
   requires com.fasterxml.jackson.datatype.jsr310;
 
-  requires transitive io.ebean.docker;
+  requires transitive io.ebean.test.containers;
   requires transitive org.assertj.core;
   requires transitive java.xml.bind;
   requires transitive com.h2database;

--- a/ebean-test/src/test/java/main/StartCockroach.java
+++ b/ebean-test/src/test/java/main/StartCockroach.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.CockroachContainer;
+import io.ebean.test.containers.CockroachContainer;
 
 public class StartCockroach {
 

--- a/ebean-test/src/test/java/main/StartDb2.java
+++ b/ebean-test/src/test/java/main/StartDb2.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.Db2Container;
+import io.ebean.test.containers.Db2Container;
 
 public class StartDb2 {
 

--- a/ebean-test/src/test/java/main/StartMariaDb.java
+++ b/ebean-test/src/test/java/main/StartMariaDb.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.MariaDBContainer;
+import io.ebean.test.containers.MariaDBContainer;
 
 public class StartMariaDb {
 

--- a/ebean-test/src/test/java/main/StartMySql.java
+++ b/ebean-test/src/test/java/main/StartMySql.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.MySqlContainer;
+import io.ebean.test.containers.MySqlContainer;
 
 public class StartMySql {
 

--- a/ebean-test/src/test/java/main/StartNuoDB.java
+++ b/ebean-test/src/test/java/main/StartNuoDB.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.NuoDBContainer;
+import io.ebean.test.containers.NuoDBContainer;
 
 public class StartNuoDB {
 

--- a/ebean-test/src/test/java/main/StartOracle.java
+++ b/ebean-test/src/test/java/main/StartOracle.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.OracleContainer;
+import io.ebean.test.containers.OracleContainer;
 
 public class StartOracle {
 

--- a/ebean-test/src/test/java/main/StartPostgres.java
+++ b/ebean-test/src/test/java/main/StartPostgres.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.PostgresContainer;
+import io.ebean.test.containers.PostgresContainer;
 
 public class StartPostgres {
 

--- a/ebean-test/src/test/java/main/StartSqlServer.java
+++ b/ebean-test/src/test/java/main/StartSqlServer.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.SqlServerContainer;
+import io.ebean.test.containers.SqlServerContainer;
 
 public class StartSqlServer {
 

--- a/ebean-test/src/test/java/main/StartYugabyte.java
+++ b/ebean-test/src/test/java/main/StartYugabyte.java
@@ -1,6 +1,6 @@
 package main;
 
-import io.ebean.docker.commands.YugabyteContainer;
+import io.ebean.test.containers.YugabyteContainer;
 
 public class StartYugabyte {
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <ebean-ddl-runner.version>2.0</ebean-ddl-runner.version>
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>13.6.0</ebean-migration.version>
-    <ebean-test-docker.version>5.3</ebean-test-docker.version>
+    <ebean-test-containers.version>5.8</ebean-test-containers.version>
     <ebean-datasource.version>8.0</ebean-datasource.version>
     <ebean-agent.version>13.6.2</ebean-agent.version>
     <ebean-maven-plugin.version>13.6.2</ebean-maven-plugin.version>


### PR DESCRIPTION
- Migrate from io.ebean:ebean-test-docker -> io.ebean:ebean-test-containers
- Migrate (with 5.8) package from io.ebean.docker.commands -> io.ebean.test.containers