### PR TITLE
Remove deprecated ExpressionList.setOrderBy() - migrate to orderBy()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/ExpressionList.java
+++ b/ebean-api/src/main/java/io/ebean/ExpressionList.java
@@ -96,12 +96,6 @@ public interface ExpressionList<T> {
   OrderBy<T> orderBy();
 
   /**
-   * Deprecated migrate to {@link #orderBy(String)}
-   */
-  @Deprecated
-  Query<T> setOrderBy(String orderBy);
-
-  /**
    * Apply the path properties to the query replacing the select and fetch clauses.
    */
   Query<T> apply(FetchPath fetchPath);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -313,11 +313,6 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
   }
 
   @Override
-  public Query<T> setOrderBy(String orderBy) {
-    return query.order(orderBy);
-  }
-
-  @Override
   public Query<T> orderById(boolean orderById) {
     return query.orderById(orderById);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
@@ -981,11 +981,6 @@ final class JunctionExpression<T> implements SpiJunction<T>, SpiExpression, Expr
   }
 
   @Override
-  public Query<T> setOrderBy(String orderBy) {
-    return exprList.setOrderBy(orderBy);
-  }
-
-  @Override
   public Query<T> setUseCache(boolean useCache) {
     return exprList.setUseCache(useCache);
   }


### PR DESCRIPTION
Migrate to `.orderBy(String orderBy)`

```java

  /**
   * Deprecated migrate to {@link #orderBy(String)}
   */
  @Deprecated
  Query<T> setOrderBy(String orderBy);

```