### PR TITLE
No functional change, change use of BeanProperty.value() to BeanProperty.getValue()

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -2171,7 +2171,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     if (idProperty == null) {
       return Collections.emptySet();
     }
-    Object id = idProperty.value(entityBean);
+    Object id = idProperty.getValue(entityBean);
     if (entityBean._ebean_getIntercept().isNew() && id != null) {
       // Primary Key is changeable only on new models - so skip check if we are not new
       Query<?> query = new DefaultOrmQuery<>(beanDesc, this, expressionFactory);
@@ -2199,10 +2199,10 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     ExpressionList<?> exprList = query.where();
     if (!entityBean._ebean_getIntercept().isNew()) {
       // if model is not new, exclude ourself.
-      exprList.ne(idProperty.name(), idProperty.value(entityBean));
+      exprList.ne(idProperty.name(), idProperty.getValue(entityBean));
     }
-    for (Property prop : props) {
-      Object value = prop.value(entityBean);
+    for (BeanProperty prop : props) {
+      Object value = prop.getValue(entityBean);
       if (value == null) {
         return null;
       }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
@@ -203,7 +203,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
    */
   @SuppressWarnings("rawtypes")
   public Collection rawCollection(EntityBean bean) {
-    return help.underlying(value(bean));
+    return help.underlying(getValue(bean));
   }
 
   /**
@@ -211,11 +211,11 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
    */
   @Override
   public void merge(EntityBean bean, EntityBean existing) {
-    Object existingCollection = value(existing);
+    Object existingCollection = getValue(existing);
     if (existingCollection instanceof BeanCollection<?>) {
       BeanCollection<?> toBC = (BeanCollection<?>) existingCollection;
       if (!toBC.isPopulated()) {
-        Object fromCollection = value(bean);
+        Object fromCollection = getValue(bean);
         if (fromCollection instanceof BeanCollection<?>) {
           BeanCollection<?> fromBC = (BeanCollection<?>) fromCollection;
           if (fromBC.isPopulated()) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManyJsonHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManyJsonHelp.java
@@ -51,7 +51,7 @@ class BeanPropertyAssocManyJsonHelp {
       throw new JsonParseException(parser, "Unexpected token " + event + " - expecting start array or object");
     }
     if (readJson.update()) {
-      many.setValueIntercept(parentBean, many.jsonReadCollection(readJson, parentBean, many.value(parentBean)));
+      many.setValueIntercept(parentBean, many.jsonReadCollection(readJson, parentBean, many.getValue(parentBean)));
     } else {
       many.setValue(parentBean, many.jsonReadCollection(readJson, parentBean, null));
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -788,7 +788,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   public void jsonRead(SpiJsonReader readJson, EntityBean bean) throws IOException {
     if (jsonDeserialize && targetDescriptor != null) {
       // CHECKME: may we skip reading the object from the json stream?
-      T target = readJson.update() ? (T) value(bean) : null;
+      T target = readJson.update() ? (T) getValue(bean) : null;
       T assocBean = targetDescriptor.jsonRead(readJson, name, target);
       if (readJson.update()) {
         setValueIntercept(bean, assocBean);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/MergeNodeAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/MergeNodeAssocOne.java
@@ -55,6 +55,6 @@ final class MergeNodeAssocOne extends MergeNode {
   }
 
   private EntityBean getEntityBean(Object bean) {
-    return (EntityBean) one.value(bean);
+    return (EntityBean) one.getValue((EntityBean)bean);
   }
 }

--- a/ebean-test/src/test/java/org/tests/insert/TestInsertCheckUnique.java
+++ b/ebean-test/src/test/java/org/tests/insert/TestInsertCheckUnique.java
@@ -94,17 +94,15 @@ public class TestInsertCheckUnique extends BaseTestCase {
 
         StringBuilder msg = new StringBuilder();
 
-        properties.forEach((it)-> {
+        properties.forEach((it) -> {
           Object propertyValue = it.value(doc2);
           String propertyName = it.name();
-          msg.append(" property["+propertyName+"] value["+propertyValue+"]");
+          msg.append(" property[" + propertyName + "] value[" + propertyValue + "]");
         });
 
-        System.out.println("uniqueProperties > "+uniqueProperties);
-        System.out.println("      custom msg > " + msg.toString());
-
+        System.out.println("uniqueProperties > " + uniqueProperties);
+        System.out.println("      custom msg > " + msg);
       }
-
 
       assertThat(DB.checkUniqueness(doc2).toString()).contains("title");
     }


### PR DESCRIPTION
Noting that value() currently calls through to getValue() hence this is no real change. This is done because value() is also a public method Property.value() [and this should probably change to use getValueIntercept() rather than getValue()]