### PR TITLE
Property.value use intercept to trigger lazy load

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -756,7 +756,7 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
 
   @Override
   public Object value(Object bean) {
-    return getValue((EntityBean) bean);
+    return getValueIntercept((EntityBean) bean);
   }
 
   /**


### PR DESCRIPTION
Hello @rbygrave 

we use often `Property.value(bean)` in our code, as this is the common interface of all properties.
Today, we discovered, that this method does not trigger lazy load and just returns null in such case.

My question is now, is this a mistake or intended. If intended, why is there no `valueIntercept` in Property?

cheers
Roland