### PR TITLE
Add query.usingMaster() to explicitly choose master data source

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DtoQuery.java
+++ b/ebean-api/src/main/java/io/ebean/DtoQuery.java
@@ -205,4 +205,16 @@ public interface DtoQuery<T> extends CancelableQuery {
    * Use the explicit transaction to execute the query.
    */
   DtoQuery<T> usingTransaction(Transaction transaction);
+
+  /**
+   * Ensure that the master DataSource is used if there is a read only data source
+   * being used (that is using a read replica database potentially with replication lag).
+   * <p>
+   * When the database is configured with a read-only DataSource via
+   * say {@link io.ebean.config.DatabaseConfig#setReadOnlyDataSource(DataSource)} then
+   * by default when a query is run without an active transaction, it uses the read-only data
+   * source. We we use {@code usingMaster()} to instead ensure that the query is executed
+   * against the master data source.
+   */
+  DtoQuery<T> usingMaster();
 }

--- a/ebean-api/src/main/java/io/ebean/Query.java
+++ b/ebean-api/src/main/java/io/ebean/Query.java
@@ -4,6 +4,7 @@ import io.avaje.lang.NonNullApi;
 import io.avaje.lang.Nullable;
 
 import javax.persistence.NonUniqueResultException;
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.Timestamp;
 import java.util.List;
@@ -684,6 +685,18 @@ public interface Query<T> extends CancelableQuery {
    * Execute the query using the given database.
    */
   Query<T> usingDatabase(Database database);
+
+  /**
+   * Ensure that the master DataSource is used if there is a read only data source
+   * being used (that is using a read replica database potentially with replication lag).
+   * <p>
+   * When the database is configured with a read-only DataSource via
+   * say {@link io.ebean.config.DatabaseConfig#setReadOnlyDataSource(DataSource)} then
+   * by default when a query is run without an active transaction, it uses the read-only data
+   * source. We we use {@code usingMaster()} to instead ensure that the query is executed
+   * against the master data source.
+   */
+  Query<T> usingMaster();
 
   /**
    * Execute the query returning the list of Id's.

--- a/ebean-api/src/main/java/io/ebean/SqlQuery.java
+++ b/ebean-api/src/main/java/io/ebean/SqlQuery.java
@@ -46,6 +46,18 @@ public interface SqlQuery extends Serializable, CancelableQuery {
   SqlQuery usingTransaction(Transaction transaction);
 
   /**
+   * Ensure that the master DataSource is used if there is a read only data source
+   * being used (that is using a read replica database potentially with replication lag).
+   * <p>
+   * When the database is configured with a read-only DataSource via
+   * say {@link io.ebean.config.DatabaseConfig#setReadOnlyDataSource(DataSource)} then
+   * by default when a query is run without an active transaction, it uses the read-only data
+   * source. We we use {@code usingMaster()} to instead ensure that the query is executed
+   * against the master data source.
+   */
+  SqlQuery usingMaster();
+
+  /**
    * Execute the query returning a list.
    */
   List<SqlRow> findList();

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
@@ -135,8 +135,9 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
    * Create a ServerTransaction for query purposes.
    *
    * @param tenantId For multi-tenant lazy loading provide the tenantId to use.
+   * @param useMaster Set to true when the query should use the master data source.
    */
-  SpiTransaction createReadOnlyTransaction(Object tenantId);
+  SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster);
 
   /**
    * An event from another server in the cluster used to notify local

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
@@ -236,6 +236,11 @@ public interface SpiQuery<T> extends Query<T>, SpiQueryFetch, TxnProfileEventCod
   String planLabel();
 
   /**
+   * Return true if this query should not use the read only data source.
+   */
+  boolean isUseMaster();
+
+  /**
    * Return true if this is a "find by id" query. This includes a check for a single "equal to" expression for the Id.
    */
   boolean isFindById();

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiSqlBinding.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiSqlBinding.java
@@ -6,6 +6,11 @@ package io.ebeaninternal.api;
 public interface SpiSqlBinding extends SpiCancelableQuery {
 
   /**
+   * Return true if this query should not use the read only data source.
+   */
+  boolean isUseMaster();
+
+  /**
    * Return the named or positioned parameters.
    */
   BindParams getBindParams();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/AbstractSqlQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/AbstractSqlQueryRequest.java
@@ -48,7 +48,7 @@ public abstract class AbstractSqlQueryRequest implements CancelableQuery {
       transaction = server.currentServerTransaction();
       if (transaction == null || !transaction.isActive()) {
         // create a local readOnly transaction
-        transaction = server.createReadOnlyTransaction(null);
+        transaction = server.createReadOnlyTransaction(null, query.isUseMaster());
         createdTransaction = true;
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -137,7 +137,7 @@ final class DefaultBeanLoader {
   private List<?> executeQuery(LoadRequest loadRequest, SpiQuery<?> query) {
     if (onIterateUseExtraTxn && loadRequest.isParentFindIterate()) {
       // MySql - we need a different transaction to execute the secondary query
-      SpiTransaction extraTxn = server.createReadOnlyTransaction(query.tenantId());
+      SpiTransaction extraTxn = server.createReadOnlyTransaction(query.tenantId(), query.isUseMaster());
       try {
         return server.findList(query, extraTxn);
       } finally {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -2123,8 +2123,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
-    return transactionManager.createReadOnlyTransaction(tenantId);
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
+    return transactionManager.createReadOnlyTransaction(tenantId, useMaster);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/MultiTenantDbCatalogSupplier.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/MultiTenantDbCatalogSupplier.java
@@ -56,7 +56,10 @@ final class MultiTenantDbCatalogSupplier implements DataSourceSupplier {
   }
 
   @Override
-  public Connection readOnlyConnection(Object tenantId) throws SQLException {
+  public Connection readOnlyConnection(Object tenantId, boolean useMaster) throws SQLException {
+    if (readOnly == null || useMaster) {
+      return catalogDataSource.getConnectionForTenant(tenantId);
+    }
     return readOnly.getConnectionForTenant(tenantId);
   }
 
@@ -103,7 +106,6 @@ final class MultiTenantDbCatalogSupplier implements DataSourceSupplier {
      */
     @Override
     public Connection getConnection() throws SQLException {
-
       Connection connection = dataSource.getConnection();
       connection.setCatalog(tenantCatalog());
       return connection;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/MultiTenantDbSchemaSupplier.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/MultiTenantDbSchemaSupplier.java
@@ -56,8 +56,12 @@ final class MultiTenantDbSchemaSupplier implements DataSourceSupplier {
   }
 
   @Override
-  public Connection readOnlyConnection(Object tenantId) throws SQLException {
-    return readOnly.getConnectionForTenant(tenantId);
+  public Connection readOnlyConnection(Object tenantId, boolean useMaster) throws SQLException {
+    if (readOnly == null || useMaster) {
+      return schemaDataSource.getConnectionForTenant(tenantId);
+    } else {
+      return readOnly.getConnectionForTenant(tenantId);
+    }
   }
 
   @Override
@@ -106,7 +110,6 @@ final class MultiTenantDbSchemaSupplier implements DataSourceSupplier {
      */
     @Override
     public Connection getConnection() throws SQLException {
-
       Connection connection = dataSource.getConnection();
       connection.setSchema(tenantSchema());
       return connection;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/MultiTenantDbSupplier.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/MultiTenantDbSupplier.java
@@ -43,8 +43,8 @@ final class MultiTenantDbSupplier implements DataSourceSupplier {
   }
 
   @Override
-  public Connection readOnlyConnection(Object tenantId) throws SQLException {
-    throw new SQLException("Not currently supported");
+  public Connection readOnlyConnection(Object tenantId, boolean useMaster) throws SQLException {
+    return dataSourceProvider.dataSource(tenantId).getConnection();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -220,7 +220,7 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
       } else {
         // create an implicit transaction to execute this query
         // potentially using read-only DataSource with autoCommit
-        transaction = server.createReadOnlyTransaction(query.tenantId());
+        transaction = server.createReadOnlyTransaction(query.tenantId(), query.isUseMaster());
       }
       createdTransaction = true;
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/SimpleDataSourceProvider.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/SimpleDataSourceProvider.java
@@ -41,8 +41,12 @@ final class SimpleDataSourceProvider implements DataSourceSupplier {
   }
 
   @Override
-  public Connection readOnlyConnection(Object tenantId) throws SQLException {
-    return readOnlyDataSource.getConnection();
+  public Connection readOnlyConnection(Object tenantId, boolean useMaster) throws SQLException {
+    if (readOnlyDataSource == null || useMaster) {
+      return dataSource.getConnection();
+    } else {
+      return readOnlyDataSource.getConnection();
+    }
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
@@ -235,6 +235,11 @@ final class DefaultFetchGroupQuery<T> implements SpiFetchGroupQuery<T>, SpiQuery
   }
 
   @Override
+  public Query<T> usingMaster() {
+    throw new RuntimeException("EB102: Not allowed on FetchGroup");
+  }
+
+  @Override
   public <A> List<A> findIds() {
     throw new RuntimeException("EB102: Only select() and fetch() clause is allowed on FetchGroup");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
@@ -236,7 +236,7 @@ final class DefaultFetchGroupQuery<T> implements SpiFetchGroupQuery<T>, SpiQuery
 
   @Override
   public Query<T> usingMaster() {
-    throw new RuntimeException("EB102: Not allowed on FetchGroup");
+    throw new RuntimeException("EB102: Only select() and fetch() clause is allowed on FetchGroup");
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/AbstractQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/AbstractQuery.java
@@ -18,6 +18,7 @@ public class AbstractQuery implements SpiCancelableQuery {
   private final ReentrantLock lock = new ReentrantLock();
   private boolean cancelled;
   private CancelableQuery cancelableQuery;
+  protected boolean useMaster;
 
   @Override
   public final void cancel() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
@@ -48,6 +48,7 @@ public final class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQue
     this.server = server;
     this.descriptor = descriptor;
     this.ormQuery = ormQuery;
+    this.useMaster = ormQuery.isUseMaster();
     this.label = ormQuery.label();
     this.profileLocation = ormQuery.profileLocation();
   }
@@ -86,6 +87,17 @@ public final class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQue
   public DtoQuery<T> usingTransaction(Transaction transaction) {
     this.transaction = transaction;
     return this;
+  }
+
+  @Override
+  public DtoQuery<T> usingMaster() {
+    this.useMaster = true;
+    return this;
+  }
+
+  @Override
+  public boolean isUseMaster() {
+    return useMaster;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -715,6 +715,7 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     // forUpdate is NOT copied - see #2762
     DefaultOrmQuery<T> copy = new DefaultOrmQuery<>(beanDescriptor, server, expressionFactory);
     copy.transaction = transaction;
+    copy.useMaster = useMaster;
     copy.m2mIncludeJoin = m2mIncludeJoin;
     copy.profilingListener = profilingListener;
     copy.profileLocation = profileLocation;
@@ -1394,6 +1395,17 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
   public final Query<T> usingDatabase(Database database) {
     this.server = (SpiEbeanServer) database;
     return this;
+  }
+
+  @Override
+  public Query<T> usingMaster() {
+    this.useMaster = true;
+    return this;
+  }
+
+  @Override
+  public boolean isUseMaster() {
+    return useMaster;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
@@ -49,6 +49,17 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
     return this;
   }
 
+  @Override
+  public SqlQuery usingMaster() {
+    this.useMaster = true;
+    return this;
+  }
+
+  @Override
+  public boolean isUseMaster() {
+    return useMaster;
+  }
+
   private void transaction(Transaction transaction) {
     this.transaction = transaction;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DataSourceSupplier.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DataSourceSupplier.java
@@ -43,10 +43,11 @@ public interface DataSourceSupplier {
   /**
    * Return a connection from the read only DataSource taking into account a tenantId for multi-tenant lazy loading.
    *
-   * @param tenantId Most often null but well supplied indicates a multi-tenant lazy loading query
+   * @param tenantId  Most often null but well supplied indicates a multi-tenant lazy loading query
+   * @param useMaster When true use the master data source
    * @return the connection to use
    */
-  Connection readOnlyConnection(Object tenantId) throws SQLException;
+  Connection readOnlyConnection(Object tenantId, boolean useMaster) throws SQLException;
 
   /**
    * Shutdown the datasource de-registering the JDBC driver if requested.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DocStoreTransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/DocStoreTransactionManager.java
@@ -24,7 +24,7 @@ public final class DocStoreTransactionManager extends TransactionManager {
   }
 
   @Override
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
     return new DocStoreOnlyTransaction(false, this);
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -65,7 +65,6 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
    * Create without a tenantId.
    */
   ImplicitReadOnlyTransaction(boolean useCommit, TransactionManager manager, Connection connection) {
-    this.useCommit = useCommit;
     this.manager = manager;
     this.logger = manager.loggerReadOnly();
     this.logSql = logger.isLogSql();
@@ -74,6 +73,11 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
     this.connection = connection;
     this.persistenceContext = new DefaultPersistenceContext();
     this.startNanos = System.nanoTime();
+    try {
+      this.useCommit = useCommit && !connection.getAutoCommit();
+    } catch (SQLException e) {
+      throw new PersistenceException(e);
+    }
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -519,15 +519,17 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
     if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
-    if (useCommit) {
-      try {
-        connection.commit();
-      } catch (SQLException e) {
-        throw new PersistenceException(e);
+    try {
+      if (useCommit) {
+        try {
+          connection.commit();
+        } catch (SQLException e) {
+          throw new PersistenceException(e);
+        }
       }
+    } finally {
+      deactivate();
     }
-    // expect AutoCommit so just deactivate / put back into pool
-    deactivate();
   }
 
   /**
@@ -569,15 +571,17 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
     if (!active) {
       throw new IllegalStateException(illegalStateMessage);
     }
-    if (useCommit) {
-      try {
-        connection.rollback();
-      } catch (SQLException e) {
-        throw new PersistenceException(e);
+    try {
+      if (useCommit) {
+        try {
+          connection.rollback();
+        } catch (SQLException e) {
+          throw new PersistenceException(e);
+        }
       }
+    } finally {
+      deactivate();
     }
-    // expect AutoCommit so it really has already committed
-    deactivate();
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactory.java
@@ -21,9 +21,10 @@ abstract class TransactionFactory {
   /**
    * Return a new query only transaction.
    *
-   * @param tenantId The tenantId for lazy loading queries.
+   * @param tenantId  The tenantId for lazy loading queries.
+   * @param useMaster Explicitly use the master data source rather than read only data source
    */
-  abstract SpiTransaction createReadOnlyTransaction(Object tenantId);
+  abstract SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster);
 
   /**
    * Return a new transaction.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasic.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasic.java
@@ -25,7 +25,7 @@ class TransactionFactoryBasic extends TransactionFactory {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      return new ImplicitReadOnlyTransaction(manager, connection);
+      return new ImplicitReadOnlyTransaction(true, manager, connection);
     } catch (PersistenceException ex) {
       JdbcClose.close(connection);
       throw ex;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasic.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasic.java
@@ -13,7 +13,7 @@ import java.sql.SQLException;
  */
 class TransactionFactoryBasic extends TransactionFactory {
 
-  private final DataSource dataSource;
+  protected final DataSource dataSource;
 
   TransactionFactoryBasic(TransactionManager manager, DataSourceSupplier dataSourceSupplier) {
     super(manager);
@@ -21,12 +21,11 @@ class TransactionFactoryBasic extends TransactionFactory {
   }
 
   @Override
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
     Connection connection = null;
     try {
       connection = dataSource.getConnection();
-      return create(false, connection);
-
+      return new ImplicitReadOnlyTransaction(manager, connection);
     } catch (PersistenceException ex) {
       JdbcClose.close(connection);
       throw ex;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasicWithRead.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasicWithRead.java
@@ -30,7 +30,7 @@ final class TransactionFactoryBasicWithRead extends TransactionFactoryBasic {
     Connection connection = null;
     try {
       connection = useMaster ? dataSource.getConnection() : readOnlyDataSource.getConnection();
-      return new ImplicitReadOnlyTransaction(manager, connection);
+      return new ImplicitReadOnlyTransaction(useMaster, manager, connection);
     } catch (PersistenceException ex) {
       JdbcClose.close(connection);
       throw ex;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasicWithRead.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBasicWithRead.java
@@ -26,10 +26,10 @@ final class TransactionFactoryBasicWithRead extends TransactionFactoryBasic {
   }
 
   @Override
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
     Connection connection = null;
     try {
-      connection = readOnlyDataSource.getConnection();
+      connection = useMaster ? dataSource.getConnection() : readOnlyDataSource.getConnection();
       return new ImplicitReadOnlyTransaction(manager, connection);
     } catch (PersistenceException ex) {
       JdbcClose.close(connection);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryBuilder.java
@@ -11,7 +11,6 @@ final class TransactionFactoryBuilder {
    * Build and return based on multi-tenancy and read only DataSource.
    */
   static TransactionFactory build(TransactionManager manager, DataSourceSupplier dataSourceSupplier, CurrentTenantProvider tenantProvider) {
-
     boolean hasReadOnlyDataSource = dataSourceSupplier.readOnlyDataSource() != null;
     if (tenantProvider == null) {
       if (hasReadOnlyDataSource) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryTenant.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryTenant.java
@@ -24,7 +24,7 @@ class TransactionFactoryTenant extends TransactionFactory {
   }
 
   @Override
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
     return create(false, tenantId);
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryTenantWithRead.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionFactoryTenantWithRead.java
@@ -23,14 +23,14 @@ final class TransactionFactoryTenantWithRead extends TransactionFactoryTenant {
   }
 
   @Override
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
     Connection connection = null;
     try {
       if (tenantId == null) {
         // obtain the tenantId if the DataSource requires it
         tenantId = dataSourceSupplier.currentTenantId();
       }
-      connection = dataSourceSupplier.readOnlyConnection(tenantId);
+      connection = dataSourceSupplier.readOnlyConnection(tenantId, useMaster);
       return new ImplicitReadOnlyTransaction(manager, connection, tenantId);
     } catch (PersistenceException ex) {
       JdbcClose.close(connection);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -274,7 +274,7 @@ public class TransactionManager implements SpiTransactionManager {
 
   private SpiTransaction createTransaction(TxScope txScope) {
     if (txScope.isReadonly()) {
-      return createReadOnlyTransaction(null);
+      return createReadOnlyTransaction(null, false);
     } else {
       return createTransaction(true, txScope.getIsolationLevel());
     }
@@ -290,8 +290,8 @@ public class TransactionManager implements SpiTransactionManager {
   /**
    * Create a new Transaction for query only purposes (can use read only datasource).
    */
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
-    return transactionFactory.createReadOnlyTransaction(tenantId);
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
+    return transactionFactory.createReadOnlyTransaction(tenantId, useMaster);
   }
 
   /**

--- a/ebean-core/src/test/java/io/ebeaninternal/server/transaction/TransactionFactoryBasicWithReadTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/transaction/TransactionFactoryBasicWithReadTest.java
@@ -1,0 +1,62 @@
+package io.ebeaninternal.server.transaction;
+
+import io.ebeaninternal.api.SpiTransaction;
+import io.ebeaninternal.api.SpiTxnLogger;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class TransactionFactoryBasicWithReadTest {
+
+  @Test
+  void createReadOnlyTransaction_expect_usesMasterDataSource() throws SQLException {
+    var connection = mock(Connection.class);
+    var tm = mockTransactionManager();
+    var dataSource = mockDataSource(connection);
+    var dss = mock(DataSourceSupplier.class);
+    when(dss.dataSource()).thenReturn(dataSource);
+
+    var txnFactory = new TransactionFactoryBasicWithRead(tm, dss);
+
+    // act
+    SpiTransaction txn = txnFactory.createReadOnlyTransaction(null, true);
+
+    assertThat(txn).isNotNull();
+    verify(dataSource).getConnection(); // used the 'master' dataSource
+  }
+
+  @Test
+  void createReadOnlyTransaction_expect_usesReadOnlyDataSource() throws SQLException {
+    var tm = mockTransactionManager();
+    var connection = mock(Connection.class);
+    var readOnlyDataSource = mockDataSource(connection);
+
+    var dss = mock(DataSourceSupplier.class);
+    when(dss.readOnlyDataSource()).thenReturn(readOnlyDataSource);
+    var txnFactory = new TransactionFactoryBasicWithRead(tm, dss);
+
+    // act
+    SpiTransaction txn = txnFactory.createReadOnlyTransaction(null, false);
+
+    assertThat(txn).isNotNull();
+    verify(readOnlyDataSource).getConnection(); // used the 'read only' dataSource
+  }
+
+  private static DataSource mockDataSource(Connection dsConnection) throws SQLException {
+    var readOnlyDataSource = mock(DataSource.class);
+    when(readOnlyDataSource.getConnection()).thenReturn(dsConnection);
+    return readOnlyDataSource;
+  }
+
+  private static TransactionManager mockTransactionManager() {
+    var tm = mock(TransactionManager.class);
+    when(tm.loggerReadOnly()).thenReturn(mock(SpiTxnLogger.class));
+    return tm;
+  }
+}

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
@@ -118,6 +118,44 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
 //  }
 
   @Test
+  public void asDto_usingMaster() {
+    ResetBasicData.reset();
+    LoggedSql.start();
+
+    DtoQuery<ContactDto> query = DB.find(Contact.class)
+      .select("id, email")
+      .where().isNotNull("email")
+      .asDto(ContactDto.class)
+      .usingMaster();
+
+    List<ContactDto> dtos = query.findList();
+
+    assertThat(dtos).isNotEmpty();
+    for (ContactDto dto : dtos) {
+      assertThat(dto.getEmail()).isNotNull();
+    }
+  }
+
+  @Test
+  public void asDto_usingMaster2() {
+    ResetBasicData.reset();
+    LoggedSql.start();
+
+    DtoQuery<ContactDto> query = DB.find(Contact.class)
+      .select("id, email")
+      .usingMaster()
+      .where().isNotNull("email")
+      .asDto(ContactDto.class);
+
+    List<ContactDto> dtos = query.findList();
+
+    assertThat(dtos).isNotEmpty();
+    for (ContactDto dto : dtos) {
+      assertThat(dto.getEmail()).isNotNull();
+    }
+  }
+
+  @Test
   public void asDto_withExplicitId() {
 
     ResetBasicData.reset();

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
@@ -215,7 +215,7 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public SpiTransaction createReadOnlyTransaction(Object tenantId) {
+  public SpiTransaction createReadOnlyTransaction(Object tenantId, boolean useMaster) {
     return null;
   }
 

--- a/ebean-test/src/test/java/org/tests/basic/TestQueryUsingConnection.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestQueryUsingConnection.java
@@ -66,10 +66,12 @@ public class TestQueryUsingConnection extends BaseTestCase {
         .findCount();
 
       final int otherCount = DB.find(Country.class).findCount();
+      final int masterCount = DB.find(Country.class).usingMaster().findCount();
 
       transaction.rollback();
 
       assertThat(count).isEqualTo(otherCount + 1);
+      assertThat(otherCount).isEqualTo(masterCount);
     }
 
   }

--- a/ebean-test/src/test/java/org/tests/query/sqlquery/SqlQueryTests.java
+++ b/ebean-test/src/test/java/org/tests/query/sqlquery/SqlQueryTests.java
@@ -253,6 +253,19 @@ class SqlQueryTests extends BaseTestCase {
   }
 
   @Test
+  void queryUsingMaster() {
+    ResetBasicData.reset();
+
+    String sql = "select id, name, status from o_customer where name is not null";
+    List<CustDto> custDtos = DB.sqlQuery(sql)
+      .usingMaster()
+      .mapTo(CUST_MAPPER)
+      .findList();
+
+    assertThat(custDtos).isNotEmpty();
+  }
+
+  @Test
   void queryUsingTransaction() throws SQLException {
     ResetBasicData.reset();
     boolean h2 = isH2();


### PR DESCRIPTION
When we have a read replica with potential for replication lag, and config a read only DataSource to use that read replica, by default a query executed without a current transaction will use the read replica.

We specify usingMaster() when we explicitly want to execute a query and use the master data source.