### PR TITLE
Bump mariadb-java-client to 3.0.7

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQuery.java
@@ -314,7 +314,7 @@ public final class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfi
       if (forwardOnlyHint) {
         // Use forward only hints for large resultSet processing (Issue 56, MySql specific)
         pstmt = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-        pstmt.setFetchSize(Integer.MIN_VALUE);
+        pstmt.setFetchSize(1);
       } else {
         pstmt = conn.prepareStatement(sql);
       }

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>2.6.0</version>
+      <version>3.0.7</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Bumped mariadb-java-client version to 3.0.7 to see which tests may break (see #2782)