### PR TITLE
[ebean-test] Add support for ebean.test.containers.mirror

### DIFF
--- a/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
@@ -399,6 +399,11 @@ class Config {
   }
 
   private void setDockerOptionalParameters() {
+    String mirror = properties.getProperty("ebean.test.containers.mirror");
+    if (mirror != null) {
+      // use a image mirror (when not running locally, i.e. CI)
+      dockerProperties.setProperty("ebean.test.containers.mirror", mirror);
+    }
     // check for shutdown mode on all containers
     String mode = properties.getProperty("ebean.test.shutdownMode");
     if (mode != null) {


### PR DESCRIPTION
Can use this property to specify a mirror to use for test images when running in CI

Currently, we assume that for local builds we actually prefer to not use the mirror (for Arm64 support etc)