### PR TITLE
Fix: DDL will get wrong hint for special migration

### DIFF
--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/BaseTableDdl.java
@@ -108,8 +108,9 @@ public class BaseTableDdl implements TableDdl {
       // altered columns will be in the alterTable buffers.
       // 'after' goes to the post-alter-buffer
       if (!after.isEmpty()) {
-        writer.applyPostAlter().append("-- NOTE: table has @History - special migration may be necessary").newLine();
-
+        if (withHistory) {
+          writer.applyPostAlter().append("-- NOTE: table has @History - special migration may be necessary").newLine();
+        }
         // here we run post migration scripts
         for (String ddlScript : after) {
           writer.applyPostAlter().appendStatement(translate(ddlScript, tableName, columnName, defaultValue));


### PR DESCRIPTION
This is uncritical, as only a comment in DDL may be produced
(probably a regression of #2721)
