### PR TITLE
Jakarta: Add suport for jakarta (via automated fork aka releasing 2 versions of ebean) - jakarta-persistence-api, jaxb, servlet

### DIFF
--- a/ebean-api/pom.xml
+++ b/ebean-api/pom.xml
@@ -44,7 +44,7 @@
 
     <dependency>
       <groupId>io.ebean</groupId>
-      <artifactId>persistence-api</artifactId>
+      <artifactId>jakarta-persistence-api</artifactId>
       <version>${ebean-persistence-api.version}</version>
     </dependency>
 
@@ -91,9 +91,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <optional>true</optional>
     </dependency>
 

--- a/ebean-autotune/pom.xml
+++ b/ebean-autotune/pom.xml
@@ -32,10 +32,15 @@
 
     <!-- needed for java 11+ -->
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
-      <scope>provided</scope>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/ebean-ddl-generator/pom.xml
+++ b/ebean-ddl-generator/pom.xml
@@ -41,10 +41,15 @@
 
     <!-- needed for java 11+ -->
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
-      <scope>provided</scope>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- test dependencies -->

--- a/ebean-externalmapping-xml/pom.xml
+++ b/ebean-externalmapping-xml/pom.xml
@@ -25,16 +25,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
     </dependency>
-
     <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-      <version>1.2.1</version>
-      <scope>provided</scope>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -72,17 +72,15 @@
 
     <!-- Including JAXB for DB Migration generation with Java 11+ -->
     <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.6</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.0</version>
     </dependency>
-
-    <!-- Needed for module path compile, jaxb foo bar needs review -->
     <dependency>
-      <groupId>jakarta.activation</groupId>
-      <artifactId>jakarta.activation-api</artifactId>
-      <version>1.2.1</version>
-      <scope>provided</scope>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- Not strictly required but bring in H2 Driver because we use it so much -->

--- a/pom.xml
+++ b/pom.xml
@@ -120,5 +120,77 @@
     </profile>
   </profiles>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>javax2jakarta</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <echo>${project.basedir}</echo>
+
+                <replace file="${project.basedir}/ebean-api/pom.xml"
+                         token="artifactId>persistence-api"
+                         value="artifactId>jakarta-persistence-api"/>
+                <replace file="${project.basedir}/ebean-bom/pom.xml"
+                         token="artifactId>persistence-api"
+                         value="artifactId>jakarta-persistence-api"/>
+
+                <replace file="${project.basedir}/ebean-api/src/main/java/module-info.java"
+                         token=" persistence.api" value=" jakarta.persistence.api"/>
+
+                <replace file="${project.basedir}/ebean-api/src/main/java/module-info.java"
+                         token=" javax.servlet.api;" value=" jakarta.servlet;"/>
+
+                <!-- replace imports and package to jakarta in java sources -->
+                <replace dir="${project.basedir}">
+                  <include name="**/*.java"/>
+                  <include name="**/*.kt"/>
+
+                  <replacefilter token="javax.persistence."
+                                 value="jakarta.persistence."/>
+                  <replacefilter token="javax.xml.bind"
+                                 value="jakarta.xml.bind"/>
+
+                  <replacefilter token="requires java.xml.bind"
+                                 value="requires jakarta.xml.bind"/>
+                  <replacefilter token="requires transitive java.xml.bind"
+                                 value="requires transitive jakarta.xml.bind"/>
+
+                </replace>
+
+                <replace dir="${project.basedir}/ebean-api/src/main/java/io/ebean/event">
+                  <include name="**/*.java"/>
+                  <replacefilter token="javax.servlet"
+                                 value="jakarta.servlet"/>
+
+                </replace>
+
+                <!-- Currently getting compile error jakarta.cdi module not found ? -->
+<!--                <replace file="${project.basedir}/ebean-core/src/main/java/module-info.java"-->
+<!--                         token=" javax.transaction;" value=" jakarta.transaction;"/>-->
+
+<!--                <replace dir="${project.basedir}/ebean-core/src/main/java/io/ebeaninternal/server/transaction">-->
+<!--                  <include name="**/*.java"/>-->
+<!--                  <replacefilter token="javax.transaction"-->
+<!--                                 value="jakarta.transaction"/>-->
+<!--                </replace>-->
+
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>
 


### PR DESCRIPTION
- Use version jakarta-persistence-api 3.0 (match javax-persistence-api) On a ongoing the jakarta-persistence-api and javax-persistence-api versions (that ebean releases) should always match.

- javax.servlet -> jakarta.servlet manipulation

- Modify ebean-api pom to explicitly use jakarta-persistence-api dependency In theory this gets modified during generated sources but it currently seems like that is too late.

- Currently excludes javax.transaction as there is a strange issue to resolve there