### PR TITLE
#2762 - forUpdate is NOT included in query copy() method

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
@@ -417,6 +417,8 @@ public interface SpiQuery<T> extends Query<T>, SpiQueryFetch, TxnProfileEventCod
 
   /**
    * Return a copy of the query.
+   * <p>
+   * Note that this does NOT copy the forUpdate property. See #2762.
    */
   @Override
   SpiQuery<T> copy();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -708,6 +708,7 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
 
   @Override
   public SpiQuery<T> copy(SpiEbeanServer server) {
+    // forUpdate is NOT copied - see #2762
     DefaultOrmQuery<T> copy = new DefaultOrmQuery<>(beanDescriptor, server, expressionFactory);
     copy.transaction = transaction;
     copy.m2mIncludeJoin = m2mIncludeJoin;
@@ -748,7 +749,6 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     copy.usageProfiling = usageProfiling;
     copy.autoTune = autoTune;
     copy.parentNode = parentNode;
-    copy.forUpdate = forUpdate;
     copy.rawSql = rawSql;
     setCancelableQuery(copy); // required to cancel findId query
     return copy;


### PR DESCRIPTION
The copy() method is used by findPagedList(), findIds(), findFutureList() etc.