### PR TITLE
IMPROVED: Tenant support for query plans

### DIFF
--- a/ebean-api/src/main/java/io/ebean/meta/MetaQueryPlan.java
+++ b/ebean-api/src/main/java/io/ebean/meta/MetaQueryPlan.java
@@ -45,6 +45,11 @@ public interface MetaQueryPlan {
   String plan();
 
   /**
+   * The tenant ID of the plan.
+   */
+  Object tenantId();
+
+  /**
    * Return the query execution time associated with the bind values capture.
    */
   long queryTimeMicros();

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiDbQueryPlan.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiDbQueryPlan.java
@@ -12,6 +12,6 @@ public interface SpiDbQueryPlan extends MetaQueryPlan {
   /**
    * Extend with queryTimeMicros, captureCount, captureMicros and when the bind values were captured.
    */
-  SpiDbQueryPlan with(long queryTimeMicros, long captureCount, long captureMicros, Instant whenCaptured);
+  SpiDbQueryPlan with(long queryTimeMicros, long captureCount, long captureMicros, Instant whenCaptured, Object tenantId);
 
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionManager.java
@@ -60,6 +60,6 @@ public interface SpiTransactionManager {
   /**
    * Return a connection used for query plan collection.
    */
-  Connection queryPlanConnection() throws SQLException;
+  Connection queryPlanConnection(Object tenantId) throws SQLException;
 
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
@@ -583,7 +583,8 @@ public final class InternalConfiguration {
       return QueryPlanManager.NOOP;
     }
     long threshold = config.getQueryPlanThresholdMicros();
-    return new CQueryPlanManager(transactionManager, threshold, queryPlanLogger(databasePlatform.platform()), extraMetrics);
+    return new CQueryPlanManager(transactionManager, config.getCurrentTenantProvider(),
+      threshold, queryPlanLogger(databasePlatform.platform()), extraMetrics);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DQueryPlanOutput.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DQueryPlanOutput.java
@@ -24,6 +24,8 @@ final class DQueryPlanOutput implements MetaQueryPlan, SpiDbQueryPlan {
   private long captureMicros;
   private Instant whenCaptured;
 
+  private Object tenantId;
+
   DQueryPlanOutput(Class<?> beanType, String label, String hash, String sql, ProfileLocation profileLocation, String bind, String plan) {
     this.beanType = beanType;
     this.label = label;
@@ -85,6 +87,14 @@ final class DQueryPlanOutput implements MetaQueryPlan, SpiDbQueryPlan {
   }
 
   /**
+   * Returns the tenant id of this plan.
+   */
+  @Override
+  public Object tenantId() {
+    return tenantId;
+  }
+
+  /**
    * Return the query execution time associated with the capture of bind values used
    * to build the query plan.
    */
@@ -113,18 +123,27 @@ final class DQueryPlanOutput implements MetaQueryPlan, SpiDbQueryPlan {
 
   @Override
   public String toString() {
-    return " BeanType:" + ((beanType == null) ? "" : beanType.getSimpleName()) + " planHash:" + hash + " label:" + label + " queryTimeMicros:" + queryTimeMicros + " captureCount:" + captureCount + "\n SQL:" + sql + "\nBIND:" + bind + "\nPLAN:" + plan;
+    return " BeanType:" + ((beanType == null) ? "" : beanType.getSimpleName())
+      + " planHash:" + hash
+      + " label:" + label
+      + " queryTimeMicros:" + queryTimeMicros
+      + " captureCount:" + captureCount
+      + (tenantId == null ? "" : (" tenant:" + tenantId))
+      + "\n SQL:" + sql
+      + "\nBIND:" + bind
+      + "\nPLAN:" + plan;
   }
 
   /**
    * Additionally set the query execution time and the number of bind captures.
    */
   @Override
-  public DQueryPlanOutput with(long queryTimeMicros, long captureCount, long captureMicros, Instant whenCaptured) {
+  public DQueryPlanOutput with(long queryTimeMicros, long captureCount, long captureMicros, Instant whenCaptured, Object tenantId) {
     this.queryTimeMicros = queryTimeMicros;
     this.captureCount = captureCount;
     this.captureMicros = captureMicros;
     this.whenCaptured = whenCaptured;
+    this.tenantId = tenantId;
     return this;
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -247,8 +247,8 @@ public class TransactionManager implements SpiTransactionManager {
   }
 
   @Override
-  public final Connection queryPlanConnection() throws SQLException {
-    return dataSourceSupplier.connection(null);
+  public final Connection queryPlanConnection(Object tenantId) throws SQLException {
+    return dataSourceSupplier.connection(tenantId);
   }
 
   @Override


### PR DESCRIPTION
We have a multi tenant application (~50 tenants, TenantMode.DB_WITH_MASTER) <strike>and with #2954 we have a great tool to generate HTML metrics and inspect the live running application.</strike>

Unfortunately, query-plan collect works only for the master DB as the tenantId is not captured.
In our case, every tenant-db has the same layout, but the master db is nearly empty and collecting plans there makes no sense.

In this PR I changed this, so that the tenantId is captured and the plan is collected from the correct DB
