### PR TITLE
Possible memory leak with BackgroundExecutor using BackgroundExecutorWrapper ThreadLocals (for scheduled tasks)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/BackgroundExecutorWrapper.java
+++ b/ebean-api/src/main/java/io/ebean/config/BackgroundExecutorWrapper.java
@@ -6,6 +6,10 @@ import java.util.concurrent.Callable;
  * BackgroundExecutorWrapper that can be used to wrap tasks that are sent to background (i.e. another thread).
  * It should copy all necessary thread-local variables. See {@link MdcBackgroundExecutorWrapper} for implementation details.
  *
+ * Note: only tasks that are executed immediately (submit, execute) are wrapped. Periodic or scheduled tasks are not wrapped,
+ * as these may keep copied variables in memory either forever or until the scheduled task is finished.
+ * The caller is responsible to handle these cases.
+ *
  * @author Roland Praml, FOCONIS AG
  */
 public interface BackgroundExecutorWrapper {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/executor/DefaultBackgroundExecutor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/executor/DefaultBackgroundExecutor.java
@@ -106,23 +106,23 @@ public final class DefaultBackgroundExecutor implements SpiBackgroundExecutor {
 
   @Override
   public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long initialDelay, long delay, TimeUnit unit) {
-    return schedulePool.scheduleWithFixedDelay(wrap(logExceptions(task)), initialDelay, delay, unit);
+    return schedulePool.scheduleWithFixedDelay(logExceptions(task), initialDelay, delay, unit);
   }
 
   @Override
   public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long initialDelay, long delay, TimeUnit unit) {
-    return schedulePool.scheduleAtFixedRate(wrap(logExceptions(task)), initialDelay, delay, unit);
+    return schedulePool.scheduleAtFixedRate(logExceptions(task), initialDelay, delay, unit);
   }
 
   @Override
   public ScheduledFuture<?> schedule(Runnable task, long delay, TimeUnit unit) {
-    return schedulePool.schedule(wrap(logExceptions(task)), delay, unit);
+    return schedulePool.schedule(logExceptions(task), delay, unit);
   }
 
   @Override
   public <V> ScheduledFuture<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
     // Note: No "logExceptions" as we expect Future.get() by the invoker
-    return schedulePool.schedule(wrap(task), delay, unit);
+    return schedulePool.schedule(task, delay, unit);
   }
 
   @Override


### PR DESCRIPTION
Hello @rbygrave ,
hello @rPraml ,

I created a PR with the fix of https://github.com/ebean-orm/ebean/issues/2854. 
Could you please check it?

@rbygrave the maven build does not work local on my machine, `CsvReaderTest` throws a `java.time.format.DateTimeParseException: Text '01-Jan-2009' could not be parsed at index 3`.
The test works only if I use `-Duser.language="en"`.

Cheers
Noemi