### PR TITLE
FIX: do not format log messages, when no parameter was specified

### DIFF
--- a/ebean-test/src/main/java/io/ebean/test/CaptureLogger.java
+++ b/ebean-test/src/main/java/io/ebean/test/CaptureLogger.java
@@ -27,7 +27,11 @@ final class CaptureLogger implements SpiLogger {
   @Override
   public void debug(String msg, Object... args) {
     if (active) {
-      messages.add(MessageFormat.format(msg, args));
+      if (args != null && args.length > 0) {
+        messages.add(MessageFormat.format(msg, args));
+      } else {
+        messages.add(msg);
+      }
     }
     wrapped.debug(msg, args);
   }

--- a/ebean-test/src/test/java/io/ebean/test/TestCaptureLogger.java
+++ b/ebean-test/src/test/java/io/ebean/test/TestCaptureLogger.java
@@ -1,10 +1,7 @@
 package io.ebean.test;
 
 import io.ebeaninternal.api.SpiLogger;
-import io.ebeaninternal.api.SpiLoggerFactory;
-import io.ebeaninternal.server.logger.DLoggerFactory;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.commons.logging.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,7 +9,7 @@ public class TestCaptureLogger {
 
   @Test
   void testDefaultLogger() {
-    SpiLogger logger = new DLoggerFactory().create("io.ebean.test.loggerTest");
+    SpiLogger logger = new CapturingLoggerFactory().create("io.ebean.test.loggerTest");
     doSomeLogs(logger);
 
     CaptureLogger captureLogger = new CaptureLogger(logger);

--- a/ebean-test/src/test/java/io/ebean/test/TestCaptureLogger.java
+++ b/ebean-test/src/test/java/io/ebean/test/TestCaptureLogger.java
@@ -1,0 +1,36 @@
+package io.ebean.test;
+
+import io.ebeaninternal.api.SpiLogger;
+import io.ebeaninternal.api.SpiLoggerFactory;
+import io.ebeaninternal.server.logger.DLoggerFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.logging.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestCaptureLogger {
+
+  @Test
+  void testDefaultLogger() {
+    SpiLogger logger = new DLoggerFactory().create("io.ebean.test.loggerTest");
+    doSomeLogs(logger);
+
+    CaptureLogger captureLogger = new CaptureLogger(logger);
+    captureLogger.start();
+    doSomeLogs(captureLogger);
+    assertThat(captureLogger.stop()).containsExactly(
+      "test {0}", "test {}", "test {bla}", "test {bla} {0}", "test {bla} {0}", "test {bla} 1", "test '{bla}' {0}");
+  }
+
+  void doSomeLogs(SpiLogger logger) {
+    logger.debug("test {0}"); // Returns "test {0}"
+    logger.debug("test {}"); // Returns "test {}"
+    logger.debug("test {bla}"); // Returns "test {bla}"
+    logger.debug("test {bla} {0}"); // Returns "test {bla} {0}"
+    logger.debug("test {bla} {0}", new Object[]{}); // Returns "test {bla} {0}"
+    //logger.debug("Test {bla} {0}", 1); // fails: "can't parse argument number: bla"
+    logger.debug("test '{bla}' {0}", 1); // Returns "test {bla} 1"
+    logger.debug("test '{bla}' {0}"); // Returns "test '{bla}' {0}"
+  }
+
+}

--- a/ebean-test/src/test/resources/logback-test.xml
+++ b/ebean-test/src/test/resources/logback-test.xml
@@ -78,6 +78,7 @@
   <logger name="io.ebean.docker" level="DEBUG"/>
   <logger name="io.ebean.test" level="TRACE"/>
   <logger name="io.ebean.MarkedAsDeleted" level="DEBUG"/>
+  <logger name="io.ebean.test.loggerTest" level="DEBUG"/>
 
 <!--  <logger name="io.ebean.DDL" level="DEBUG"/>-->
 


### PR DESCRIPTION
How to reproduce:
if have a `@Where("someField = 'someValue'")` annoation, the CaptureLogger may remove the single quotes from the string, because it passes the `msg` argument to `MessageFormat`, although there are no parameters specified.

This PR changes the behaviour of the CaptureLogger to line up with the default logger (= if args are null or empty, don't format them)