### PR TITLE
Support a naming convention function that can be applied to metrics names for reporting

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -16,6 +16,7 @@ import io.ebean.event.changelog.ChangeLogPrepare;
 import io.ebean.event.changelog.ChangeLogRegister;
 import io.ebean.event.readaudit.ReadAuditLogger;
 import io.ebean.event.readaudit.ReadAuditPrepare;
+import io.ebean.meta.MetricNamingMatch;
 import io.ebean.util.StringHelper;
 
 import javax.persistence.EnumType;
@@ -24,6 +25,7 @@ import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.function.Function;
 
 /**
  * The configuration used for creating a Database.
@@ -545,6 +547,8 @@ public class DatabaseConfig {
   private boolean dumpMetricsOnShutdown;
 
   private String dumpMetricsOptions;
+
+  private Function<String, String> metricNaming = MetricNamingMatch.INSTANCE;
 
   /**
    * Construct a Database Configuration for programmatically creating an Database.
@@ -3394,6 +3398,20 @@ public class DatabaseConfig {
    */
   public void setLoadModuleInfo(boolean loadModuleInfo) {
     this.loadModuleInfo = loadModuleInfo;
+  }
+
+  /**
+   * Return the naming convention to apply to metrics names.
+   */
+  public Function<String, String> getMetricNaming() {
+    return metricNaming;
+  }
+
+  /**
+   * Set the naming convention to apply to metrics names.
+   */
+  public void setMetricNaming(Function<String, String> metricNaming) {
+    this.metricNaming = metricNaming;
   }
 
   public enum UuidVersion {

--- a/ebean-api/src/main/java/io/ebean/meta/BasicMetricVisitor.java
+++ b/ebean-api/src/main/java/io/ebean/meta/BasicMetricVisitor.java
@@ -2,6 +2,7 @@ package io.ebean.meta;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * A simple MetricVisitor that can collect the desired metrics into lists.
@@ -9,32 +10,39 @@ import java.util.List;
 public class BasicMetricVisitor extends AbstractMetricVisitor implements ServerMetrics {
 
   private final String name;
+  private final Function<String,String> naming;
   private final List<MetaTimedMetric> timed = new ArrayList<>();
   private final List<MetaQueryMetric> query = new ArrayList<>();
   private final List<MetaCountMetric> count = new ArrayList<>();
 
   public BasicMetricVisitor() {
-    this("db");
+    this("db", MetricNamingMatch.INSTANCE);
   }
 
   /**
    * Construct to reset and collect everything.
    */
-  public BasicMetricVisitor(String name) {
-    this(name, true, true, true, true);
+  public BasicMetricVisitor(String name, Function<String,String> naming) {
+    this(name, naming, true, true, true, true);
   }
 
   /**
    * Construct specifying reset and what to collect.
    */
-  public BasicMetricVisitor(String name, boolean reset, boolean collectTransactionMetrics, boolean collectQueryMetrics, boolean collectL2Metrics) {
+  public BasicMetricVisitor(String name, Function<String,String> naming, boolean reset, boolean collectTransactionMetrics, boolean collectQueryMetrics, boolean collectL2Metrics) {
     super(reset, collectTransactionMetrics, collectQueryMetrics, collectL2Metrics);
     this.name = name;
+    this.naming = naming;
   }
 
   @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public Function<String, String> namingConvention() {
+    return naming;
   }
 
   @Override

--- a/ebean-api/src/main/java/io/ebean/meta/MetricNamingMatch.java
+++ b/ebean-api/src/main/java/io/ebean/meta/MetricNamingMatch.java
@@ -1,0 +1,16 @@
+package io.ebean.meta;
+
+import java.util.function.Function;
+
+/**
+ * Metric naming convention that is exact match.
+ */
+public final class MetricNamingMatch implements Function<String, String> {
+
+  public static final Function<String, String> INSTANCE = new MetricNamingMatch();
+
+  @Override
+  public String apply(String name) {
+    return name;
+  }
+}

--- a/ebean-api/src/main/java/io/ebean/meta/MetricVisitor.java
+++ b/ebean-api/src/main/java/io/ebean/meta/MetricVisitor.java
@@ -1,9 +1,16 @@
 package io.ebean.meta;
 
+import java.util.function.Function;
+
 /**
  * Defines visitor to read and report the transaction and query metrics.
  */
 public interface MetricVisitor {
+
+  /**
+   * Return the naming convention that should be applied to the reported metric names.
+   */
+  Function<String, String> namingConvention();
 
   /**
    * Return true if the metrics should be reset.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultMetaInfoManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultMetaInfoManager.java
@@ -1,20 +1,9 @@
 package io.ebeaninternal.server.core;
 
-import io.ebean.meta.AbstractMetricVisitor;
-import io.ebean.meta.BasicMetricVisitor;
-import io.ebean.meta.MetaCountMetric;
-import io.ebean.meta.MetaInfoManager;
-import io.ebean.meta.MetaQueryMetric;
-import io.ebean.meta.MetaQueryPlan;
-import io.ebean.meta.MetaTimedMetric;
-import io.ebean.meta.MetricData;
-import io.ebean.meta.MetricVisitor;
-import io.ebean.meta.QueryPlanInit;
-import io.ebean.meta.QueryPlanRequest;
-import io.ebean.meta.ServerMetrics;
-import io.ebean.meta.ServerMetricsAsJson;
+import io.ebean.meta.*;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * DefaultServer based implementation of MetaInfoManager.
@@ -22,9 +11,11 @@ import java.util.List;
 final class DefaultMetaInfoManager implements MetaInfoManager {
 
   private final DefaultServer server;
+  private final Function<String, String> naming;
 
-  DefaultMetaInfoManager(DefaultServer server) {
+  DefaultMetaInfoManager(DefaultServer server, Function<String, String> naming) {
     this.server = server;
+    this.naming = naming;
   }
 
   @Override
@@ -49,7 +40,7 @@ final class DefaultMetaInfoManager implements MetaInfoManager {
 
   @Override
   public BasicMetricVisitor visitBasic() {
-    BasicMetricVisitor basic = new BasicMetricVisitor(server.name());
+    BasicMetricVisitor basic = new BasicMetricVisitor(server.name(), naming);
     visitMetrics(basic);
     return basic;
   }
@@ -66,6 +57,11 @@ final class DefaultMetaInfoManager implements MetaInfoManager {
 
     ResetVisitor() {
       super(true, true, true, true);
+    }
+
+    @Override
+    public Function<String, String> namingConvention() {
+      return MetricNamingMatch.INSTANCE;
     }
 
     @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -213,7 +213,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     this.transactionManager = config.createTransactionManager(this, docStoreComponents.updateProcessor());
     this.documentStore = docStoreComponents.documentStore();
     this.queryPlanManager = config.initQueryPlanManager(transactionManager);
-    this.metaInfoManager = new DefaultMetaInfoManager(this);
+    this.metaInfoManager = new DefaultMetaInfoManager(this, this.config.getMetricNaming());
     this.serverPlugins = config.getPlugins();
     this.ddlGenerator = config.initDdlGenerator(this);
     this.scriptRunner = new DScriptRunner(this);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1482,7 +1482,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
     iudMetrics.visit(visitor);
     for (CQueryPlan queryPlan : queryPlanCache.values()) {
       if (!queryPlan.isEmptyStats()) {
-        visitor.visitQuery(queryPlan.getSnapshot(visitor.reset()));
+        visitor.visitQuery(queryPlan.visit(visitor));
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/profile/DCountMetric.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/profile/DCountMetric.java
@@ -13,6 +13,7 @@ final class DCountMetric implements CountMetric {
 
   private final String name;
   private final LongAdder count = new LongAdder();
+  private String reportName;
 
   DCountMetric(String name) {
     this.name = name;
@@ -50,8 +51,15 @@ final class DCountMetric implements CountMetric {
   public void visit(MetricVisitor visitor) {
     long val = visitor.reset() ? count.sumThenReset() : count.sum();
     if (val > 0) {
+      final String name = reportName != null ? reportName : reportName(visitor);
       visitor.visitCount(new DCountMetricStats(name, val));
     }
+  }
+
+  String reportName(MetricVisitor visitor) {
+    final String tmp = visitor.namingConvention().apply(name);
+    this.reportName = tmp;
+    return tmp;
   }
 
   private static class DCountMetricStats implements CountMetricStats {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/profile/DTimedProfileLocation.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/profile/DTimedProfileLocation.java
@@ -13,6 +13,7 @@ final class DTimedProfileLocation extends DProfileLocation implements TimedProfi
   private final TimedMetric timedMetric;
   private final boolean overrideMetricName;
   private String fullName;
+  private String reportName;
 
   DTimedProfileLocation(int lineNumber, String label, TimedMetric timedMetric) {
     super(lineNumber);
@@ -47,11 +48,17 @@ final class DTimedProfileLocation extends DProfileLocation implements TimedProfi
   public void visit(MetricVisitor visitor) {
     TimedMetricStats collect = timedMetric.collect(visitor.reset());
     if (collect != null) {
-      if (overrideMetricName) {
-        collect.setName(fullName);
-      }
+      final String name = reportName != null ? reportName : reportName(visitor, collect.name());
+      collect.setName(name);
       collect.setLocation(location());
       visitor.visitTimed(collect);
     }
+  }
+
+  private String reportName(MetricVisitor visitor, String name) {
+    final String defaultName = overrideMetricName ? fullName : name;
+    final String tmp = visitor.namingConvention().apply(defaultName);
+    this.reportName = tmp;
+    return tmp;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
@@ -4,6 +4,7 @@ import io.ebean.ProfileLocation;
 import io.ebean.config.dbplatform.SqlLimitResponse;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.ScalarDataReader;
+import io.ebean.meta.MetricVisitor;
 import io.ebean.metric.MetricFactory;
 import io.ebean.metric.TimedMetric;
 import io.ebeaninternal.api.*;
@@ -279,8 +280,8 @@ public class CQueryPlan implements SpiQueryPlan {
   /**
    * Return a copy of the current query statistics.
    */
-  public final Snapshot getSnapshot(boolean reset) {
-    return stats.getSnapshot(reset);
+  public final Snapshot visit(MetricVisitor visitor) {
+    return stats.visit(visitor);
   }
 
   /**

--- a/ebean-core/src/test/java/io/ebeaninternal/server/profile/BasicProfileLocationTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/profile/BasicProfileLocationTest.java
@@ -1,11 +1,54 @@
 package io.ebeaninternal.server.profile;
 
+import io.ebean.meta.BasicMetricVisitor;
+import io.ebean.meta.MetaTimedMetric;
 import io.ebean.metric.MetricFactory;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BasicProfileLocationTest {
+
+  Function<String,String> naming = (String name) -> "prefix[" + name.replace('.', '-') + "]";
+
+  @Test
+  void metricNameFromOverride() {
+    DTimedProfileLocation loc = new DTimedProfileLocation(12, "", MetricFactory.get().createTimedMetric("a.b.c"));
+    loc.initWith("foo.label");
+    loc.add(42);
+
+    BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming);
+    loc.visit(visitor);
+
+    List<MetaTimedMetric> result = visitor.timedMetrics();
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).name()).isEqualTo("prefix[txn-named-foo-label]");
+    assertThat(result.get(0).total()).isEqualTo(42);
+
+    loc.add(21);
+    BasicMetricVisitor visitor2 = new BasicMetricVisitor("v", naming);
+    loc.visit(visitor2);
+    List<MetaTimedMetric> result2 = visitor2.timedMetrics();
+    assertThat(result2).hasSize(1);
+    assertThat(result2.get(0).name()).isEqualTo("prefix[txn-named-foo-label]");
+    assertThat(result2.get(0).total()).isEqualTo(21);
+  }
+
+  @Test
+  void metricNameFromTimed() {
+    DTimedProfileLocation loc = new DTimedProfileLocation(12, "foo", MetricFactory.get().createTimedMetric("a.b.c"));
+    loc.add(42);
+
+    BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming);
+    loc.visit(visitor);
+
+    List<MetaTimedMetric> result = visitor.timedMetrics();
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).name()).isEqualTo("prefix[a-b-c]");
+  }
 
   @Test
   void obtain() {

--- a/ebean-core/src/test/java/io/ebeaninternal/server/profile/DCountMetricTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/profile/DCountMetricTest.java
@@ -1,0 +1,43 @@
+package io.ebeaninternal.server.profile;
+
+import io.ebean.meta.BasicMetricVisitor;
+import io.ebean.meta.MetaCountMetric;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DCountMetricTest {
+
+  Function<String, String> naming = (String name) -> "prefix[" + name.replace('.', '-') + "]";
+
+  @Test
+  void visit() {
+
+    DCountMetric counter = new DCountMetric("org.hello");
+    counter.add(7);
+    {
+      BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming);
+      counter.visit(visitor);
+      List<MetaCountMetric> result = visitor.countMetrics();
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).name()).isEqualTo("prefix[org-hello]");
+      assertThat(result.get(0).count()).isEqualTo(7);
+    }
+    {
+      // second collection
+      counter.add(4);
+      counter.add(8);
+      BasicMetricVisitor visitor2 = new BasicMetricVisitor("v", naming);
+      counter.visit(visitor2);
+
+      List<MetaCountMetric> result2 = visitor2.countMetrics();
+      assertThat(result2).hasSize(1);
+      assertThat(result2.get(0).name()).isEqualTo("prefix[org-hello]");
+      assertThat(result2.get(0).count()).isEqualTo(12);
+    }
+  }
+}

--- a/ebean-core/src/test/java/io/ebeaninternal/server/profile/DQueryPlanMetricTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/profile/DQueryPlanMetricTest.java
@@ -1,0 +1,47 @@
+package io.ebeaninternal.server.profile;
+
+import io.ebean.meta.BasicMetricVisitor;
+import io.ebean.meta.MetaQueryMetric;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DQueryPlanMetricTest {
+
+  Function<String, String> naming = (String name) -> "prefix[" + name.replace('.', '-') + "]";
+
+  @Test
+  void visit() {
+
+    DQueryPlanMeta meta = new DQueryPlanMeta(Object.class, "lab", null, "sql");
+    DTimedMetric metric = new DTimedMetric("org.timed.plan");
+    DQueryPlanMetric planMetric = new DQueryPlanMetric(meta, metric);
+
+    metric.add(560);
+    metric.add(260);
+    {
+      BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming);
+      planMetric.visit(visitor);
+      List<MetaQueryMetric> result = visitor.queryMetrics();
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).name()).isEqualTo("prefix[dto-Object_lab]");
+      assertThat(result.get(0).count()).isEqualTo(2);
+      assertThat(result.get(0).total()).isEqualTo(820);
+    }
+    metric.add(410);
+    {
+      BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming);
+      planMetric.visit(visitor);
+      List<MetaQueryMetric> result = visitor.queryMetrics();
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).name()).isEqualTo("prefix[dto-Object_lab]");
+      assertThat(result.get(0).count()).isEqualTo(1);
+      assertThat(result.get(0).total()).isEqualTo(410);
+    }
+  }
+}

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQuery2Test.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQuery2Test.java
@@ -14,6 +14,7 @@ import org.tests.model.basic.ResetBasicData;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -209,8 +210,10 @@ public class DtoQuery2Test extends BaseTestCase {
       log.info("Found " + custs);
     }
 
+    Function<String, String> lowerUnderscore = (String key) -> "prefix:" + key.replace('.','_').toLowerCase();
+
     // collect without reset
-    BasicMetricVisitor basic = new BasicMetricVisitor("db", false, true, true, true);
+    BasicMetricVisitor basic = new BasicMetricVisitor("db", lowerUnderscore, false, true, true, true);
     server().metaInfo().visitMetrics(basic);
 
     List<MetaQueryMetric> stats = basic.queryMetrics();
@@ -219,7 +222,7 @@ public class DtoQuery2Test extends BaseTestCase {
     MetaQueryMetric queryMetric = stats.get(0);
     assertThat(queryMetric.label()).isEqualTo("basic");
     assertThat(queryMetric.count()).isEqualTo(3);
-    assertThat(queryMetric.name()).isEqualTo("dto.DCust_basic");
+    assertThat(queryMetric.name()).isEqualTo("prefix:dto_dcust_basic");
 
 
     server().findDto(DCust.class, "select c4.id, c4.name from o_customer c4 where lower(c4.name) = :name")

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryTest.java
@@ -1,5 +1,6 @@
 package io.ebean.xtest.base;
 
+import io.ebean.meta.MetricNamingMatch;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.DtoQuery;
@@ -286,7 +287,7 @@ class DtoQueryTest extends BaseTestCase {
     }
 
     // collect without reset
-    BasicMetricVisitor basic = new BasicMetricVisitor("db", false, true, true, true);
+    BasicMetricVisitor basic = new BasicMetricVisitor("db", MetricNamingMatch.INSTANCE, false, true, true, true);
     server().metaInfo().visitMetrics(basic);
 
     List<MetaQueryMetric> stats = basic.queryMetrics();


### PR DESCRIPTION
For example, can apply a lower case underscore naming convention to the metrics names. This
can be done such that it doesn't have to be applied every time the metrics are collected and
reported.