### PR TITLE
Possible bug: Setting isolation level disables query cache

### DIFF
--- a/ebean-test/src/test/java/org/tests/cache/TestQueryCache.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestQueryCache.java
@@ -3,6 +3,8 @@ package org.tests.cache;
 import io.ebean.CacheMode;
 import io.ebean.DB;
 import io.ebean.ExpressionList;
+import io.ebean.annotation.Transactional;
+import io.ebean.annotation.TxIsolation;
 import io.ebean.bean.BeanCollection;
 import io.ebean.cache.ServerCache;
 import io.ebean.test.LoggedSql;
@@ -159,6 +161,30 @@ public class TestQueryCache extends BaseTestCase {
     assertThat(count2).isEqualTo(count1);
     sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
+
+
+    LoggedSql.start();
+    findCountNoTxn();
+    sql = LoggedSql.stop();
+    assertThat(sql).hasSize(0);
+
+    LoggedSql.start();
+    findCountTxn();
+    sql = LoggedSql.stop();
+    assertThat(sql).hasSize(0);
+  }
+
+  private void findCountNoTxn() {
+    DB.find(EColAB.class)
+      .setUseQueryCache(CacheMode.ON)
+      .where()
+      .eq("columnB", "count")
+      .findCount();
+  }
+
+  @Transactional(isolation = TxIsolation.READ_UNCOMMITTED)
+  private void findCountTxn() {
+    findCountNoTxn();
   }
 
   @Test


### PR DESCRIPTION
We discovered an issue, that the query cache does not work, when isolation level is set.

**use case**
We show a counter in the UI how many unread messages a user has. It is important, that this method is fast and does not block so we set READ_UNCOMMITED. We also want to use the query-cache in this case.

As we only want to show an indicator of unread messages, it is not important to get the exact correct number. (it is better to get a possible wrong number than blocking the UI request when some tables are locked)

**What happens**
TransactionFactory.setIsolationLevel calls [connection](https://github.com/ebean-orm/ebean/blob/master/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactory.java#L38) and JdbcTransaction.connection sets `queryOnly = false`: https://github.com/ebean-orm/ebean/blob/master/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java#L768

**Question**
Is this really a bug or intended, that the query cache will be disabled when isolation level is changed?

I know, that the result of READ_UNCOMMITTED may differ from the cache. But it seems it does not matter to which value you set the isolation level.