### PR TITLE
FIX: Rethrow error in commit path of callbacks

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -190,7 +190,6 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   }
 
 
-
   @Override
   public final void setAutoPersistUpdates(boolean autoPersistUpdates) {
     this.autoPersistUpdates = autoPersistUpdates;
@@ -251,7 +250,7 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
     callbackList.add(callback);
   }
 
-  private void withEachCallback(Consumer<TransactionCallback> consumer) {
+  private void withEachCallbackFailSilent(Consumer<TransactionCallback> consumer) {
     if (callbackList != null) {
       // using old style loop to cater for case when new callbacks are added recursively (as otherwise iterator fails fast)
       for (int i = 0; i < callbackList.size(); i++) {
@@ -259,17 +258,27 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
           consumer.accept(callbackList.get(i));
         } catch (Exception e) {
           log.log(ERROR, "Error executing transaction callback", e);
+          throw wrapIfNeeded(e);
         }
       }
     }
   }
 
+  private void withEachCallback(Consumer<TransactionCallback> consumer) {
+    if (callbackList != null) {
+      // using old style loop to cater for case when new callbacks are added recursively (as otherwise iterator fails fast)
+      for (int i = 0; i < callbackList.size(); i++) {
+        consumer.accept(callbackList.get(i));
+      }
+    }
+  }
+
   private void firePreRollback() {
-    withEachCallback(TransactionCallback::preRollback);
+    withEachCallbackFailSilent(TransactionCallback::preRollback);
   }
 
   private void firePostRollback() {
-    withEachCallback(TransactionCallback::postRollback);
+    withEachCallbackFailSilent(TransactionCallback::postRollback);
     if (changeLogHolder != null) {
       changeLogHolder.postRollback();
     }


### PR DESCRIPTION
**Actual behaviour**
If you have callbacks in your transaction and they fail due any reason, the error is just added to the log and subsequent callbacks will be invoked and finally the transaction will be commited

**Expected behaviour**
If a callback in the commit path (preCommit/postCommit) has a problem, the exception should be thrown up to the caller and the transaction should NOT be committed, if a preCommit hook fails.

In our situation, we performed a DB.save on an entity. The preCommit hook on that entity performed some DB access in an nested transaction. The JDBC driver failed with an error and the nested transaction perfomed a roll-back. As there were no save-points involved, the whole transaction is rolled back. For the caller the `DB.save` seems to be successful. We discovered the error, when we reviewed the logs and see that there was a problem.

Our suggestion is, that exceptions, that happen in a "preCommit" or "postCommit" hook should always be rethrown up to the caller.
For "preRollback" and "postRollback" we are a bit unsure, and we keep the behaviour as it is (log exception and continue)