### PR TITLE
Bugfix for wrong batch statement ordering with many2many relations

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/Persister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/Persister.java
@@ -101,7 +101,7 @@ public interface Persister {
   /**
    * Execute or queue the update.
    */
-  void executeOrQueue(SpiSqlUpdate update, SpiTransaction t, boolean queue);
+  void executeOrQueue(SpiSqlUpdate update, SpiTransaction t, boolean queue, int queuePosition);
 
   /**
    * Queue the SqlUpdate for execution with position 0, 1 or 2 defining

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchControl.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchControl.java
@@ -83,6 +83,9 @@ public final class BatchControl {
 
   private final Queue[] queues = new Queue[3];
 
+  static final int DELETE_QUEUE = 1;
+  static final int INSERT_QUEUE = 2;
+
   /**
    * Create for a given transaction, PersistExecute, default size and getGeneratedKeys.
    */
@@ -267,8 +270,8 @@ public final class BatchControl {
   private void flushBuffer(boolean reset) throws BatchedSqlException {
     flushQueue(queues[0]);
     flushInternal(reset);
-    flushQueue(queues[1]);
-    flushQueue(queues[2]);
+    flushQueue(queues[DELETE_QUEUE]);
+    flushQueue(queues[INSERT_QUEUE]);
   }
 
   private void flushQueue(Queue queue) throws BatchedSqlException {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -106,9 +106,9 @@ public final class DefaultPersister implements Persister {
   }
 
   @Override
-  public void executeOrQueue(SpiSqlUpdate update, SpiTransaction t, boolean queue) {
+  public void executeOrQueue(SpiSqlUpdate update, SpiTransaction t, boolean queue, int queuePosition) {
     if (queue) {
-      addToFlushQueue(update, t, 2);
+      addToFlushQueue(update, t, queuePosition);
     } else {
       executeSqlUpdate(update, t);
     }
@@ -907,7 +907,7 @@ public final class DefaultPersister implements Persister {
   void deleteManyIntersection(EntityBean bean, BeanPropertyAssocMany<?> many, SpiTransaction t, boolean publish, boolean queue) {
     SpiSqlUpdate sqlDelete = deleteAllIntersection(bean, many, publish);
     if (queue) {
-      addToFlushQueue(sqlDelete, t, 1);
+      addToFlushQueue(sqlDelete, t, BatchControl.DELETE_QUEUE);
     } else {
       executeSqlUpdate(sqlDelete, t);
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBase.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBase.java
@@ -48,7 +48,7 @@ abstract class SaveManyBase implements SaveMany {
   final void preElementCollectionUpdate() {
     if (!insertedParent) {
       request.preElementCollectionUpdate();
-      persister.addToFlushQueue(many.deleteByParentId(request.beanId(), null), transaction, 1);
+      persister.addToFlushQueue(many.deleteByParentId(request.beanId(), null), transaction, BatchControl.DELETE_QUEUE);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -294,7 +294,7 @@ final class SaveManyBeans extends SaveManyBase {
         // build a intersection row for 'delete'
         IntersectionRow intRow = many.buildManyToManyMapBean(parentBean, otherDelete, publish);
         SpiSqlUpdate sqlDelete = intRow.createDelete(server, DeleteMode.HARD);
-        persister.executeOrQueue(sqlDelete, transaction, queue);
+        persister.executeOrQueue(sqlDelete, transaction, queue, BatchControl.DELETE_QUEUE);
       }
     }
     if (additions != null && !additions.isEmpty()) {
@@ -314,7 +314,7 @@ final class SaveManyBeans extends SaveManyBase {
             // build a intersection row for 'insert'
             IntersectionRow intRow = many.buildManyToManyMapBean(parentBean, otherBean, publish);
             SpiSqlUpdate sqlInsert = intRow.createInsert(server);
-            persister.executeOrQueue(sqlInsert, transaction, queue);
+            persister.executeOrQueue(sqlInsert, transaction, queue, BatchControl.INSERT_QUEUE);
           }
         }
       }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyElementCollection.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyElementCollection.java
@@ -48,7 +48,7 @@ final class SaveManyElementCollection extends SaveManyBase {
       final SpiSqlUpdate sqlInsert = proto.copy();
       sqlInsert.setParameter(parentId);
       many.bindElementValue(sqlInsert, value);
-      persister.addToFlushQueue(sqlInsert, transaction, 2);
+      persister.addToFlushQueue(sqlInsert, transaction, BatchControl.INSERT_QUEUE);
     }
     resetModifyState();
     postElementCollectionUpdate();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyElementCollectionMap.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyElementCollectionMap.java
@@ -51,7 +51,7 @@ final class SaveManyElementCollectionMap extends SaveManyBase {
       sqlInsert.setParameter(parentId);
       sqlInsert.setParameter(entry.getKey());
       many.bindElementValue(sqlInsert, entry.getValue());
-      persister.addToFlushQueue(sqlInsert, transaction, 2);
+      persister.addToFlushQueue(sqlInsert, transaction, BatchControl.INSERT_QUEUE);
     }
     resetModifyState();
     postElementCollectionUpdate();

--- a/ebean-test/src/test/java/org/tests/m2m/TestM2MModifyTest.java
+++ b/ebean-test/src/test/java/org/tests/m2m/TestM2MModifyTest.java
@@ -1,11 +1,12 @@
 package org.tests.m2m;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.MRole;
 import org.tests.model.basic.MUser;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,5 +52,28 @@ public class TestM2MModifyTest extends BaseTestCase {
 
     roles = u0.getRoles();
     assertThat(roles).hasSize(1);
+  }
+
+  @Test
+  public void test1() {
+    List<MRole> roles = new ArrayList<>();
+    for (int i = 0; i < 56; i++) {
+      MRole r0 = new MRole("mrole" + i);
+      roles.add(r0);
+    }
+
+    DB.saveAll(roles);
+
+    MUser u0 = new MUser("usr0");
+    u0.getRoles().addAll(roles);
+
+    DB.save(u0);
+
+    u0 = DB.find(MUser.class, u0.getUserid());
+
+    u0.getRoles().clear();
+    u0.getRoles().addAll(roles);
+
+    DB.save(u0);
   }
 }


### PR DESCRIPTION
Hello Rob,

this PR fixes an issue, when a List representing a ManyToMany-relation is cleared and then filled with (some of) the original elements. Functionally this resulted in the delete and the following insert statements to be executed within the same batch queue, because with m2m intersection tables the same queue was used for both types of SqlUpdate. The end result was that in these cases the first insert statements were executed before all delete statements were flushed, resulting in a DuplicateKeyException. Additionally, I introduced constants for the delete and insert queue positions for better readability.