### PR TITLE
[QueryBeans] Refactor splitting TQAssocBean into TQAssoc & TQAssocBean

### DIFF
--- a/ebean-querybean/pom.xml
+++ b/ebean-querybean/pom.xml
@@ -103,11 +103,11 @@
       <plugin>
         <groupId>io.repaint.maven</groupId>
         <artifactId>tiles-maven-plugin</artifactId>
-        <version>2.24</version>
+        <version>2.34</version>
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:13.13.1</tile>
+            <tile>io.ebean.tile:enhancement:13.13.2</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQAssoc.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQAssoc.java
@@ -1,0 +1,162 @@
+package io.ebean.typequery;
+
+import io.avaje.lang.Nullable;
+
+import java.util.Collection;
+
+/**
+ * Base type for associated beans.
+ *
+ * @param <T> the entity bean type (normal entity bean type e.g. Customer)
+ * @param <R> the specific root query bean type (e.g. QCustomer)
+ */
+public abstract class TQAssoc<T, R> extends TQProperty<R, Object> {
+
+  /**
+   * Construct with a property name and root instance.
+   *
+   * @param name the name of the property
+   * @param root the root query bean instance
+   */
+  public TQAssoc(String name, R root) {
+    this(name, root, null);
+  }
+
+  /**
+   * Construct with additional path prefix.
+   */
+  public TQAssoc(String name, R root, String prefix) {
+    super(name, root, prefix);
+  }
+
+  /**
+   * Is equal to by ID property.
+   */
+  public final R eq(T other) {
+    expr().eq(_name, other);
+    return _root;
+  }
+
+  /**
+   * Is EQUAL TO if value is non-null and otherwise no expression is added to the query.
+   * <p>
+   * This is effectively a helper method that allows a query to be built in fluid style where some predicates are
+   * effectively optional. We can use <code>eqIfPresent()</code> rather than having a separate if block.
+   */
+  public final R eqIfPresent(@Nullable T other) {
+    expr().eqIfPresent(_name, other);
+    return _root;
+  }
+
+  /**
+   * Is equal to by ID property.
+   */
+  public final R equalTo(T other) {
+    return eq(other);
+  }
+
+  /**
+   * Is not equal to by ID property.
+   */
+  public final R ne(T other) {
+    expr().ne(_name, other);
+    return _root;
+  }
+
+  /**
+   * Is not equal to by ID property.
+   */
+  public final R notEqualTo(T other) {
+    return ne(other);
+  }
+
+  /**
+   * Is in a list of values.
+   *
+   * @param values the list of values for the predicate
+   * @return the root query bean instance
+   */
+  @SafeVarargs
+  public final R in(T... values) {
+    expr().in(_name, (Object[]) values);
+    return _root;
+  }
+
+  /**
+   * Is in a list of values.
+   *
+   * @param values the list of values for the predicate
+   * @return the root query bean instance
+   */
+  public final R in(Collection<T> values) {
+    expr().in(_name, values);
+    return _root;
+  }
+
+  /**
+   * In where null or empty values means that no predicate is added to the query.
+   * <p>
+   * That is, only add the IN predicate if the values are not null or empty.
+   * <p>
+   * Without this we typically need to code an <code>if</code> block to only add
+   * the IN predicate if the collection is not empty like:
+   * </p>
+   *
+   * <h3>Without inOrEmpty()</h3>
+   * <pre>{@code
+   *
+   *   List<String> names = Arrays.asList("foo", "bar");
+   *
+   *   QCustomer query = new QCustomer()
+   *       .registered.before(LocalDate.now())
+   *
+   *   // conditionally add the IN expression to the query
+   *   if (names != null && !names.isEmpty()) {
+   *       query.name.in(names)
+   *   }
+   *
+   *   query.findList();
+   *
+   * }</pre>
+   *
+   * <h3>Using inOrEmpty()</h3>
+   * <pre>{@code
+   *
+   *   List<String> names = Arrays.asList("foo", "bar");
+   *
+   *   new QCustomer()
+   *       .registered.before(LocalDate.now())
+   *       .name.inOrEmpty(names)
+   *       .findList();
+   *
+   * }</pre>
+   */
+  public final R inOrEmpty(Collection<T> values) {
+    expr().inOrEmpty(_name, values);
+    return _root;
+  }
+
+  /**
+   * Is NOT in a list of values.
+   *
+   * @param values the list of values for the predicate
+   * @return the root query bean instance
+   */
+  public final R notIn(Collection<T> values) {
+    expr().notIn(_name, values);
+    return _root;
+  }
+
+  /**
+   * Is NOT in a list of values.
+   *
+   * @param values the list of values for the predicate
+   * @return the root query bean instance
+   */
+  @SafeVarargs
+  public final R notIn(T... values) {
+    expr().notIn(_name, (Object[]) values);
+    return _root;
+  }
+
+}

--- a/kotlin-querybean-generator/pom.xml
+++ b/kotlin-querybean-generator/pom.xml
@@ -113,7 +113,7 @@
                 <annotationProcessorPath>
                   <groupId>io.ebean</groupId>
                   <artifactId>kotlin-querybean-generator</artifactId>
-                  <version>13.13.0</version>
+                  <version>13.13.3-RC1</version>
                 </annotationProcessorPath>
               </annotationProcessorPaths>
             </configuration>

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -19,6 +19,7 @@ interface Constants {
   String DBNAME = "io.ebean.annotation.DbName";
 
   String TQROOTBEAN = "io.ebean.typequery.TQRootBean";
+  String TQASSOC = "io.ebean.typequery.TQAssoc";
   String TQASSOCBEAN = "io.ebean.typequery.TQAssocBean";
   String TQPROPERTY = "io.ebean.typequery.TQProperty";
   String TYPEQUERYBEAN = "io.ebean.typequery.TypeQueryBean";

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
@@ -9,7 +9,7 @@ class KotlinLangAdapter implements LangAdapter {
 
   @Override
   public void beginAssocClass(Append writer, String shortName, String origShortName) {
-    writer.append("class Q%s<R> : TQAssocBean<%s,R> {", shortName, origShortName).eol();
+//    writer.append("class Q%s<R> : TQAssocBean<%s,R> {", shortName, origShortName).eol();
   }
 
   @Override

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -236,7 +236,11 @@ class SimpleQueryBeanWriter {
     importTypes.remove(Constants.DATABASE);
     importTypes.remove(Constants.FETCHGROUP);
     importTypes.remove(Constants.QUERY);
-    importTypes.add(Constants.TQASSOCBEAN);
+    if (embeddable) {
+      importTypes.add(Constants.TQASSOC);
+    } else {
+      importTypes.add(Constants.TQASSOCBEAN);
+    }
     if (isEntity()) {
       importTypes.add(Constants.TQPROPERTY);
       importTypes.add(origDestPackage + ".Q" + origShortName);
@@ -280,7 +284,6 @@ class SimpleQueryBeanWriter {
 
   private void writeAssocBeanFetch() {
     if (isEntity()) {
-      lang().fetch(writer, origShortName);
       //if (implementsInterface != null) {
       //  writeAssocBeanExpression(false, "eq", "Is equal to by ID property.");
       //  writeAssocBeanExpression(true, "eqIfPresent", "Is equal to by ID property if the value is not null, if null no expression is added.");
@@ -340,7 +343,11 @@ class SimpleQueryBeanWriter {
       writer.append(" */").eol();
       writer.append(Constants.AT_GENERATED).eol();
       writer.append(Constants.AT_TYPEQUERYBEAN).eol();
-      lang().beginAssocClass(writer, shortName, shortInnerName);
+      if (embeddable) {
+        writer.append("class Q%s<R> : TQAssoc<%s,R> {", shortName, shortInnerName).eol();
+      } else {
+        writer.append("class Q%s<R> : TQAssocBean<%s,R,Q%s> {", shortName, shortInnerName, origShortName).eol();
+      }
 
     } else {
       writer.append("/**").eol();

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -20,6 +20,7 @@ interface Constants {
   String DBNAME = "io.ebean.annotation.DbName";
 
   String TQROOTBEAN = "io.ebean.typequery.TQRootBean";
+  String TQASSOC = "io.ebean.typequery.TQAssoc";
   String TQASSOCBEAN = "io.ebean.typequery.TQAssocBean";
   String TQPROPERTY = "io.ebean.typequery.TQProperty";
   String TYPEQUERYBEAN = "io.ebean.typequery.TypeQueryBean";

--- a/tests/test-java16/pom.xml
+++ b/tests/test-java16/pom.xml
@@ -52,7 +52,7 @@
             <path>
               <groupId>io.ebean</groupId>
               <artifactId>querybean-generator</artifactId>
-              <version>13.13.1</version>
+              <version>13.13.2</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
### This change requires an up-to-date ebean-agent and hence we will put this in **13.14.0**


### Changes

- Requires ebean-agent to be up-to-date (13.13.2 or greater)
- Split TQAssocBean into 2, one for embeddable beans and the other for the reset
- The eq(), in() etc expressions go to TQAssoc
- Add fetch() methods to TQAssocBean
- No longer generate the fetch() methods as we now have them on TQAssocBean