### PR TITLE
#3033 - Fix for ConcurrentModificationException introduced in 13.17.1

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/InterceptReadWrite.java
+++ b/ebean-api/src/main/java/io/ebean/bean/InterceptReadWrite.java
@@ -128,7 +128,6 @@ public final class InterceptReadWrite implements EntityBeanIntercept {
       (lazyLoadProperty > -1 ? (", lazyLoadProperty=" + lazyLoadProperty) : "") +
       ", loader=" + beanLoader +
       (ownerId != null ? (", ownerId=" + ownerId) : "") +
-      ", owner=" + owner +
       '}';
   }
 


### PR DESCRIPTION
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1493)
	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1516)
	at java.base/java.util.AbstractCollection.toString(AbstractCollection.java:472)
	at java.base/java.lang.String.valueOf(String.java:2951)
	at io.ebeaninternal.server.core.DefaultBeanLoader.loadBean(DefaultBeanLoader.java:134)
	at io.ebeaninternal.server.core.DefaultServer.loadBean(DefaultServer.java:475)
	at io.ebeaninternal.server.loadcontext.DLoadBeanContext$LoadBuffer.loadBean(DLoadBeanContext.java:217)
	at io.ebean.bean.InterceptReadWrite.loadBeanInternal(InterceptReadWrite.java:742)
	at io.ebean.bean.InterceptReadWrite.loadBean(InterceptReadWrite.java:724)
	at io.ebean.bean.InterceptReadWrite.preGetter(InterceptReadWrite.java:837)
	at ...