### PR TITLE
#2968 - [ebean-test] - Default ebean.test.registerTestTenantProvider = false ... by default not auto register a test TenantProvider

### DIFF
--- a/ebean-test/src/main/java/io/ebean/test/config/provider/ProviderAutoConfig.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/provider/ProviderAutoConfig.java
@@ -38,7 +38,7 @@ public class ProviderAutoConfig {
 
     CurrentTenantProvider tenantProvider = config.getCurrentTenantProvider();
     if (tenantProvider == null) {
-      if (Boolean.parseBoolean(properties.getProperty("ebean.test.registerTestTenantProvider", "true"))) {
+      if (Boolean.parseBoolean(properties.getProperty("ebean.test.registerTestTenantProvider", "false"))) {
         providerSetFlag += 2;
         config.setCurrentTenantProvider(new WhoTenantProvider());
       }


### PR DESCRIPTION
…