### PR TITLE
TEST: TestServerOffline

### DIFF
--- a/ebean-test/src/test/java/io/ebean/test/config/TestServerOffline.java
+++ b/ebean-test/src/test/java/io/ebean/test/config/TestServerOffline.java
@@ -20,7 +20,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import javax.persistence.PersistenceException;
+import jakarta.persistence.PersistenceException;
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,9 +67,6 @@ public class TestServerOffline {
     @Override
     public void dataSourceDown(DataSource dataSource, SQLException reason) {}
 
-    @Override
-    public void dataSourceWarning(DataSource dataSource, String msg) {}
-
   }
 
   @Test
@@ -89,8 +86,8 @@ public class TestServerOffline {
       DatabaseConfig config = config(props);
 
       LazyDatasourceInitializer alert = new LazyDatasourceInitializer() ;
-      config.getDataSourceConfig().setAlert(alert);
-      config.getDataSourceConfig().setHeartbeatFreqSecs(1);
+      config.getDataSourceConfig().alert(alert);
+      config.getDataSourceConfig().heartbeatFreqSecs(1);
 
       Database h2Offline = DatabaseFactory.create(config);
       alert.server = h2Offline;
@@ -147,7 +144,7 @@ public class TestServerOffline {
     config.loadFromProperties(props);
     config.setDefaultServer(false);
     config.setRegister(false);
-    config.getClasses().add(EBasicVer.class);
+    config.classes().add(EBasicVer.class);
     return config;
   }
 


### PR DESCRIPTION
While DB recovery during run should be fine, this test checks, if ebean can start up with an offline DB.

This might be important, if you fire up a stack in kubernetes and the DB is not yet ready or the DB has a network outage. What we do NOT want is, that the (web)application fails completely to start (as we cannot display some error page to the user)