### PR TITLE
Deprecate order() methods on Query, ExpressionList - migrate to orderBy()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/ExpressionList.java
+++ b/ebean-api/src/main/java/io/ebean/ExpressionList.java
@@ -54,14 +54,12 @@ public interface ExpressionList<T> {
   Query<T> orderById(boolean orderById);
 
   /**
-   * Set the order by clause replacing the existing order by clause if there is
-   * one.
-   * <p>
-   * This follows SQL syntax using commas between each property with the
-   * optional asc and desc keywords representing ascending and descending order
-   * respectively.
+   * Deprecated migrate to {@link #orderBy(String)}
    */
-  ExpressionList<T> order(String orderByClause);
+  @Deprecated(since = "13.19")
+  default ExpressionList<T> order(String orderByClause) {
+    return orderBy(orderByClause);
+  }
 
   /**
    * Set the order by clause replacing the existing order by clause if there is
@@ -74,15 +72,12 @@ public interface ExpressionList<T> {
   ExpressionList<T> orderBy(String orderBy);
 
   /**
-   * Return the OrderBy so that you can append an ascending or descending
-   * property to the order by clause.
-   * <p>
-   * This will never return a null. If no order by clause exists then an 'empty'
-   * OrderBy object is returned.
-   * <p>
-   * This is the same as <code>orderBy()</code>
+   * Deprecated migrate to orderBy().
    */
-  OrderBy<T> order();
+  @Deprecated
+  default OrderBy<T> order() {
+    return orderBy();
+  }
 
   /**
    * Return the OrderBy so that you can append an ascending or descending

--- a/ebean-api/src/main/java/io/ebean/Query.java
+++ b/ebean-api/src/main/java/io/ebean/Query.java
@@ -1372,13 +1372,9 @@ public interface Query<T> extends CancelableQuery {
   Query<T> orderBy(String orderByClause);
 
   /**
-   * Set the order by clause replacing the existing order by clause if there is
-   * one.
-   * <p>
-   * This follows SQL syntax using commas between each property with the
-   * optional asc and desc keywords representing ascending and descending order
-   * respectively.
+   * Deprecated migrate to orderBy().
    */
+  @Deprecated(since = "13.19")
   default Query<T> order(String orderByClause) {
     return orderBy(orderByClause);
   }
@@ -1395,14 +1391,9 @@ public interface Query<T> extends CancelableQuery {
   OrderBy<T> orderBy();
 
   /**
-   * Return the OrderBy so that you can append an ascending or descending
-   * property to the order by clause.
-   * <p>
-   * This will never return a null. If no order by clause exists then an 'empty'
-   * OrderBy object is returned.
-   * <p>
-   * This is the same as <code>orderBy()</code>
+   * Deprecated migrate to orderBy().
    */
+  @Deprecated(since = "13.19")
   default OrderBy<T> order() {
     return orderBy();
   }
@@ -1413,8 +1404,9 @@ public interface Query<T> extends CancelableQuery {
   Query<T> setOrderBy(OrderBy<T> orderBy);
 
   /**
-   * Set an OrderBy object to replace any existing OrderBy clause.
+   * Deprecated migrate to setOrderBy().
    */
+  @Deprecated(since = "13.19")
   default Query<T> setOrder(OrderBy<T> orderBy) {
     return setOrderBy(orderBy);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -291,24 +291,13 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
   }
 
   @Override
-  public OrderBy<T> order() {
-    return query.order();
-  }
-
-  @Override
   public OrderBy<T> orderBy() {
-    return query.order();
-  }
-
-  @Override
-  public ExpressionList<T> order(String orderByClause) {
-    query.order(orderByClause);
-    return this;
+    return query.orderBy();
   }
 
   @Override
   public ExpressionList<T> orderBy(String orderBy) {
-    query.order(orderBy);
+    query.orderBy(orderBy);
     return this;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/FilterExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/FilterExpressionList.java
@@ -131,18 +131,12 @@ public final class FilterExpressionList<T> extends DefaultExpressionList<T> {
   }
 
   @Override
-  public OrderBy<T> order() {
-    return rootQuery.order();
+  public OrderBy<T> orderBy() {
+    return rootQuery.orderBy();
   }
 
   @Override
   public ExpressionList<T> orderBy(String orderByClause) {
-    this.orderByClause = orderByClause;
-    return this;
-  }
-
-  @Override
-  public ExpressionList<T> order(String orderByClause) {
     this.orderByClause = orderByClause;
     return this;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
@@ -896,16 +896,6 @@ final class JunctionExpression<T> implements SpiJunction<T>, SpiExpression, Expr
   }
 
   @Override
-  public OrderBy<T> order() {
-    return exprList.order();
-  }
-
-  @Override
-  public ExpressionList<T> order(String orderByClause) {
-    return exprList.order(orderByClause);
-  }
-
-  @Override
   public OrderBy<T> orderBy() {
     return exprList.orderBy();
   }

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
@@ -1241,23 +1241,10 @@ public abstract class TQRootBean<T, R> {
   }
 
   /**
-   * Marker that can be used to indicate that the order by clause is defined after this.
-   * <p>
-   * <h2>Example: order by customer name, order date</h2>
-   * <pre>{@code
-   *   List<Order> orders =
-   *          new QOrder()
-   *            .customer.name.ilike("rob")
-   *            .orderBy()
-   *              .customer.name.asc()
-   *              .orderDate.asc()
-   *            .findList();
-   *
-   * }</pre>
+   * Deprecated migrate to orderBy().
    */
+  @Deprecated(since = "13.19")
   public R order() {
-    // Yes this does not actually do anything! We include it because style wise it makes
-    // the query nicer to read and suggests that order by definitions are added after this
     return root;
   }
 
@@ -1274,15 +1261,11 @@ public abstract class TQRootBean<T, R> {
   }
 
   /**
-   * Set the full raw order by clause replacing the existing order by clause if there is one.
-   * <p>
-   * This follows SQL syntax using commas between each property with the
-   * optional asc and desc keywords representing ascending and descending order
-   * respectively.
+   * Deprecated migrate to {@link #orderBy(String)}
    */
+  @Deprecated(since = "13.19")
   public R order(String orderByClause) {
-    query.order(orderByClause);
-    return root;
+    return orderBy(orderByClause);
   }
 
   /**


### PR DESCRIPTION
…By()

Unfortunately we have order() and orderBy() methods which do the same thing. I have decided to deprecate the order() ones in favour of the orderBy() methods so that ultimately we will end up with less methods and I think orderBy() is the correct choice.

Apologies for the migration pain here.