### PR TITLE
FIX: LogFormat for SystemLogger

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1RndIdGenerator.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1RndIdGenerator.java
@@ -106,7 +106,7 @@ public class UuidV1RndIdGenerator implements PlatformIdGenerator {
 
         delta = current - last;
         if (delta < -10000 * 20000) {
-          log.log(INFO, "Clock skew of {} ms detected", delta / -10000);
+          log.log(INFO, "Clock skew of {0} ms detected", delta / -10000);
           // The clock was adjusted back about 2 seconds, or we were generating a lot of ids too fast
           // if so, we try to set the current as last and also increment the clockSeq.
           lock.lock();

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/extraddl/model/ExtraDdlXmlReader.java
@@ -42,7 +42,7 @@ public class ExtraDdlXmlReader {
     StringBuilder sb = new StringBuilder(300);
     for (DdlScript script : read.getDdlScript()) {
       if (script.isDrop() == drops && matchPlatform(platform, script.getPlatforms())) {
-        logger.log(DEBUG, "include script {}", script.getName());
+        logger.log(DEBUG, "include script {0}", script.getName());
         String value = script.getValue();
         sb.append(value);
         if (value.lastIndexOf(';') == -1) {


### PR DESCRIPTION
Found two wrong formatted log messages (Search regexp `\.log\(.*\{\}`)