### PR TITLE
FIX: Flush transaction if it is modified in callback

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -885,6 +885,9 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   public final void preCommit() {
     internalBatchFlush();
     firePreCommit();
+    // we must flush the batch queue again, because the callback can
+    // modify current transaction
+    internalBatchFlush();
   }
 
   /**


### PR DESCRIPTION
When a TransactionCallback modifies the current transaction, the batch was not flushed.