### PR TITLE
ENH: Add Transaction.rollbackAndContinue()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DuplicateKeyException.java
+++ b/ebean-api/src/main/java/io/ebean/DuplicateKeyException.java
@@ -2,6 +2,28 @@ package io.ebean;
 
 /**
  * Thrown when a duplicate is attempted on a unique constraint.
+ * <p>
+ * In terms of catching this exception with the view of continuing processing
+ * using the same transaction look to use {@link Transaction#rollbackAndContinue()}.
+ *
+ * <pre>{@code
+ *
+ *   try (Transaction txn = database.beginTransaction()) {
+ *
+ *     try {
+ *       ...
+ *       database.save(bean);
+ *       database.flush();
+ *     } catch (DuplicateKeyException e) {
+ *       // carry on processing using the transaction
+ *       txn.rollbackAndContinue();
+ *       ...
+ *     }
+ *
+ *     txn.commit();
+ *   }
+ *
+ * }</pre>
  */
 public class DuplicateKeyException extends DataIntegrityException {
   private static final long serialVersionUID = -4771932723285724817L;

--- a/ebean-api/src/main/java/io/ebean/Transaction.java
+++ b/ebean-api/src/main/java/io/ebean/Transaction.java
@@ -145,6 +145,35 @@ public interface Transaction extends AutoCloseable {
   void rollback(Throwable e) throws PersistenceException;
 
   /**
+   * Performs a rollback on the underlying JDBC connection with the intention of
+   * continuing to use this same transaction and performing a commit or rollback
+   * later to complete the transaction.
+   * <p>
+   * Typically used when catching {@link DuplicateKeyException} where we wish to
+   * rollback work done at that point but carry on processing using the transaction.
+   *
+   * <pre>{@code
+   *
+   *   try (Transaction txn = database.beginTransaction()) {
+   *
+   *     try {
+   *       ...
+   *       database.save(bean);
+   *       database.flush();
+   *     } catch (DuplicateKeyException e) {
+   *       // carry on processing using the transaction
+   *       txn.rollbackAndContinue();
+   *       ...
+   *     }
+   *
+   *     txn.commit();
+   *   }
+   *
+   * }</pre>
+   */
+  void rollbackAndContinue();
+
+  /**
    * Set when we want nested transactions to use Savepoint's.
    * <p>
    * This means that for a nested transaction:

--- a/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
@@ -112,6 +112,11 @@ public final class ScopedTransaction extends SpiTransactionProxy {
   }
 
   @Override
+  public void rollbackAndContinue() {
+    transaction.rollbackAndContinue();
+  }
+
+  @Override
   public void rollback() throws PersistenceException {
     try {
       current.rollback(null);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -240,7 +240,7 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
 
   @Override
   public boolean isReadOnly() {
-    if (!isActive()) {
+    if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
     try {
@@ -252,7 +252,7 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
 
   @Override
   public void setReadOnly(boolean readOnly) {
-    if (!isActive()) {
+    if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
     try {
@@ -403,7 +403,7 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    */
   @Override
   public void setPersistenceContext(SpiPersistenceContext context) {
-    if (!isActive()) {
+    if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
     this.persistenceContext = context;
@@ -465,7 +465,7 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    */
   @Override
   public Connection getInternalConnection() {
-    if (!isActive()) {
+    if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
     return connection;
@@ -508,7 +508,7 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    */
   @Override
   public void commit() {
-    if (!isActive()) {
+    if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
     // expect AutoCommit so just deactivate / put back into pool
@@ -532,6 +532,11 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
     throw new IllegalStateException(notExpectedMessage);
   }
 
+  @Override
+  public void rollbackAndContinue() {
+    // do nothing
+  }
+
   /**
    * Rollback the transaction.
    */
@@ -546,7 +551,7 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    */
   @Override
   public void rollback(Throwable cause) throws PersistenceException {
-    if (!isActive()) {
+    if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
     // expect AutoCommit so it really has already committed

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
@@ -78,10 +78,14 @@ final class NoTransaction implements SpiTransaction {
   }
 
   @Override
-  public void rollback() throws PersistenceException {
+  public void rollbackAndContinue() {
     // do nothing
   }
 
+  @Override
+  public void rollback() throws PersistenceException {
+    // do nothing
+  }
 
   @Override
   public void rollback(Throwable e) throws PersistenceException {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/SavepointTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/SavepointTransaction.java
@@ -70,6 +70,11 @@ final class SavepointTransaction extends SpiTransactionProxy {
   }
 
   @Override
+  public void rollbackAndContinue() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void rollback() throws PersistenceException {
     rollbackSavepoint(null);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TChangeLogHolder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TChangeLogHolder.java
@@ -96,4 +96,7 @@ public final class TChangeLogHolder {
     owner.sendChangeLog(changes);
   }
 
+  void clear() {
+    changes.getChanges().clear();
+  }
 }

--- a/ebean-test/src/test/java/org/tests/insert/TestInsertDuplicateKey.java
+++ b/ebean-test/src/test/java/org/tests/insert/TestInsertDuplicateKey.java
@@ -1,16 +1,15 @@
 package org.tests.insert;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.DuplicateKeyException;
 import io.ebean.annotation.Transactional;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tests.model.draftable.Document;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,14 +91,8 @@ public class TestInsertDuplicateKey extends BaseTestCase {
       DB.getDefault().currentTransaction().flush();
     } catch (DuplicateKeyException e) {
       log.info("duplicate failed but just continue" + e.getMessage());
-      try {
-        // typically we would use transaction.commitAndContinue()
-        // ... this is a rollback and continue type scenario
-        // ... more sensible to use a second transaction that do this
-        DB.getDefault().currentTransaction().connection().rollback();
-      } catch (SQLException e1) {
-        e1.printStackTrace();
-      }
+      // rollback and continue using the transaction
+      DB.getDefault().currentTransaction().rollbackAndContinue();
     }
 
     Document doc0 = new Document();


### PR DESCRIPTION
Typically useful for handling DuplicateKeyException where we expect
DuplicateKeyException to be thrown and catch it with the intention of
continuing processing using the same transaction.

Note that some databases like Oracle do not require this explicit
rollback() and would work without the rollbackAndContinue(). Postgres
in particular requires the rollback() call on the underlying connection
such that we can continue using that transaction/java.sql.Connection.

Note that in the existing test we can see that rollbackAndContinue()
is pretty close to being syntactic sugar. I think adding rollbackAndContinue()
is justified and complements the existing commitAndContinue().