### PR TITLE
FIX: Use correct quotes when logging

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -673,7 +673,7 @@ public class DatabasePlatform {
 
   protected String withForUpdate(String sql, Query.LockWait lockWait, Query.LockType lockType) {
     // silently assume the database does not support the "for update" clause.
-    log.log(INFO, "it seems your database does not support the 'for update' clause");
+    log.log(INFO, "it seems your database does not support the ''for update'' clause");
     return sql;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -137,7 +137,7 @@ public final class DefaultContainer implements SpiContainer {
   private void checkMissingModulePathProvides() {
     URL servicesFile = ClassLoader.getSystemResource("META-INF/services/io.ebean.config.EntityClassRegister");
     if (servicesFile != null) {
-      log.log(ERROR, "module-info.java is probably missing 'provides io.ebean.config.EntityClassRegister with EbeanEntityRegister' clause. EntityClassRegister exists but was not service loaded.");
+      log.log(ERROR, "module-info.java is probably missing ''provides io.ebean.config.EntityClassRegister with EbeanEntityRegister'' clause. EntityClassRegister exists but was not service loaded.");
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1IdGenerator.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1IdGenerator.java
@@ -130,7 +130,7 @@ public class UuidV1IdGenerator extends UuidV1RndIdGenerator {
       saveState();
       log.log(DEBUG, "Saved state: clockSeq {0}, timestamp {1}, uuid {2}, stateFile: {3})", clockSeq.get(), new Date(ts), uuid, stateFile);
     } catch (IOException e) {
-      log.log(ERROR, "There was a problem while detecting the nodeId. Falling back to random mode. Try using to specify 'ebean.uuidNodeId' property", e);
+      log.log(ERROR, "There was a problem while detecting the nodeId. Falling back to random mode. Try using to specify ''ebean.uuidNodeId'' property", e);
       useRandomMode();
     }
   }
@@ -147,7 +147,7 @@ public class UuidV1IdGenerator extends UuidV1RndIdGenerator {
     try {
       nodeId = getHardwareId();
     } catch (IOException e) {
-      log.log(ERROR, "Error while reading MAC address. Fall back to 'generate' mode", e);
+      log.log(ERROR, "Error while reading MAC address. Fall back to ''generate'' mode", e);
       tryGenerateMode();
     }
 
@@ -156,7 +156,7 @@ public class UuidV1IdGenerator extends UuidV1RndIdGenerator {
       log.log(INFO, "Using MAC {0} to generate Type 1 UUIDs", getNodeIdentifier());
       return;
     }
-    log.log(WARNING, "No suitable network interface found. Fall back to 'generate' mode");
+    log.log(WARNING, "No suitable network interface found. Fall back to ''generate'' mode");
     tryGenerateMode();
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1IdGenerator.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/idgen/UuidV1IdGenerator.java
@@ -212,7 +212,7 @@ public class UuidV1IdGenerator extends UuidV1RndIdGenerator {
 
     String propNodeId = prop.getProperty("nodeId");
     if (propNodeId == null || propNodeId.isEmpty()) {
-      log.log(WARNING, "State file '{0}' is incomplete", stateFile);
+      log.log(WARNING, "State file ''{0}'' is incomplete", stateFile);
       return false; // we cannot restore
     }
     try {
@@ -220,7 +220,7 @@ public class UuidV1IdGenerator extends UuidV1RndIdGenerator {
         nodeId = parseAlternativeNodeId(propNodeId);
       } else if (!getNodeIdentifier().equals(propNodeId)) {
         log.log(WARNING,
-          "The nodeId in the state file '{0}' has changed from {1} to {2}. "
+          "The nodeId in the state file ''{0}'' has changed from {1} to {2}. "
             + "This can happen when MAC address changes or when two containers share the same state file",
           stateFile, propNodeId, getNodeIdentifier());
         return false;

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DdlGenerator.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DdlGenerator.java
@@ -61,7 +61,7 @@ public class DdlGenerator implements SpiDdlGenerator {
     this.platform = databasePlatform.platform();
     this.platformName = platform.base().name();
     if (!config.getTenantMode().isDdlEnabled() && config.isDdlRun()) {
-      log.log(WARNING, "DDL can't be run on startup with TenantMode " + config.getTenantMode());
+      log.log(WARNING, "DDL can''t be run on startup with TenantMode " + config.getTenantMode());
       this.runDdl = false;
       this.useMigrationStoredProcedures = false;
     } else {


### PR DESCRIPTION
Single quotes have special meaning in [MessageFormat](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/MessageFormat.html)

I noticed this in the UuidV1Generator and fixed also other places.