### PR TITLE
Part 1: Fix read/write/query LocalTime values

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/DataTimeZone.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/DataTimeZone.java
@@ -13,11 +13,10 @@ public interface DataTimeZone {
   Calendar getTimeZone();
 
   /**
-   * Return the Calendar to use for Timezone information when reading/writing date.
-   * A 'date' only value has normally no timezone information, but some platforms (like MySQL)
-   * reqire this.
+   * Return the Calendar to use for Timezone information when reading/writing a time component (date only/time only).
+   * A time component has normally no timezone information, but some platforms (like MySQL) reqire this.
    */
-  default Calendar getDateTimeZone() {
+  default Calendar getTimeComponentTimeZone() {
     return null;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/MySqlDataTimeZone.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/timezone/MySqlDataTimeZone.java
@@ -19,7 +19,7 @@ public class MySqlDataTimeZone implements DataTimeZone {
   }
 
   @Override
-  public Calendar getDateTimeZone() {
+  public Calendar getTimeComponentTimeZone() {
     return zone;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
@@ -158,7 +158,7 @@ public class DataBind implements DataBinder {
 
   @Override
   public final void setDate(java.sql.Date v) throws SQLException {
-    Calendar timeZone = dataTimeZone.getDateTimeZone();
+    Calendar timeZone = dataTimeZone.getTimeComponentTimeZone();
     if (timeZone != null) {
       pstmt.setDate(++pos, v, timeZone);
     } else {
@@ -178,7 +178,7 @@ public class DataBind implements DataBinder {
 
   @Override
   public final void setTime(Time v) throws SQLException {
-    Calendar timeZone = dataTimeZone.getDateTimeZone();
+    Calendar timeZone = dataTimeZone.getTimeComponentTimeZone();
     if (timeZone != null) {
       pstmt.setTime(++pos, v, timeZone);
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DataBind.java
@@ -178,7 +178,7 @@ public class DataBind implements DataBinder {
 
   @Override
   public final void setTime(Time v) throws SQLException {
-    Calendar timeZone = dataTimeZone.getTimeZone();
+    Calendar timeZone = dataTimeZone.getDateTimeZone();
     if (timeZone != null) {
       pstmt.setTime(++pos, v, timeZone);
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
@@ -107,7 +107,7 @@ public class RsetDataReader implements DataReader {
 
   @Override
   public final Date getDate() throws SQLException {
-    Calendar cal = dataTimeZone.getDateTimeZone();
+    Calendar cal = dataTimeZone.getTimeComponentTimeZone();
     if (cal != null) {
       return rset.getDate(pos(), cal);
     } else {
@@ -156,7 +156,7 @@ public class RsetDataReader implements DataReader {
 
   @Override
   public final Time getTime() throws SQLException {
-    Calendar cal = dataTimeZone.getDateTimeZone();
+    Calendar cal = dataTimeZone.getTimeComponentTimeZone();
     if (cal != null) {
       return rset.getTime(pos(), cal);
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/RsetDataReader.java
@@ -156,7 +156,7 @@ public class RsetDataReader implements DataReader {
 
   @Override
   public final Time getTime() throws SQLException {
-    Calendar cal = dataTimeZone.getTimeZone();
+    Calendar cal = dataTimeZone.getDateTimeZone();
     if (cal != null) {
       return rset.getTime(pos(), cal);
     } else {

--- a/ebean-test/src/test/java/org/tests/timezone/LocalTimeTest.java
+++ b/ebean-test/src/test/java/org/tests/timezone/LocalTimeTest.java
@@ -1,0 +1,69 @@
+package org.tests.timezone;
+
+import io.ebean.Database;
+import io.ebean.DatabaseFactory;
+import io.ebean.config.DatabaseConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LocalTimeTest {
+
+  protected String platform="h2";
+  protected Database db;
+
+  @BeforeAll
+  public void startTest() {
+    db = createServer("GMT"); // test uses GMT database
+  }
+
+  @AfterAll
+  public void shutdown() {
+    if (db != null) {
+      db.find(MLocalTime.class).delete();
+      db.shutdown();
+    }
+  }
+
+  /**
+   * The test checks the write and read of LocalTime values. The database is in GMT time zone.
+   * In order to verify the test in different java time zones (where the application runs),
+   * use the <code>-Duser.timezone</code> as JVM argument,
+   * e.g. <code>-Duser.timezone="America/New_York"</code> or <code>-Duser.timezone="PST"</code>>
+   * or any other timezone: <a href="https://garygregory.wordpress.com/2013/06/18/what-are-the-java-timezone-ids/">https://garygregory.wordpress.com/2013/06/18/what-are-the-java-timezone-ids/</a>.
+   */
+  @Test
+  public void testLocalTime() {
+    LocalTime lt = LocalTime.of(5, 15, 15);
+    assertThat(db.find(MLocalTime.class).findCount()).isEqualTo(0);
+    db.sqlUpdate("insert into mlocal_time (id, local_time) values (1, '05:15:15')").execute();
+
+    int count = db.find(MLocalTime.class).where().eq("local_time", lt).findCount();
+    assertThat(count).isEqualTo(1);
+
+    MLocalTime dbModel = db.find(MLocalTime.class).where().eq("local_time", lt).findOne();
+    assertThat(dbModel.getLocalTime().toString()).isEqualTo(lt.toString());
+  }
+
+  private Database createServer(String dbTimeZone) {
+    DatabaseConfig config = new DatabaseConfig();
+    config.setName(platform);
+    config.loadFromProperties();
+    config.setDdlExtra(false);
+    config.setDefaultServer(false);
+    config.setRegister(false);
+    config.setChangeLogAsync(false);
+    config.addClass(MLocalTime.class);
+
+    config.setDumpMetricsOnShutdown(false);
+    config.setDataTimeZone(dbTimeZone);
+
+    return DatabaseFactory.create(config);
+  }
+}

--- a/ebean-test/src/test/java/org/tests/timezone/MLocalTime.java
+++ b/ebean-test/src/test/java/org/tests/timezone/MLocalTime.java
@@ -1,0 +1,28 @@
+package org.tests.timezone;
+
+import javax.annotation.Nullable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.time.LocalTime;
+
+@Entity
+public class MLocalTime {
+
+  @Id
+  private Integer id;
+
+  @Nullable
+  private LocalTime localTime;
+
+  @Nullable
+  public LocalTime getLocalTime() {
+    return localTime;
+  }
+  public Integer getId() {
+    return id;
+  }
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+}


### PR DESCRIPTION
Hello @rbygrave ,

we decided to split our big refactoring PR https://github.com/ebean-orm/ebean/pull/2443 in smaller ones.
This PR would be the first which tests the write & read & query of the LocalTime values.

In the Javadoc I noticed how it can be tested in different java time zones with -Duser.timezone.

Can you take a look at this PR?

Kind regards
Noemi


----
## Summary of this change
This changes how `Time` type is read (ResultSet) and bound (PreparedStatement) when there is a time zone set via `DatabaseConfig`.

Previously, `Time` was using the time zone method for `Timestamp types` rather than `Date types` and this changes it to use the method for `Date types` (which is actually null for everything apart from MySql).

Effectively no change for MySql.
Effectively for non-MySql, the `Time` types where incorrectly using the timezone if specified and this change means they no longer use that configured time zone.

