### PR TITLE
Change to loose json parsing for boolean and number types to allow string values

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBoolean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeBoolean.java
@@ -2,12 +2,7 @@ package io.ebeaninternal.server.type;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import io.ebean.core.type.DataBinder;
-import io.ebean.core.type.DataReader;
-import io.ebean.core.type.DocPropertyType;
-import io.ebean.core.type.ScalarTypeBase;
-import io.ebean.core.type.BasicTypeConverter;
+import io.ebean.core.type.*;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -348,8 +343,8 @@ public final class ScalarTypeBoolean {
     }
 
     @Override
-    public Boolean jsonRead(JsonParser parser) {
-      return JsonToken.VALUE_TRUE == parser.getCurrentToken() ? Boolean.TRUE : Boolean.FALSE;
+    public Boolean jsonRead(JsonParser parser) throws IOException {
+      return parser.getValueAsBoolean();
     }
 
     @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDouble.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeDouble.java
@@ -78,7 +78,7 @@ final class ScalarTypeDouble extends ScalarTypeBase<Double> {
 
   @Override
   public Double jsonRead(JsonParser parser) throws IOException {
-    return parser.getDoubleValue();
+    return parser.getValueAsDouble();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInteger.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeInteger.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.type;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import io.ebean.core.type.DataBinder;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.DocPropertyType;
@@ -88,7 +89,7 @@ final class ScalarTypeInteger extends ScalarTypeBase<Integer> {
 
   @Override
   public Integer jsonRead(JsonParser parser) throws IOException {
-    return parser.getIntValue();
+    return parser.getValueAsInt();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLong.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeLong.java
@@ -88,7 +88,7 @@ final class ScalarTypeLong extends ScalarTypeBase<Long> {
 
   @Override
   public Long jsonRead(JsonParser parser) throws IOException {
-    return parser.getLongValue();
+    return parser.getValueAsLong();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeYear.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeYear.java
@@ -83,7 +83,7 @@ final class ScalarTypeYear extends ScalarTypeBase<Year> {
 
   @Override
   public Year jsonRead(JsonParser parser) throws IOException {
-    return Year.of(parser.getIntValue());
+    return Year.of(parser.getValueAsInt());
   }
 
   @Override

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeIntegerTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeIntegerTest.java
@@ -1,7 +1,12 @@
 package io.ebeaninternal.server.type;
 
 
+import com.fasterxml.jackson.core.JsonParser;
+import io.ebean.DB;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,6 +22,20 @@ public class ScalarTypeIntegerTest {
   @Test
   public void format_when_integer() {
     assertThat(type.format(1)).isEqualTo("1");
+  }
+
+  @Test
+  public void json() throws IOException {
+
+    JsonParser parser = DB.json().createParser(new StringReader("1"));
+    parser.nextToken();
+    Object parsed = type.jsonRead(parser);
+    assertThat(parsed).isEqualTo(1);
+
+    parser = DB.json().createParser(new StringReader("\"1.0\""));
+    parser.nextToken();
+    parsed = type.jsonRead(parser);
+    assertThat(parsed).isEqualTo(1);
   }
 
 }


### PR DESCRIPTION
We use `parser.getValueAsXXX` as it does some auto-detection, if the data type does not match exactly.
This allows to read jsons from other sources, where numeric values are encoded as string òr boolean values are encoded as `1` or `0` or `"true"`,`"false"`