### PR TITLE
DDL - Refactor DDL for Postgres and YugabyteDB to just create a default partition table

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -803,20 +803,6 @@ public class DatabasePlatform {
   }
 
   /**
-   * Return true if partitions exist for the given table.
-   */
-  public boolean tablePartitionsExist(Connection connection, String table) throws SQLException {
-    return true;
-  }
-
-  /**
-   * Return the SQL to create an initial partition for the given table.
-   */
-  public String tablePartitionInit(String tableName, PartitionMode mode) {
-    return null;
-  }
-
-  /**
    * Escapes the like string for this DB-Platform
    */
   public String escapeLikeString(String value) {

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
@@ -213,6 +213,8 @@ public class BaseTableDdl implements TableDdl {
     String partitionMode = createTable.getPartitionMode();
     if (partitionMode != null) {
       platformDdl.addTablePartition(apply, partitionMode, createTable.getPartitionColumn());
+      apply.endOfStatement().newLine();
+      platformDdl.addDefaultTablePartition(apply, createTable.getName());
     }
     apply.endOfStatement();
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PlatformDdl.java
@@ -733,7 +733,11 @@ public class PlatformDdl {
   }
 
   public void addTablePartition(DdlBuffer apply, String partitionMode, String partitionColumn) {
-    // only supported by postgres initially
+    // only supported by postgres and yugabyte
+  }
+
+  public void addDefaultTablePartition(DdlBuffer apply, String tableName) {
+    // only supported by postgres and yugabyte
   }
 
   /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresDdl.java
@@ -46,6 +46,11 @@ public class PostgresDdl extends PlatformDdl {
   }
 
   @Override
+  public void addDefaultTablePartition(DdlBuffer apply, String tableName) {
+    apply.append("create table ").append(tableName).append("_default partition of ").append(tableName).append(" default");
+  }
+
+  @Override
   public String dropIndex(String indexName, String tableName, boolean concurrent) {
     return (concurrent ? dropIndexConcurrentlyIfExists : dropIndexIfExists) + maxConstraintName(indexName);
   }

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/PostgresPlatformTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/PostgresPlatformTest.java
@@ -7,11 +7,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PostgresPlatformTest {
+class PostgresPlatformTest {
 
   @Test
-  public void testTypeConversion() {
-
+  void testTypeConversion() {
     PostgresPlatform platform = new PostgresPlatform();
     PlatformDdl ddl = PlatformDdlBuilder.create(platform);
 

--- a/platforms/postgres/src/main/java/io/ebean/platform/postgres/PostgresPlatform.java
+++ b/platforms/postgres/src/main/java/io/ebean/platform/postgres/PostgresPlatform.java
@@ -147,40 +147,4 @@ public class PostgresPlatform extends DatabasePlatform {
     }
     return FOR_UPDATE;
   }
-
-  @Override
-  public boolean tablePartitionsExist(Connection connection, String table) throws SQLException {
-    try (PreparedStatement statement = connection.prepareStatement("select count(*) from pg_inherits i WHERE  i.inhparent = ?::regclass")) {
-      statement.setString(1, table);
-      try (ResultSet resultSet = statement.executeQuery()) {
-        return resultSet.next() && resultSet.getInt(1) > 0;
-      }
-    }
-  }
-
-  /**
-   * Return SQL using built in partition helper functions to create some initial partitions.
-   * <p>
-   * Only use this if extra-ddl doesn't have some initial partitions defined (which it should).
-   */
-  @Override
-  public String tablePartitionInit(String tableName, PartitionMode mode) {
-    // default partition required pg11 but this is only used for testing but bumped test docker container to pg14 by default
-    String[] schemaTable = SplitName.split(tableName);
-
-    String baseTable;
-    String plusSchema;
-    if (schemaTable[0] == null) {
-      plusSchema = "";
-      baseTable = tableName;
-    } else {
-      // table in an explicit schema
-      plusSchema = ",'" + schemaTable[0] + "'";
-      baseTable = schemaTable[1];
-    }
-    return
-      "create table " + tableName + "_default" + " partition of " + tableName + " default;\n" +
-        "select partition('" + mode.name().toLowerCase() + "','" + baseTable + "',1" + plusSchema + ");";
-  }
-
 }

--- a/platforms/postgres/src/test/java/io/ebean/platform/postgres/PostgresPlatformTest.java
+++ b/platforms/postgres/src/test/java/io/ebean/platform/postgres/PostgresPlatformTest.java
@@ -1,6 +1,5 @@
 package io.ebean.platform.postgres;
 
-import io.ebean.annotation.PartitionMode;
 import io.ebean.annotation.Platform;
 import io.ebean.config.PlatformConfig;
 import io.ebean.config.dbplatform.DatabasePlatform;
@@ -16,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class PostgresPlatformTest {
 
   @Test
- void testUuidType() {
+  void testUuidType() {
     PostgresPlatform platform = new PostgresPlatform();
     platform.configure(new PlatformConfig());
 
@@ -24,20 +23,6 @@ class PostgresPlatformTest {
     String columnDefn = dbType.renderType(0, 0);
 
     assertThat(columnDefn).isEqualTo("uuid");
-  }
-
-  @Test
-  void tablePartitionInit() {
-    String sql = new PostgresPlatform().tablePartitionInit("foo", PartitionMode.WEEK);
-    assertThat(sql).isEqualTo("create table foo_default partition of foo default;\n" +
-      "select partition('week','foo',1);");
-  }
-
-  @Test
-  void tablePartitionInit_withSchema() {
-    String sql = new PostgresPlatform().tablePartitionInit("bar.foo", PartitionMode.WEEK);
-    assertThat(sql).isEqualTo("create table bar.foo_default partition of bar.foo default;\n" +
-      "select partition('week','foo',1,'bar');");
   }
 
   @Test


### PR DESCRIPTION
Removes the need and use of  PostgresPlatform.tablePartitionsExist() and PostgresPlatform.tablePartitionInit() altogether.