### PR TITLE
#3109 Fix for JtaTransactionManager when no active transaction

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
@@ -78,8 +78,9 @@ public final class JtaTransactionManager implements ExternalTransactionManager {
    */
   @Override
   public Object getCurrentTransaction() {
-    TransactionSynchronizationRegistry syncRegistry = registry();
+    TransactionSynchronizationRegistry syncRegistry;
     try {
+      syncRegistry = registry();
       SpiTransaction t = (SpiTransaction) syncRegistry.getResource(EBEAN_TXN_RESOURCE);
       if (t != null) {
         // we have already seen this transaction


### PR DESCRIPTION
The call to registry() can throw an exception so
pulling that inside the try catch block and handle that as no active transaction returning null.