### PR TITLE
[QueryBeans] Fix for missing inherited properties when parent only has @DiscriminatorValue

### DIFF
--- a/ebean-querybean/src/test/java/org/example/domain/ACat.java
+++ b/ebean-querybean/src/test/java/org/example/domain/ACat.java
@@ -2,15 +2,22 @@ package org.example.domain;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.persistence.Inheritance;
 
-@Inheritance
 @DiscriminatorValue("CAT")
 @Entity
 public class ACat extends Animal {
+
+  private String catProp;
 
   public ACat(String name) {
     super(name);
   }
 
+  public String getCatProp() {
+    return catProp;
+  }
+
+  public void setCatProp(String catProp) {
+    this.catProp = catProp;
+  }
 }

--- a/ebean-querybean/src/test/java/org/example/domain/ASuperCat.java
+++ b/ebean-querybean/src/test/java/org/example/domain/ASuperCat.java
@@ -1,0 +1,23 @@
+package org.example.domain;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@DiscriminatorValue("SCAT")
+@Entity
+public class ASuperCat extends ACat {
+
+  private String superCat;
+
+  public ASuperCat(String name) {
+    super(name);
+  }
+
+  public String getSuperCat() {
+    return superCat;
+  }
+
+  public void setSuperCat(String superCat) {
+    this.superCat = superCat;
+  }
+}

--- a/ebean-querybean/src/test/java/org/querytest/InheritanceTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/InheritanceTest.java
@@ -1,0 +1,54 @@
+package org.querytest;
+
+import org.example.domain.ACat;
+import org.example.domain.ADog;
+import org.example.domain.Animal;
+import org.example.domain.query.QACat;
+import org.example.domain.query.QASuperCat;
+import org.example.domain.query.QAnimal;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InheritanceTest {
+
+  @Test
+  void query_setInheritType() {
+
+    ACat cat = new ACat("C1");
+    cat.save();
+
+    ACat cat2 = new ACat("C2");
+    cat2.save();
+
+    ADog dog = new ADog("D1", "D878");
+    dog.save();
+
+    List<Animal> animals = new QAnimal()
+      .id.greaterOrEqualTo(1L)
+      .setInheritType(ACat.class)
+      .findList();
+
+    assertThat(animals).isNotEmpty();
+  }
+
+  @Test
+  void query_onInheritedProperty() {
+    new QACat()
+      .name.eq("foo")
+      .catProp.eq("foo")
+      .findList();
+  }
+
+  @Test
+  void query_onInheritedProperty_whenParentOnlyHasDiscriminator() {
+    // the .name and .catProp properties exist on QASuperCat()
+    new QASuperCat()
+      .superCat.eq("foo")
+      .name.eq("foo")
+      .catProp.eq("foo")
+      .findList();
+  }
+}

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -591,25 +591,7 @@ public class QCustomerTest {
       .findList();
   }
 
-  @Test
-  public void query_setInheritType() {
 
-    ACat cat = new ACat("C1");
-    cat.save();
-
-    ACat cat2 = new ACat("C2");
-    cat2.save();
-
-    ADog dog = new ADog("D1", "D878");
-    dog.save();
-
-    List<Animal> animals = new QAnimal()
-      .id.greaterOrEqualTo(1L)
-      .setInheritType(ACat.class)
-      .findList();
-
-    System.out.println(animals);
-  }
 
   @Test
   public void select_assocManyToOne() {

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -7,6 +7,7 @@ interface Constants {
   String GENERATED = "io.ebean.typequery.Generated";
 
   String MAPPED_SUPERCLASS = "javax.persistence.MappedSuperclass";
+  String DISCRIMINATOR_VALUE = "javax.persistence.DiscriminatorValue";
   String INHERITANCE = "javax.persistence.Inheritance";
   String ENTITY = "javax.persistence.Entity";
   String EMBEDDABLE = "javax.persistence.Embeddable";

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -224,7 +224,7 @@ class ProcessingContext implements Constants {
   }
 
   private boolean isMappedSuperOrInheritance(Element mappedSuper) {
-    return hasAnnotations(mappedSuper, MAPPED_SUPERCLASS, INHERITANCE);
+    return hasAnnotations(mappedSuper, MAPPED_SUPERCLASS, INHERITANCE, DISCRIMINATOR_VALUE);
   }
 
   private boolean isEntityOrEmbedded(Element mappedSuper) {

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -8,6 +8,7 @@ interface Constants {
   String GENERATED = "io.ebean.typequery.Generated";
 
   String MAPPED_SUPERCLASS = "javax.persistence.MappedSuperclass";
+  String DISCRIMINATOR_VALUE = "javax.persistence.DiscriminatorValue";
   String INHERITANCE = "javax.persistence.Inheritance";
   String ENTITY = "javax.persistence.Entity";
   String EMBEDDABLE = "javax.persistence.Embeddable";

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -181,7 +181,7 @@ class ProcessingContext implements Constants {
   }
 
   private boolean isMappedSuperOrInheritance(Element mappedSuper) {
-    return hasAnnotations(mappedSuper, MAPPED_SUPERCLASS, INHERITANCE);
+    return hasAnnotations(mappedSuper, MAPPED_SUPERCLASS, INHERITANCE, DISCRIMINATOR_VALUE);
   }
 
   private boolean isEntityOrEmbedded(Element mappedSuper) {

--- a/tests/test-java16/pom.xml
+++ b/tests/test-java16/pom.xml
@@ -52,7 +52,7 @@
             <path>
               <groupId>io.ebean</groupId>
               <artifactId>querybean-generator</artifactId>
-              <version>13.13.2</version>
+              <version>13.13.3-SNAPSHOT</version>
             </path>
           </annotationProcessorPaths>
         </configuration>
@@ -65,7 +65,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:13.12.0</tile>
+            <tile>io.ebean.tile:enhancement:13.13.2</tile>
           </tiles>
         </configuration>
       </plugin>


### PR DESCRIPTION
A parent in the Inheritance hierarchy has @DiscriminatorValue but not the @Inheritance annotation. The bug means the inherited properties are not included on the generated query bean.

The fix is to the querybean-generator to pick up inherited properties for this case.