### PR TITLE
IMPROVED: checkUniqueness supports queryCache and skipClean

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DB.java
+++ b/ebean-api/src/main/java/io/ebean/DB.java
@@ -458,8 +458,8 @@ public final class DB {
   /**
    * Same as {@link #checkUniqueness(Object)} but with given transaction.
    */
-  public static Set<Property> checkUniqueness(Object bean, Transaction transaction) {
-    return getDefault().checkUniqueness(bean, transaction);
+  public static Set<Property> checkUniqueness(Object bean, Transaction transaction, boolean useQueryCache, boolean skipClean) {
+    return getDefault().checkUniqueness(bean, transaction, useQueryCache, skipClean);
   }
 
   /**

--- a/ebean-api/src/main/java/io/ebean/Database.java
+++ b/ebean-api/src/main/java/io/ebean/Database.java
@@ -1085,12 +1085,21 @@ public interface Database {
    * @param bean The entity bean to check uniqueness on
    * @return a set of Properties if constraint validation was detected or empty list.
    */
-  Set<Property> checkUniqueness(Object bean);
+  default Set<Property> checkUniqueness(Object bean) {
+    return checkUniqueness(bean, null, false, true);
+  }
 
   /**
    * Same as {@link #checkUniqueness(Object)}. but with given transaction.
    */
-  Set<Property> checkUniqueness(Object bean, Transaction transaction);
+  default Set<Property> checkUniqueness(Object bean, Transaction transaction) {
+    return checkUniqueness(bean, transaction, false, true);
+  }
+
+  /**
+   * Same as {@link #checkUniqueness(Object)}. but with given transaction and extended search options.
+   */
+  Set<Property> checkUniqueness(Object bean, Transaction transaction, boolean useQueryCache, boolean skipClean);
 
   /**
    * Marks the entity bean as dirty.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -2191,12 +2191,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public Set<Property> checkUniqueness(Object bean) {
-    return checkUniqueness(bean, null);
-  }
-
-  @Override
-  public Set<Property> checkUniqueness(Object bean, @Nullable Transaction transaction) {
+  public Set<Property> checkUniqueness(Object bean, @Nullable Transaction transaction, boolean useQueryCache, boolean skipClean) {
     EntityBean entityBean = checkEntityBean(bean);
     BeanDescriptor<?> beanDesc = descriptor(entityBean.getClass());
     BeanProperty idProperty = beanDesc.idProperty();
@@ -2208,14 +2203,15 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     if (entityBean._ebean_getIntercept().isNew() && id != null) {
       // Primary Key is changeable only on new models - so skip check if we are not new
       SpiQuery<?> query = new DefaultOrmQuery<>(beanDesc, this, expressionFactory);
+      query.setUseQueryCache(useQueryCache);
       query.usingTransaction(transaction);
       query.setId(id);
-      if (findCount(query) > 0) {
+      if (exists(query)) {
         return Collections.singleton(idProperty);
       }
     }
     for (BeanProperty[] props : beanDesc.uniqueProps()) {
-      Set<Property> ret = checkUniqueness(entityBean, beanDesc, props, transaction);
+      Set<Property> ret = checkUniqueness(entityBean, beanDesc, props, transaction, useQueryCache, skipClean);
       if (ret != null) {
         return ret;
       }
@@ -2224,12 +2220,33 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   /**
+   * Checks, if any property is dirty.
+   */
+  private boolean isAnyPropertyDirty(EntityBean entityBean, BeanProperty[] props) {
+    if (entityBean._ebean_getIntercept().isNew()) {
+      return true;
+    }
+    for (BeanProperty prop : props) {
+      if (entityBean._ebean_getIntercept().isDirtyProperty(prop.propertyIndex())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Returns a set of properties if saving the bean will violate the unique constraints (defined by given properties).
    */
   @Nullable
-  private Set<Property> checkUniqueness(EntityBean entityBean, BeanDescriptor<?> beanDesc, BeanProperty[] props, @Nullable Transaction transaction) {
+  private Set<Property> checkUniqueness(EntityBean entityBean, BeanDescriptor<?> beanDesc, BeanProperty[] props, @Nullable Transaction transaction,
+                                        boolean useQueryCache, boolean skipClean) {
+    if (skipClean && !isAnyPropertyDirty(entityBean, props)) {
+      return null;
+    }
+
     BeanProperty idProperty = beanDesc.idProperty();
     SpiQuery<?> query = new DefaultOrmQuery<>(beanDesc, this, expressionFactory);
+    query.setUseQueryCache(useQueryCache);
     query.usingTransaction(transaction);
     ExpressionList<?> exprList = query.where();
     if (!entityBean._ebean_getIntercept().isNew()) {
@@ -2243,7 +2260,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
       }
       exprList.eq(prop.name(), value);
     }
-    if (findCount(query) > 0) {
+    if (exists(query)) {
       Set<Property> ret = new LinkedHashSet<>();
       Collections.addAll(ret, props);
       return ret;

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
@@ -950,12 +950,7 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public Set<Property> checkUniqueness(Object bean) {
-    return Collections.emptySet();
-  }
-
-  @Override
-  public Set<Property> checkUniqueness(Object bean, Transaction transaction) {
+  public Set<Property> checkUniqueness(Object bean, Transaction transaction, boolean useQueryCache, boolean skipClean) {
     return Collections.emptySet();
   }
 

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiServer.java
@@ -384,12 +384,7 @@ public class TDSpiServer implements SpiServer {
   }
 
   @Override
-  public Set<Property> checkUniqueness(Object bean) {
-    return null;
-  }
-
-  @Override
-  public Set<Property> checkUniqueness(Object bean, Transaction transaction) {
+  public Set<Property> checkUniqueness(Object bean, Transaction transaction, boolean useQueryCache, boolean skipClean) {
     return null;
   }
 

--- a/ebean-test/src/test/java/org/tests/insert/TestInsertCheckUnique.java
+++ b/ebean-test/src/test/java/org/tests/insert/TestInsertCheckUnique.java
@@ -1,13 +1,16 @@
 package org.tests.insert;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Transaction;
 import io.ebean.plugin.Property;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tests.model.basic.EBasicWithUniqueCon;
 import org.tests.model.draftable.Document;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -102,9 +105,123 @@ public class TestInsertCheckUnique extends BaseTestCase {
 
         System.out.println("uniqueProperties > " + uniqueProperties);
         System.out.println("      custom msg > " + msg);
+
       }
 
+      LoggedSql.start();
       assertThat(DB.checkUniqueness(doc2).toString()).contains("title");
+      List<String> sql = LoggedSql.stop();
+      assertThat(sql).hasSize(1);
+      assertThat(sql.get(0)).contains("select t0.id from document t0 where t0.title = ?");
+
+
+    }
+  }
+
+  /**
+   * When invoking checkUniqueness multiple times, we can benefit from the "exists" query cache if bean has query cache enabled
+   */
+  @Test
+  public void testUseQueryCache() {
+    DB.find(EBasicWithUniqueCon.class).delete(); // clean up DB (otherwise test may be affected by other test)
+
+    EBasicWithUniqueCon basic = new EBasicWithUniqueCon();
+    basic.setName("foo");
+    basic.setOther("bar");
+    basic.setOtherOne("baz");
+
+    // create a new bean
+    LoggedSql.start();
+    assertThat(DB.checkUniqueness(basic, null, true, false)).isEmpty();
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(2);
+    assertThat(sql.get(0)).contains("select t0.id from e_basicverucon t0 where t0.name = ?");
+    assertThat(sql.get(1)).contains("select t0.id from e_basicverucon t0 where t0.other = ? and t0.other_one = ?");
+    DB.save(basic);
+    try {
+      // reload from database
+      basic = DB.find(EBasicWithUniqueCon.class, basic.getId());
+
+      // and check again
+      LoggedSql.start();
+      assertThat(DB.checkUniqueness(basic, null, true, false)).isEmpty();
+      sql = LoggedSql.stop();
+      assertThat(sql).hasSize(2);
+      assertThat(sql.get(0)).contains("select t0.id from e_basicverucon t0 where t0.id <> ? and t0.name = ?");
+      assertThat(sql.get(1)).contains("select t0.id from e_basicverucon t0 where t0.id <> ? and t0.other = ? and t0.other_one = ?");
+
+      // and check again - expect to hit query cache
+      LoggedSql.start();
+      assertThat(DB.checkUniqueness(basic, null, true, false)).isEmpty();
+      sql = LoggedSql.stop();
+      assertThat(sql).as("Expected to hit query cache").hasSize(0);
+
+      // and check again, where only one value is changed
+      basic.setOther("fooo");
+      LoggedSql.start();
+      assertThat(DB.checkUniqueness(basic, null, true, false)).isEmpty();
+      sql = LoggedSql.stop();
+      assertThat(sql).hasSize(1);
+      assertThat(sql.get(0)).contains("fooo,baz)");
+
+    } finally {
+      DB.delete(EBasicWithUniqueCon.class, basic.getId());
+    }
+  }
+
+
+  /**
+   * When invoking checkUniqueness multiple times, we can benefit from the "exists" query cache if bean has query cache enabled
+   */
+  @Test
+  public void testSkipClean() {
+    DB.find(EBasicWithUniqueCon.class).delete(); // clean up DB (otherwise test may be affected by other test)
+
+    EBasicWithUniqueCon basic = new EBasicWithUniqueCon();
+    basic.setName("foo");
+    basic.setOther("bar");
+    basic.setOtherOne("baz");
+
+    // create a new bean
+    LoggedSql.start();
+    assertThat(DB.checkUniqueness(basic, null, false, true)).isEmpty();
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(2);
+    assertThat(sql.get(0)).contains("select t0.id from e_basicverucon t0 where t0.name = ?");
+    assertThat(sql.get(1)).contains("select t0.id from e_basicverucon t0 where t0.other = ? and t0.other_one = ?");
+    DB.save(basic);
+    try (Transaction txn = DB.beginTransaction()) {
+      // reload from database
+      basic = DB.find(EBasicWithUniqueCon.class, basic.getId());
+
+      // and check again. We do not check unmodified properties
+      LoggedSql.start();
+      assertThat(DB.checkUniqueness(basic, txn, false, true)).isEmpty();
+      sql = LoggedSql.stop();
+      assertThat(sql).hasSize(0);
+
+      // and check again, where only one value is changed
+      basic.setOther("fooo");
+      LoggedSql.start();
+      assertThat(DB.checkUniqueness(basic, txn, false, true)).isEmpty();
+      sql = LoggedSql.stop();
+      assertThat(sql).hasSize(1);
+      assertThat(sql.get(0)).contains("fooo,baz)");
+
+      // multiple checks will hit DB
+      LoggedSql.start();
+      assertThat(DB.checkUniqueness(basic, txn, false, true)).isEmpty();
+      sql = LoggedSql.stop();
+      assertThat(sql).hasSize(1);
+
+      // enable also query cache
+      assertThat(DB.checkUniqueness(basic, txn, true, true)).isEmpty();
+      LoggedSql.start();
+      assertThat(DB.checkUniqueness(basic, txn, true, true)).isEmpty();
+      sql = LoggedSql.stop();
+      assertThat(sql).isEmpty();
+    } finally {
+      DB.delete(EBasicWithUniqueCon.class, basic.getId());
     }
   }
 }

--- a/ebean-test/src/test/java/org/tests/model/basic/EBasicWithUniqueCon.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/EBasicWithUniqueCon.java
@@ -1,10 +1,12 @@
 package org.tests.model.basic;
 
+import io.ebean.annotation.Cache;
 import jakarta.persistence.*;
 import javax.validation.constraints.Size;
 import java.sql.Timestamp;
 
 @Entity
+@Cache(enableQueryCache = true)
 @Table(name = "e_basicverucon")
 @UniqueConstraint(columnNames = {"other", "other_one"})
 public class EBasicWithUniqueCon {


### PR DESCRIPTION
Hello Rob, with #1303 I implemented the checkUniqueness method, that we use in validation to verify that a new or modified bean does not violate unique constraints of the database.

This is neccessary to provide good user feedback in our UI

As already mentioned in #1303, this could be a performance killer, especially if you do a mass import/update of some entities, where unique constraints are involved. To minimize this, I tried to do two improvements
- `skipClean` if you load a bean from database and do not touch the unique properties, they need not to be validated
- `useQueryCache` I use an `exists` query instead of `findCount` as this may be slightly faster. Adittionally I enabe the queryCache on that query. This eliminates subsequent DB hits if the bean gets validated multiple times