### PR TITLE
Adds configurable destination package for querybeans

### DIFF
--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -37,4 +37,7 @@ interface Constants {
 
   String AVAJE_LANG_NULLABLE = "io.avaje.lang.Nullable";
   String JAVA_COLLECTION = "java.util.Collection";
+
+  String DESTINATION_PACKAGE_OPTION = "querybeanDestPackage";
+  String ASSOC_DESTINATION_PACKAGE_OPTION = "querybeanAssocDestPackage";
 }

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -371,9 +371,9 @@ class ProcessingContext implements Constants {
    */
   private String packageAppend(String origPackage) {
     if (origPackage == null) {
-      return "query.assoc";
+      return String.join(".", getDestPackage(), getAssocDestPackage());
     } else {
-      return origPackage + "." + "query.assoc";
+      return origPackage + "." + String.join(".", getDestPackage(), getAssocDestPackage());
     }
   }
 
@@ -540,6 +540,22 @@ class ProcessingContext implements Constants {
       logError(null, "Error reading services file: " + e.getMessage());
     }
     return null;
+  }
+
+  String getDestPackage() {
+    String destPackage = processingEnv.getOptions().getOrDefault(DESTINATION_PACKAGE_OPTION, "query");
+    if(destPackage == null) {
+      destPackage = "";
+    }
+    return destPackage;
+  }
+
+  String getAssocDestPackage() {
+    String destPackage = processingEnv.getOptions().getOrDefault(ASSOC_DESTINATION_PACKAGE_OPTION, "assoc");
+    if(destPackage == null) {
+      destPackage = "";
+    }
+    return destPackage;
   }
 
   Element asElement(TypeMirror mirror) {

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -28,6 +28,14 @@ public class Processor extends AbstractProcessor implements Constants {
   }
 
   @Override
+  public Set<String> getSupportedOptions() {
+    Set<String> options = new LinkedHashSet<>();
+    options.add(DESTINATION_PACKAGE_OPTION);
+    options.add(ASSOC_DESTINATION_PACKAGE_OPTION);
+    return options;
+  }
+
+  @Override
   public Set<String> getSupportedAnnotationTypes() {
     Set<String> annotations = new LinkedHashSet<>();
     annotations.add(ENTITY);

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -32,6 +32,7 @@ class SimpleQueryBeanWriter {
   private boolean writingAssocBean;
 
   private String destPackage;
+  private final String assocPackage;
   private String origDestPackage;
   private String shortName;
   private final String shortInnerName;
@@ -43,7 +44,8 @@ class SimpleQueryBeanWriter {
     this.processingContext = processingContext;
     this.beanFullName = element.getQualifiedName().toString();
     boolean nested = element.getNestingKind().isNested();
-    this.destPackage = Util.packageOf(nested, beanFullName) + ".query";
+    this.destPackage = Util.packageOf(nested, beanFullName) + completePackagePath(processingContext.getDestPackage());
+    this.assocPackage = completePackagePath(processingContext.getAssocDestPackage());
     String sn = Util.shortName(nested, beanFullName);
     this.shortInnerName = Util.shortName(false, sn);
     this.shortName = sn.replace('.', '$');
@@ -437,6 +439,11 @@ class SimpleQueryBeanWriter {
   private Writer createFileWriter() throws IOException {
     JavaFileObject jfo = processingContext.createWriter(destPackage + "." + "Q" + shortName, element);
     return jfo.openWriter();
+  }
+
+
+  private String completePackagePath(String packageName) {
+    return (packageName.equals("") ? packageName : "." + packageName);
   }
 
 }

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -145,7 +145,7 @@ class SimpleQueryBeanWriter {
   void writeAssocBean() throws IOException {
     writingAssocBean = true;
     origDestPackage = destPackage;
-    destPackage = destPackage + ".assoc";
+    destPackage = destPackage + assocPackage;
     shortName = "Assoc" + shortName;
 
     prepareAssocBeanImports();


### PR DESCRIPTION
added compiler arguments to allow custom destination package suffix for querybeans. motivation behind this is to allow Entities to be package protected. With the .query + . assoc hardcoded this can't compile because the querybeans cannot find the enitities. Kept the default by omission as it was (.query + .assoc). Only did base querybean-generator, no changes were made to kotlin generator.