### PR TITLE
Fix for IndexOutOfBoundsException: The size must be at least 1

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadManyContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadManyContext.java
@@ -212,7 +212,7 @@ final class DLoadManyContext extends DLoadBaseContext implements LoadManyContext
           }
         }
 
-        context.parent.getEbeanServer().loadMany(new LoadManyRequest(this, onlyIds, useCache));
+        context.parent.getEbeanServer().loadMany(new LoadManyRequest(this, onlyIds, useCache, bc));
         // clear the buffer as all entries have been loaded
         clear();
       } finally {


### PR DESCRIPTION
Stack trace observed:

java.lang.IndexOutOfBoundsException: The size must be at least 1
    at io.ebeaninternal.server.deploy.id.IdBinderSimple.getIdInValueExpr(IdBinderSimple.java:135)
    at io.ebeaninternal.server.deploy.BeanDescriptor.parentIdInExpr(BeanDescriptor.java:1634)
    at io.ebeaninternal.server.deploy.BeanPropertyAssocManySqlHelp.addWhereParentIdIn(BeanPropertyAssocManySqlHelp.java:121)
    at io.ebeaninternal.server.deploy.BeanPropertyAssocMany.addWhereParentIdIn(BeanPropertyAssocMany.java:342)
    at io.ebeaninternal.api.LoadManyRequest.createQuery(LoadManyRequest.java:90)
    at io.ebeaninternal.server.core.DefaultBeanLoader.loadMany(DefaultBeanLoader.java:39)
    at io.ebeaninternal.server.core.DefaultServer.loadMany(DefaultServer.java:475)
    at io.ebeaninternal.server.loadcontext.DLoadManyContext$LoadBuffer.loadMany(DLoadManyContext.java:215)
    at io.ebean.common.AbstractBeanCollection.lazyLoadCollection(AbstractBeanCollection.java:90)
    at io.ebean.common.BeanList.init(BeanList.java:141)
    at io.ebean.common.BeanList.iterator(BeanList.java:327)