### PR TITLE
FEATURE: Tenant partitioned caches could improve cache-hit ratio

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
+++ b/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
@@ -897,6 +897,12 @@ public interface DatabaseBuilder {
   DatabaseBuilder setBackgroundExecutorWrapper(BackgroundExecutorWrapper backgroundExecutorWrapper);
 
   /**
+   * Sets the tenant partitioning mode for caches. This means, caches are created on demand,
+   * but they may not get invalidated across tenant boundaries   *
+   */
+  void setTenantPartitionedCache(boolean tenantPartitionedCache);
+
+  /**
    * Set the L2 cache default max size.
    */
   default DatabaseBuilder cacheMaxSize(int cacheMaxSize) {
@@ -2562,6 +2568,11 @@ public interface DatabaseBuilder {
      * Return true if dirty beans are automatically persisted.
      */
     boolean isAutoPersistUpdates();
+
+    /**
+     * Returns, if the caches are partitioned by tenant.
+     */
+    boolean isTenantPartitionedCache();
 
     /**
      * Return the L2 cache default max size.

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -452,6 +452,8 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
   private int backgroundExecutorShutdownSecs = 30;
   private BackgroundExecutorWrapper backgroundExecutorWrapper = new MdcBackgroundExecutorWrapper();
 
+  private boolean tenantPartitionedCache;
+
   // defaults for the L2 bean caching
 
   private int cacheMaxSize = 10000;
@@ -1200,6 +1202,26 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
     return this;
   }
 
+  /**
+   * Returns, if the caches are partitioned by tenant.
+   */
+  @Override
+  public boolean isTenantPartitionedCache() {
+    return tenantPartitionedCache;
+  }
+
+  /**
+   * Sets the tenant partitioning mode for caches. This means, caches are created on demand,
+   * but they may not get invalidated across tenant boundaries   *
+   */
+  @Override
+  public void setTenantPartitionedCache(boolean tenantPartitionedCache) {
+    this.tenantPartitionedCache = tenantPartitionedCache;
+  }
+
+  /**
+   * Return the L2 cache default max size.
+   */
   @Override
   public int getCacheMaxSize() {
     return cacheMaxSize;
@@ -2234,6 +2256,15 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
     ddlStrictMode = p.getBoolean("ddl.strictMode", ddlStrictMode);
     ddlPlaceholders = p.get("ddl.placeholders", ddlPlaceholders);
     ddlHeader = p.get("ddl.header", ddlHeader);
+
+    tenantPartitionedCache = p.getBoolean("tenantPartitionedCache", tenantPartitionedCache);
+
+    cacheMaxIdleTime = p.getInt("cacheMaxIdleTime", cacheMaxIdleTime);
+    cacheMaxSize = p.getInt("cacheMaxSize", cacheMaxSize);
+    cacheMaxTimeToLive = p.getInt("cacheMaxTimeToLive", cacheMaxTimeToLive);
+    queryCacheMaxIdleTime = p.getInt("queryCacheMaxIdleTime", queryCacheMaxIdleTime);
+    queryCacheMaxSize = p.getInt("queryCacheMaxSize", queryCacheMaxSize);
+    queryCacheMaxTimeToLive = p.getInt("queryCacheMaxTimeToLive", queryCacheMaxTimeToLive);
 
     // read tenant-configuration from config:
     // tenant.mode = NONE | DB | SCHEMA | CATALOG | PARTITION

--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/CacheManagerOptions.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/CacheManagerOptions.java
@@ -13,18 +13,20 @@ import io.ebeaninternal.server.cluster.ClusterManager;
 public final class CacheManagerOptions {
 
   private final ClusterManager clusterManager;
-  private final DatabaseBuilder.Settings databaseBuilder;
+  private final String serverName;
   private final boolean localL2Caching;
   private CurrentTenantProvider currentTenantProvider;
   private QueryCacheEntryValidate queryCacheEntryValidate;
   private ServerCacheFactory cacheFactory = new DefaultServerCacheFactory();
   private ServerCacheOptions beanDefault = new ServerCacheOptions();
   private ServerCacheOptions queryDefault = new ServerCacheOptions();
+  private final boolean tenantPartitionedCache;
 
   CacheManagerOptions() {
     this.localL2Caching = true;
     this.clusterManager = null;
-    this.databaseBuilder = null;
+    this.serverName = "db";
+    this.tenantPartitionedCache = false;
     this.cacheFactory = new DefaultServerCacheFactory();
     this.beanDefault = new ServerCacheOptions();
     this.queryDefault = new ServerCacheOptions();
@@ -32,9 +34,10 @@ public final class CacheManagerOptions {
 
   public CacheManagerOptions(ClusterManager clusterManager, DatabaseBuilder.Settings config, boolean localL2Caching) {
     this.clusterManager = clusterManager;
-    this.databaseBuilder = config;
+    this.serverName = config.getName();
     this.localL2Caching = localL2Caching;
     this.currentTenantProvider = config.getCurrentTenantProvider();
+    this.tenantPartitionedCache = config.isTenantPartitionedCache();
   }
 
   public CacheManagerOptions with(ServerCacheOptions beanDefault, ServerCacheOptions queryDefault) {
@@ -55,7 +58,7 @@ public final class CacheManagerOptions {
   }
 
   public String getServerName() {
-    return (databaseBuilder == null) ? "db" : databaseBuilder.getName();
+    return serverName;
   }
 
   public boolean isLocalL2Caching() {
@@ -85,4 +88,6 @@ public final class CacheManagerOptions {
   public QueryCacheEntryValidate getQueryCacheEntryValidate() {
     return queryCacheEntryValidate;
   }
+
+  public boolean isTenantPartitionedCache() { return tenantPartitionedCache; }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/DefaultServerCacheManager.java
@@ -154,4 +154,8 @@ public final class DefaultServerCacheManager implements SpiCacheManager {
     return cacheHolder.getCache(beanType, ServerCacheType.BEAN);
   }
 
+  @Override
+  public boolean isTenantPartitionedCache() {
+    return cacheHolder.isTenantPartitionedCache();
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/cache/SpiCacheManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/cache/SpiCacheManager.java
@@ -88,4 +88,10 @@ public interface SpiCacheManager {
    */
   void clearLocal(Class<?> beanType);
 
+  /**
+   * returns true, if this chacheManager runs in tenant partitioned mode
+   * @return
+   */
+  boolean isTenantPartitionedCache();
+
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -318,7 +318,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
     this.idOnlyReference = isIdOnlyReference(propertiesBaseScalar);
     boolean noRelationships = propertiesOne.length + propertiesMany.length == 0;
     this.cacheSharableBeans = noRelationships && deploy.getCacheOptions().isReadOnly();
-    this.cacheHelp = new BeanDescriptorCacheHelp<>(this, owner.cacheManager(), deploy.getCacheOptions(), cacheSharableBeans, propertiesOneImported);
+    this.cacheHelp = BeanDescriptorCacheHelpPartitioned.create(this, owner.cacheManager(), deploy.getCacheOptions(), cacheSharableBeans, propertiesOneImported);
     this.jsonHelp = initJsonHelp();
     this.draftHelp = new BeanDescriptorDraftHelp<>(this);
     this.docStoreAdapter = owner.createDocStoreBeanAdapter(this, deploy);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelpFixed.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelpFixed.java
@@ -1,0 +1,72 @@
+package io.ebeaninternal.server.deploy;
+
+import io.ebean.cache.ServerCache;
+import io.ebeaninternal.server.cache.SpiCacheManager;
+import io.ebeaninternal.server.core.CacheOptions;
+
+
+/**
+ * Helper for BeanDescriptor that manages the bean, query and collection caches.
+ *
+ * @param <T> The entity bean type
+ */
+final class BeanDescriptorCacheHelpFixed<T> extends BeanDescriptorCacheHelp<T> {
+  private final ServerCache beanCache;
+  private final ServerCache naturalKeyCache;
+  private final ServerCache queryCache;
+
+
+  BeanDescriptorCacheHelpFixed(BeanDescriptor<T> desc, SpiCacheManager cacheManager, CacheOptions cacheOptions,
+                               boolean cacheSharableBeans, BeanPropertyAssocOne<?>[] propertiesOneImported) {
+    super(desc, cacheManager, cacheOptions, cacheSharableBeans, propertiesOneImported);
+    if (!cacheOptions.isEnableQueryCache()) {
+      this.queryCache = null;
+    } else {
+      this.queryCache = cacheManager.getQueryCache(beanType);
+    }
+
+    if (cacheOptions.isEnableBeanCache()) {
+      this.beanCache = cacheManager.getBeanCache(beanType);
+      if (cacheOptions.getNaturalKey() != null) {
+        this.naturalKeyCache = cacheManager.getNaturalKeyCache(beanType);
+      } else {
+        this.naturalKeyCache = null;
+      }
+    } else {
+      this.beanCache = null;
+      this.naturalKeyCache = null;
+    }
+  }
+
+  @Override
+  boolean hasBeanCache() {
+    return beanCache != null;
+  }
+
+  @Override
+  boolean hasQueryCache() {
+    return queryCache != null;
+  }
+
+
+  @Override
+  ServerCache getQueryCache() {
+    return queryCache;
+  }
+
+  @Override
+  ServerCache getNaturalKeyCache() {
+    return naturalKeyCache;
+  }
+
+  /**
+   * Return the beanCache creating it if necessary.
+   */
+  @Override
+  ServerCache getBeanCache() {
+    if (beanCache == null) {
+      throw new IllegalStateException("No bean cache enabled for " + desc + ". Add the @Cache annotation.");
+    }
+    return beanCache;
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelpPartitioned.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelpPartitioned.java
@@ -1,0 +1,74 @@
+package io.ebeaninternal.server.deploy;
+
+import io.ebean.cache.ServerCache;
+import io.ebeaninternal.server.cache.SpiCacheManager;
+import io.ebeaninternal.server.core.CacheOptions;
+
+import java.util.function.Supplier;
+
+/**
+ * Helper for BeanDescriptor that manages the bean, query and collection caches.
+ *
+ * @param <T> The entity bean type
+ */
+final class BeanDescriptorCacheHelpPartitioned<T> extends BeanDescriptorCacheHelp<T> {
+  private final Supplier<ServerCache> beanCacheSupplier;
+  private final Supplier<ServerCache> naturalKeyCacheSupplier;
+  private final Supplier<ServerCache> queryCacheSupplier;
+
+
+  BeanDescriptorCacheHelpPartitioned(BeanDescriptor<T> desc, SpiCacheManager cacheManager, CacheOptions cacheOptions,
+                                     boolean cacheSharableBeans, BeanPropertyAssocOne<?>[] propertiesOneImported) {
+    super(desc, cacheManager, cacheOptions, cacheSharableBeans, propertiesOneImported);
+    if (!cacheOptions.isEnableQueryCache()) {
+      this.queryCacheSupplier = null;
+    } else {
+      this.queryCacheSupplier = () -> cacheManager.getQueryCache(beanType);
+    }
+
+    if (cacheOptions.isEnableBeanCache()) {
+      this.beanCacheSupplier = () -> cacheManager.getBeanCache(beanType);
+      if (cacheOptions.getNaturalKey() != null) {
+        this.naturalKeyCacheSupplier = () -> cacheManager.getNaturalKeyCache(beanType);
+      } else {
+        this.naturalKeyCacheSupplier = null;
+      }
+    } else {
+      this.beanCacheSupplier = null;
+      this.naturalKeyCacheSupplier = null;
+    }
+  }
+
+  @Override
+  boolean hasBeanCache() {
+    return beanCacheSupplier != null;
+  }
+
+  @Override
+  boolean hasQueryCache() {
+    return queryCacheSupplier != null;
+  }
+
+
+  @Override
+  ServerCache getQueryCache() {
+    return queryCacheSupplier.get();
+  }
+
+  @Override
+  ServerCache getNaturalKeyCache() {
+    return naturalKeyCacheSupplier.get();
+  }
+
+  /**
+   * Return the beanCache creating it if necessary.
+   */
+  @Override
+  ServerCache getBeanCache() {
+    if (beanCacheSupplier != null) {
+      return beanCacheSupplier.get();
+    } else {
+      throw new IllegalStateException("No bean cache enabled for " + desc + ". Add the @Cache annotation.");
+    }
+  }
+}


### PR DESCRIPTION
Hello @rbygrave,

this is more or less a proof-of-concept, where I need your feedback

we have a multi-tenant application with ~ 50 tenants. I noticed, that we get a lot of 'cache clears' from other customers.
We cache a lot of things in our applications (user-directory, settings, ...) and if one customer updates the settings e.g. it will invalidate the caches for all other. So I tried to experimet with tenant partitioned caches, which means, each tenant has its own set of caches.

On the other hand, caches had to be created dynamically and would - at least in current implementation - stay there forever, also if the tenant does not longer exist.

I don't have exact numbers about this improvement, but do you think, this could be useful?

