### PR TITLE
JSON/String/Stream length validation (Take 2)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DataIntegrityException.java
+++ b/ebean-api/src/main/java/io/ebean/DataIntegrityException.java
@@ -3,7 +3,7 @@ package io.ebean;
 import javax.persistence.PersistenceException;
 
 /**
- * Thrown when a foreign key constraint is enforced.
+ * Thrown when a foreign key constraint is enforced or a field is too large.
  */
 public class DataIntegrityException extends PersistenceException {
   private static final long serialVersionUID = -6740171949170180970L;
@@ -13,5 +13,12 @@ public class DataIntegrityException extends PersistenceException {
    */
   public DataIntegrityException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  /**
+   * Create with message only.
+   */
+  public DataIntegrityException(String message) {
+    super(message);
   }
 }

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -540,6 +540,7 @@ public class DatabaseConfig {
 
   private String dumpMetricsOptions;
 
+  private LengthCheck lengthCheck = LengthCheck.OFF;
   private Function<String, String> metricNaming = MetricNamingMatch.INSTANCE;
 
   /**
@@ -2919,6 +2920,7 @@ public class DatabaseConfig {
     jdbcFetchSizeFindEach = p.getInt("jdbcFetchSizeFindEach", jdbcFetchSizeFindEach);
     jdbcFetchSizeFindList = p.getInt("jdbcFetchSizeFindList", jdbcFetchSizeFindList);
     databasePlatformName = p.get("databasePlatformName", databasePlatformName);
+    lengthCheck = p.getEnum(LengthCheck.class, "lengthCheck", lengthCheck);
 
     uuidVersion = p.getEnum(UuidVersion.class, "uuidVersion", uuidVersion);
     uuidStateFile = p.get("uuidStateFile", uuidStateFile);
@@ -3417,6 +3419,20 @@ public class DatabaseConfig {
    */
   public void setMetricNaming(Function<String, String> metricNaming) {
     this.metricNaming = metricNaming;
+  }
+
+  /**
+   * Returns the length check mode.
+   */
+  public LengthCheck getLengthCheck() {
+    return lengthCheck;
+  }
+
+  /**
+   * Sets the length check mode.
+   */
+  public void setLengthCheck(LengthCheck lengthCheck) {
+    this.lengthCheck = lengthCheck;
   }
 
   public enum UuidVersion {

--- a/ebean-api/src/main/java/io/ebean/config/LengthCheck.java
+++ b/ebean-api/src/main/java/io/ebean/config/LengthCheck.java
@@ -1,0 +1,22 @@
+package io.ebean.config;
+
+/**
+ * Defines the length-check mode.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public enum LengthCheck {
+  /**
+   * By default, length checking is off. This means, strings/jsons and files are passed to the DB and the DB might or might not check the length.
+   * The DB has to check the data length. Note this is not possible for certain datatypes (e.g. clob without size)
+   */
+  OFF,
+  /**
+   * When enabling length check, ebean validates strings/json strings and files before saving them to DB.
+   */
+  ON,
+  /**
+   * Same as "ON", but take the UTF8-bytelength for validation. This may be useful, if you have an UTF8 based charset (default for DB2)
+   */
+  UTF8
+}

--- a/ebean-core-type/src/main/java/io/ebean/core/type/DataBinder.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/DataBinder.java
@@ -174,4 +174,9 @@ public interface DataBinder {
    */
   String popJson();
 
+  /**
+   * Returns the last bound object (e.g. for BindValidation). Note for InputStreams you'll get an InputStreamInfo.
+   */
+  Object popLastObject();
+
 }

--- a/ebean-core-type/src/main/java/io/ebean/core/type/InputStreamInfo.java
+++ b/ebean-core-type/src/main/java/io/ebean/core/type/InputStreamInfo.java
@@ -1,0 +1,27 @@
+package io.ebean.core.type;
+
+import java.io.InputStream;
+
+/**
+ * Helper to transports length info of DataBind.setBinaryStream(stream, length) to BindValidation
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+public class InputStreamInfo {
+  private final InputStream stream;
+
+  private final long length;
+
+  public InputStreamInfo(InputStream stream, long length) {
+    this.stream = stream;
+    this.length = length;
+  }
+
+  public InputStream stream() {
+    return stream;
+  }
+
+  public long length() {
+    return length;
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/bind/DataBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/bind/DataBind.java
@@ -1,10 +1,14 @@
 package io.ebeaninternal.server.bind;
 
 import io.ebean.core.type.DataBinder;
+import io.ebean.core.type.InputStreamInfo;
 import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.sql.*;
 import java.util.ArrayList;
@@ -15,6 +19,7 @@ import static java.lang.System.Logger.Level.WARNING;
 
 public class DataBind implements DataBinder {
 
+  private static final Object UNBOUND = new Object();
   private final DataTimeZone dataTimeZone;
   private final PreparedStatement pstmt;
   private final Connection connection;
@@ -22,6 +27,8 @@ public class DataBind implements DataBinder {
   private List<InputStream> inputStreams;
   protected int pos;
   private String json;
+
+  private Object lastObject = UNBOUND;
 
   public DataBind(DataTimeZone dataTimeZone, PreparedStatement pstmt, Connection connection) {
     this.dataTimeZone = dataTimeZone;
@@ -65,16 +72,19 @@ public class DataBind implements DataBinder {
   @Override
   public void setObject(Object value) throws SQLException {
     pstmt.setObject(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setObject(Object value, int sqlType) throws SQLException {
     pstmt.setObject(++pos, value, sqlType);
+    lastObject = value;
   }
 
   @Override
   public void setNull(int jdbcType) throws SQLException {
     pstmt.setNull(++pos, jdbcType);
+    lastObject = null;
   }
 
   @Override
@@ -96,7 +106,7 @@ public class DataBind implements DataBinder {
     }
   }
 
-  private void closeInputStreams() {
+  public void closeInputStreams() {
     if (inputStreams != null) {
       for (InputStream inputStream : inputStreams) {
         try {
@@ -117,36 +127,43 @@ public class DataBind implements DataBinder {
   @Override
   public void setString(String value) throws SQLException {
     pstmt.setString(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setInt(int value) throws SQLException {
     pstmt.setInt(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setLong(long value) throws SQLException {
     pstmt.setLong(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setShort(short value) throws SQLException {
     pstmt.setShort(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setFloat(float value) throws SQLException {
     pstmt.setFloat(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setDouble(double value) throws SQLException {
     pstmt.setDouble(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public final void setBigDecimal(BigDecimal value) throws SQLException {
     pstmt.setBigDecimal(++pos, value);
+    lastObject = value;
   }
 
   @Override
@@ -157,6 +174,7 @@ public class DataBind implements DataBinder {
     } else {
       pstmt.setDate(++pos, value);
     }
+    lastObject = value;
   }
 
   @Override
@@ -167,6 +185,7 @@ public class DataBind implements DataBinder {
     } else {
       pstmt.setTimestamp(++pos, value);
     }
+    lastObject = value;
   }
 
   @Override
@@ -177,26 +196,31 @@ public class DataBind implements DataBinder {
     } else {
       pstmt.setTime(++pos, value);
     }
+    lastObject = value;
   }
 
   @Override
   public void setBoolean(boolean value) throws SQLException {
     pstmt.setBoolean(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public void setBytes(byte[] value) throws SQLException {
     pstmt.setBytes(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public void setByte(byte value) throws SQLException {
     pstmt.setByte(++pos, value);
+    lastObject = value;
   }
 
   @Override
   public void setChar(char value) throws SQLException {
     pstmt.setString(++pos, String.valueOf(value));
+    lastObject = value;
   }
 
   @Override
@@ -211,21 +235,34 @@ public class DataBind implements DataBinder {
     }
     inputStreams.add(inputStream);
     pstmt.setBinaryStream(++pos, inputStream, length);
+    lastObject = new InputStreamInfo(inputStream, length);
   }
 
   @Override
   public void setBlob(byte[] bytes) throws SQLException {
     pstmt.setBinaryStream(++pos, new ByteArrayInputStream(bytes), bytes.length);
+    lastObject = bytes;
   }
 
   @Override
   public void setClob(String content) throws SQLException {
     pstmt.setCharacterStream(++pos, new StringReader(content), content.length());
+    lastObject = content;
   }
 
   @Override
   public void setArray(String arrayType, Object[] elements) throws SQLException {
     pstmt.setArray(++pos, connection.createArrayOf(arrayType, elements));
+    lastObject = elements;
   }
 
+  @Override
+  public Object popLastObject() {
+    Object ret = lastObject;
+    lastObject = UNBOUND;
+    if (ret == UNBOUND) {
+      throw new IllegalStateException("No object bound");
+    }
+    return ret;
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/bind/DataBind.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/bind/DataBind.java
@@ -19,7 +19,6 @@ import static java.lang.System.Logger.Level.WARNING;
 
 public class DataBind implements DataBinder {
 
-  private static final Object UNBOUND = new Object();
   private final DataTimeZone dataTimeZone;
   private final PreparedStatement pstmt;
   private final Connection connection;
@@ -28,7 +27,7 @@ public class DataBind implements DataBinder {
   protected int pos;
   private String json;
 
-  private Object lastObject = UNBOUND;
+  private Object lastObject = null;
 
   public DataBind(DataTimeZone dataTimeZone, PreparedStatement pstmt, Connection connection) {
     this.dataTimeZone = dataTimeZone;
@@ -259,10 +258,7 @@ public class DataBind implements DataBinder {
   @Override
   public Object popLastObject() {
     Object ret = lastObject;
-    lastObject = UNBOUND;
-    if (ret == UNBOUND) {
-      throw new IllegalStateException("No object bound");
-    }
+    lastObject = null;
     return ret;
   }
 }

--- a/ebean-test/src/test/java/org/tests/basic/TestLength.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLength.java
@@ -1,0 +1,101 @@
+package org.tests.basic;
+
+import io.ebean.DB;
+import io.ebean.DataIntegrityException;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+import org.tests.model.json.EBasicJsonList;
+import org.tests.model.json.EBasicJsonMap;
+import org.tests.model.types.SomeFileBean;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Roland Praml, FOCONIS AG
+ */
+public class TestLength extends BaseTestCase {
+
+  @Test
+  void testFileSize() throws IOException {
+    File f1 = File.createTempFile("testfile", "tmp");
+    byte[] buf = new byte[1024];
+    try (FileOutputStream fos = new FileOutputStream(f1)) {
+      for (int i = 0; i < 100; i++) {
+        fos.write(buf);
+      }
+    }
+
+    SomeFileBean sfb1 = new SomeFileBean();
+    sfb1.setContent(f1);
+    DB.save(sfb1);
+
+    try (FileOutputStream fos = new FileOutputStream(f1)) {
+      for (int i = 0; i < 101; i++) {
+        fos.write(buf);
+      }
+    }
+
+    SomeFileBean sfb2 = new SomeFileBean();
+    sfb2.setContent(f1);
+    assertThatThrownBy(() -> DB.save(sfb2)).isInstanceOf(DataIntegrityException.class);
+  }
+
+
+  /**
+   * The property 'EBasicJsonMap.content' is annotated with @DbJson(length=5000). So we assume, that we cannot save Json-objects
+   * where the serialized form exceed that limit and we would expect an error on save.
+   * The length check works for platforms like h2, as H2 uses a 'varchar(5000)'. So it is impossible to save such long jsons,
+   * but it won't work for SqlServer, as here 'nvarchar(max)' is used. No validation happens at DB level and you might get very
+   * large Json objects in your database. This mostly happens unintentionally (programming error, misconfiguration)
+   * So they are in the database and they cannot be accessed by ebean any more, because there are new limits in Jackson:
+   * - Max 5 Meg per string in 2.15.0
+   * - Max 20 Meg per string in 2.15.1
+   * see https://github.com/FasterXML/jackson-core/issues/1014
+   */
+  @Test
+  void testLongString() {
+    // s is so big, that it could not be deserialized by jackson
+    String s = new String(new char[20_000_001]).replace('\0', 'x');
+
+    EBasicJsonMap bean = new EBasicJsonMap();
+    bean.setName("b1");
+    bean.setContent(Map.of("string", s));
+
+    assertThatThrownBy(() -> {
+      // we expect, that we can NOT save the bean, this is ensured by the bind validator.
+      DB.save(bean);
+    }).isInstanceOf(DataIntegrityException.class);
+
+  }
+
+
+  /**
+   * Tests the UTF8 validation.
+   */
+  @Test
+  void testUtf8() {
+
+    String s = new String(new char[40]).replace('\0', '€');
+
+    EBasicJsonList bean = new EBasicJsonList();
+    bean.setName("b1");
+    bean.setTags(List.of(s));
+
+    if (isDb2() || isOracle()) {
+      // by default, DB2 && oracle uses bytes in varchar, so an '€' symbol needs 3 bytes
+      assertThatThrownBy(() -> {
+        // we expect, that we can NOT save the bean, this is ensured by the bind validator.
+        DB.save(bean);
+      }).isInstanceOf(DataIntegrityException.class);
+    } else {
+      DB.save(bean);
+    }
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/json/TestDbJsonLength.java
+++ b/ebean-test/src/test/java/org/tests/json/TestDbJsonLength.java
@@ -1,0 +1,52 @@
+package org.tests.json;
+
+import io.ebean.DB;
+import io.ebean.DataIntegrityException;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.tests.model.json.EBasicJsonMap;
+
+import java.util.Map;
+
+class TestDbJsonLength {
+
+
+    /**
+   * The property 'EBasicJsonMap.content' is annotated with @DbJson(length=5000). So we assume, that we cannot save Json-objects
+   * where the serialized form exceed that limit and we would expect an error on save.
+   * The length check works for platforms like h2, as H2 uses a 'varchar(5000)'. So it is impossible to save such long jsons,
+   * but it won't work for SqlServer, as here 'nvarchar(max)' is used. No validation happens at DB level and you might get very
+   * large Json objects in your database. This mostly happens unintentionally (programming error, misconfiguration)
+   * So they are in the database and they cannot be accessed by ebean any more, because there are new limits in Jackson:
+   * - Max 5 Meg per string in 2.15.0
+   * - Max 20 Meg per string in 2.15.1
+   * see https://github.com/FasterXML/jackson-core/issues/1014
+   */
+  @Test
+  void testLongString() {
+    // s is so big, that it could not be deserialized by jackson
+    String s = new String(new char[20_000_001]).replace('\0', 'x');
+
+    EBasicJsonMap bean = new EBasicJsonMap();
+    bean.setName("b1");
+    bean.setContent(Map.of("string", s));
+
+    SoftAssertions softly = new SoftAssertions();
+
+    softly.assertThatThrownBy(() -> {
+      DB.save(bean);
+    }).isInstanceOf(DataIntegrityException.class);
+
+
+    if (bean.getId() != null) {
+      // we expect, that we could NOT save the bean, but this is not true for sqlServer.
+      // we will get a javax.persistence.PersistenceException: Error loading on org.tests.model.json.EBasicJsonMap.content
+      // when we try to load the bean back from DB
+      DB.find(EBasicJsonMap.class, bean.getId());
+    }
+
+    softly.assertAll();
+
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/model/json/EBasicJsonMap.java
+++ b/ebean-test/src/test/java/org/tests/model/json/EBasicJsonMap.java
@@ -18,7 +18,7 @@ public class EBasicJsonMap {
 
   String name;
 
-  @DbJson
+  @DbJson(length = 5000)
   Map<String, Object> content;
 
   @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)

--- a/ebean-test/src/test/java/org/tests/model/types/SomeFileBean.java
+++ b/ebean-test/src/test/java/org/tests/model/types/SomeFileBean.java
@@ -1,9 +1,6 @@
 package org.tests.model.types;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
-import javax.persistence.Version;
+import javax.persistence.*;
 import java.io.File;
 
 @Entity
@@ -18,6 +15,7 @@ public class SomeFileBean {
   String name;
 
   @Lob
+  @Column(length = 100 * 1024) // limit to 100kb
   File content;
 
   public Long getId() {

--- a/ebean-test/testconfig/ebean-db2.properties
+++ b/ebean-test/testconfig/ebean-db2.properties
@@ -5,3 +5,4 @@ ebean.test.username=admin
 ebean.test.password=admin
 datasource.default=db2-11
 ebean.db2-11.databasePlatformName=db2luw
+ebean.lengthCheck=utf8

--- a/ebean-test/testconfig/ebean-oracle.properties
+++ b/ebean-test/testconfig/ebean-oracle.properties
@@ -1,3 +1,4 @@
 ebean.test.platform=oracle
 ebean.test.dbName=test_eb
 datasource.default=oracle
+ebean.lengthCheck=utf8

--- a/ebean-test/testconfig/ebean-sqlserver19.properties
+++ b/ebean-test/testconfig/ebean-sqlserver19.properties
@@ -7,6 +7,7 @@ ebean.test.sqlserver.port=9434
 ebean.test.sqlserver.url=jdbc:sqlserver://localhost:9434;databaseName=test_ebean;sendTimeAsDateTime=false;integratedSecurity=false;trustServerCertificate=true
 datasource.default=sqlserver2019
 ebean.sqlserver2019.databasePlatformName=sqlserver17
+ebean.lengthCheck=on
 
 ## A case sensitive collation example:
 #ebean.test.sqlserver.collation=LATIN1_GENERAL_100_CI_AS_SC_UTF8

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <nexus.staging.keepStagingRepositoryOnFailure>true</nexus.staging.keepStagingRepositoryOnFailure>
     <nexus.staging.skipStagingRepositoryClose>true</nexus.staging.skipStagingRepositoryClose>
     <nexus.staging.autoReleaseAfterClose>false</nexus.staging.autoReleaseAfterClose>
-    <jackson.version>2.15.0</jackson.version>
+    <jackson.version>2.15.2</jackson.version>
     <h2database.version>2.1.214</h2database.version>
     <ebean-persistence-api.version>3.0</ebean-persistence-api.version>
     <ebean-types.version>3.0</ebean-types.version>


### PR DESCRIPTION
Hello Rob,

thanks for the feedback in #3115. First I want to explain what I want:

**What do I need**

When I save a JSON/Varchar/File that exceedes the defined db-length, I want an exception on every platform
While H2 enforces these constraints on DB level, other platforms do not and allow to store gigabytes in such fields

**Why do I need this** 

I need this to detect programming errors, misconfiguration and misuse early. 
1) A Json field, where I do not expect more than 4K should not be filled with some GB
2) Same for a field, where the user can write down some notes (expected < 32k) 
3) A file field, where I expect a file less than 1MB should not be misused by the user with a 700MB ISO image ;)

**Can this implemented in the application**

Partially. While 2 + 3 are implemented with `@Size` + BeanValidation in our application, I fail to implement this in our application, as I do not have access to the JSON, that ebean will write. Of course, I can serialize such beans twice, but I still see the problem to get BeanValidation working.

I tried different approaches the last days and also spent hours of implementing something that will not work ;-)

- Tried to change the return value from `ScalarType.bind(DataBinder binder, T value)` from void to Object, so that bind returns, what it has effectively bound. Problem: API change -> Breaks external modules
- Wondering, if I should implement the validation in ScalarType. Problem: Currently there is a singleton instance of ScalarTypeString. I did not want to change this
- So the most promising approach seems to "capture" the last value in the DataBinder. I am still wondering, if I should focus only on strings, arrays and files here.

The next problem is, when and how to enable this feature. While H2 performs all checks itself, I explicitly had to switch this on on other platforms. Oracle and DB2 are special cases, as they define the varchar limit on byte level (I assume, other platforms will do that also, depending on the underlying charset)

So maybe you can give me a hint in what direction I should go.
(I would also be satisfied if I could determine on the application side if a JSON object is getting too large.)
