### PR TITLE
FIX build on system without JAVA_HOME set

### DIFF
--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -201,7 +201,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M4</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
           <trimStackTrace>false</trimStackTrace>

--- a/ebean-core/pom.xml
+++ b/ebean-core/pom.xml
@@ -229,7 +229,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.1</version>
         <configuration>
           <doctitle>Ebean 12</doctitle>
           <overview>src/main/java/io/ebean/overview.html</overview>

--- a/kotlin-querybean-generator/pom.xml
+++ b/kotlin-querybean-generator/pom.xml
@@ -120,7 +120,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
         <executions>
           <execution>
             <id>default-testCompile</id>

--- a/querybean-generator/pom.xml
+++ b/querybean-generator/pom.xml
@@ -27,7 +27,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
         <configuration>
           <source>11</source>
           <target>11</target>


### PR DESCRIPTION
On our machines , JAVA_HOME is not set by default.
There is a bug in older javadoc plugins and it will fail with:

Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set

See: https://issues.apache.org/jira/browse/MJAVADOC-650

In this PR I removed some overriding version declarations. So we use the versions managed by the `java11-oss` pom:
- javadoc 3.5.0 
- maven-surefire 4.0.0
- maven-compiler 3.11.0

@rbygrave Note, that there are diffent kotlin versions specified:
- 1.6.0 in ebean-kotlin (this is still compiled for java 8) - maybe intended?
- 1.8.10 in querybean-generator and tests

