### PR TITLE
FIX: @Formula / @Where Annotations should also match on base platform

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -1123,7 +1123,7 @@ public class DeployBeanProperty {
 
   private boolean matchPlatform(Platform[] platforms, Platform match) {
     for (Platform platform : platforms) {
-      if (platform == match) {
+      if (platform == match || platform == match.base()) {
         return true;
       }
     }


### PR DESCRIPTION
A property annotated with
```java
@Formula(select = "...", platforms = SQLSERVER)
```
should match for SQLSERVER17 and SQLSERVER19