### PR TITLE
Migrate to Jakarta JAXB (jakarta.xml.bind <- javax.xml.bind)

### DIFF
--- a/ebean-autotune/pom.xml
+++ b/ebean-autotune/pom.xml
@@ -32,10 +32,15 @@
 
     <!-- needed for java 11+ -->
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
-      <scope>provided</scope>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/Autotune.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/Autotune.java
@@ -1,9 +1,9 @@
 package io.ebeaninternal.server.autotune.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ObjectFactory.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ObjectFactory.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.server.autotune.model;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/Origin.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/Origin.java
@@ -1,10 +1,10 @@
 package io.ebeaninternal.server.autotune.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ProfileDiff.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ProfileDiff.java
@@ -1,9 +1,9 @@
 package io.ebeaninternal.server.autotune.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ProfileEmpty.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ProfileEmpty.java
@@ -1,9 +1,9 @@
 package io.ebeaninternal.server.autotune.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ProfileNew.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/ProfileNew.java
@@ -1,9 +1,9 @@
 package io.ebeaninternal.server.autotune.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/package-info.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/model/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/autotune", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/autotune", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package io.ebeaninternal.server.autotune.model;

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/AutoTuneXmlReader.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/AutoTuneXmlReader.java
@@ -3,9 +3,9 @@ package io.ebeaninternal.server.autotune.service;
 
 import io.ebeaninternal.server.autotune.model.Autotune;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/AutoTuneXmlWriter.java
+++ b/ebean-autotune/src/main/java/io/ebeaninternal/server/autotune/service/AutoTuneXmlWriter.java
@@ -3,9 +3,9 @@ package io.ebeaninternal.server.autotune.service;
 
 import io.ebeaninternal.server.autotune.model.Autotune;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/ebean-autotune/src/main/java/module-info.java
+++ b/ebean-autotune/src/main/java/module-info.java
@@ -10,6 +10,5 @@ module io.ebean.autotune {
 
   requires io.ebean.api;
   requires io.ebean.core;
-  requires java.xml;
-  requires java.xml.bind;
+  requires jakarta.xml.bind;
 }

--- a/ebean-ddl-generator/pom.xml
+++ b/ebean-ddl-generator/pom.xml
@@ -39,12 +39,16 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- needed for java 11+ -->
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
-      <scope>provided</scope>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- test dependencies -->

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/Detect.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/Detect.java
@@ -11,6 +11,6 @@ public class Detect {
    * Return true if JAXB is present.
    */
   public static boolean isJAXBPresent(DatabaseConfig config) {
-    return config.getClassLoadConfig().isPresent("javax.xml.bind.JAXBException");
+    return config.getClassLoadConfig().isPresent("jakarta.xml.bind.JAXBException");
   }
 }

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddColumn.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddColumn.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddHistoryTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddHistoryTable.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddTableComment.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddTableComment.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddUniqueConstraint.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AddUniqueConstraint.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterColumn.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterColumn.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterForeignKey.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterForeignKey.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterHistoryTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterHistoryTable.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/AlterTable.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.math.BigInteger;
 
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Application.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Application.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Applications.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Applications.java
@@ -1,9 +1,9 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Apply.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Apply.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSet.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSet.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSetType.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ChangeSetType.java
@@ -1,8 +1,8 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Column.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Column.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Configuration.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Configuration.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/CreateIndex.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/CreateIndex.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/CreateSchema.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/CreateSchema.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/CreateTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/CreateTable.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DdlScript.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DdlScript.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DefaultTablespace.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DefaultTablespace.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropColumn.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropColumn.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropHistoryTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropHistoryTable.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropIndex.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropIndex.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/DropTable.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ForeignKey.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ForeignKey.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/IdentityType.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/IdentityType.java
@@ -1,8 +1,8 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Migration.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Migration.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ObjectFactory.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/ObjectFactory.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/RenameColumn.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/RenameColumn.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/RenameTable.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/RenameTable.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Rollback.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Rollback.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Sql.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/Sql.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/UniqueConstraint.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/UniqueConstraint.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.dbmigration.migration;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/package-info.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migration/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/dbmigration", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/dbmigration", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package io.ebeaninternal.dbmigration.migration;

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migrationreader/MigrationXmlReader.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migrationreader/MigrationXmlReader.java
@@ -3,9 +3,9 @@ package io.ebeaninternal.dbmigration.migrationreader;
 
 import io.ebeaninternal.dbmigration.migration.Migration;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migrationreader/MigrationXmlWriter.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/migrationreader/MigrationXmlWriter.java
@@ -4,9 +4,9 @@ package io.ebeaninternal.dbmigration.migrationreader;
 import io.ebean.util.IOUtils;
 import io.ebeaninternal.dbmigration.migration.Migration;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/DdlScript.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/DdlScript.java
@@ -1,11 +1,11 @@
 package io.ebeaninternal.extraddl.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdl.java
@@ -1,10 +1,10 @@
 package io.ebeaninternal.extraddl.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
@@ -4,9 +4,9 @@ import io.ebean.annotation.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ObjectFactory.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ObjectFactory.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.extraddl.model;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/package-info.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/extraddl", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/extraddl", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package io.ebeaninternal.extraddl.model;

--- a/ebean-ddl-generator/src/main/java/module-info.java
+++ b/ebean-ddl-generator/src/main/java/module-info.java
@@ -7,7 +7,7 @@ module io.ebean.ddl.generator {
 
   requires transitive io.ebean.ddl.runner;
   requires transitive io.ebean.core;
-  requires transitive java.xml.bind;
+  requires transitive jakarta.xml.bind;
   requires io.ebean.core.type;
   requires io.ebean.migration;
 

--- a/ebean-externalmapping-xml/pom.xml
+++ b/ebean-externalmapping-xml/pom.xml
@@ -32,16 +32,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
     </dependency>
-
     <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-      <version>1.2.1</version>
-      <scope>provided</scope>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/XmlMappingReader.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/XmlMappingReader.java
@@ -3,9 +3,9 @@ package io.ebeaninternal.xmlmapping;
 import io.avaje.classpath.scanner.Resource;
 import io.ebeaninternal.xmlmapping.model.XmEbean;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/ObjectFactory.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/ObjectFactory.java
@@ -1,6 +1,6 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 
 /**

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmAliasMapping.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmAliasMapping.java
@@ -1,10 +1,10 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmColumnMapping.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmColumnMapping.java
@@ -1,10 +1,10 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmDto.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmDto.java
@@ -1,11 +1,11 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmEbean.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmEbean.java
@@ -1,10 +1,10 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmEntity.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmEntity.java
@@ -1,11 +1,11 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmNamedQuery.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmNamedQuery.java
@@ -1,11 +1,11 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmQuery.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmQuery.java
@@ -1,10 +1,10 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
 
 
 /**

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmRawSql.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/XmRawSql.java
@@ -1,11 +1,11 @@
 package io.ebeaninternal.xmlmapping.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/package-info.java
+++ b/ebean-externalmapping-xml/src/main/java/io/ebeaninternal/xmlmapping/model/package-info.java
@@ -1,2 +1,2 @@
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/ebean", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://ebean-orm.github.io/xml/ns/ebean", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package io.ebeaninternal.xmlmapping.model;

--- a/ebean-externalmapping-xml/src/main/java/module-info.java
+++ b/ebean-externalmapping-xml/src/main/java/module-info.java
@@ -10,8 +10,7 @@ module io.ebean.xmapping.xml {
   provides XmapService with JaxbXmapService;
 
   requires transitive io.ebean.xmapping.api;
-  requires transitive java.xml;
-  requires transitive java.xml.bind;
+  requires transitive jakarta.xml.bind;
   requires io.avaje.classpath.scanner.api;
   requires io.avaje.classpath.scanner;
   requires static org.slf4j;

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -73,17 +73,15 @@
 
     <!-- Including JAXB for DB Migration generation with Java 11+ -->
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
     </dependency>
-
-    <!-- Needed for module path compile, jaxb foo bar needs review -->
     <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-      <version>1.2.1</version>
-      <scope>provided</scope>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Not strictly required but bring in H2 Driver because we use it so much -->

--- a/ebean-test/src/main/java/module-info.java
+++ b/ebean-test/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module io.ebean.test {
 
   requires transitive io.ebean.test.containers;
   requires transitive org.assertj.core;
-  requires transitive java.xml.bind;
+  requires transitive jakarta.xml.bind;
   requires transitive com.h2database;
 
   // support testing


### PR DESCRIPTION
We use JAXB & XML for DDL generation and running DDL in test, and also at runtime for ebean-externalmapping-xml (which I suspect is only rarely used these days, it's now an optional dependency that is not included by default ).

The main uses of JAXB should all be in the test classpath only. Still, this migrates from using `javax.xml.bind` to `jakarta.xml.bind` so probably need to assess how disruptive that would be. Will people using javax.xml.bind for other things get messed up?  In theory they should not.

### Moving to jakarta.xml.bind
```xml
    <dependency>
      <groupId>jakarta.xml.bind</groupId>
      <artifactId>jakarta.xml.bind-api</artifactId>
      <version>4.0.0</version>
    </dependency>
    <dependency>
      <groupId>com.sun.xml.bind</groupId>
      <artifactId>jaxb-impl</artifactId>
      <version>4.0.0</version>
      <scope>runtime</scope>
    </dependency>
```

### From ...

```xml
    <dependency>
      <groupId>org.glassfish.jaxb</groupId>
      <artifactId>jaxb-runtime</artifactId>
      <version>2.3.6</version>
    </dependency>
```
