### PR TITLE
#2766 Explicitly specify disableLazyLoad on beans created from JSON by default 

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/text/json/ReadJson.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/text/json/ReadJson.java
@@ -33,6 +33,7 @@ public final class ReadJson implements SpiJsonReader {
   private final PersistenceContext persistenceContext;
   private final LoadContext loadContext;
   private final boolean intercept;
+  private final boolean enableLazyLoading;
 
   /**
    * Construct with parser and readOptions.
@@ -43,6 +44,7 @@ public final class ReadJson implements SpiJsonReader {
     this.objectMapper = objectMapper;
     this.persistenceContext = initPersistenceContext(readOptions);
     this.loadContext = initLoadContext(desc, readOptions);
+    this.enableLazyLoading = readOptions != null && readOptions.isEnableLazyLoading();
     // only create visitorMap, pathStack if needed ...
     this.visitorMap = (readOptions == null) ? null : readOptions.getVisitorMap();
     this.pathStack = (visitorMap == null && loadContext == null) ? null : new PathStack();
@@ -61,6 +63,7 @@ public final class ReadJson implements SpiJsonReader {
     this.persistenceContext = source.persistenceContext;
     this.loadContext = source.loadContext;
     this.intercept = source.intercept;
+    this.enableLazyLoading = source.enableLazyLoading;
   }
 
   private LoadContext initLoadContext(BeanDescriptor<?> desc, JsonReadOptions readOptions) {
@@ -109,6 +112,9 @@ public final class ReadJson implements SpiJsonReader {
    */
   @Override
   public Object persistenceContextPutIfAbsent(Object id, EntityBean bean, BeanDescriptor<?> beanDesc) {
+    if (!enableLazyLoading) {
+      bean._ebean_getIntercept().setDisableLazyLoad(true);
+    }
     if (persistenceContext == null) {
       // no persistenceContext means no lazy loading either
       return null;

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
@@ -1,5 +1,6 @@
 package org.tests.text.json;
 
+import io.ebean.text.json.JsonReadOptions;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.BeanState;
 import io.ebean.DB;
@@ -54,7 +55,7 @@ public class TestTextJsonReferenceBean extends BaseTestCase {
 
       String jsonString = jsonContext.toJson(product);
 
-      Product refProd = jsonContext.toBean(Product.class, jsonString);
+      Product refProd = jsonContext.toBean(Product.class, jsonString, new JsonReadOptions().setEnableLazyLoading(true));
 
       BeanDescriptor<Product> prodDesc = server.descriptor(Product.class);
       EntityBean eb = (EntityBean) refProd;

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
@@ -17,10 +17,23 @@ import org.tests.model.basic.ResetBasicData;
 import java.io.IOException;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestTextJsonReferenceBean extends BaseTestCase {
+
+  @Test
+  void fromJson_refBean_shouldNotLazyLoadByDefault() {
+    ResetBasicData.reset();
+
+    JsonContext jsonContext = DB.json();
+    Product productRefBean = jsonContext.toBean(Product.class, "{\"id\": 1}");
+
+    assertThat(DB.beanState(productRefBean).isReference()).isTrue();
+    // does not lazy load by default
+    assertThat(productRefBean.getName()).isNull();
+  }
 
   @Test
   public void test() throws IOException {


### PR DESCRIPTION
- Beans created from JSON default to disableLazyLoad true
- Explicitly use new JsonReadOptions().setEnableLazyLoading(true) when lazy loading is needed