### PR TITLE
Change such that querybean generated class registration can be used with explicit class registration

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -123,10 +123,10 @@ public class DatabaseConfig {
   private boolean loadModuleInfo = true;
 
   /**
-   * List of interesting classes such as entities, embedded, ScalarTypes,
-   * Listeners, Finders, Controllers etc.
+   * Interesting classes such as entities, embedded, ScalarTypes,
+   * Listeners, Finders, Controllers, AttributeConverters etc.
    */
-  private List<Class<?>> classes = new ArrayList<>();
+  private Set<Class<?>> classes = new HashSet<>();
 
   /**
    * The packages that are searched for interesting classes. Only used when
@@ -2320,8 +2320,7 @@ public class DatabaseConfig {
   }
 
   /**
-   * Programmatically add classes (typically entities) that this server should
-   * use.
+   * Programmatically add classes (typically entities) that this server should use.
    * <p>
    * The class can be an Entity, Embedded type, ScalarType, BeanPersistListener,
    * BeanFinder or BeanPersistController.
@@ -2331,8 +2330,7 @@ public class DatabaseConfig {
    * <p>
    * Alternatively the classes can be added via {@link #setClasses(List)}.
    *
-   * @param cls the entity type (or other type) that should be registered by this
-   *            database.
+   * @param cls the entity type (or other type) that should be registered by this database.
    */
   public void addClass(Class<?> cls) {
     classes.add(cls);
@@ -2341,7 +2339,7 @@ public class DatabaseConfig {
   /**
    * Register all the classes (typically entity classes).
    */
-  public void addAll(List<Class<?>> classList) {
+  public void addAll(Collection<Class<?>> classList) {
     if (classList != null && !classList.isEmpty()) {
       classes.addAll(classList);
     }
@@ -2383,16 +2381,24 @@ public class DatabaseConfig {
    * <p>
    * Alternatively the classes can contain added via {@link #addClass(Class)}.
    */
-  public void setClasses(List<Class<?>> classes) {
-    this.classes = classes;
+  public void setClasses(Collection<Class<?>> classes) {
+    this.classes = new HashSet<>(classes);
   }
 
   /**
-   * Return the classes registered for this database. Typically this includes
+   * Return the classes registered for this database. Typically, this includes
    * entities and perhaps listeners.
    */
-  public List<Class<?>> getClasses() {
+  public Set<Class<?>> classes() {
     return classes;
+  }
+
+  /**
+   * Deprecated - migrate to classes().
+   */
+  @Deprecated
+  public List<Class<?>> getClasses() {
+    return new ArrayList<>(classes);
   }
 
   /**
@@ -2760,8 +2766,6 @@ public class DatabaseConfig {
     this.classLoadConfig = classLoadConfig;
   }
 
-
-
   /**
    * Load settings from application.properties, application.yaml and other sources.
    * <p>
@@ -2906,7 +2910,7 @@ public class DatabaseConfig {
     serverCachePlugin = p.createInstance(ServerCachePlugin.class, "serverCachePlugin", serverCachePlugin);
 
     String packagesProp = p.get("search.packages", p.get("packages", null));
-    packages = getSearchList(packagesProp, packages);
+    packages = searchList(packagesProp, packages);
 
     skipCacheAfterWrite = p.getBoolean("skipCacheAfterWrite", skipCacheAfterWrite);
     updateAllPropertiesInBatch = p.getBoolean("updateAllPropertiesInBatch", updateAllPropertiesInBatch);
@@ -2982,10 +2986,10 @@ public class DatabaseConfig {
     tenantCatalogProvider = p.createInstance(TenantCatalogProvider.class, "tenant.catalogProvider", tenantCatalogProvider);
     tenantSchemaProvider = p.createInstance(TenantSchemaProvider.class, "tenant.schemaProvider", tenantSchemaProvider);
     tenantPartitionColumn = p.get("tenant.partitionColumn", tenantPartitionColumn);
-    classes = getClasses(p);
+    classes = readClasses(p);
 
     String mappingsProp = p.get("mappingLocations", null);
-    mappingLocations = getSearchList(mappingsProp, mappingLocations);
+    mappingLocations = searchList(mappingsProp, mappingLocations);
   }
 
   private NamingConvention createNamingConvention(PropertiesWrapper properties, NamingConvention namingConvention) {
@@ -2999,13 +3003,13 @@ public class DatabaseConfig {
    * @param properties the properties
    * @return the classes
    */
-  private List<Class<?>> getClasses(PropertiesWrapper properties) {
+  private Set<Class<?>> readClasses(PropertiesWrapper properties) {
     String classNames = properties.get("classes", null);
     if (classNames == null) {
       return classes;
     }
 
-    List<Class<?>> classList = new ArrayList<>();
+    Set<Class<?>> classList = new HashSet<>();
     String[] split = StringHelper.splitNames(classNames);
     for (String cn : split) {
       if (!"class".equalsIgnoreCase(cn)) {
@@ -3020,7 +3024,7 @@ public class DatabaseConfig {
     return classList;
   }
 
-  private List<String> getSearchList(String searchNames, List<String> defaultValue) {
+  private List<String> searchList(String searchNames, List<String> defaultValue) {
     if (searchNames != null) {
       String[] entries = StringHelper.splitNames(searchNames);
       List<String> hitList = new ArrayList<>(entries.length);
@@ -3399,8 +3403,16 @@ public class DatabaseConfig {
    * When false we either register entity classes via application code or use classpath
    * scanning to find and register entity classes.
    */
+  public boolean isLoadModuleInfo() {
+    return loadModuleInfo;
+  }
+
+  /**
+   * Deprecated - migrate to isLoadModuleInfo().
+   */
+  @Deprecated
   public boolean isAutoLoadModuleInfo() {
-    return loadModuleInfo && classes.isEmpty();
+    return loadModuleInfo;
   }
 
   /**

--- a/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
+++ b/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
@@ -3,10 +3,6 @@ package io.ebean.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ebean.annotation.MutationDetection;
 import io.ebean.annotation.PersistBatch;
-import io.ebean.config.DatabaseConfig;
-import io.ebean.config.JsonConfig;
-import io.ebean.config.MatchingNamingConvention;
-import io.ebean.config.PlatformConfig;
 import io.ebean.config.dbplatform.IdType;
 import io.ebean.datasource.DataSourceConfig;
 import org.junit.jupiter.api.Assertions;
@@ -93,6 +89,7 @@ class DatabaseConfigTest {
     assertTrue(config.isDbOffline());
     assertTrue(config.isAutoReadOnlyDataSource());
     assertTrue(config.isAutoLoadModuleInfo());
+    assertTrue(config.isLoadModuleInfo());
     assertTrue(config.skipDataSourceCheck());
 
     assertTrue(config.isIdGeneratorAutomatic());
@@ -165,6 +162,7 @@ class DatabaseConfigTest {
     assertEquals(MutationDetection.HASH, config.getJsonMutationDetection());
     assertTrue(config.getPlatformConfig().isCaseSensitiveCollation());
     assertTrue(config.isAutoLoadModuleInfo());
+    assertTrue(config.isLoadModuleInfo());
 
     assertFalse(config.isQueryPlanEnable());
     assertEquals(Long.MAX_VALUE, config.getQueryPlanThresholdMicros());
@@ -175,6 +173,7 @@ class DatabaseConfigTest {
 
     config.setLoadModuleInfo(false);
     assertFalse(config.isAutoLoadModuleInfo());
+    assertFalse(config.isLoadModuleInfo());
     config.setAutoPersistUpdates(true);
     assertTrue(config.isAutoPersistUpdates());
     config.setSkipDataSourceCheck(true);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -17,8 +17,8 @@ import javax.persistence.PersistenceException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.lang.System.Logger.Level.*;
@@ -121,7 +121,7 @@ public final class DefaultContainer implements SpiContainer {
         configProvider.apply(config);
       }
     }
-    if (config.isAutoLoadModuleInfo()) {
+    if (config.isLoadModuleInfo()) {
       // auto register entity classes
       boolean found = false;
       for (EntityClassRegister loader : ServiceLoader.load(EntityClassRegister.class)) {
@@ -177,10 +177,10 @@ public final class DefaultContainer implements SpiContainer {
    * Get the class based entities, scalarTypes, Listeners etc.
    */
   private BootupClasses bootupClasses1(DatabaseConfig config) {
-    List<Class<?>> entityClasses = config.getClasses();
-    if (config.isDisableClasspathSearch() || (entityClasses != null && !entityClasses.isEmpty())) {
+    Set<Class<?>> classes = config.classes();
+    if (config.isDisableClasspathSearch() || (classes != null && !classes.isEmpty())) {
       // use classes we explicitly added via configuration
-      return new BootupClasses(entityClasses);
+      return new BootupClasses(classes);
     }
     return BootupClassPathSearch.search(config);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClasses.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/bootup/BootupClasses.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import static java.lang.System.Logger.Level.DEBUG;
@@ -79,9 +80,9 @@ public class BootupClasses implements Predicate<Class<?>> {
   public BootupClasses() {
   }
 
-  public BootupClasses(List<Class<?>> list) {
-    if (list != null) {
-      for (Class<?> cls : list) {
+  public BootupClasses(Set<Class<?>> classes) {
+    if (classes != null) {
+      for (Class<?> cls : classes) {
         test(cls);
       }
     }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/deploy/BeanDescriptor_registerTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/deploy/BeanDescriptor_registerTest.java
@@ -24,7 +24,7 @@ public class BeanDescriptor_registerTest {
     config.setDdlExtra(false);
     config.setRegister(false);
     config.setDefaultServer(false);
-    config.getClasses().add(EBasic.class);
+    config.addClass(EBasic.class);
 
     SpiEbeanServer ebeanServer = (SpiEbeanServer)DatabaseFactory.create(config);
     try {

--- a/ebean-test/src/test/java/io/ebean/xtest/config/PlatformNoGeneratedKeysTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/config/PlatformNoGeneratedKeysTest.java
@@ -111,8 +111,8 @@ public class PlatformNoGeneratedKeysTest {
     config.setRegister(false);
     config.setDdlGenerate(true);
     config.setDdlRun(true);
-    config.getClasses().add(EBasicVer.class);
-    config.getClasses().add(BasicDraftableBean.class);
+    config.addClass(EBasicVer.class);
+    config.addClass(BasicDraftableBean.class);
     config.loadFromProperties(); // trigger auto config for H2 1.x
 
     return DatabaseFactory.create(config);

--- a/ebean-test/src/test/java/io/ebean/xtest/config/ServerConfigSqlServerTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/config/ServerConfigSqlServerTest.java
@@ -3,9 +3,9 @@ package io.ebean.xtest.config;
 
 import io.ebean.Database;
 import io.ebean.DatabaseFactory;
-import io.ebean.xtest.ForPlatform;
 import io.ebean.annotation.Platform;
 import io.ebean.config.DatabaseConfig;
+import io.ebean.xtest.ForPlatform;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.EBasicVer;
@@ -36,7 +36,7 @@ public class ServerConfigSqlServerTest {
 
     config.setDefaultServer(false);
     config.setRegister(false);
-    config.getClasses().add(EBasicVer.class);
+    config.addClass(EBasicVer.class);
 
     Database sqlServer = DatabaseFactory.create(config);
 
@@ -77,7 +77,7 @@ public class ServerConfigSqlServerTest {
     config.setDdlGenerate(true);
     config.setDdlRun(true);
     config.loadFromProperties(props);
-    config.getClasses().add(EBasicVer.class);
+    config.addClass(EBasicVer.class);
 
     Database sqlServer = DatabaseFactory.create(config);
 
@@ -103,7 +103,7 @@ public class ServerConfigSqlServerTest {
     config.setName(name); // match dataSource
     config.setDatabasePlatformName("sqlserver16");
     config.loadFromProperties(props);
-    config.getClasses().add(EBasicVer.class);
+    config.addClass(EBasicVer.class);
 
     Database sqlServer = DatabaseFactory.create(config);
 

--- a/ebean-test/src/test/java/io/ebean/xtest/event/BeanFindControllerTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/event/BeanFindControllerTest.java
@@ -1,6 +1,5 @@
 package io.ebean.xtest.event;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.Database;
 import io.ebean.DatabaseFactory;
 import io.ebean.bean.BeanCollection;
@@ -8,6 +7,7 @@ import io.ebean.common.BeanList;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.event.BeanFindController;
 import io.ebean.event.BeanQueryRequest;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.Test;
 import org.tests.example.ModUuidGenerator;
 import org.tests.model.basic.EBasic;
@@ -37,8 +37,8 @@ public class BeanFindControllerTest extends BaseTestCase {
     config.setRegister(false);
     config.setDefaultServer(false);
     config.add(new ModUuidGenerator());
-    config.getClasses().add(EBasic.class);
-    config.getClasses().add(ECustomId.class);
+    config.addClass(EBasic.class);
+    config.addClass(ECustomId.class);
 
     EBasicFindController findController = new EBasicFindController();
     config.getFindControllers().add(findController);
@@ -180,9 +180,9 @@ public class BeanFindControllerTest extends BaseTestCase {
     config.setRegister(false);
     config.setDefaultServer(false);
     config.add(new ModUuidGenerator());
-    config.getClasses().add(FindControllerMain.class);
-    config.getClasses().add(SoftRefA.class);
-    config.getClasses().add(SoftRefB.class);
+    config.addClass(FindControllerMain.class);
+    config.addClass(SoftRefA.class);
+    config.addClass(SoftRefB.class);
 
     config.getFindControllers().add(new TestBeanFindController());
 

--- a/ebean-test/src/test/java/io/ebean/xtest/event/BeanPersistControllerTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/event/BeanPersistControllerTest.java
@@ -4,7 +4,6 @@ package io.ebean.xtest.event;
 import io.ebean.Database;
 import io.ebean.DatabaseFactory;
 import io.ebean.Transaction;
-import io.ebean.ValuePair;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.event.BeanDeleteIdRequest;
 import io.ebean.event.BeanPersistAdapter;
@@ -14,7 +13,9 @@ import org.tests.model.basic.EBasicVer;
 import org.tests.model.basic.UTDetail;
 import org.tests.model.basic.UTMaster;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -148,9 +149,9 @@ public class BeanPersistControllerTest {
 
     config.setRegister(false);
     config.setDefaultServer(false);
-    config.getClasses().add(EBasicVer.class);
-    config.getClasses().add(UTMaster.class);
-    config.getClasses().add(UTDetail.class);
+    config.addClass(EBasicVer.class);
+    config.addClass(UTMaster.class);
+    config.addClass(UTDetail.class);
 
     config.add(persistAdapter);
     return DatabaseFactory.create(config);

--- a/ebean-test/src/test/java/io/ebean/xtest/event/BeanPostLoadTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/event/BeanPostLoadTest.java
@@ -1,7 +1,10 @@
 package io.ebean.xtest.event;
 
 
-import io.ebean.*;
+import io.ebean.BeanState;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.DatabaseFactory;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.event.BeanPostLoad;
 import io.ebean.xtest.BaseTestCase;
@@ -55,7 +58,7 @@ public class BeanPostLoadTest extends BaseTestCase {
 
     config.setRegister(false);
     config.setDefaultServer(false);
-    config.getClasses().add(EBasicVer.class);
+    config.addClass(EBasicVer.class);
 
     config.add(postLoad);
 

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/transaction/DefaultTransactionThreadLocalTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/transaction/DefaultTransactionThreadLocalTest.java
@@ -1,10 +1,13 @@
 package io.ebean.xtest.internal.server.transaction;
 
-import io.ebean.*;
-import io.ebean.xtest.BaseTestCase;
-import io.ebean.xtest.ForPlatform;
+import io.ebean.DB;
+import io.ebean.Database;
+import io.ebean.DatabaseFactory;
+import io.ebean.Transaction;
 import io.ebean.annotation.Platform;
 import io.ebean.config.DatabaseConfig;
+import io.ebean.xtest.BaseTestCase;
+import io.ebean.xtest.ForPlatform;
 import io.ebeaninternal.api.SpiTransaction;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.EBasicVer;
@@ -139,9 +142,9 @@ public class DefaultTransactionThreadLocalTest extends BaseTestCase {
 
     config.setRegister(false);
     config.setDefaultServer(false);
-    config.getClasses().add(EBasicVer.class);
-    config.getClasses().add(UTMaster.class);
-    config.getClasses().add(UTDetail.class);
+    config.addClass(EBasicVer.class);
+    config.addClass(UTMaster.class);
+    config.addClass(UTDetail.class);
 
     return DatabaseFactory.create(config);
   }

--- a/ebean-test/src/test/java/org/multitenant/partition/MultiTenantPartitionTest.java
+++ b/ebean-test/src/test/java/org/multitenant/partition/MultiTenantPartitionTest.java
@@ -130,9 +130,9 @@ class MultiTenantPartitionTest extends BaseTestCase {
     config.setCurrentTenantProvider(new CurrentTenant());
     config.setTenantMode(TenantMode.PARTITION);
 
-    config.getClasses().add(MtTenant.class);
-    config.getClasses().add(MtContent.class);
-    config.getClasses().add(MtNone.class);
+    config.addClass(MtTenant.class);
+    config.addClass(MtContent.class);
+    config.addClass(MtNone.class);
 
     return DatabaseFactory.create(config);
   }


### PR DESCRIPTION
In `DatabaseConfig.isAutoLoadModuleInfo()` it only used the querybean generated class registration if `classes.isEmpty()`. Changing this so that it only uses the `loadModuleInfo` flag.

This means, unless loadModuleInfo is set to false the classes that register with ebean will be a combination of both the explicitly registered ones plus the classes from the querybean generated EbeanEntityRegister. This is a behaviour change.

In addition, this changes the classes from List to Set.