### PR TITLE
Included ebean-migration as a dependency of ebean, ebean-postgres etc

### DIFF
--- a/composites/ebean-clickhouse/pom.xml
+++ b/composites/ebean-clickhouse/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-cockroach/pom.xml
+++ b/composites/ebean-cockroach/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-db2/pom.xml
+++ b/composites/ebean-db2/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-h2/pom.xml
+++ b/composites/ebean-h2/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-hana/pom.xml
+++ b/composites/ebean-hana/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-mariadb/pom.xml
+++ b/composites/ebean-mariadb/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-mysql/pom.xml
+++ b/composites/ebean-mysql/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-nuodb/pom.xml
+++ b/composites/ebean-nuodb/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-oracle/pom.xml
+++ b/composites/ebean-oracle/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-postgres/pom.xml
+++ b/composites/ebean-postgres/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-sqlite/pom.xml
+++ b/composites/ebean-sqlite/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-sqlserver/pom.xml
+++ b/composites/ebean-sqlserver/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean-yugabyte/pom.xml
+++ b/composites/ebean-yugabyte/pom.xml
@@ -31,6 +31,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>

--- a/composites/ebean/pom.xml
+++ b/composites/ebean/pom.xml
@@ -49,6 +49,12 @@
       <version>${ebean-datasource.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
     <!-- Technically optional but most expected to use query beans -->
     <dependency>
       <groupId>io.ebean</groupId>


### PR DESCRIPTION
Include ebean-migration as a dependency of all the composites. The thinking here is that we now expect to prefer ebean-migration over flyway or liquibase as the migration runner of choice. Including it means one less thing for folks to worry about in terms of syncing the versions to use etc.