### PR TITLE
NEW: ExpressionList has clear() method

### DIFF
--- a/ebean-api/src/main/java/io/ebean/ExpressionList.java
+++ b/ebean-api/src/main/java/io/ebean/ExpressionList.java
@@ -1730,4 +1730,8 @@ public interface ExpressionList<T> {
    */
   ExpressionList<T> endNot();
 
+  /**
+   * Clears the current expression list.
+   */
+  ExpressionList<T> clear();
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -1268,4 +1268,10 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
     }
     return null;
   }
+
+  @Override
+  public ExpressionList<T> clear() {
+    list.clear();
+    return this;
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
@@ -1068,4 +1068,9 @@ final class JunctionExpression<T> implements SpiJunction<T>, SpiExpression, Expr
     }
     return null;
   }
+
+  @Override
+  public ExpressionList<T> clear() {
+    return exprList.clear();
+  }
 }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/expression/DefaultExpressionListTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/expression/DefaultExpressionListTest.java
@@ -99,6 +99,14 @@ public class DefaultExpressionListTest extends BaseExpressionTest {
       .isSameByBind(spi(exp().eq("a", 10).eq("b", 20)))).isFalse();
   }
 
+  @Test
+  public void isSameWithClear() {
+    DefaultExpressionList<?> exp1 = spi(exp().eq("a", 10).eq("b", 20).clear().eq("c", 30));
+    DefaultExpressionList<?> exp2 = spi(exp().eq("c", 30));
+    same(exp1, exp2);
+    assertThat(exp1.isSameByBind(exp2)).isTrue();
+  }
+  
   @SuppressWarnings("unchecked")
   @Test
   void copy() {


### PR DESCRIPTION
We had an issue in our application, where we had a (complex) query and we wanted to get only a subset of models for paging in a web app, where we had the IDs. Here is a use case, why we need this and cannot rebuild the query.

**Use case**
```java
class Pager<T> {
  final List<UUID> ids;
  final Query<T> query;
  final int PAGE_SIZE = 20;

  Pager(Query<T> query) {
    this.query = query;
    this.ids = query.findIds();  // fetch IDs in correct order;
  }
  
  List<T> getPage(int page) {
     return query.copy().where().idIn(ids.subList(page * PAGE_SIZE, PAGE_SIZE));
  }
}

// construct pager with a query for the user's search result (where & fetch)
Pager<Customer> pager = new Pager(DB.find(Customer.class).fetch("address").where().like("name", "%foo%").query())
// (expensive) searching is done one time in the constructor, the pager is then hold in the http-session
result = pager.getPage(0);
// subsequent web requests will retrive more pages, that should be found fast, because we already have the IDs
result = pager.getPage(1);
...
```

We have really slow queries here (complex searches, especially in non indexed fields could take up several seconds), but then we have the whole search result in memory (we store only the IDs, so not to run in an OOM), then we display the results in the browser.
In theory, the ID queries should be superfast, but not always, Especially on MariaDB, we discvered some cases, that the query-optimizer not always starts with the `id in (?, ?)` clause, but with some other conditions, which makes the query slow.

So we removed the old where conditions with
```
     return query.copy().clear().where().idIn(ids.subList(page * PAGE_SIZE, PAGE_SIZE));
```
and the query is fast again.
(Yes, we know, that data can change during paging, but this is not a problem in our use case)



