### PR TITLE
#2814 - Change setNestedUseSavepoint() to use 'ScopeTrans' rather than the underlying Transaction

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/ScopeTrans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/ScopeTrans.java
@@ -45,15 +45,14 @@ public final class ScopeTrans {
    * Flag set when nested commit has occurred.
    */
   private boolean nestedCommit;
+  private boolean nestedUseSavepoint;
 
   public ScopeTrans(boolean rollbackOnChecked, boolean created, SpiTransaction transaction, TxScope txScope) {
-
     this.rollbackOnChecked = rollbackOnChecked;
     this.created = created;
     this.transaction = transaction;
     this.noRollbackFor = txScope.getNoRollbackFor();
     this.rollbackFor = txScope.getRollbackFor();
-
     if (transaction != null) {
       if (!created && txScope.isBatchSet() || txScope.isBatchOnCascadeSet() || txScope.isBatchSizeSet()) {
         restoreBatch = transaction.isBatchMode();
@@ -90,6 +89,14 @@ public final class ScopeTrans {
     return "ScopeTrans " + transaction;
   }
 
+  void setNestedUseSavepoint() {
+    nestedUseSavepoint = true;
+  }
+
+  boolean isNestedUseSavepoint() {
+    return nestedUseSavepoint;
+  }
+
   /**
    * Return the current/active transaction.
    */
@@ -101,7 +108,6 @@ public final class ScopeTrans {
    * Complete the transaction from enhanced transactional. Try to commit.
    */
   void complete(Object returnOrThrowable, int opCode) {
-
     if (opCode == OPCODE_ATHROW) {
       // exited with a Throwable
       caughtThrowable((Throwable) returnOrThrowable);
@@ -168,7 +174,6 @@ public final class ScopeTrans {
    * Returns the exception and this should be thrown by the calling code.
    */
   public <T extends Throwable> T caughtThrowable(T e) {
-
     if (isRollbackThrowable(e)) {
       rollback(e);
     }
@@ -188,21 +193,17 @@ public final class ScopeTrans {
    * Return true if this throwable should cause a rollback to occur.
    */
   private boolean isRollbackThrowable(Throwable e) {
-
     if (e instanceof Error) {
       return true;
     }
-
     if (noRollbackFor != null) {
       for (Class<? extends Throwable> aNoRollbackFor : noRollbackFor) {
         if (aNoRollbackFor.equals(e.getClass())) {
-
           // explicit no rollback for this one
           return false;
         }
       }
     }
-
     if (rollbackFor != null) {
       for (Class<? extends Throwable> aRollbackFor : rollbackFor) {
         if (aRollbackFor.equals(e.getClass())) {
@@ -211,7 +212,6 @@ public final class ScopeTrans {
         }
       }
     }
-
     // checked exceptions...
     // EJB defaults this to false which is not intuitive IMO
     // Ebean makes this configurable (default to true)

--- a/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
@@ -33,13 +33,26 @@ public final class ScopedTransaction extends SpiTransactionProxy {
     return "ScopedTransaction " + current;
   }
 
+  @Override
+  public void setNestedUseSavepoint() {
+    current.setNestedUseSavepoint();
+  }
+
+  @Override
+  public boolean isNestedUseSavepoint() {
+    return current.isNestedUseSavepoint();
+  }
+
   /**
    * Push the scope transaction.
    */
   public void push(ScopeTrans scopeTrans) {
-
     if (current != null) {
       stack.push(current);
+      if (current.isNestedUseSavepoint()) {
+        // child scope 'inherits' nestedUseSavepoint
+        scopeTrans.setNestedUseSavepoint();
+      }
     }
     current = scopeTrans;
     transaction = scopeTrans.getTransaction();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -573,7 +573,7 @@ public class TransactionManager implements SpiTransactionManager {
     } else {
       setToScope = false;
       transaction = txnContainer.current();
-      nestedSavepoint = transaction.isNestedUseSavepoint();
+      nestedSavepoint = txnContainer.isNestedUseSavepoint();
     }
 
     TxType type = txScope.getType();

--- a/ebean-test/src/test/java/org/tests/transaction/TestNestedSubTransaction.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestNestedSubTransaction.java
@@ -1,11 +1,14 @@
 package org.tests.transaction;
 
 import io.ebean.*;
+import io.ebean.test.LoggedSql;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.xtest.IgnorePlatform;
 import io.ebean.annotation.Platform;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.EBasic;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -60,6 +63,34 @@ public class TestNestedSubTransaction extends BaseTestCase {
     }
   }
 
+  @IgnorePlatform({Platform.SQLSERVER, Platform.MYSQL, Platform.HANA, Platform.ORACLE})
+  @Test
+  void nestedNested() {
+    LoggedSql.start();
+    try (Transaction txn0 = DB.beginTransaction()) {
+      runNestedMethod();
+      try (Transaction txnAfter = DB.beginTransaction()) {
+        DB.save(new EBasic("startAfter"));
+      }
+    }
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(3);
+    assertThat(sql.get(0)).contains("insert into e_basic").contains("sp[");
+    assertThat(sql.get(1)).contains("insert into e_basic").doesNotContain("sp[");
+    assertThat(sql.get(2)).contains("insert into e_basic").doesNotContain("sp[");
+  }
+
+  void runNestedMethod() {
+    try (Transaction txn0 = DB.beginTransaction()) {
+      txn0.setNestedUseSavepoint();
+      try (Transaction nested = DB.beginTransaction()) {
+        DB.save(new EBasic("nested in sp"));
+        nested.commit();
+      }
+      DB.save(new EBasic("nested"));
+      txn0.commit();
+    }
+  }
 
   @IgnorePlatform({Platform.SQLSERVER, Platform.MYSQL, Platform.HANA, Platform.ORACLE})
   @Test


### PR DESCRIPTION
The reason for this is that ScopedTransaction holds a stack of ScopeTrans and Transaction, but
the actual transaction in this stack is often the same instance / shared when nesting. The issue
is that currently setNestedUseSavepoint() sets this flag on the *_underlying transaction_* and
this instance is the same / shared when 'nesting'.

This change moves the nestedUseSavepoint flag for ScopedTransaction to be on ScopeTrans
(from the underlying transaction).