### PR TITLE
Revert the use of ${revision} in poms to plain old version dur to issues not being able to use mvn --rf --resume-from ... as it complains about the parent pom version

### DIFF
--- a/composites/ebean-clickhouse/pom.xml
+++ b/composites/ebean-clickhouse/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-clickhouse</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-clickhouse</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-cockroach/pom.xml
+++ b/composites/ebean-cockroach/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-cockroach</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-postgres</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-db2/pom.xml
+++ b/composites/ebean-db2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-db2</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-db2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-h2/pom.xml
+++ b/composites/ebean-h2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-h2</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-hana/pom.xml
+++ b/composites/ebean-hana/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-hana</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-hana</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-mariadb/pom.xml
+++ b/composites/ebean-mariadb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-mariadb</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-mariadb</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-mysql/pom.xml
+++ b/composites/ebean-mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-mysql</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-mysql</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-nuodb/pom.xml
+++ b/composites/ebean-nuodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-nuodb</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-nuodb</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-oracle/pom.xml
+++ b/composites/ebean-oracle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-oracle</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-oracle</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-postgres/pom.xml
+++ b/composites/ebean-postgres/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-postgres</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-postgres</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-sqlite/pom.xml
+++ b/composites/ebean-sqlite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-sqlite</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-sqlite</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-sqlserver/pom.xml
+++ b/composites/ebean-sqlserver/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-sqlserver</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-sqlserver</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean-yugabyte/pom.xml
+++ b/composites/ebean-yugabyte/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean-yugabyte</name>
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-postgres</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/ebean/pom.xml
+++ b/composites/ebean/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>composites</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean (all platforms)</name>
@@ -16,31 +16,31 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-joda-time</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-jackson-jsonnode</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-jackson-mapper</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -53,13 +53,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-all</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/composites/pom.xml
+++ b/composites/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>composites</artifactId>

--- a/ebean-api/pom.xml
+++ b/ebean-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean api</name>

--- a/ebean-autotune/pom.xml
+++ b/ebean-autotune/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 <!--  <parent>-->
 <!--    <groupId>org.avaje</groupId>-->
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-bom/pom.xml
+++ b/ebean-bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean bom</name>
@@ -89,106 +89,106 @@
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-api</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-core</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-core-type</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-joda-time</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-jackson-jsonnode</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-jackson-mapper</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-ddl-generator</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-externalmapping-api</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-externalmapping-xml</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-autotune</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-querybean</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>querybean-generator</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>kotlin-querybean-generator</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-test</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-postgis</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-redis</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <!-- platforms -->
@@ -196,67 +196,67 @@
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-clickhouse</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-db2</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-h2</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-hana</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-mariadb</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-mysql</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-nuodb</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-oracle</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-postgres</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-sqlite</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
       <dependency>
         <groupId>io.ebean</groupId>
         <artifactId>ebean-sqlserver</artifactId>
-        <version>${revision}</version>
+        <version>13.13.1</version>
       </dependency>
 
     </dependencies>

--- a/ebean-core-type/pom.xml
+++ b/ebean-core-type/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-core-type</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>

--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-core</artifactId>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -46,13 +46,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core-type</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-externalmapping-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -143,21 +143,21 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-postgres</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-sqlserver</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-csv-reader/pom.xml
+++ b/ebean-csv-reader/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-csv-reader</artifactId>
@@ -14,21 +14,21 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-ddl-generator/pom.xml
+++ b/ebean-ddl-generator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean ddl generation</name>
@@ -28,14 +28,14 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core-type</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-all</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-externalmapping-api/pom.xml
+++ b/ebean-externalmapping-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean external mapping api</name>

--- a/ebean-externalmapping-xml/pom.xml
+++ b/ebean-externalmapping-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <scm>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-externalmapping-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -54,21 +54,21 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-ddl-generator</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-jackson-jsonnode/pom.xml
+++ b/ebean-jackson-jsonnode/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-jackson-jsonnode</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core-type</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/ebean-jackson-mapper/pom.xml
+++ b/ebean-jackson-mapper/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core-type</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/ebean-joda-time/pom.xml
+++ b/ebean-joda-time/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core-type</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/ebean-kotlin/pom.xml
+++ b/ebean-kotlin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-kotlin</artifactId>
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-postgis/pom.xml
+++ b/ebean-postgis/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean postgis</name>
@@ -22,14 +22,14 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-postgres</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <!-- provided scope -->
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-querybean/pom.xml
+++ b/ebean-querybean/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean querybean</name>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -63,21 +63,21 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-ddl-generator</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>querybean-generator</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-redis/pom.xml
+++ b/ebean-redis/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-redis</artifactId>
@@ -22,35 +22,35 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>querybean-generator</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>ebean test</name>
@@ -28,20 +28,20 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-ddl-generator</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -105,28 +105,28 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-joda-time</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-jackson-jsonnode</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-jackson-mapper</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-all</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/kotlin-querybean-generator/pom.xml
+++ b/kotlin-querybean-generator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>kotlin querybean generator</name>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-querybean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -64,14 +64,14 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-ddl-generator</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/platforms/all/pom.xml
+++ b/platforms/all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-all</artifactId>
@@ -14,67 +14,67 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-clickhouse</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-db2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-hana</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-hsqldb</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-mysql</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-mariadb</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-nuodb</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-oracle</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-postgres</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-sqlanywhere</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-sqlite</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-sqlserver</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/clickhouse/pom.xml
+++ b/platforms/clickhouse/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-clickhouse</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/db2/pom.xml
+++ b/platforms/db2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-db2</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/h2/pom.xml
+++ b/platforms/h2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-h2</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <!-- Provided scope so that the H2HistoryTrigger can live in Ebean core

--- a/platforms/hana/pom.xml
+++ b/platforms/hana/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-hana</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/hsqldb/pom.xml
+++ b/platforms/hsqldb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-hsqldb</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-h2</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/mariadb/pom.xml
+++ b/platforms/mariadb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-mariadb</artifactId>
@@ -14,13 +14,13 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-platform-mysql</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/mysql/pom.xml
+++ b/platforms/mysql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-mysql</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>

--- a/platforms/nuodb/pom.xml
+++ b/platforms/nuodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-nuodb</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/oracle/pom.xml
+++ b/platforms/oracle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-oracle</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>

--- a/platforms/pom.xml
+++ b/platforms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>platforms</artifactId>

--- a/platforms/postgres/pom.xml
+++ b/platforms/postgres/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-postgres</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>

--- a/platforms/sqlanywhere/pom.xml
+++ b/platforms/sqlanywhere/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-sqlanywhere</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/sqlite/pom.xml
+++ b/platforms/sqlite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-sqlite</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
   </dependencies>

--- a/platforms/sqlserver/pom.xml
+++ b/platforms/sqlserver/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>platforms</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>ebean-platform-sqlserver</artifactId>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>io.ebean</groupId>
   <artifactId>ebean-parent</artifactId>
-  <version>${revision}</version>
+  <version>13.13.1</version>
   <packaging>pom</packaging>
 
   <name>ebean parent</name>
@@ -38,7 +38,6 @@
   </developers>
 
   <properties>
-    <revision>13.13.1-SNAPSHOT</revision>
     <nexus.staging.autoReleaseAfterClose>false</nexus.staging.autoReleaseAfterClose>
     <jackson.version>2.14.0</jackson.version>
     <h2database.version>2.1.214</h2database.version>

--- a/querybean-generator/pom.xml
+++ b/querybean-generator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <name>querybean generator</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ebean-parent</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>tests</artifactId>

--- a/tests/test-java16/pom.xml
+++ b/tests/test-java16/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>tests</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>test-java16</artifactId>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
     </dependency>
 
     <dependency>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -56,7 +56,7 @@
             <path>
               <groupId>io.ebean</groupId>
               <artifactId>querybean-generator</artifactId>
-              <version>${revision}</version>
+              <version>13.13.1</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/tests/test-kotlin/pom.xml
+++ b/tests/test-kotlin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>tests</artifactId>
     <groupId>io.ebean</groupId>
-    <version>${revision}</version>
+    <version>13.13.1</version>
   </parent>
 
   <artifactId>test-kotlin</artifactId>
@@ -31,14 +31,14 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-core</artifactId>
-      <version>${revision}</version>
+      <version>13.13.1</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
…