### PR TITLE
NEW: Support for lazy add on BeanList

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/BeanCollection.java
+++ b/ebean-api/src/main/java/io/ebean/bean/BeanCollection.java
@@ -165,6 +165,13 @@ public interface BeanCollection<E> extends Serializable, ToStringAware {
   Collection<?> getActualEntries();
 
   /**
+   * Returns entries, that were lazily added at the end of the list. Might be null.
+   */
+  default Collection<E> getLazyAddedEntries() {
+    return null;
+  }
+
+  /**
    * return true if there are real rows held. Return false is this is using
    * Deferred fetch to lazy load the rows and the rows have not yet been
    * fetched.

--- a/ebean-api/src/main/java/io/ebean/common/BeanList.java
+++ b/ebean-api/src/main/java/io/ebean/common/BeanList.java
@@ -13,14 +13,14 @@ import java.util.ListIterator;
 /**
  * List capable of lazy loading and modification awareness.
  */
-public final class BeanList<E> extends AbstractBeanCollection<E> implements List<E>, BeanCollectionAdd {
+public class BeanList<E> extends AbstractBeanCollection<E> implements List<E>, BeanCollectionAdd {
 
   private static final long serialVersionUID = 1L;
 
   /**
    * The underlying List implementation.
    */
-  private List<E> list;
+  List<E> list;
 
   /**
    * Specify the underlying List implementation.
@@ -131,7 +131,7 @@ public final class BeanList<E> extends AbstractBeanCollection<E> implements List
     }
   }
 
-  private void init() {
+  void init() {
     lock.lock();
     try {
       if (list == null) {

--- a/ebean-api/src/main/java/io/ebean/common/BeanListLazyAdd.java
+++ b/ebean-api/src/main/java/io/ebean/common/BeanListLazyAdd.java
@@ -1,0 +1,107 @@
+package io.ebean.common;
+
+import io.ebean.bean.BeanCollectionLoader;
+import io.ebean.bean.EntityBean;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This bean list can perform additions without populating the list.
+ * This might be useful, if you just want to add entries to an existing collection.
+ * Works only for lists and only if there is no order column
+ */
+public class BeanListLazyAdd<E> extends BeanList<E> {
+
+  public BeanListLazyAdd(BeanCollectionLoader loader, EntityBean ownerBean, String propertyName) {
+    super(loader, ownerBean, propertyName);
+  }
+
+  private List<E> lazyAddedEntries;
+
+  @Override
+  public boolean add(E bean) {
+    checkReadOnly();
+
+    lock.lock();
+    try {
+      if (list == null) {
+        // list is not yet initialized, so we may add elements to a spare list
+        if (lazyAddedEntries == null) {
+          lazyAddedEntries = new ArrayList<>();
+        }
+        lazyAddedEntries.add(bean);
+      } else {
+        list.add(bean);
+      }
+    } finally {
+      lock.unlock();
+    }
+
+    if (modifyListening) {
+      modifyAddition(bean);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends E> beans) {
+    checkReadOnly();
+
+    lock.lock();
+    try {
+      if (list == null) {
+        // list is not yet initialized, so we may add elements to a spare list
+        if (lazyAddedEntries == null) {
+          lazyAddedEntries = new ArrayList<>();
+        }
+        lazyAddedEntries.addAll(beans);
+      } else {
+        list.addAll(beans);
+      }
+    } finally {
+      lock.unlock();
+    }
+
+    if (modifyListening) {
+      getModifyHolder().modifyAdditionAll(beans);
+    }
+
+    return true;
+  }
+
+  /**
+   * on init, this happens on all accessor methods except on 'add' and addAll,
+   * we add the lazy added entries at the end of the list
+   */
+  @Override
+  void init() {
+    lock.lock();
+    try {
+      if (list == null) {
+        if (disableLazyLoad) {
+          list = lazyAddedEntries == null ? new ArrayList<>() : lazyAddedEntries;
+        } else {
+          lazyLoadCollection(false);
+          if (lazyAddedEntries != null) {
+            list.addAll(lazyAddedEntries);
+          }
+        }
+      }
+      lazyAddedEntries = null;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public List<E> getLazyAddedEntries() {
+    return lazyAddedEntries;
+  }
+
+  @Override
+  public boolean isSkipSave() {
+    return lazyAddedEntries == null && super.isSkipSave();
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BaseCollectionHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BaseCollectionHelp.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 abstract class BaseCollectionHelp<T> implements BeanCollectionHelp<T> {
 
   final BeanPropertyAssocMany<T> many;
-  private final BeanDescriptor<T> targetDescriptor;
+  final BeanDescriptor<T> targetDescriptor;
   final String propertyName;
   BeanCollectionLoader loader;
 
@@ -19,12 +19,6 @@ abstract class BaseCollectionHelp<T> implements BeanCollectionHelp<T> {
     this.many = many;
     this.targetDescriptor = many.targetDescriptor();
     this.propertyName = many.name();
-  }
-
-   BaseCollectionHelp() {
-    this.many = null;
-    this.targetDescriptor = null;
-    this.propertyName = null;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanCollectionUtil.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanCollectionUtil.java
@@ -32,7 +32,7 @@ public final class BeanCollectionUtil {
     if (o instanceof BeanCollection<?>) {
       BeanCollection<?> bc = (BeanCollection<?>) o;
       if (!bc.isPopulated()) {
-        return null;
+        return bc.getLazyAddedEntries();
       }
       // For maps this is a collection of Map.Entry, otherwise it
       // returns a collection of beans

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanListHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanListHelp.java
@@ -6,6 +6,7 @@ import io.ebean.bean.BeanCollection;
 import io.ebean.bean.BeanCollectionAdd;
 import io.ebean.bean.EntityBean;
 import io.ebean.common.BeanList;
+import io.ebean.common.BeanListLazyAdd;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.json.SpiJsonWriter;
 
@@ -19,12 +20,11 @@ import java.util.List;
  */
 public class BeanListHelp<T> extends BaseCollectionHelp<T> {
 
+  private final boolean hasOrderColumn;
+
   BeanListHelp(BeanPropertyAssocMany<T> many) {
     super(many);
-  }
-
-  BeanListHelp() {
-    super();
+    hasOrderColumn = many.hasOrderColumn();
   }
 
   @Override
@@ -53,7 +53,12 @@ public class BeanListHelp<T> extends BaseCollectionHelp<T> {
 
   @Override
   public final BeanCollection<T> createEmpty(EntityBean parentBean) {
-    BeanList<T> beanList = new BeanList<>(loader, parentBean, propertyName);
+    BeanList<T> beanList;
+    if (hasOrderColumn) {
+      beanList = new BeanList<>(loader, parentBean, propertyName);
+    } else {
+      beanList = new BeanListLazyAdd<>(loader, parentBean, propertyName);
+    }
     if (many != null) {
       beanList.setModifyListening(many.modifyListenMode());
     }
@@ -62,7 +67,12 @@ public class BeanListHelp<T> extends BaseCollectionHelp<T> {
 
   @Override
   public final BeanCollection<T> createReference(EntityBean parentBean) {
-    BeanList<T> beanList = new BeanList<>(loader, parentBean, propertyName);
+    BeanList<T> beanList;
+    if (hasOrderColumn) {
+      beanList = new BeanList<>(loader, parentBean, propertyName);
+    } else {
+      beanList = new BeanListLazyAdd<>(loader, parentBean, propertyName);
+    }
     beanList.setModifyListening(many.modifyListenMode());
     return beanList;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanMapHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanMapHelp.java
@@ -20,18 +20,13 @@ import java.util.Map.Entry;
  */
 public class BeanMapHelp<T> extends BaseCollectionHelp<T> {
 
-  private final BeanPropertyAssocMany<T> many;
-  private final BeanDescriptor<T> targetDescriptor;
-  private final String propertyName;
   private final BeanProperty beanProperty;
 
   /**
    * When help is attached to a specific many property.
    */
   BeanMapHelp(BeanPropertyAssocMany<T> many) {
-    this.many = many;
-    this.targetDescriptor = many.targetDescriptor();
-    this.propertyName = many.name();
+    super(many);
     this.beanProperty = targetDescriptor.beanProperty(many.mapKey());
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanSetHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanSetHelp.java
@@ -26,13 +26,6 @@ public class BeanSetHelp<T> extends BaseCollectionHelp<T> {
     super(many);
   }
 
-  /**
-   * For a query that returns a set.
-   */
-  BeanSetHelp() {
-    super();
-  }
-
   @Override
   public final BeanCollectionAdd getBeanCollectionAdd(Object bc, String mapKey) {
     if (bc instanceof BeanSet<?>) {

--- a/ebean-test/src/test/java/org/tests/batchload/TestLazyAddBeanList.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestLazyAddBeanList.java
@@ -1,0 +1,137 @@
+package org.tests.batchload;
+
+import io.ebean.DB;
+import io.ebean.common.BeanList;
+import io.ebean.common.BeanListLazyAdd;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Contact;
+import org.tests.model.basic.Customer;
+import org.tests.order.OrderMaster;
+import org.tests.order.OrderReferencedChild;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLazyAddBeanList extends BaseTestCase {
+
+  private Customer cust;
+  private OrderMaster orderMaster;
+
+  @BeforeEach
+  void init() {
+    cust = new Customer();
+    cust.setName("noFetch");
+    DB.save(cust);
+    cust = DB.find(Customer.class, cust.getId()); // fetch fresh from DB
+
+    orderMaster = new OrderMaster();
+    DB.save(orderMaster);
+    orderMaster = DB.find(OrderMaster.class, orderMaster.getId());
+  }
+
+  @AfterEach
+  void tearDown() {
+    DB.delete(cust);
+    DB.delete(orderMaster);
+  }
+
+  @Test
+  public void testCollectionType() {
+    assertThat(cust.getContacts())
+      .isInstanceOf(BeanListLazyAdd.class);
+
+    assertThat(orderMaster.getChildren())
+      .isInstanceOf(BeanList.class)
+      .isNotInstanceOf(BeanListLazyAdd.class);
+
+    assertThat(DB.reference(Customer.class, 1).getContacts())
+      .isInstanceOf(BeanListLazyAdd.class);
+
+    assertThat(DB.reference(OrderMaster.class, 1).getChildren())
+      .isInstanceOf(BeanList.class)
+      .isNotInstanceOf(BeanListLazyAdd.class);
+  }
+
+  @Test
+  public void testNoFetch() {
+
+    LoggedSql.start();
+    cust.addContact(new Contact("jim", "slim"));
+    cust.addContact(new Contact("joe", "big"));
+    DB.save(cust);
+
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql.get(0)).contains("insert into contact");
+    assertThat(sql.get(1)).contains("bind(jim,slim,");
+    assertThat(sql.get(2)).contains("bind(joe,big,");
+    assertThat(sql).hasSize(3);
+
+    List<String> list = DB.find(Customer.class)
+      .fetch("contacts", "firstName")
+      .where()
+      .idEq(cust.getId()).findSingleAttributeList();
+// check if it is really saved
+    assertThat(list).containsExactlyInAnyOrder("jim", "joe");
+  }
+
+  @Test
+  public void testFetch() {
+
+    LoggedSql.start();
+    orderMaster.getChildren().add(new OrderReferencedChild("foo"));
+    orderMaster.getChildren().add(new OrderReferencedChild("bar"));
+    DB.save(orderMaster);
+
+    List<String> sql = LoggedSql.stop();
+
+    assertThat(sql.get(0)).contains("from order_referenced_parent"); // lazy load children
+    assertThat(sql.get(1)).contains("insert into order_referenced_parent");
+    assertThat(sql.get(2)).contains("bind(D,foo,");
+    assertThat(sql.get(3)).contains("bind(D,bar,");
+
+    List<String> list = DB.find(OrderMaster.class)
+      .fetch("children", "name")
+      .where().idEq(orderMaster.getId())
+      .findSingleAttributeList();
+    // check if it is really saved
+    assertThat(list).containsExactlyInAnyOrder("foo", "bar");
+  }
+
+  @Test
+  public void testAddToExisting() {
+
+    // add some existing entries
+    LoggedSql.start();
+    cust.getContacts().addAll(Arrays.asList(
+      new Contact("jim", "slim"),
+      new Contact("joe", "big")));
+    assertThat(LoggedSql.stop()).isEmpty();
+
+    LoggedSql.start();
+    DB.save(cust);
+    assertThat(LoggedSql.stop()).hasSize(3); // insert + 2x bind
+
+    cust = DB.find(Customer.class, cust.getId());
+
+    LoggedSql.start();
+    List<Contact> contacts = cust.getContacts();
+    contacts.add(new Contact("charlie", "brown"));
+    assertThat(LoggedSql.stop()).isEmpty();
+
+    LoggedSql.start();
+    assertThat(contacts).
+      extracting(Contact::getFirstName).
+      containsExactlyInAnyOrder("jim", "joe", "charlie");
+    List<String> sql = LoggedSql.stop();
+
+    assertThat(sql.get(0)).contains("from o_customer t0 left join contact t1 ");
+    assertThat(sql).hasSize(1);
+  }
+
+}


### PR DESCRIPTION
When just adding new entries to an existing BeanList, there is no need to load the underlying collection.

this should provide a performance benefit, where you just want to add new entries to a BeanList