### PR TITLE
#2702 - IllegalArgumentException: No rule for io.ebeaninternal.dbmigration.migration.RenameTable

### DIFF
--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/MTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/MTable.java
@@ -28,7 +28,7 @@ public class MTable {
 
   private static final Logger logger = LoggerFactory.getLogger(MTable.class);
 
-  private final String name;
+  private String name;
   private MTable draftTable;
   /**
    * Marked true for draft tables. These need to have their FK references adjusted
@@ -408,6 +408,14 @@ public class MTable {
     addColumn(column.rename(renameColumn.getNewName()));
   }
 
+  /**
+   * Apply table rename to the model.
+   */
+  public void apply(RenameTable renameTable) {
+    checkTableName(renameTable.getOldName());
+    this.name = renameTable.getNewName();
+  }
+
   public String getName() {
     return name;
   }
@@ -547,7 +555,7 @@ public class MTable {
 
   private void checkTableName(String tableName) {
     if (!name.equals(tableName)) {
-      throw new IllegalArgumentException("addColumn tableName [" + tableName + "] does not match [" + name + "]");
+      throw new IllegalArgumentException("tableName [" + tableName + "] does not match [" + name + "]");
     }
   }
 

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/model/ModelContainerTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/model/ModelContainerTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ModelContainerTest {
 
@@ -150,6 +151,42 @@ class ModelContainerTest {
     final MTable table = container.getTable("document");
     assertThat(table.getColumn("title")).isNotNull();
     assertThat(table.getColumn("short_title")).isNull();
+  }
+
+  @Test
+  void apply_renameTable() {
+    ModelContainer container = new ModelContainer();
+    container.apply(mig("7.0__renameTable.model.xml"), ver("7.0"));
+
+    final MTable table = container.getTable("document_newname");
+    assertThat(table.getColumn("title")).isNotNull();
+    assertThat(table.getColumn("short_title")).isNull();
+  }
+
+  @Test
+  void apply_renameTable_when_oldTableNotFound() {
+    ModelContainer container = new ModelContainer();
+
+    assertThatThrownBy(() -> {
+      container.apply(mig("7.0__renameTable.errOldTable.xml"), ver("7.0"));
+    }).isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("RenameTable oldName");
+
+    final MTable table = container.getTable("document");
+    assertThat(table.getColumn("title")).isNotNull();
+  }
+
+  @Test
+  void apply_renameTable_when_newTableAlreadyExists() {
+    ModelContainer container = new ModelContainer();
+
+    assertThatThrownBy(() -> {
+      container.apply(mig("7.0__renameTable.errNewTable.xml"), ver("7.0"));
+    }).isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("RenameTable to newName");
+
+    final MTable table = container.getTable("document");
+    assertThat(table.getColumn("title")).isNotNull();
   }
 
   @Test

--- a/ebean-ddl-generator/src/test/resources/io/ebeaninternal/dbmigration/model/7.0__renameTable.errNewTable.xml
+++ b/ebean-ddl-generator/src/test/resources/io/ebeaninternal/dbmigration/model/7.0__renameTable.errNewTable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<migration xmlns="http://ebean-orm.github.io/xml/ns/dbmigration">
+  <changeSet type="apply">
+
+    <createTable name="document" withHistory="true" pkName="pk_document">
+      <column name="id" type="bigint" primaryKey="true" references="document_draft.id" foreignKeyName="fk_document_id"/>
+      <column name="title" type="varchar(255)"/>
+    </createTable>
+
+    <createTable name="document_newname" pkName="pk_document">
+      <column name="id" type="bigint"/>
+    </createTable>
+
+    <renameTable oldName="document" newName="document_newname"/>
+
+  </changeSet>
+</migration>

--- a/ebean-ddl-generator/src/test/resources/io/ebeaninternal/dbmigration/model/7.0__renameTable.errOldTable.xml
+++ b/ebean-ddl-generator/src/test/resources/io/ebeaninternal/dbmigration/model/7.0__renameTable.errOldTable.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<migration xmlns="http://ebean-orm.github.io/xml/ns/dbmigration">
+  <changeSet type="apply">
+
+    <createTable name="document" withHistory="true" pkName="pk_document">
+      <column name="id" type="bigint" primaryKey="true" references="document_draft.id" foreignKeyName="fk_document_id"/>
+      <column name="title" type="varchar(255)"/>
+    </createTable>
+
+    <renameTable oldName="document_doesNotExist" newName="document_newname"/>
+
+  </changeSet>
+</migration>

--- a/ebean-ddl-generator/src/test/resources/io/ebeaninternal/dbmigration/model/7.0__renameTable.model.xml
+++ b/ebean-ddl-generator/src/test/resources/io/ebeaninternal/dbmigration/model/7.0__renameTable.model.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<migration xmlns="http://ebean-orm.github.io/xml/ns/dbmigration">
+  <changeSet type="apply">
+
+    <createTable name="document" withHistory="true" pkName="pk_document">
+      <column name="id" type="bigint" primaryKey="true" references="document_draft.id" foreignKeyName="fk_document_id"/>
+      <column name="title" type="varchar(255)"/>
+    </createTable>
+
+    <renameTable oldName="document" newName="document_newname"/>
+
+  </changeSet>
+</migration>


### PR DESCRIPTION
Add support for applying the RenameTable change to the model.