### PR TITLE
Remove deprecated MetaInfoManager.collectMetricsAsJson() - move to co…

### DIFF
--- a/ebean-api/src/main/java/io/ebean/meta/MetaInfoManager.java
+++ b/ebean-api/src/main/java/io/ebean/meta/MetaInfoManager.java
@@ -17,22 +17,6 @@ public interface MetaInfoManager {
   ServerMetrics collectMetrics();
 
   /**
-   * Deprecated migrate to collectMetrics().asJson().
-   */
-  @Deprecated
-  default ServerMetricsAsJson collectMetricsAsJson() {
-    return collectMetrics().asJson();
-  }
-
-  /**
-   * Deprecated migrate to collectMetrics().asData().
-   */
-  @Deprecated
-  default List<MetricData> collectMetricsAsData() {
-    return collectMetrics().asData();
-  }
-
-  /**
    * Visit the metrics resetting and collecting/reporting as desired.
    */
   void visitMetrics(MetricVisitor visitor);

--- a/ebean-test/src/test/java/org/tests/query/finder/TestCustomerFinder.java
+++ b/ebean-test/src/test/java/org/tests/query/finder/TestCustomerFinder.java
@@ -28,7 +28,7 @@ public class TestCustomerFinder extends BaseTestCase {
 
     StringBuilder buffer0 = new StringBuilder();
     DB.getDefault().metaInfo()
-      .collectMetricsAsJson()
+      .collectMetrics().asJson()
       .withHeader(false)
       .write(buffer0);
 
@@ -42,7 +42,7 @@ public class TestCustomerFinder extends BaseTestCase {
 
     StringBuilder buffer1 = new StringBuilder();
     DB.getDefault().metaInfo()
-      .collectMetricsAsJson()
+      .collectMetrics().asJson()
       .withHeader(false)
       .write(buffer1);
 
@@ -230,7 +230,7 @@ public class TestCustomerFinder extends BaseTestCase {
     runQueries();
 
     String metricsJson = server().metaInfo()
-      .collectMetricsAsJson()
+      .collectMetrics().asJson()
       .withHash(true)
       .withExtraAttributes(true)
       .withNewLine(true)
@@ -254,7 +254,7 @@ public class TestCustomerFinder extends BaseTestCase {
     runQueries();
 
     String metricsJson = server().metaInfo()
-      .collectMetricsAsJson()
+      .collectMetrics().asJson()
       .withHash(false)
       .withExtraAttributes(false)
       .withNewLine(false)
@@ -277,7 +277,7 @@ public class TestCustomerFinder extends BaseTestCase {
 
     StringBuilder buffer = new StringBuilder();
     server().metaInfo()
-      .collectMetricsAsJson()
+      .collectMetrics().asJson()
       .withHeader(false)
       .write(buffer);
 
@@ -295,7 +295,7 @@ public class TestCustomerFinder extends BaseTestCase {
 
     StringBuilder buffer = new StringBuilder();
     server().metaInfo()
-      .collectMetricsAsJson()
+      .collectMetrics().asJson()
       .withHeader(true)
       .write(buffer);
 


### PR DESCRIPTION
…llectMetrics().asJson()

Removing these deprecated methods:
- collectMetricsAsJson() -> collectMetrics().asJson();
- collectMetricsAsData() -> collectMetrics().asData()

```java
  /**
   * Deprecated migrate to collectMetrics().asJson().
   */
  @Deprecated
  default ServerMetricsAsJson collectMetricsAsJson() {
    return collectMetrics().asJson();
  }

  /**
   * Deprecated migrate to collectMetrics().asData().
   */
  @Deprecated
  default List<MetricData> collectMetricsAsData() {
    return collectMetrics().asData();
  }
```