### PR TITLE
FEATURE: Disable overwriting generated properties at transaction level

### DIFF
--- a/ebean-api/src/main/java/io/ebean/Transaction.java
+++ b/ebean-api/src/main/java/io/ebean/Transaction.java
@@ -261,6 +261,12 @@ public interface Transaction extends AutoCloseable {
   void setUpdateAllLoadedProperties(boolean updateAllLoadedProperties);
 
   /**
+   * If set to false (default is true) generated propertes are only set, if it is the version property or have a null value.
+   * This may be useful in backup & restore scenarios, if you want set WhenCreated/WhenModified.
+   */
+  void setOverwriteGeneratedProperties(boolean overwriteGeneratedProperties);
+
+  /**
    * Set if the L2 cache should be skipped for "find by id" and "find by natural key" queries.
    * <p>
    * By default {@link DatabaseConfig#isSkipCacheAfterWrite()} is true and that means that for

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransaction.java
@@ -104,6 +104,11 @@ public interface SpiTransaction extends Transaction {
   Boolean isUpdateAllLoadedProperties();
 
   /**
+   * Returns true, if generated properties are overwritten (default) or are only set, if they are null.
+   */
+  boolean isOverwriteGeneratedProperties();
+
+  /**
    * Return the batchSize specifically set for this transaction or 0.
    * <p>
    * Returning 0 implies to use the system wide default batch size.

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
@@ -249,6 +249,16 @@ public abstract class SpiTransactionProxy implements SpiTransaction {
   }
 
   @Override
+  public void setOverwriteGeneratedProperties(boolean overwriteGeneratedProperties) {
+    transaction.setOverwriteGeneratedProperties(overwriteGeneratedProperties);
+  }
+
+  @Override
+  public boolean isOverwriteGeneratedProperties() {
+    return transaction.isOverwriteGeneratedProperties();
+  }
+
+  @Override
   public Boolean isUpdateAllLoadedProperties() {
     return transaction.isUpdateAllLoadedProperties();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
@@ -274,24 +274,30 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
       } else {
         // @WhenModified set without invoking interception
         Object oldVal = prop.getValue(entityBean);
-        Object value = generatedProperty.getUpdateValue(prop, entityBean, now());
-        prop.setValueChanged(entityBean, value);
-        intercept.setOldValue(prop.propertyIndex(), oldVal);
+        if (transaction == null || transaction.isOverwriteGeneratedProperties() || oldVal == null) { // version handled above
+          Object value = generatedProperty.getUpdateValue(prop, entityBean, now());
+          prop.setValueChanged(entityBean, value);
+          intercept.setOldValue(prop.propertyIndex(), oldVal);
+        }
       }
     }
   }
 
   private void onFailedUpdateUndoGeneratedProperties() {
     for (BeanProperty prop : beanDescriptor.propertiesGenUpdate()) {
-      Object oldVal = intercept.origValue(prop.propertyIndex());
-      prop.setValue(entityBean, oldVal);
+      if (transaction == null || transaction.isOverwriteGeneratedProperties() || prop.isVersion()) {
+        Object oldVal = intercept.origValue(prop.propertyIndex());
+        prop.setValue(entityBean, oldVal);
+      }
     }
   }
 
   private void onInsertGeneratedProperties() {
     for (BeanProperty prop : beanDescriptor.propertiesGenInsert()) {
-      Object value = prop.generatedProperty().getInsertValue(prop, entityBean, now());
-      prop.setValueChanged(entityBean, value);
+      if (transaction == null || transaction.isOverwriteGeneratedProperties() || prop.isVersion() || prop.getValue(entityBean) == null) {
+        Object value = prop.generatedProperty().getInsertValue(prop, entityBean, now());
+        prop.setValueChanged(entityBean, value);
+      }
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -273,6 +273,15 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
   }
 
   @Override
+  public void setOverwriteGeneratedProperties(boolean overwriteGeneratedProperties) {
+  }
+
+  @Override
+  public boolean isOverwriteGeneratedProperties() {
+    return true;
+  }
+
+  @Override
   public Boolean isUpdateAllLoadedProperties() {
     return null;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -53,6 +53,7 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   private boolean queryOnly = true;
   private boolean localReadOnly;
   private Boolean updateAllLoadedProperties;
+  private boolean overwriteGeneratedProperties = true;
   private boolean oldBatchMode;
   private boolean batchMode;
   private boolean batchOnCascadeMode;
@@ -446,6 +447,16 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   @Override
   public final Boolean isUpdateAllLoadedProperties() {
     return updateAllLoadedProperties;
+  }
+
+  @Override
+  public void setOverwriteGeneratedProperties(boolean overwriteGeneratedProperties) {
+    this.overwriteGeneratedProperties = overwriteGeneratedProperties;
+  }
+
+  @Override
+  public boolean isOverwriteGeneratedProperties() {
+    return overwriteGeneratedProperties;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
@@ -231,6 +231,15 @@ final class NoTransaction implements SpiTransaction {
   }
 
   @Override
+  public void setOverwriteGeneratedProperties(boolean overwriteGeneratedProperties) {
+  }
+
+  @Override
+  public boolean isOverwriteGeneratedProperties() {
+    return true;
+  }
+
+  @Override
   public void setSkipCache(boolean skipCache) {
   }
 


### PR DESCRIPTION
We want to backup & restore some data by exporting it to JSON. For this use case we need to preserve

- whenCreated
- whoCreated
- whenModified
- whoModified

This PR allows to disable the update of these properties for a particular transaction