### PR TITLE
DB.refrence throws EntityNotFoundException instead returning null

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -45,6 +45,7 @@ import io.ebeaninternal.util.ParamTypeHelper;
 import io.ebeaninternal.util.ParamTypeHelper.TypeInfo;
 import io.ebeanservice.docstore.api.DocStoreIntegration;
 
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
@@ -630,7 +631,11 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     }
     // we actually need to do a query because we don't know the type without the discriminator
     // value, just select the id property and discriminator column (auto added)
-    return find(type).select(idProp.name()).setId(id).findOne();
+    T bean = find(type).select(idProp.name()).setId(id).findOne();
+    if (bean == null) {
+      throw new EntityNotFoundException("Could not find reference bean " + id + " for " + desc);
+    }
+    return bean;
   }
 
   @Override


### PR DESCRIPTION
There are cases, where `DB.refrence` has to hit the database (e.g. on inheritance, when specified class is not a concrete class).
Here it is possible, that null will be returned.
As DB.reference is part of the NonNullApi, an EntityNotFound exception with type and ID is thrown now.

See discussion in #3060 