### PR TITLE
#2773 Fix wrong query in combination with fetch & where

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -677,11 +677,6 @@ public final class SqlTreeBuilder {
         } else {
           // look in register ...
           String parentPropertyName = includeProp.substring(0, dotPos);
-          if (selectIncludes.contains(parentPropertyName)) {
-            // parent already handled by select
-            return childJoin;
-          }
-
           SqlTreeNodeExtraJoin parentJoin = joinRegister.get(parentPropertyName);
           if (parentJoin == null) {
             // we need to create this the parent implicitly...

--- a/ebean-test/src/test/java/org/tests/model/family/ChildPerson.java
+++ b/ebean-test/src/test/java/org/tests/model/family/ChildPerson.java
@@ -29,7 +29,7 @@ public class ChildPerson extends InheritablePerson {
   @Formula(select = "coalesce(${ta}.address, j1.address, j2.address)", join = PARENTS_JOIN)
   private String effectiveAddress;
 
-  @Formula(select = "coalesce(${ta}.some_bean_id, j1.some_bean_id, j2.some_bean_id)")
+  @Formula(select = "coalesce(${ta}.some_bean_id, j1.some_bean_id, j2.some_bean_id)", join = PARENTS_JOIN)
   @ManyToOne
   private EBasic effectiveBean;
 


### PR DESCRIPTION
Hello Rob,

we may have a fix for #2773 

we debugged and noticed, that combinations of joins between 'fetch' & 'where' will not always work.

By trial&error we found out, that deleting of
```java
          if (selectIncludes.contains(parentPropertyName)) {
            // parent already handled by select
            return childJoin;
          }
```
will solve the problem.... and will not break any other test.

I admit that I don't quite understand the fix. Maybe you can take another look to see if this is correct.

cheers
Roland