### PR TITLE
FIX: TypeManager initialization fails, if Jackson is not on class path

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -120,10 +120,12 @@ public final class DefaultTypeManager implements TypeManager {
         if (mapper.markerAnnotation() != null) {
           return mapper;
         } else {
-          log.log(System.Logger.Level.WARNING, "Not using {0}, because markerAnnotation is null", mapper.getClass().getName());
+          log.log(System.Logger.Level.WARNING, "Not using {0}, because no marker annotation was provided. " +
+            "Please check, if there is a supported json library (e.g. jackson) on your classpath", mapper.getClass().getName());
         }
       } catch (NoClassDefFoundError e) {
-        log.log(System.Logger.Level.WARNING, "Not using {0}, because markerAnnotation is inacessible ({1})", mapper.getClass().getName(), e.getMessage());
+        log.log(System.Logger.Level.WARNING, "Can not use {0}. An error occured: {1}. " +
+          "Please check, if there is a supported json library (e.g. jackson) on your classpath", mapper.getClass().getName(), e.getMessage());
       }
     }
     return null;


### PR DESCRIPTION
If `ebean-jackson-mapper` but no jackson is on classpath, it can happen, that the service-loader finds the `ScalarJsonJacksonMapper` class, and ebean thinks, there is a jsonMapper, but when trying to call `jsonMapper.markerAnnotation()` you'll get a `NoClassDefFoundError`

This PR checks on initialization, if the markerAnnotation is accessible.