### PR TITLE
Remove deprecated Query setLoadBeanCache() - migrate to setBeanCacheMode()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/Query.java
+++ b/ebean-api/src/main/java/io/ebean/Query.java
@@ -1580,14 +1580,6 @@ public interface Query<T> extends CancelableQuery {
   Query<T> setReadOnly(boolean readOnly);
 
   /**
-   * Deprecated - migrate to use setBeanCacheMode(CacheMode.PUT) or other CacheMode.
-   * <p>
-   * When set to true all the beans from this query are loaded into the bean cache.
-   */
-  @Deprecated
-  Query<T> setLoadBeanCache(boolean loadBeanCache);
-
-  /**
    * Set a timeout on this query.
    * <p>
    * This will typically result in a call to setQueryTimeout() on a

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
@@ -501,11 +501,6 @@ final class DefaultFetchGroupQuery<T> implements SpiFetchGroupQuery<T>, SpiQuery
   }
 
   @Override
-  public Query<T> setLoadBeanCache(boolean loadBeanCache) {
-    throw new RuntimeException("EB102: Only select() and fetch() clause is allowed on FetchGroup");
-  }
-
-  @Override
   public Query<T> setTimeout(int secs) {
     throw new RuntimeException("EB102: Only select() and fetch() clause is allowed on FetchGroup");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1277,12 +1277,6 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
   }
 
   @Override
-  public final Query<T> setLoadBeanCache(boolean loadBeanCache) {
-    this.useBeanCache = loadBeanCache ? CacheMode.PUT : CacheMode.OFF;
-    return this;
-  }
-
-  @Override
   public final Query<T> setTimeout(int secs) {
     this.timeout = secs;
     return this;

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
@@ -914,17 +914,6 @@ public abstract class TQRootBean<T, R> {
   }
 
   /**
-   * Deprecated migrate to setBeanCacheMode() or setUseCache().
-   * <p>
-   * When set to true all the beans from this query are loaded into the bean cache.
-   */
-  @Deprecated
-  public R setLoadBeanCache(boolean loadBeanCache) {
-    query.setLoadBeanCache(loadBeanCache);
-    return root;
-  }
-
-  /**
    * Set the property to use as keys for a map.
    * <p>
    * If no property is set then the id property is used.

--- a/ebean-test/src/test/java/org/tests/basic/TestLoadBeanCache.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLoadBeanCache.java
@@ -1,5 +1,6 @@
 package org.tests.basic;
 
+import io.ebean.CacheMode;
 import io.ebean.Query;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
@@ -20,7 +21,7 @@ class TestLoadBeanCache extends BaseTestCase {
 
   @Test
   void loadBeanCache_false() {
-    Query<Country> query = DB.find(Country.class).setLoadBeanCache(false);
+    Query<Country> query = DB.find(Country.class).setBeanCacheMode(CacheMode.OFF);
 
     SpiQuery<?> spiQuery = (SpiQuery<?>) query;
     assertThat(spiQuery.isBeanCachePut()).isFalse();
@@ -32,7 +33,7 @@ class TestLoadBeanCache extends BaseTestCase {
     ResetBasicData.reset();
 
     Map<String, Country> map = DB.find(Country.class)
-      .setLoadBeanCache(true)
+      .setBeanCacheMode(CacheMode.PUT)
       .setUseQueryCache(true)
       .setReadOnly(true)
       .order("name")


### PR DESCRIPTION
…ode()

Typically migrate to `.setBeanCacheMode(CacheMode.PUT)` or `.setBeanCacheMode(CacheMode.OFF)`

```java

  /**
   * Deprecated - migrate to use setBeanCacheMode(CacheMode.PUT) or other CacheMode.
   * <p>
   * When set to true all the beans from this query are loaded into the bean cache.
   */
  @Deprecated
  Query<T> setLoadBeanCache(boolean loadBeanCache);

```