### PR TITLE
#2782 - Support MariaDB jdbc driver update - Batched JDBC SQLException translation, SqlRow BLOB reading

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/SqlCodeTranslator.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/SqlCodeTranslator.java
@@ -32,7 +32,12 @@ public class SqlCodeTranslator implements SqlExceptionTranslator {
   }
 
   private DataErrorType getErrorType(SQLException e) {
-    DataErrorType errorType = map.get(e.getSQLState());
+    String sqlState = e.getSQLState();
+    while (sqlState == null && e.getCause() instanceof SQLException) {
+      e = (SQLException)e.getCause();
+      sqlState = e.getSQLState();
+    }
+    DataErrorType errorType = map.get(sqlState);
     if (errorType == null) {
       // fall back to error code
       errorType = map.get(String.valueOf(e.getErrorCode()));

--- a/ebean-core/src/main/java/io/ebeaninternal/server/rawsql/DRawSqlService.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/rawsql/DRawSqlService.java
@@ -58,6 +58,7 @@ public final class DRawSqlService implements SpiRawSqlService {
           ret.put(name, resultSet.getString(i));
           break;
 
+        case Types.LONGVARBINARY:
         case Types.BLOB:
           ret.put(name, resultSet.getBytes(i));
           break;

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/rawsql/TestRawSqlBuilder.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/rawsql/TestRawSqlBuilder.java
@@ -298,7 +298,7 @@ public class TestRawSqlBuilder extends BaseTestCase {
   }
 
   @Test
-  public void testBLobClosedConnection() throws Exception {
+  void testBLobClosedConnection() throws Exception {
     final PersistentFileContent pfc = new PersistentFileContent();
     final byte[] bytes = "This is the blob as String".getBytes(StandardCharsets.UTF_8);
     pfc.setContent(bytes);

--- a/ebean-test/src/test/java/main/StartMariaDb.java
+++ b/ebean-test/src/test/java/main/StartMariaDb.java
@@ -5,11 +5,12 @@ import io.ebean.test.containers.MariaDBContainer;
 public class StartMariaDb {
 
   public static void main(String[] args) {
-    MariaDBContainer.builder("10.5")
+    MariaDBContainer.builder("10.6")
       .dbName("unit")
       .user("unit")
       .password("unit")
+      .port(5306)
       .build()
-      .startWithDropCreate();
+      .start();
   }
 }

--- a/ebean-test/src/test/java/org/tests/history/TestHistoryInsert.java
+++ b/ebean-test/src/test/java/org/tests/history/TestHistoryInsert.java
@@ -15,9 +15,13 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestHistoryInsert extends BaseTestCase {
+class TestHistoryInsert extends BaseTestCase {
 
   private final Logger logger = LoggerFactory.getLogger(TestHistoryInsert.class);
+
+  private Timestamp currentDbSystemTime() {
+    return DB.sqlQuery("select current_timestamp(6)").mapToScalar(Timestamp.class).findOne();
+  }
 
   /**
    * Looks like we MUST use useLegacyDatetimeCode=false ... in order for
@@ -25,9 +29,9 @@ public class TestHistoryInsert extends BaseTestCase {
    */
   @Test
   @ForPlatform({Platform.MARIADB})
-  public void mariadb_simple_history() {
+  void mariadb_simple_history() {
 
-    Timestamp t0 = new Timestamp(System.currentTimeMillis());
+    Timestamp t0 = currentDbSystemTime();
     littleSleep(50);
 
     User user = new User();
@@ -35,19 +39,19 @@ public class TestHistoryInsert extends BaseTestCase {
     user.setEmail("one@email.com");
     user.setPasswordHash("someHash");
     DB.save(user);
-    Timestamp t1 = new Timestamp(System.currentTimeMillis());
+    Timestamp t1 = currentDbSystemTime();
 
     littleSleep(100);
     user.setName("NotJim");
     user.save();
-    Timestamp t2 = new Timestamp(System.currentTimeMillis());
+    Timestamp t2 = currentDbSystemTime();
 
     littleSleep(100);
     user.setName("NotJimV2");
     user.setEmail("two@email.com");
     user.save();
     littleSleep(50);
-    Timestamp t3 = new Timestamp(System.currentTimeMillis());
+    Timestamp t3 = currentDbSystemTime();
 
     List<Version<User>> versions = DB.find(User.class).setId(user.getId()).findVersionsBetween(t0, t3);
     assertThat(versions).hasSize(3);

--- a/ebean-test/src/test/java/org/tests/query/cancel/SqlQueryCancelTest.java
+++ b/ebean-test/src/test/java/org/tests/query/cancel/SqlQueryCancelTest.java
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * @author Roland Praml, FOCONIS AG
  */
-public class SqlQueryCancelTest extends BaseTestCase {
+class SqlQueryCancelTest extends BaseTestCase {
 
   private final int timing = 20;
 
@@ -191,17 +191,13 @@ public class SqlQueryCancelTest extends BaseTestCase {
   }
 
   @Test
-  public void cancelOrmDtoDuringIterate() {
+  void cancelOrmDtoDuringIterate() {
     DtoQuery<EBasicDto> query = DB.find(EBasic.class).select("id,status").asDto(EBasicDto.class);
 
     QueryIterator<EBasicDto> iter = query.findIterate();
     assertThat(iter.hasNext()).isTrue();
     query.cancel();
-    if (isMariaDB()) {
-      assertThrows(PersistenceException.class, iter::next);
-    } else {
-      assertThat(iter.next()).isNotNull();
-    }
+    assertThat(iter.next()).isNotNull();
 
     // We might have 100 entities in a buffer. So we must iterate through all.
     assertThatThrownBy(() -> {

--- a/ebean-test/src/test/java/org/tests/update/TestSqlUpdateExceptions.java
+++ b/ebean-test/src/test/java/org/tests/update/TestSqlUpdateExceptions.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TestSqlUpdateExceptions extends BaseTestCase {
+class TestSqlUpdateExceptions extends BaseTestCase {
 
   private String sql = "insert into uuone (id, name, version) values (?,?,?)";
 
@@ -63,7 +63,7 @@ public class TestSqlUpdateExceptions extends BaseTestCase {
   }
 
   @Test
-  public void duplicateKey_inBatch() {
+  void duplicateKey_inBatch() {
     UUID id = UUID.randomUUID();
     assertThrows(DuplicateKeyException.class, () -> {
       try (Transaction transaction = DB.beginTransaction()) {
@@ -85,7 +85,7 @@ public class TestSqlUpdateExceptions extends BaseTestCase {
   }
 
   @Test
-  public void duplicateKey_executeBatch() {
+  void duplicateKey_executeBatch() {
     UUID id = UUID.randomUUID();
     assertThrows(DuplicateKeyException.class, () -> {
       try (Transaction transaction = DB.beginTransaction()) {

--- a/ebean-test/src/test/resources/ebean.properties
+++ b/ebean-test/src/test/resources/ebean.properties
@@ -138,7 +138,7 @@ datasource.mysql.url=jdbc:mysql://127.0.0.1:4306/unit
 
 datasource.mariadb.username=unit
 datasource.mariadb.password=unit
-datasource.mariadb.url=jdbc:mariadb://localhost:4306/unit?useLegacyDatetimeCode=false
+datasource.mariadb.url=jdbc:mariadb://localhost:5306/unit?useLegacyDatetimeCode=false
 
 datasource.cockroach.username=root
 datasource.cockroach.password=


### PR DESCRIPTION
- Batched JDBC SQLException translation - Need to dig into nested exception to get cause error state
- SqlRow BLOB reading - BLOB can come as LONGVARBINARY (TestRawSqlBuilder)
- Fix test for history using system time (TestHistoryInsert)
- Fix SqlQueryCancelTest
- Fix TestSqlUpdateExceptions