### PR TITLE
Remove ScalarType.isDateTimeCapable() ... (only used by CSV reader)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/plugin/ExpressionPath.java
+++ b/ebean-api/src/main/java/io/ebean/plugin/ExpressionPath.java
@@ -46,12 +46,6 @@ public interface ExpressionPath {
   Object parseDateTime(long systemTimeMillis);
 
   /**
-   * Return true if the last type is "DateTime capable" - can support
-   * {@link #parseDateTime(long)}.
-   */
-  boolean isDateTimeCapable();
-
-  /**
    * Return the underlying JDBC type or 0 if this is not a scalar type.
    */
   int jdbcType();

--- a/ebean-core-type/src/main/java/io/ebean/core/type/ScalarType.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/ScalarType.java
@@ -164,20 +164,6 @@ public interface ScalarType<T> extends StringParser, StringFormatter, ScalarData
   DocPropertyType getDocType();
 
   /**
-   * Return true if the type can accept long systemTimeMillis input.
-   * <p>
-   * This is used to determine if it is sensible to use the
-   * {@link #convertFromMillis(long)} method.
-   * <p>
-   * This includes the Date, Calendar, sql Date, Time, Timestamp, JODA types
-   * as well as Long, BigDecimal and String (although it generally is not
-   * expected to parse systemTimeMillis to a String or BigDecimal).
-   */
-  default boolean isDateTimeCapable() {
-    return false;
-  }
-
-  /**
    * Convert the value into a long version value.
    */
   default long asVersion(T value) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanFkeyProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanFkeyProperty.java
@@ -181,11 +181,6 @@ public final class BeanFkeyProperty implements ElPropertyValue {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return false;
-  }
-
-  @Override
   public int jdbcType() {
     return 0;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -941,11 +941,6 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return scalarType != null && scalarType.isDateTimeCapable();
-  }
-
-  @Override
   public int jdbcType() {
     return scalarType == null ? 0 : scalarType.getJdbcType();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
@@ -227,12 +227,6 @@ public final class ElPropertyChain implements ElPropertyValue {
     return lastBeanProperty;
   }
 
-
-  @Override
-  public boolean isDateTimeCapable() {
-    return scalarType != null && scalarType.isDateTimeCapable();
-  }
-
   @Override
   public int jdbcType() {
     return scalarType == null ? 0 : scalarType.getJdbcType();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/text/csv/TCsvReader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/text/csv/TCsvReader.java
@@ -123,11 +123,7 @@ public class TCsvReader<T> implements CsvReader<T> {
 
   @Override
   public void addDateTime(String propertyName, String dateTimeFormat, Locale locale) {
-
     ExpressionPath elProp = descriptor.expressionPath(propertyName);
-    if (!elProp.isDateTimeCapable()) {
-      throw new TextException("Property " + propertyName + " is not DateTime capable");
-    }
     if (dateTimeFormat == null) {
       dateTimeFormat = getDefaultDateTimeFormat(elProp.jdbcType());
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDate.java
@@ -83,11 +83,6 @@ abstract class ScalarTypeBaseDate<T> extends ScalarTypeBase<T> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public T jsonRead(JsonParser parser) throws IOException {
     if (JsonToken.VALUE_NUMBER_INT == parser.getCurrentToken()) {
       return convertFromMillis(parser.getLongValue());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
@@ -161,11 +161,6 @@ abstract class ScalarTypeBaseDateTime<T> extends ScalarTypeBase<T> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public T readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBigDecimal.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBigDecimal.java
@@ -63,11 +63,6 @@ class ScalarTypeBigDecimal extends ScalarTypeBase<BigDecimal> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public BigDecimal readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBytesEncrypted.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBytesEncrypted.java
@@ -53,11 +53,6 @@ public final class ScalarTypeBytesEncrypted implements ScalarType<byte[]> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return baseType.isDateTimeCapable();
-  }
-
-  @Override
   public boolean isJdbcNative() {
     return baseType.isJdbcNative();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDouble.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDouble.java
@@ -62,11 +62,6 @@ final class ScalarTypeDouble extends ScalarTypeBase<Double> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public Double readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeEncryptedWrapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeEncryptedWrapper.java
@@ -95,11 +95,6 @@ public final class ScalarTypeEncryptedWrapper<T> implements ScalarType<T>, Local
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return wrapped.isDateTimeCapable();
-  }
-
-  @Override
   public boolean isJdbcNative() {
     return false;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeFloat.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeFloat.java
@@ -62,11 +62,6 @@ final class ScalarTypeFloat extends ScalarTypeBase<Float> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public Float readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInteger.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInteger.java
@@ -92,11 +92,6 @@ final class ScalarTypeInteger extends ScalarTypeBase<Integer> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return false;
-  }
-
-  @Override
   public Integer jsonRead(JsonParser parser) throws IOException {
     return parser.getIntValue();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalTime.java
@@ -78,11 +78,6 @@ class ScalarTypeJodaLocalTime extends ScalarTypeBase<LocalTime> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public LocalTime readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalTime.java
@@ -87,11 +87,6 @@ class ScalarTypeLocalTime extends ScalarTypeBase<LocalTime> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return false;
-  }
-
-  @Override
   public LocalTime convertFromMillis(long systemTimeMillis) {
     throw new TextException("Not Supported");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLong.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLong.java
@@ -72,11 +72,6 @@ final class ScalarTypeLong extends ScalarTypeBase<Long> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public Long readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeMathBigInteger.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeMathBigInteger.java
@@ -67,11 +67,6 @@ final class ScalarTypeMathBigInteger extends ScalarTypeBase<BigInteger> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public BigInteger readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeStringBase.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeStringBase.java
@@ -62,11 +62,6 @@ abstract class ScalarTypeStringBase extends ScalarTypeBase<String> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public String readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTime.java
@@ -63,11 +63,6 @@ final class ScalarTypeTime extends ScalarTypeBase<Time> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return true;
-  }
-
-  @Override
   public Time readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeWrapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeWrapper.java
@@ -100,11 +100,6 @@ public class ScalarTypeWrapper<B, S> implements ScalarType<B> {
   }
 
   @Override
-  public boolean isDateTimeCapable() {
-    return scalarType.isDateTimeCapable();
-  }
-
-  @Override
   public boolean isJdbcNative() {
     return false;
   }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationTest.java
@@ -76,11 +76,6 @@ class ScalarTypeDurationTest {
   }
 
   @Test
-  void testIsDateTimeCapable() {
-    assertFalse(type.isDateTimeCapable());
-  }
-
-  @Test
   void testConvertFromMillis() {
     assertThrows(UnsupportedOperationException.class, () -> type.convertFromMillis(1000));
   }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationWithNanosTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationWithNanosTest.java
@@ -76,11 +76,6 @@ class ScalarTypeDurationWithNanosTest {
   }
 
   @Test
-  void testIsDateTimeCapable() {
-    assertFalse(type.isDateTimeCapable());
-  }
-
-  @Test
   void testConvertFromMillis() {
     assertThrows(UnsupportedOperationException.class, () -> type.convertFromMillis(1000));
   }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeInstantTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeInstantTest.java
@@ -11,7 +11,8 @@ import java.sql.Timestamp;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ScalarTypeInstantTest {
 
@@ -105,12 +106,6 @@ public class ScalarTypeInstantTest {
     String format = type.format(now);
     Instant val1 = type.parse(format);
     assertEquals(now, val1);
-  }
-
-  @Test
-  public void testIsDateTimeCapable() throws Exception {
-
-    assertTrue(type.isDateTimeCapable());
   }
 
   @Test

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeTest.java
@@ -78,11 +78,6 @@ public class ScalarTypeLocalTimeTest {
   }
 
   @Test
-  public void testIsDateTimeCapable() {
-    assertFalse(type.isDateTimeCapable());
-  }
-
-  @Test
   public void testConvertFromMillis() {
     assertThrows(TextException.class, () -> type.convertFromMillis(1234));
   }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeWithNanosTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeWithNanosTest.java
@@ -75,11 +75,6 @@ public class ScalarTypeLocalTimeWithNanosTest {
   }
 
   @Test
-  public void testIsDateTimeCapable() {
-    assertFalse(type.isDateTimeCapable());
-  }
-
-  @Test
   public void testConvertFromMillis() {
     assertThrows(TextException.class, () -> type.convertFromMillis(1234));
   }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeMonthDayTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeMonthDayTest.java
@@ -6,7 +6,8 @@ import java.sql.Date;
 import java.time.LocalDate;
 import java.time.MonthDay;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ScalarTypeMonthDayTest {
 
@@ -46,11 +47,6 @@ public class ScalarTypeMonthDayTest {
 
     assertEquals("--04-29", val1);
     assertEquals(value, monthDay);
-  }
-
-  @Test
-  public void testIsDateTimeCapable() {
-    assertFalse(type.isDateTimeCapable());
   }
 
   @Test

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypePostgresHstoreTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypePostgresHstoreTest.java
@@ -27,11 +27,6 @@ public class ScalarTypePostgresHstoreTest {
   }
 
   @Test
-  public void testIsDateTimeCapable() {
-    assertFalse(hstore.isDateTimeCapable());
-  }
-
-  @Test
   public void testIsDirty() {
     Map<String, Object> emptyMap = new HashMap<>();
     assertTrue(hstore.isDirty(emptyMap));

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeYearTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeYearTest.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.type;
 
-import io.ebean.text.TextException;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -69,11 +68,6 @@ class ScalarTypeYearTest {
   void testParse() {
     Year year = type.parse("2013");
     assertEquals(Year.of(2013), year);
-  }
-
-  @Test
-  void testIsDateTimeCapable() {
-    assertFalse(type.isDateTimeCapable());
   }
 
   @Test


### PR DESCRIPTION
So the complexity cost doesn't justify itself against only being used
by CSV reader to validate when assigning a date/time format to a property
/ expression path.