### PR TITLE
Validate the lengths of Strings/Json, before they are written to database

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DataBindException.java
+++ b/ebean-api/src/main/java/io/ebean/DataBindException.java
@@ -1,0 +1,24 @@
+package io.ebean;
+
+import javax.persistence.PersistenceException;
+
+/**
+ * Thrown when a bind validator detects a data bind error.
+ */
+public class DataBindException extends PersistenceException {
+  private static final long serialVersionUID = -1755215106960660645L;
+
+  /**
+   * Create with a message.
+   */
+  public DataBindException(String message) {
+    super(message);
+  }
+
+  /**
+   * Create with a message and cause.
+   */
+  public DataBindException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/ebean-api/src/main/java/io/ebean/config/PlatformConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/PlatformConfig.java
@@ -1,6 +1,7 @@
 package io.ebean.config;
 
 import io.ebean.annotation.Platform;
+import io.ebean.config.dbplatform.BindValidatorFactory;
 import io.ebean.config.dbplatform.DbType;
 import io.ebean.config.dbplatform.IdType;
 import io.ebean.util.StringHelper;
@@ -23,6 +24,11 @@ public class PlatformConfig {
   private boolean forUpdateNoKey;
 
   private DbConstraintNaming constraintNaming;
+
+  /**
+   * The BindValidatorFactory to use.
+   */
+  private BindValidatorFactory bindValidatorFactory;
 
   /**
    * Flag set when a supplied constraintNaming is used.
@@ -96,6 +102,7 @@ public class PlatformConfig {
     this.allQuotedIdentifiers = platformConfig.allQuotedIdentifiers;
     this.databaseInetAddressVarchar = platformConfig.databaseInetAddressVarchar;
     this.customDbTypeMappings = platformConfig.customDbTypeMappings;
+    this.bindValidatorFactory = platformConfig.bindValidatorFactory;
     this.constraintNaming = new DbConstraintNaming(!allQuotedIdentifiers);
   }
 
@@ -325,6 +332,21 @@ public class PlatformConfig {
     return customDbTypeMappings;
   }
 
+  /**
+   * Set the bindValidatorFactory.
+   */
+  public void setBindValidatorFactory(BindValidatorFactory bindValidatorFactory) {
+    this.bindValidatorFactory = bindValidatorFactory;
+  }
+
+  /**
+   * Return the bindValidatorFactory for this platform.
+   */
+  public BindValidatorFactory getBindValidatorFactory() {
+    return bindValidatorFactory;
+  }
+
+
   public void loadSettings(PropertiesWrapper p) {
 
     idType = p.getEnum(IdType.class, "idType", idType);
@@ -335,6 +357,7 @@ public class PlatformConfig {
     databaseInetAddressVarchar = p.getBoolean("databaseInetAddressVarchar", databaseInetAddressVarchar);
     caseSensitiveCollation = p.getBoolean("caseSensitiveCollation", caseSensitiveCollation);
     useMigrationStoredProcedures = p.getBoolean("useMigrationStoredProcedures", useMigrationStoredProcedures);
+    bindValidatorFactory = p.createInstance(BindValidatorFactory.class, "bindValidatorFactory", bindValidatorFactory);
 
     DbUuid dbUuid = p.getEnum(DbUuid.class, "dbuuid", null);
     if (dbUuid != null) {

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/BindValidator.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/BindValidator.java
@@ -1,0 +1,18 @@
+package io.ebean.config.dbplatform;
+
+import io.ebean.DataBindException;
+
+/**
+ * Validates a value at bind level. See BindValidatorFactory for details.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+@FunctionalInterface
+public interface BindValidator {
+
+  /**
+   * The validate method should throw a DataBindException, if the value is invalid.
+   */
+  void validate(Object value) throws DataBindException;
+
+}

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/BindValidatorFactory.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/BindValidatorFactory.java
@@ -1,0 +1,42 @@
+package io.ebean.config.dbplatform;
+
+/**
+ * The database platforms treat values that will exceed length or precision differently.
+ * Some will silently truncate varchars, if they are too long. This is fatal, when saving JSONs,
+ * because the JSON mostly breaks by this truncation.
+ * <p>
+ * BindValidators can be implemented depending on the database platform needs.
+ * E.g. they can perform length checks of varchars/blobs/clobs/...
+ * It would be also possible to implement precision and range checks for timestamps or numeric values.
+ * or 'confidental checks' - e.g. detect if all password hashes are SHA256
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+@FunctionalInterface
+public interface BindValidatorFactory {
+
+  /**
+   * Creates a bindValidator. The <code>propertyDefinition</code> provides information like JDBC-type or DbLength.
+   */
+  BindValidator create(PropertyDefinition propertyDefinition);
+
+  /**
+   * Combines this BindValidatorFactory with another one and returns a new factory.
+   */
+  default BindValidatorFactory combine(BindValidatorFactory other) {
+    return propertyDefinition -> {
+      BindValidator validator1 = this.create(propertyDefinition);
+      BindValidator validator2 = other.create(propertyDefinition);
+      if (validator1 != null && validator2 != null) {
+        return value -> {
+          validator1.validate(value);
+          validator2.validate(value);
+        };
+      } else if (validator1 != null) {
+        return validator1;
+      } else {
+        return validator2;
+      }
+    };
+  }
+}

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -197,6 +197,8 @@ public class DatabasePlatform {
 
   protected boolean supportsNativeIlike;
 
+  protected BindValidatorFactory bindValidatorFactory = new DefaultBindValidatorFactory();
+
   protected SqlExceptionTranslator exceptionTranslator = new SqlCodeTranslator();
 
   /**
@@ -219,6 +221,9 @@ public class DatabasePlatform {
     this.sequenceBatchSize = config.getDatabaseSequenceBatchSize();
     this.caseSensitiveCollation = config.isCaseSensitiveCollation();
     this.useMigrationStoredProcedures = config.isUseMigrationStoredProcedures();
+    if (config.getBindValidatorFactory() != null) {
+      this.bindValidatorFactory = config.getBindValidatorFactory();
+    }
     configureIdType(config.getIdType());
     configure(config, config.isAllQuotedIdentifiers());
   }
@@ -299,6 +304,20 @@ public class DatabasePlatform {
    */
   public boolean supportsNativeIlike() {
     return supportsNativeIlike;
+  }
+
+  /**
+   * Return the bindValidatorFactory for this platform.
+   */
+  public BindValidatorFactory getBindValidatorFactory() {
+    return bindValidatorFactory;
+  }
+
+  /**
+   * Set the bindValidatorFactory.
+   */
+  public void setBindValidatorFactory(BindValidatorFactory bindValidatorFactory) {
+    this.bindValidatorFactory = bindValidatorFactory;
   }
 
   /**

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/DefaultBindValidatorFactory.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/DefaultBindValidatorFactory.java
@@ -1,0 +1,72 @@
+package io.ebean.config.dbplatform;
+
+import io.ebean.DataBindException;
+
+import java.lang.reflect.Array;
+import java.sql.Types;
+
+/**
+ * Default implementation of BindValidatorFactory.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class DefaultBindValidatorFactory implements BindValidatorFactory {
+
+  /**
+   * Returns true, if the JDBC-type is length based.
+   */
+  protected boolean isLengthBased(int jdbcType) {
+    switch (jdbcType) {
+      case Types.BLOB:
+      case Types.CLOB:
+      case Types.LONGVARBINARY:
+      case Types.LONGVARCHAR:
+      case Types.VARBINARY:
+      case Types.BINARY:
+      case Types.CHAR:
+      case Types.VARCHAR:
+      case Types.NCHAR:
+      case Types.NVARCHAR:
+      case Types.NCLOB:
+      case Types.LONGNVARCHAR:
+      case Types.SQLXML:
+      case ExtraDbTypes.JSON:
+      case ExtraDbTypes.JSONB:
+      case ExtraDbTypes.JSONClob:
+      case ExtraDbTypes.JSONBlob:
+      case ExtraDbTypes.JSONVarchar:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Create BindValidator for length-based properties.
+   */
+  @Override
+  public BindValidator create(PropertyDefinition property) {
+    if (property.getDbLength() > 0 && isLengthBased(property.getJdbcType())) {
+      return value -> validate(value, property.getDbLength(), property.getTable(), property.getColumn());
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Default validator, that handles length check for String, Arrays, and Files, respectively InputStreamInfo.
+   */
+  protected void validate(Object value, int dbLength, String table, String column) {
+    int valueLength = 0;
+    if (value instanceof String) {
+      valueLength = ((String) value).length();
+    } else if (value instanceof InputStreamInfo) {
+      valueLength = (int) ((InputStreamInfo) value).length();
+    } else if (value != null && value.getClass().isArray()) {
+      valueLength = Array.getLength(value);
+    }
+    if (valueLength > dbLength) {
+      throw new DataBindException("Value of length " + valueLength + " exceeds limit of " + dbLength + " for " + table + "." + column);
+    }
+  }
+}

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/InputStreamInfo.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/InputStreamInfo.java
@@ -1,0 +1,27 @@
+package io.ebean.config.dbplatform;
+
+import java.io.InputStream;
+
+/**
+ * Helper to transports length info of DataBind.setBinaryStream(stream, length) to BindValidation
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class InputStreamInfo {
+  private final InputStream stream;
+
+  private final long length;
+
+  public InputStreamInfo(InputStream stream, long length) {
+    this.stream = stream;
+    this.length = length;
+  }
+
+  public InputStream stream() {
+    return stream;
+  }
+
+  public long length() {
+    return length;
+  }
+}

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/NoopBindValidatorFactory.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/NoopBindValidatorFactory.java
@@ -1,0 +1,18 @@
+package io.ebean.config.dbplatform;
+
+/**
+ * noop implementation. Use 'ebean.bindValidatorFactory=io.ebean.config.dbplatform.NoopBindValidatorFactory'.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class NoopBindValidatorFactory implements BindValidatorFactory {
+
+  /**
+   * Create BindValidator for length-based properties.
+   */
+  @Override
+  public BindValidator create(PropertyDefinition property) {
+    return null;
+  }
+
+}

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/PropertyDefinition.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/PropertyDefinition.java
@@ -1,0 +1,42 @@
+package io.ebean.config.dbplatform;
+
+/**
+ * Information about the property, that should be bind-validated.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class PropertyDefinition {
+  private final int jdbcType;
+  private final int dbLength;
+  private final String table;
+  private final String column;
+  private final String columnDefn;
+
+  public PropertyDefinition(int jdbcType, int dbLength, String baseTable, String column, String columnDefn) {
+    this.jdbcType = jdbcType;
+    this.dbLength = dbLength;
+    this.table = baseTable;
+    this.column = column;
+    this.columnDefn = columnDefn;
+  }
+
+  public int getJdbcType() {
+    return jdbcType;
+  }
+
+  public int getDbLength() {
+    return dbLength;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public String getColumn() {
+    return column;
+  }
+
+  public String getColumnDefn() {
+    return columnDefn;
+  }
+}

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/Utf8BindValidatorFactory.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/Utf8BindValidatorFactory.java
@@ -1,0 +1,25 @@
+package io.ebean.config.dbplatform;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * BindValidator that validates the UTF8 length. For example, this is required for DB2 when not using the CODEUNITS32 character set.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class Utf8BindValidatorFactory extends DefaultBindValidatorFactory {
+
+  /**
+   * Default validator, that handles length check for String, Arrays, and Files, respectively InputStreamInfo.
+   */
+  protected void validate(Object value, int dbLength, String table, String column) {
+    if (value instanceof String) {
+      String s = (String) value;
+      if (s.length() < dbLength * 4) {
+        return;
+      }
+      value = s.getBytes(StandardCharsets.UTF_8);
+    }
+    super.validate(value, dbLength, table, column);
+  }
+}

--- a/ebean-core-type/src/main/java/io/ebean/core/type/DataBinder.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/DataBinder.java
@@ -174,4 +174,9 @@ public interface DataBinder {
    */
   String popJson();
 
+  /**
+   * Returns the last bound object (e.g. for BindValidation)
+   */
+  Object popLastObject();
+
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/bind/DataBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/bind/DataBind.java
@@ -1,10 +1,14 @@
 package io.ebeaninternal.server.bind;
 
+import io.ebean.config.dbplatform.InputStreamInfo;
 import io.ebean.core.type.DataBinder;
 import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.sql.*;
 import java.util.ArrayList;
@@ -15,6 +19,7 @@ import static java.lang.System.Logger.Level.WARNING;
 
 public class DataBind implements DataBinder {
 
+  private static final Object UNBOUND = new Object();
   private final DataTimeZone dataTimeZone;
   private final PreparedStatement pstmt;
   private final Connection connection;
@@ -22,6 +27,8 @@ public class DataBind implements DataBinder {
   private List<InputStream> inputStreams;
   protected int pos;
   private String json;
+
+  private Object lastObject = UNBOUND;
 
   public DataBind(DataTimeZone dataTimeZone, PreparedStatement pstmt, Connection connection) {
     this.dataTimeZone = dataTimeZone;
@@ -65,16 +72,19 @@ public class DataBind implements DataBinder {
   @Override
   public void setObject(Object value) throws SQLException {
     pstmt.setObject(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setObject(Object value, int sqlType) throws SQLException {
     pstmt.setObject(++pos, value, sqlType);
+    lastObject = value;
   }
 
   @Override
   public void setNull(int jdbcType) throws SQLException {
     pstmt.setNull(++pos, jdbcType);
+    lastObject = null;
   }
 
   @Override
@@ -96,7 +106,7 @@ public class DataBind implements DataBinder {
     }
   }
 
-  private void closeInputStreams() {
+  public void closeInputStreams() {
     if (inputStreams != null) {
       for (InputStream inputStream : inputStreams) {
         try {
@@ -117,36 +127,43 @@ public class DataBind implements DataBinder {
   @Override
   public void setString(String value) throws SQLException {
     pstmt.setString(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setInt(int value) throws SQLException {
     pstmt.setInt(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setLong(long value) throws SQLException {
     pstmt.setLong(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setShort(short value) throws SQLException {
     pstmt.setShort(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setFloat(float value) throws SQLException {
     pstmt.setFloat(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setDouble(double value) throws SQLException {
     pstmt.setDouble(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setBigDecimal(BigDecimal value) throws SQLException {
     pstmt.setBigDecimal(++pos, value);
+    lastObject = value;
   }
 
   @Override
@@ -157,6 +174,7 @@ public class DataBind implements DataBinder {
     } else {
       pstmt.setDate(++pos, value);
     }
+    lastObject = value;
   }
 
   @Override
@@ -167,6 +185,7 @@ public class DataBind implements DataBinder {
     } else {
       pstmt.setTimestamp(++pos, value);
     }
+    lastObject = value;
   }
 
   @Override
@@ -177,26 +196,31 @@ public class DataBind implements DataBinder {
     } else {
       pstmt.setTime(++pos, value);
     }
+    lastObject = value;
   }
 
   @Override
   public void setBoolean(boolean value) throws SQLException {
     pstmt.setBoolean(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public void setBytes(byte[] value) throws SQLException {
     pstmt.setBytes(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public void setByte(byte value) throws SQLException {
     pstmt.setByte(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public void setChar(char value) throws SQLException {
     pstmt.setString(++pos, String.valueOf(value));
+    lastObject = value;
   }
 
   @Override
@@ -211,21 +235,34 @@ public class DataBind implements DataBinder {
     }
     inputStreams.add(inputStream);
     pstmt.setBinaryStream(++pos, inputStream, length);
+    lastObject = new InputStreamInfo(inputStream, length);
   }
 
   @Override
   public void setBlob(byte[] bytes) throws SQLException {
     pstmt.setBinaryStream(++pos, new ByteArrayInputStream(bytes), bytes.length);
+    lastObject = bytes;
   }
 
   @Override
   public void setClob(String content) throws SQLException {
     pstmt.setCharacterStream(++pos, new StringReader(content), content.length());
+    lastObject = content;
   }
 
   @Override
   public void setArray(String arrayType, Object[] elements) throws SQLException {
     pstmt.setArray(++pos, connection.createArrayOf(arrayType, elements));
+    lastObject = elements;
   }
 
+  @Override
+  public Object popLastObject() {
+    Object ret = lastObject;
+    lastObject = UNBOUND;
+    if (ret == UNBOUND) {
+      throw new IllegalStateException("No object bound");
+    }
+    return ret;
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -138,7 +138,7 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
     this.queryPlanTTLSeconds = this.config.getQueryPlanTTLSeconds();
     this.asOfViewSuffix = asOfViewSuffix(databasePlatform, this.config);
     String versionsBetweenSuffix = versionsBetweenSuffix(databasePlatform, this.config);
-    this.readAnnotations = new ReadAnnotations(config.getGeneratedPropertyFactory(), asOfViewSuffix, versionsBetweenSuffix, this.config);
+    this.readAnnotations = new ReadAnnotations(config.getGeneratedPropertyFactory(), asOfViewSuffix, versionsBetweenSuffix, this.config, this.databasePlatform.getBindValidatorFactory());
     this.bootupClasses = config.getBootupClasses();
     this.createProperties = config.getDeployCreateProperties();
     this.namingConvention = this.config.getNamingConvention();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.deploy.meta;
 
 import io.ebean.annotation.*;
 import io.ebean.config.ScalarTypeConverter;
+import io.ebean.config.dbplatform.BindValidator;
 import io.ebean.config.dbplatform.DbDefaultValue;
 import io.ebean.config.dbplatform.DbEncrypt;
 import io.ebean.config.dbplatform.DbEncryptFunction;
@@ -168,6 +169,7 @@ public class DeployBeanProperty {
   private String dbComment;
   private String dbColumnDefault;
   private List<DbMigrationInfo> dbMigrationInfos;
+  private BindValidator bindValidator;
   private Set<Annotation> metaAnnotations;
 
   public DeployBeanProperty(DeployBeanDescriptor<?> desc, Class<?> propertyType, ScalarType<?> scalarType, ScalarTypeConverter<?, ?> typeConverter) {
@@ -1036,6 +1038,20 @@ public class DeployBeanProperty {
    */
   public void setElementProperty() {
     this.elementProperty = true;
+  }
+
+  /**
+   * Returns the bind validator for this property.
+   */
+  public BindValidator getBindValidator() {
+    return bindValidator;
+  }
+
+  /**
+   * Sets the bind validator for this property.
+   */
+  public void setBindValidator(BindValidator bindValidator) {
+    this.bindValidator = bindValidator;
   }
 
   public void initMetaAnnotations(Set<Class<?>> metaAnnotationsFilter) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationFields.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationFields.java
@@ -4,10 +4,7 @@ import io.ebean.annotation.Index;
 import io.ebean.annotation.*;
 import io.ebean.config.EncryptDeploy;
 import io.ebean.config.EncryptDeploy.Mode;
-import io.ebean.config.dbplatform.DbEncrypt;
-import io.ebean.config.dbplatform.DbEncryptFunction;
-import io.ebean.config.dbplatform.IdType;
-import io.ebean.config.dbplatform.PlatformIdGenerator;
+import io.ebean.config.dbplatform.*;
 import io.ebean.core.type.ScalarType;
 import io.ebeaninternal.server.deploy.DbMigrationInfo;
 import io.ebeaninternal.server.deploy.IndexDefinition;
@@ -153,6 +150,7 @@ final class AnnotationFields extends AnnotationParser {
     for (Index index : annotationIndexes(prop)) {
       addIndex(prop, index);
     }
+    initBindValidator(prop);
   }
 
   private void initIdentity(DeployBeanProperty prop) {
@@ -310,6 +308,18 @@ final class AnnotationFields extends AnnotationParser {
       } else if (Mode.MODE_ENCRYPT == encryptDeploy.getMode()) {
         setEncryption(prop, encryptDeploy.isDbEncrypt(), encryptDeploy.getDbLength());
       }
+    }
+  }
+
+  private void initBindValidator(DeployBeanProperty prop) {
+    if (!prop.isTransient() && readConfig.bindValidatorFatory() != null) {
+      PropertyDefinition meta = new PropertyDefinition(
+        prop.getDbType(),
+        prop.getDbLength(),
+        prop.getDesc().getBaseTable(),
+        prop.getDbColumn(),
+        prop.getDbColumnDefn());
+      prop.setBindValidator(readConfig.bindValidatorFatory().create(meta));
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/ReadAnnotationConfig.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/ReadAnnotationConfig.java
@@ -5,6 +5,7 @@ import io.ebean.annotation.Formula;
 import io.ebean.annotation.Where;
 import io.ebean.config.ClassLoadConfig;
 import io.ebean.config.DatabaseConfig;
+import io.ebean.config.dbplatform.BindValidatorFactory;
 import io.ebeaninternal.server.deploy.generatedproperty.GeneratedPropertyFactory;
 import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
 
@@ -30,8 +31,9 @@ final class ReadAnnotationConfig {
   private final ReadValidationAnnotations javaxValidation;
   private final ReadValidationAnnotations jakartaValidation;
   private final Set<Class<?>> metaAnnotations = new HashSet<>();
+  private final BindValidatorFactory bindValidatorFatory;
 
-  ReadAnnotationConfig(GeneratedPropertyFactory generatedPropFactory, String asOfViewSuffix, String versionsBetweenSuffix, DatabaseConfig config) {
+  ReadAnnotationConfig(GeneratedPropertyFactory generatedPropFactory, String asOfViewSuffix, String versionsBetweenSuffix, DatabaseConfig config, BindValidatorFactory bindValidatorFatory) {
     this.generatedPropFactory = generatedPropFactory;
     this.asOfViewSuffix = asOfViewSuffix;
     this.versionsBetweenSuffix = versionsBetweenSuffix;
@@ -51,6 +53,7 @@ final class ReadAnnotationConfig {
     this.metaAnnotations.add(Aggregation.class);
     this.javaxValidation = javaxValidationAnnotations ? new ReadValidationAnnotationsJavax(this) : null;
     this.jakartaValidation = jakartaValidationAnnotations ? new ReadValidationAnnotationsJakarta(this) : null;
+    this.bindValidatorFatory = bindValidatorFatory;
     if (jacksonAnnotations) {
       InitMetaJacksonAnnotation.init(this);
     }
@@ -123,4 +126,7 @@ final class ReadAnnotationConfig {
     return maxSize;
   }
 
+  BindValidatorFactory bindValidatorFatory() {
+    return bindValidatorFatory;
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/ReadAnnotations.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/ReadAnnotations.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.deploy.parse;
 
 import io.ebean.config.DatabaseConfig;
+import io.ebean.config.dbplatform.BindValidatorFactory;
 import io.ebeaninternal.server.deploy.BeanDescriptorManager;
 import io.ebeaninternal.server.deploy.generatedproperty.GeneratedPropertyFactory;
 
@@ -12,8 +13,8 @@ public final class ReadAnnotations {
 
   private final ReadAnnotationConfig readConfig;
 
-  public ReadAnnotations(GeneratedPropertyFactory generatedPropFactory, String asOfViewSuffix, String versionsBetweenSuffix, DatabaseConfig config) {
-    this.readConfig = new ReadAnnotationConfig(generatedPropFactory, asOfViewSuffix, versionsBetweenSuffix, config);
+  public ReadAnnotations(GeneratedPropertyFactory generatedPropFactory, String asOfViewSuffix, String versionsBetweenSuffix, DatabaseConfig config, BindValidatorFactory bindValidatorFatory) {
+    this.readConfig = new ReadAnnotationConfig(generatedPropFactory, asOfViewSuffix, versionsBetweenSuffix, config, bindValidatorFatory);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultUpdateQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultUpdateQuery.java
@@ -4,6 +4,7 @@ import io.ebean.ExpressionList;
 import io.ebean.ProfileLocation;
 import io.ebean.Query;
 import io.ebean.UpdateQuery;
+import io.ebean.config.dbplatform.BindValidator;
 import io.ebean.core.type.ScalarType;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanProperty;
@@ -30,7 +31,8 @@ public final class DefaultUpdateQuery<T> implements UpdateQuery<T> {
     } else {
       final BeanProperty beanProperty = descriptor.beanProperty(property);
       final ScalarType<Object> scalarType = (beanProperty == null) ? null: beanProperty.scalarType();
-      values.set(property, value, scalarType);
+      final BindValidator bindValidator = (beanProperty == null) ? null: beanProperty.bindValidator();
+      values.set(property, value, scalarType, bindValidator);
     }
     return this;
   }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/deploy/parse/AnnotationClassTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/deploy/parse/AnnotationClassTest.java
@@ -48,7 +48,7 @@ public class AnnotationClassTest {
     DeployUtil deployUtil = new DeployUtil(new DefaultTypeManager(config, new BootupClasses()), config);
 
     DeployBeanInfo deployBeanInfo = new DeployBeanInfo(deployUtil, new DeployBeanDescriptor<>(null, null, null));
-    ReadAnnotationConfig readAnnotationConfig = new ReadAnnotationConfig(new GeneratedPropertyFactory(true, new DatabaseConfig(), Collections.emptyList()), "","", new DatabaseConfig());
+    ReadAnnotationConfig readAnnotationConfig = new ReadAnnotationConfig(new GeneratedPropertyFactory(true, new DatabaseConfig(), Collections.emptyList()), "","", new DatabaseConfig(), null);
     return new AnnotationClass(deployBeanInfo, readAnnotationConfig);
   }
 

--- a/ebean-test/src/test/java/org/tests/basic/TestMetaAnnotation.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestMetaAnnotation.java
@@ -1,9 +1,9 @@
 package org.tests.basic;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
-import io.ebean.xtest.IgnorePlatform;
 import io.ebean.annotation.Platform;
+import io.ebean.xtest.BaseTestCase;
+import io.ebean.xtest.IgnorePlatform;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Address;
 import org.tests.model.basic.metaannotation.SizeMedium;
@@ -49,7 +49,6 @@ public class TestMetaAnnotation extends BaseTestCase {
    * This test writes 101 spaces to "line1" which is annotated with &#64;Size(max=100).
    */
   @Test
-  @IgnorePlatform({Platform.POSTGRES, Platform.SQLSERVER, Platform.MYSQL, Platform.MARIADB, Platform.DB2, Platform.YUGABYTE}) // pg & mssql does not fail if string is too long.
   public void testWrite101SpacesToLine1() {
 
     Address address = new Address();

--- a/ebean-test/src/test/java/org/tests/json/TestDbJsonLength.java
+++ b/ebean-test/src/test/java/org/tests/json/TestDbJsonLength.java
@@ -1,0 +1,52 @@
+package org.tests.json;
+
+import io.ebean.DB;
+import io.ebean.DataIntegrityException;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.tests.model.json.EBasicJsonMap;
+
+import java.util.Map;
+
+class TestDbJsonLength {
+
+
+    /**
+   * The property 'EBasicJsonMap.content' is annotated with @DbJson(length=5000). So we assume, that we cannot save Json-objects
+   * where the serialized form exceed that limit and we would expect an error on save.
+   * The length check works for platforms like h2, as H2 uses a 'varchar(5000)'. So it is impossible to save such long jsons,
+   * but it won't work for SqlServer, as here 'nvarchar(max)' is used. No validation happens at DB level and you might get very
+   * large Json objects in your database. This mostly happens unintentionally (programming error, misconfiguration)
+   * So they are in the database and they cannot be accessed by ebean any more, because there are new limits in Jackson:
+   * - Max 5 Meg per string in 2.15.0
+   * - Max 20 Meg per string in 2.15.1
+   * see https://github.com/FasterXML/jackson-core/issues/1014
+   */
+  @Test
+  void testLongString() {
+    // s is so big, that it could not be deserialized by jackson
+    String s = new String(new char[20_000_001]).replace('\0', 'x');
+
+    EBasicJsonMap bean = new EBasicJsonMap();
+    bean.setName("b1");
+    bean.setContent(Map.of("string", s));
+
+    SoftAssertions softly = new SoftAssertions();
+
+    softly.assertThatThrownBy(() -> {
+      DB.save(bean);
+    }).isInstanceOf(DataIntegrityException.class);
+
+
+    if (bean.getId() != null) {
+      // we expect, that we could NOT save the bean, but this is not true for sqlServer.
+      // we will get a javax.persistence.PersistenceException: Error loading on org.tests.model.json.EBasicJsonMap.content
+      // when we try to load the bean back from DB
+      DB.find(EBasicJsonMap.class, bean.getId());
+    }
+
+    softly.assertAll();
+
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/model/json/EBasicJsonMap.java
+++ b/ebean-test/src/test/java/org/tests/model/json/EBasicJsonMap.java
@@ -18,7 +18,7 @@ public class EBasicJsonMap {
 
   String name;
 
-  @DbJson
+  @DbJson(length = 5000)
   Map<String, Object> content;
 
   @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)

--- a/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
+++ b/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
@@ -15,6 +15,7 @@ public abstract class BaseDB2Platform extends DatabasePlatform {
   public BaseDB2Platform() {
     super();
     this.platform = Platform.DB2;
+    this.bindValidatorFactory = new Utf8BindValidatorFactory();
     this.supportsNativeJavaTime = false;
     this.truncateTable = "truncate table %s reuse storage ignore delete triggers immediate";
     this.likeClauseRaw = "like ?";

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <nexus.staging.keepStagingRepositoryOnFailure>true</nexus.staging.keepStagingRepositoryOnFailure>
     <nexus.staging.skipStagingRepositoryClose>true</nexus.staging.skipStagingRepositoryClose>
     <nexus.staging.autoReleaseAfterClose>false</nexus.staging.autoReleaseAfterClose>
-    <jackson.version>2.15.0</jackson.version>
+    <jackson.version>2.15.2</jackson.version>
     <h2database.version>2.1.214</h2database.version>
     <ebean-persistence-api.version>3.0</ebean-persistence-api.version>
     <ebean-types.version>3.0</ebean-types.version>


### PR DESCRIPTION
So with #3107 it is now possible to use length limits across platforms.
Unfortunately, platforms that do not use varchars or fall back to a lob (like SqlServer) do not enforce that limit.

**Problem**
The JSON in an annotated field with `@DbJson(length = 5000)` is not size limited.
Due programming errors, it is possible to write gigabytes to the DB.

Due recent Jackson updates, these strings could not be read anymore. See https://github.com/ebean-orm/ebean/commit/ca3c02bc1cce66e1176b9b7bcf414ac074a25e6e

**Possible fix**
When a BeanProperty writes its value to the dataBind, it will pass the previously written value to a BindValidator.
The BindValidator can decide, if the value is OK or not.
It can validate string length, file sizes, array sizes and so on.