### PR TITLE
Modify ebean-test H2Database setup to default KEY,VALUE as non-keywords

### DIFF
--- a/ebean-redis/src/test/java/org/domain/Person.java
+++ b/ebean-redis/src/test/java/org/domain/Person.java
@@ -28,6 +28,11 @@ public class Person extends EBase {
 
   String notes;
 
+  /**
+   * Test that KEY and VALUE are now by default not h2database keywords.
+   */
+  String key;
+
   public Person(String name) {
     this.name = name;
     this.status = Status.NEW;

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
@@ -50,6 +50,16 @@ class Config {
     this.properties = config.getProperties();
   }
 
+  /**
+   * Return the property given the key and default value.
+   */
+  String property(String key, String defaultValue) {
+    if (properties == null) {
+      return null;
+    }
+    return properties.getProperty(key, defaultValue);
+  }
+
   void setSchemaFromDbName(String newDbName) {
     this.schema = databaseName;
     this.databaseName = newDbName;

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/H2Setup.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/H2Setup.java
@@ -6,14 +6,17 @@ class H2Setup implements PlatformSetup {
 
   @Override
   public Properties setup(Config config) {
-
     config.ddlMode("create");
     config.setUsername("sa");
     config.setPassword("");
     config.setUrl("jdbc:h2:mem:${databaseName}");
     config.setDriver("org.h2.Driver");
-    config.datasourceDefaults();
+    var dataSourceConfig = config.datasourceDefaults();
 
+    String nonKeyWords = config.property("ebean.test.nonKeywords", "KEY,VALUE");
+    if (!nonKeyWords.isBlank()) {
+      dataSourceConfig.addProperty("NON_KEYWORDS", nonKeyWords);
+    }
     // return empty properties
     return new Properties();
   }


### PR DESCRIPTION
H2Database 2.x changed KEY and VALUE to be deemed keywords for SQL compliance. This is actually a bit of a pain as all the other databases we test allow KEY and VALUE as column names.

This changes the setup for H2Database to treat KEY and VALUE as non keywords as before and be more consistent with the other databases.