### PR TITLE
#2818 - Fix Concurrent modification of listenerNotify TransactionEvent list

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/SavepointTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/SavepointTransaction.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.transaction;
 
 import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.api.SpiTransactionProxy;
+import io.ebeaninternal.api.TransactionEvent;
 import io.ebeaninternal.server.util.Str;
 
 import javax.persistence.PersistenceException;
@@ -25,6 +26,7 @@ final class SavepointTransaction extends SpiTransactionProxy {
 
   private boolean rollbackOnly;
   private int state;
+  private TransactionEvent event;
 
   SavepointTransaction(SpiTransaction transaction, TransactionManager manager) throws SQLException {
     this.manager = manager;
@@ -38,6 +40,14 @@ final class SavepointTransaction extends SpiTransactionProxy {
       this.spPrefix = "sp[] ";
     }
     this.logPrefix = transaction.getLogPrefix() + spPrefix;
+  }
+
+  @Override
+  public TransactionEvent getEvent() {
+    if (event == null) {
+      event = new TransactionEvent();
+    }
+    return event;
   }
 
   @Override

--- a/ebean-test/src/test/java/org/tests/transaction/TestNestedSubTransaction.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestNestedSubTransaction.java
@@ -4,6 +4,8 @@ import io.ebean.*;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.xtest.IgnorePlatform;
 import io.ebean.annotation.Platform;
+import io.ebeaninternal.api.SpiTransaction;
+import io.ebeaninternal.api.TransactionEvent;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.EBasic;
 
@@ -75,9 +77,14 @@ public class TestNestedSubTransaction extends BaseTestCase {
 
       server.save(bean);
 
+      TransactionEvent event0 = ((SpiTransaction) txn0).getEvent();
+
       try (Transaction txn1 = server.beginTransaction()) {
         bean.setName("updateNested");
         server.save(bean);
+
+        TransactionEvent event1 = ((SpiTransaction) txn1).getEvent();
+        assertThat(event1).isNotSameAs(event0);
 
         try (Transaction txn2 = server.beginTransaction()) {
           bean.setName("barney");


### PR DESCRIPTION
The issue fixed here is that SavepointTransaction was effectively using the
TransactionEvent of the underlying 'parent' transaction. The fix is for
SavepointTransaction to have its own TransactionEvent.