### PR TITLE
Refactor ScalarType, remove convertFromMillis() method (no longer needed)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/plugin/ExpressionPath.java
+++ b/ebean-api/src/main/java/io/ebean/plugin/ExpressionPath.java
@@ -40,12 +40,6 @@ public interface ExpressionPath {
   StringParser stringParser();
 
   /**
-   * For DateTime capable scalar types convert the long systemTimeMillis into
-   * an appropriate java time (Date,Timestamp,Time,Calendar, JODA type etc).
-   */
-  Object parseDateTime(long systemTimeMillis);
-
-  /**
    * Return the underlying JDBC type or 0 if this is not a scalar type.
    */
   int jdbcType();

--- a/ebean-core-type/src/main/java/io/ebean/core/type/ScalarType.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/ScalarType.java
@@ -167,15 +167,6 @@ public interface ScalarType<T> extends StringParser, StringFormatter, ScalarData
   }
 
   /**
-   * Convert the systemTimeMillis into the appropriate java object.
-   * <p>
-   * For non dateTime types this will throw an exception.
-   */
-  default T convertFromMillis(long dateTime) {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
    * Read the value from binary input.
    */
   T readData(DataInput dataInput) throws IOException;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanFkeyProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanFkeyProperty.java
@@ -191,11 +191,6 @@ public final class BeanFkeyProperty implements ElPropertyValue {
   }
 
   @Override
-  public Object parseDateTime(long systemTimeMillis) {
-    throw new RuntimeException("ElPropertyDeploy only - not implemented");
-  }
-
-  @Override
   public StringParser stringParser() {
     throw new RuntimeException("ElPropertyDeploy only - not implemented");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -945,11 +945,6 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
     return scalarType == null ? 0 : scalarType.jdbcType();
   }
 
-  @Override
-  public Object parseDateTime(long systemTimeMillis) {
-    return scalarType.convertFromMillis(systemTimeMillis);
-  }
-
   /**
    * Return the DB max length (varchar) or precision (decimal).
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
@@ -233,11 +233,6 @@ public final class ElPropertyChain implements ElPropertyValue {
   }
 
   @Override
-  public Object parseDateTime(long systemTimeMillis) {
-    return scalarType.convertFromMillis(systemTimeMillis);
-  }
-
-  @Override
   public StringParser stringParser() {
     return scalarType;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDate.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDate.java
@@ -77,7 +77,6 @@ abstract class ScalarTypeBaseDate<T> extends ScalarTypeBase<T> {
     }
   }
 
-  @Override
   public T convertFromMillis(long systemTimeMillis) {
     Date ts = new Date(systemTimeMillis);
     return convertFromDate(ts);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBaseDateTime.java
@@ -54,7 +54,6 @@ abstract class ScalarTypeBaseDateTime<T> extends ScalarTypeBase<T> {
   /**
    * Convert from epoch millis to the value.
    */
-  @Override
   public abstract T convertFromMillis(long systemTimeMillis);
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBigDecimal.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBigDecimal.java
@@ -59,11 +59,6 @@ class ScalarTypeBigDecimal extends ScalarTypeBase<BigDecimal> {
   }
 
   @Override
-  public BigDecimal convertFromMillis(long systemTimeMillis) {
-    return BigDecimal.valueOf(systemTimeMillis);
-  }
-
-  @Override
   public BigDecimal readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBytesEncrypted.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBytesEncrypted.java
@@ -85,11 +85,6 @@ public final class ScalarTypeBytesEncrypted implements ScalarType<byte[]> {
   }
 
   @Override
-  public byte[] convertFromMillis(long systemTimeMillis) {
-    return baseType.convertFromMillis(systemTimeMillis);
-  }
-
-  @Override
   public byte[] read(DataReader reader) throws SQLException {
     byte[] data = baseType.read(reader);
     data = dataEncryptSupport.decrypt(data);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDouble.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDouble.java
@@ -58,11 +58,6 @@ final class ScalarTypeDouble extends ScalarTypeBase<Double> {
   }
 
   @Override
-  public Double convertFromMillis(long systemTimeMillis) {
-    return (double) systemTimeMillis;
-  }
-
-  @Override
   public Double readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeEncryptedWrapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeEncryptedWrapper.java
@@ -110,11 +110,6 @@ public final class ScalarTypeEncryptedWrapper<T> implements ScalarType<T>, Local
   }
 
   @Override
-  public T convertFromMillis(long systemTimeMillis) {
-    return wrapped.convertFromMillis(systemTimeMillis);
-  }
-
-  @Override
   public T toBeanType(Object value) {
     return wrapped.toBeanType(value);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeFloat.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeFloat.java
@@ -58,11 +58,6 @@ final class ScalarTypeFloat extends ScalarTypeBase<Float> {
   }
 
   @Override
-  public Float convertFromMillis(long systemTimeMillis) {
-    return (float) systemTimeMillis;
-  }
-
-  @Override
   public Float readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInteger.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInteger.java
@@ -6,7 +6,6 @@ import io.ebean.core.type.DataBinder;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.core.type.ScalarTypeBase;
-import io.ebean.text.TextException;
 import io.ebeaninternal.server.core.BasicTypeConverter;
 
 import java.io.DataInput;
@@ -85,11 +84,6 @@ final class ScalarTypeInteger extends ScalarTypeBase<Integer> {
   @Override
   public Integer parse(String value) {
     return Integer.valueOf(value);
-  }
-
-  @Override
-  public Integer convertFromMillis(long systemTimeMillis) {
-    throw new TextException("Not Supported");
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJodaLocalTime.java
@@ -73,7 +73,6 @@ class ScalarTypeJodaLocalTime extends ScalarTypeBase<LocalTime> {
     return new LocalTime(value);
   }
 
-  @Override
   public LocalTime convertFromMillis(long systemTimeMillis) {
     return new LocalTime(systemTimeMillis, DateTimeZone.getDefault());
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLocalTime.java
@@ -88,11 +88,6 @@ class ScalarTypeLocalTime extends ScalarTypeBase<LocalTime> {
   }
 
   @Override
-  public LocalTime convertFromMillis(long systemTimeMillis) {
-    throw new TextException("Not Supported");
-  }
-
-  @Override
   public LocalTime jsonRead(JsonParser parser) throws IOException {
     return LocalTime.parse(parser.getValueAsString());
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLong.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLong.java
@@ -68,11 +68,6 @@ final class ScalarTypeLong extends ScalarTypeBase<Long> {
   }
 
   @Override
-  public Long convertFromMillis(long systemTimeMillis) {
-    return systemTimeMillis;
-  }
-
-  @Override
   public Long readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeMathBigInteger.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeMathBigInteger.java
@@ -63,11 +63,6 @@ final class ScalarTypeMathBigInteger extends ScalarTypeBase<BigInteger> {
   }
 
   @Override
-  public BigInteger convertFromMillis(long systemTimeMillis) {
-    return BigInteger.valueOf(systemTimeMillis);
-  }
-
-  @Override
   public BigInteger readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeStringBase.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeStringBase.java
@@ -58,11 +58,6 @@ abstract class ScalarTypeStringBase extends ScalarTypeBase<String> {
   }
 
   @Override
-  public String convertFromMillis(long systemTimeMillis) {
-    return String.valueOf(systemTimeMillis);
-  }
-
-  @Override
   public String readData(DataInput dataInput) throws IOException {
     if (!dataInput.readBoolean()) {
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTime.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeTime.java
@@ -58,7 +58,6 @@ final class ScalarTypeTime extends ScalarTypeBase<Time> {
     return Time.valueOf(value);
   }
 
-  @Override
   public Time convertFromMillis(long systemTimeMillis) {
     return new Time(systemTimeMillis);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeWrapper.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeWrapper.java
@@ -120,15 +120,6 @@ public class ScalarTypeWrapper<B, S> implements ScalarType<B> {
   }
 
   @Override
-  public B convertFromMillis(long systemTimeMillis) {
-    S sv = scalarType.convertFromMillis(systemTimeMillis);
-    if (sv == null) {
-      return nullValue;
-    }
-    return converter.wrapValue(sv);
-  }
-
-  @Override
   public B read(DataReader reader) throws SQLException {
     S sv = scalarType.read(reader);
     if (sv == null) {

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationTest.java
@@ -76,11 +76,6 @@ class ScalarTypeDurationTest {
   }
 
   @Test
-  void testConvertFromMillis() {
-    assertThrows(UnsupportedOperationException.class, () -> type.convertFromMillis(1000));
-  }
-
-  @Test
   void testJsonRead() throws Exception {
     Duration duration = Duration.ofSeconds(1234);
 

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationWithNanosTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeDurationWithNanosTest.java
@@ -76,11 +76,6 @@ class ScalarTypeDurationWithNanosTest {
   }
 
   @Test
-  void testConvertFromMillis() {
-    assertThrows(UnsupportedOperationException.class, () -> type.convertFromMillis(1000));
-  }
-
-  @Test
   void testJsonRead() throws Exception {
     Duration duration = Duration.ofSeconds(323, 1500000);
 

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeTest.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.type;
 
-import io.ebean.text.TextException;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -10,7 +9,8 @@ import java.io.ObjectOutputStream;
 import java.sql.Time;
 import java.time.LocalTime;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ScalarTypeLocalTimeTest {
 
@@ -75,11 +75,6 @@ public class ScalarTypeLocalTimeTest {
     LocalTime localTime = LocalTime.of(9, 23, 45);
     LocalTime val1 = type.parse("09:23:45");
     assertEquals(localTime, val1);
-  }
-
-  @Test
-  public void testConvertFromMillis() {
-    assertThrows(TextException.class, () -> type.convertFromMillis(1234));
   }
 
   @Test

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeWithNanosTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeLocalTimeWithNanosTest.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.type;
 
-import io.ebean.text.TextException;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -9,7 +8,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.time.LocalTime;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ScalarTypeLocalTimeWithNanosTest {
 
@@ -72,11 +72,6 @@ public class ScalarTypeLocalTimeWithNanosTest {
     LocalTime localTime = LocalTime.of(9, 23, 45);
     LocalTime val1 = type.parse("09:23:45");
     assertEquals(localTime, val1);
-  }
-
-  @Test
-  public void testConvertFromMillis() {
-    assertThrows(TextException.class, () -> type.convertFromMillis(1234));
   }
 
   @Test

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeMonthDayTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeMonthDayTest.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 import java.time.MonthDay;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ScalarTypeMonthDayTest {
 
@@ -47,11 +46,6 @@ public class ScalarTypeMonthDayTest {
 
     assertEquals("--04-29", val1);
     assertEquals(value, monthDay);
-  }
-
-  @Test
-  public void testConvertFromMillis() {
-    assertThrows(RuntimeException.class, () -> type.convertFromMillis(1203));
   }
 
   @Test

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypePostgresHstoreTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypePostgresHstoreTest.java
@@ -46,16 +46,6 @@ public class ScalarTypePostgresHstoreTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
-  public void testParseDateTime() {
-    assertThrows(RuntimeException.class, () -> {
-      Map<String, Object> map = (Map<String, Object>) hstore.convertFromMillis(1234L);
-      assertEquals(1, map.size());
-      assertEquals("rob", map.get("name"));
-    });
-  }
-
-  @Test
   public void testJsonWrite() throws Exception {
     Map<String, Object> map = new LinkedHashMap<>();
     assertEquals("{\"key\":{}}", generateJson(map));

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeYearTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeYearTest.java
@@ -71,11 +71,6 @@ class ScalarTypeYearTest {
   }
 
   @Test
-  void testConvertFromMillis() {
-    assertThrows(UnsupportedOperationException.class, () -> type.convertFromMillis(1000));
-  }
-
-  @Test
   void testJson() throws Exception {
     JsonTester<Year> jsonTester = new JsonTester<>(type);
     jsonTester.test(Year.of(2013));


### PR DESCRIPTION
Due to the move and change of CsvReader using StringParser ScalarType no longer
needs that general convertFromMillis() method. Note that date and dateTime ScalarTypes
still retain this conversion method.