### PR TITLE
Fixed mandatory LIMIT generation in case of firstRow>0

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/LimitOffsetSqlLimiter.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/LimitOffsetSqlLimiter.java
@@ -31,12 +31,12 @@ public class LimitOffsetSqlLimiter implements SqlLimiter {
     int firstRow = request.getFirstRow();
     int maxRows = request.getMaxRows();
 
-    if (maxRows > 0 || firstRow > 0) {
+    if (maxRows > 0) {
       sb.append(" ").append(LIMIT).append(" ").append(maxRows);
-      if (firstRow > 0) {
-        sb.append(" ").append(OFFSET).append(" ");
-        sb.append(firstRow);
-      }
+    }
+    if (firstRow > 0) {
+      sb.append(" ").append(OFFSET).append(" ");
+      sb.append(firstRow);
     }
 
     String sql = request.getDbPlatform().completeSql(sb.toString(), request.getOrmQuery());

--- a/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
@@ -40,7 +40,7 @@ public class TestLimitQuery extends BaseTestCase {
     String sql = query.getGeneratedSql();
     if (isH2()) {
       assertThat(sql).contains("offset 3");
-      assertThat(sql).contains("limit 0");
+      assertThat(sql).doesNotContain("limit");
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/ebean-orm/ebean/issues/2903 issue