### PR TITLE
Ignore private/package private classes from CP-scan / FIX: Order of runServerConfigStartup

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -160,6 +160,8 @@ public final class DefaultContainer implements SpiContainer {
    */
   private BootupClasses bootupClasses(DatabaseConfig config) {
     BootupClasses bootup = bootupClasses1(config);
+    bootup.addServerConfigStartup(config.getServerConfigStartupListeners());
+    bootup.runServerConfigStartup(config);
     bootup.addIdGenerators(config.getIdGenerators());
     bootup.addPersistControllers(config.getPersistControllers());
     bootup.addPostLoaders(config.getPostLoaders());
@@ -167,9 +169,7 @@ public final class DefaultContainer implements SpiContainer {
     bootup.addFindControllers(config.getFindControllers());
     bootup.addPersistListeners(config.getPersistListeners());
     bootup.addQueryAdapters(config.getQueryAdapters());
-    bootup.addServerConfigStartup(config.getServerConfigStartupListeners());
     bootup.addChangeLogInstances(config);
-    bootup.runServerConfigStartup(config);
     return bootup;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClasses.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClasses.java
@@ -342,8 +342,9 @@ public class BootupClasses implements Predicate<Class<?>> {
    */
   @SuppressWarnings("unchecked")
   private boolean isInterestingInterface(Class<?> cls) {
-    if (Modifier.isAbstract(cls.getModifiers())) {
-      // do not include abstract classes as we can
+    if (Modifier.isAbstract(cls.getModifiers())
+      || !(Modifier.isPublic(cls.getModifiers()) || Modifier.isProtected(cls.getModifiers()))) {
+      // do not include abstract and non pupbic/protected classes as we can
       // not instantiate them
       return false;
     }

--- a/ebean-test/src/test/java/io/ebean/xtest/event/BeanFindControllerTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/event/BeanFindControllerTest.java
@@ -15,7 +15,6 @@ import org.tests.model.basic.ECustomId;
 import org.tests.model.controller.FindControllerMain;
 import org.tests.model.controller.SoftRefA;
 import org.tests.model.controller.SoftRefB;
-import org.tests.model.controller.TestBeanFindController;
 
 import java.util.List;
 

--- a/ebean-test/src/test/java/io/ebean/xtest/event/TestBeanFindController.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/event/TestBeanFindController.java
@@ -1,16 +1,17 @@
-package org.tests.model.controller;
+package io.ebean.xtest.event;
 
 import io.ebean.bean.BeanCollection;
 import io.ebean.event.BeanFindController;
 import io.ebean.event.BeanQueryRequest;
 import io.ebean.plugin.BeanType;
+import org.tests.model.controller.FindControllerMain;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class TestBeanFindController implements BeanFindController {
+class TestBeanFindController implements BeanFindController {
 
   @Override
   public boolean isRegisterFor(final Class<?> cls) {

--- a/ebean-test/src/test/java/org/tests/changelog/TestChangeLog.java
+++ b/ebean-test/src/test/java/org/tests/changelog/TestChangeLog.java
@@ -189,7 +189,7 @@ public class TestChangeLog extends BaseTestCase {
     return DatabaseFactory.create(config);
   }
 
-  public static class TDChangeLogPrepare implements ChangeLogPrepare {
+  static class TDChangeLogPrepare implements ChangeLogPrepare {
     @Override
     public boolean prepare(ChangeSet changes) {
       changes.setUserId("appUser1");
@@ -198,7 +198,7 @@ public class TestChangeLog extends BaseTestCase {
     }
   }
 
-  public static class TDChangeLogListener implements ChangeLogListener {
+  static class TDChangeLogListener implements ChangeLogListener {
 
     ObjectMapper objectMapper = new ObjectMapper();
 
@@ -226,7 +226,7 @@ public class TestChangeLog extends BaseTestCase {
 
   }
 
-  public static class TDChangeLogRegister implements ChangeLogRegister {
+  static class TDChangeLogRegister implements ChangeLogRegister {
 
     @Override
     public ChangeLogFilter getChangeFilter(Class<?> beanType) {

--- a/ebean-test/src/test/java/org/tests/model/basic/MyEBasicConfigStartup.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/MyEBasicConfigStartup.java
@@ -29,7 +29,7 @@ public class MyEBasicConfigStartup implements ServerConfigStartup {
     serverConfig.add(new EbasicBulkListener());
   }
 
-  public static class EbasicBulkListener implements BulkTableEventListener {
+  private static class EbasicBulkListener implements BulkTableEventListener {
 
     final Set<String> s = new HashSet<>();
 
@@ -49,7 +49,7 @@ public class MyEBasicConfigStartup implements ServerConfigStartup {
 
   }
 
-  public static class EbasicPersistList extends AbstractBeanPersistListener {
+  private static class EbasicPersistList extends AbstractBeanPersistListener {
 
     @Override
     public boolean isRegisterFor(Class<?> cls) {


### PR DESCRIPTION
Hello @rbygrave,

this addesses the issue mentioned here: https://github.com/ebean-orm/ebean/issues/2918#issuecomment-1354654050
> The default server should not find classes like TDChangelogListener and use them.

So, I skip (package) private classes, as they will fail when you try to instantiate them. 
I considered to filter only for `public` classes, but also protected inner classes can be instantiated with reflection. So I did not want to introduce a behaviour change here

Unfortunately, one test broke: `TestExplicitInsert` relies on `MyEBasicConfigStartup`

And MyEBasicConfigStartup adds two persistListeners. But this happens too late in DefaultContainer L172
It has to happen before `bootup.addPersistListeners(config.getPersistListeners());`

The test passed before, because the persistListeners were found and added earlier by the cp-scan.

According to the docs of `ServerConfigStartup.onStart(config)` this should work:

> Provides a simple way to construct and register multiple listeners and adapters that need shared services without using DI.

So I think it should be correct now, to invoke `runServerConfigStartup` earlier.

cheers
Roland