### PR TITLE
Fixed issue with using offset without limit

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/LimitOffsetSqlLimiter.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/LimitOffsetSqlLimiter.java
@@ -31,12 +31,12 @@ public class LimitOffsetSqlLimiter implements SqlLimiter {
     int firstRow = request.getFirstRow();
     int maxRows = request.getMaxRows();
 
-    if (maxRows > 0 || firstRow > 0) {
+    if (maxRows >= 0) {
       sb.append(" ").append(LIMIT).append(" ").append(maxRows);
-      if (firstRow > 0) {
-        sb.append(" ").append(OFFSET).append(" ");
-        sb.append(firstRow);
-      }
+    }
+    if (firstRow > 0) {
+      sb.append(" ").append(OFFSET).append(" ");
+      sb.append(firstRow);
     }
 
     String sql = request.getDbPlatform().completeSql(sb.toString(), request.getOrmQuery());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1307,8 +1307,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   public <T> PagedList<T> findPagedList(Query<T> query, Transaction transaction) {
     SpiQuery<T> spiQuery = (SpiQuery<T>) query;
     int maxRows = spiQuery.getMaxRows();
-    if (maxRows == 0) {
-      throw new PersistenceException("maxRows must be specified for findPagedList() query");
+    if (maxRows <= 0) {
+      throw new PersistenceException("maxRows must be specified as positive integer for findPagedList() query");
     }
     if (spiQuery.isUseDocStore()) {
       return docStore().findPagedList(createQueryRequest(Type.LIST, query, transaction));

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -62,7 +62,7 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
    * Holds query in structured form.
    */
   private OrmQueryDetail detail;
-  private int maxRows;
+  private int maxRows = -1;
   private int firstRow;
   private boolean disableLazyLoading;
   /**

--- a/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
@@ -23,6 +23,28 @@ public class TestLimitQuery extends BaseTestCase {
   }
 
   @Test
+  public void testMaxRowsZeroWithFirstRow() {
+
+    ResetBasicData.reset();
+
+    Query<Order> query = DB.find(Order.class)
+      .setAutoTune(false)
+      .fetch("details")
+      .where().gt("details.id", 0)
+      .setMaxRows(0)
+      .setFirstRow(3)
+      .order().asc("orderDate");
+
+    query.findList();
+
+    String sql = query.getGeneratedSql();
+    if (isH2()) {
+      assertThat(sql).contains("offset 3");
+      assertThat(sql).contains("limit 0");
+    }
+  }
+
+  @Test
   public void testMaxRowsNotSetWithFirstRow() {
 
     ResetBasicData.reset();

--- a/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
@@ -23,7 +23,7 @@ public class TestLimitQuery extends BaseTestCase {
   }
 
   @Test
-  public void testMaxRowsZeroWithFirstRow() {
+  public void testMaxRowsNotSetWithFirstRow() {
 
     ResetBasicData.reset();
 
@@ -31,7 +31,6 @@ public class TestLimitQuery extends BaseTestCase {
       .setAutoTune(false)
       .fetch("details")
       .where().gt("details.id", 0)
-      .setMaxRows(0)
       .setFirstRow(3)
       .order().asc("orderDate");
 
@@ -40,7 +39,7 @@ public class TestLimitQuery extends BaseTestCase {
     String sql = query.getGeneratedSql();
     if (isH2()) {
       assertThat(sql).contains("offset 3");
-      assertThat(sql).contains("limit 0");
+      assertThat(sql).doesNotContain("limit");
     }
   }
 


### PR DESCRIPTION
This PR contains the fix for the issue https://github.com/ebean-orm/ebean/issues/2903: `LimitOffsetSqlLimiter` that applies `LIMIT 0` to the query even if `firstRow` is set only and `maxRows` is untouched.