### PR TITLE
FIX: prepare FindMap query for proper bean cache / DB access

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1107,12 +1107,13 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
   public <K, T> Map<K, T> findMap(Query<T> query, @Nullable Transaction transaction) {
-    SpiOrmQueryRequest request = createQueryRequest(Type.MAP, query, transaction);
+    SpiOrmQueryRequest request = buildQueryRequest(Type.MAP, query, transaction);
     request.resetBeanCacheAutoMode(false);
     if ((transaction == null || !transaction.isSkipCache()) && request.getFromBeanCache()) {
       // hit bean cache and got all results from cache
       return request.beanCacheHitsAsMap();
     }
+    request.prepareQuery();
     Object result = request.getFromQueryCache();
     if (result != null) {
       return (Map<K, T>) result;


### PR DESCRIPTION
This fixes #2916 

Under rare cirumstances, it could happen, that wrong queries were generated (wrong bind parameter count) when findMap is used

- fetch `idIn(1)` - so Bean#1 is in cache. SQL of this query was `id in (?)` cache-key of query was `List[IdIn[?1],]`
- fetch `idIn(1,2,3,4,5)` - Bean#1 is in cache, one bind value is removed. Sql-query was `id in (?,?,?,?)`. cache-key of query was `List[IdIn[?5],]` - Note: Cache says 5 params, sql has only 4
- fetch `idIn(3,4,5,6,7)` - We have 5 beans, so reuse query `List[IdIn[?5],]` - Bean#3,4,5 are in cache - so remove bind params. Two bind params for Bean#6+7 are left, but cached query has 4 SQL parameter (which is also wrong, it should be 5)

