### PR TITLE
Tidy IdBinderEmbedded - merge use of getIdProperty() and idSelect() 

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -87,7 +87,7 @@ final class DefaultBeanLoader {
       query.setLoadDescription("+lazy", null);
     }
 
-    query.select(parentDesc.idBinder().getIdProperty());
+    query.select(parentDesc.idBinder().idSelect());
     if (onlyIds) {
       query.fetch(many.name(), many.targetIdProperty());
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistDeferredRelationship.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistDeferredRelationship.java
@@ -44,7 +44,7 @@ public final class PersistDeferredRelationship {
       return; // could not bind: TODO: should we log/throw an error?
     }
     // bind the where clause for the bean
-    Object[] idValues = beanDescriptor.idBinder().getIdValues(bean);
+    Object[] idValues = beanDescriptor.idBinder().values(bean);
     for (int j = 0; j < idValues.length; j++) {
       sqlUpdate.setParameter(pos + j, idValues[j]);
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -530,10 +530,10 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       unidirectional.initialise(initContext);
     }
     idBinder.initialise();
-    idBinderInLHSSql = idBinder.getBindIdInSql(baseTableAlias);
-    idBinderIdSql = idBinder.getBindIdSql(baseTableAlias);
-    String idBinderInLHSSqlNoAlias = idBinder.getBindIdInSql(null);
-    String idEqualsSql = idBinder.getBindIdSql(null);
+    idBinderInLHSSql = idBinder.bindInSql(baseTableAlias);
+    idBinderIdSql = idBinder.bindEqSql(baseTableAlias);
+    String idBinderInLHSSqlNoAlias = idBinder.bindInSql(null);
+    String idEqualsSql = idBinder.bindEqSql(null);
     deleteByIdSql = "delete from " + baseTable + " where " + idEqualsSql;
     whereIdInSql = " where " + idBinderInLHSSqlNoAlias + " ";
     deleteByIdInSql = "delete from " + baseTable + whereIdInSql;
@@ -855,10 +855,10 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   private SqlUpdate deleteByIdList(List<Object> idList, DeleteMode mode) {
     String baseSql = mode.isHard() ? deleteByIdInSql : softDeleteByIdInSql;
     StringBuilder sb = new StringBuilder(baseSql);
-    String inClause = idBinder.getIdInValueExprDelete(idList.size());
+    String inClause = idBinder.idInValueExprDelete(idList.size());
     sb.append(inClause);
     DefaultSqlUpdate delete = new DefaultSqlUpdate(sb.toString());
-    idBinder.addIdInBindValues(delete, idList);
+    idBinder.addBindValues(delete, idList);
     return delete;
   }
 
@@ -869,7 +869,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   private SqlUpdate deleteById(Object id, DeleteMode mode) {
     String baseSql = mode.isHard() ? deleteByIdSql : softDeleteByIdSql;
     DefaultSqlUpdate sqlDelete = new DefaultSqlUpdate(baseSql);
-    Object[] bindValues = idBinder.getBindValues(id);
+    Object[] bindValues = idBinder.bindValues(id);
     for (Object bindValue : bindValues) {
       sqlDelete.setParameter(bindValue);
     }
@@ -1524,7 +1524,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * Return a Sql update statement to set the importedId value (deferred execution).
    */
   public String updateImportedIdSql(ImportedId prop) {
-    return "update " + baseTable + " set " + prop.importedIdClause() + " where " + idBinder.getBindIdSql(null);
+    return "update " + baseTable + " set " + prop.importedIdClause() + " where " + idBinder.bindEqSql(null);
   }
 
   /**
@@ -1618,7 +1618,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * Return a raw expression for 'where parent id in ...' clause.
    */
   String parentIdInExpr(int parentIdSize, String rawWhere) {
-    String inClause = idBinder.getIdInValueExpr(false, parentIdSize);
+    String inClause = idBinder.idInValueExpr(false, parentIdSize);
     return idBinder.isIdInExpandedForm() ? inClause : rawWhere + inClause;
   }
 
@@ -1671,7 +1671,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
     if (alias == null) {
       return idBinderIdSql;
     } else {
-      return idBinder.getBindIdSql(alias);
+      return idBinder.bindEqSql(alias);
     }
   }
 
@@ -1697,7 +1697,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * This 'flattens' any EmbeddedId or multiple Id property cases.
    */
   public Object[] bindIdValues(Object idValue) {
-    return idBinder.getBindValues(idValue);
+    return idBinder.bindValues(idValue);
   }
 
   @Override
@@ -2105,7 +2105,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * The usage is to provide simple id types for JSON processing (for embeddedId's).
    */
   public Object idForJson(Object bean) {
-    return idBinder.getIdForJson((EntityBean) bean);
+    return idBinder.convertForJson((EntityBean) bean);
   }
 
   /**
@@ -2114,7 +2114,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * The usage is to provide simple id types for JSON processing (for embeddedId's).
    */
   Object convertIdFromJson(Object idValue) {
-    return idBinder.convertIdFromJson(idValue);
+    return idBinder.convertFromJson(idValue);
   }
 
   /**
@@ -2122,7 +2122,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * included in the query.
    */
   public String defaultOrderBy() {
-    return idBinder.getDefaultOrderBy();
+    return idBinder.orderBy();
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -518,7 +518,7 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
     IdBinder idBinder = d.idBinder();
     if (idBinder instanceof IdBinderEmbedded) {
       IdBinderEmbedded embId = (IdBinderEmbedded) idBinder;
-      BeanDescriptor<?> idBeanDescriptor = embId.getIdBeanDescriptor();
+      BeanDescriptor<?> idBeanDescriptor = embId.descriptor();
       Class<?> idType = idBeanDescriptor.type();
       try {
         idType.getDeclaredMethod("hashCode");

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
@@ -122,7 +122,7 @@ public abstract class BeanPropertyAssoc<T> extends BeanProperty implements STree
       targetInheritInfo = targetDescriptor.inheritInfo();
       saveRecurseSkippable = targetDescriptor.isSaveRecurseSkippable();
       if (!targetIdBinder.isComplexId()) {
-        targetIdProperty = targetIdBinder.getIdProperty();
+        targetIdProperty = targetIdBinder.idSelect();
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
@@ -458,7 +458,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
    */
   @Override
   public Object[] assocIdValues(EntityBean bean) {
-    return targetDescriptor.idBinder().getIdValues(bean);
+    return targetDescriptor.idBinder().values(bean);
   }
 
   /**
@@ -466,7 +466,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
    */
   @Override
   public String assocIdExpression(String prefix, String operator) {
-    return targetDescriptor.idBinder().getAssocOneIdExpr(prefix, operator);
+    return targetDescriptor.idBinder().assocExpr(prefix, operator);
   }
 
   /**
@@ -474,7 +474,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
    */
   @Override
   public String assocIdInValueExpr(boolean not, int size) {
-    return targetDescriptor.idBinder().getIdInValueExpr(not, size);
+    return targetDescriptor.idBinder().idInValueExpr(not, size);
   }
 
   /**
@@ -482,7 +482,7 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
    */
   @Override
   public String assocIdInExpr(String prefix) {
-    return targetDescriptor.idBinder().getAssocIdInExpr(prefix);
+    return targetDescriptor.idBinder().assocInExpr(prefix);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManySqlHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManySqlHelp.java
@@ -218,7 +218,7 @@ class BeanPropertyAssocManySqlHelp<T> {
    */
   private String rawParentIdMultiBinder(String tableAlias, int size) {
     final String property = '(' + tableAlias + exportedProperties[0].getForeignDbColumn() + ')';
-    final String inValueExpr = descriptor.idBinder().getIdInValueExpr(false, size);
+    final String inValueExpr = descriptor.idBinder().idInValueExpr(false, size);
     return property + inValueExpr;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -246,7 +246,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   }
 
   private SqlUpdate deleteByParentIdList(List<Object> parentIds) {
-    String sql = deleteByParentIdInSql + targetIdBinder.getIdInValueExpr(false, parentIds.size());
+    String sql = deleteByParentIdInSql + targetIdBinder.idInValueExpr(false, parentIds.size());
     DefaultSqlUpdate delete = new DefaultSqlUpdate(sql);
     bindParentIds(delete, parentIds);
     return delete;
@@ -276,7 +276,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
 
   private List<Object> findIdsByParentIdList(List<Object> parentIds, Transaction t) {
     String rawWhere = deriveWhereParentIdSql(true);
-    String inClause = idBinder().getIdInValueExpr(false, parentIds.size());
+    String inClause = idBinder().idInValueExpr(false, parentIds.size());
     String expr = rawWhere + inClause;
     SpiEbeanServer server = server();
     Query<?> q = server.find(type());
@@ -487,7 +487,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
    */
   @Override
   public Object[] assocIdValues(EntityBean bean) {
-    return targetDescriptor.idBinder().getIdValues(bean);
+    return targetDescriptor.idBinder().values(bean);
   }
 
   /**
@@ -495,7 +495,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
    */
   @Override
   public String assocIdExpression(String prefix, String operator) {
-    return targetDescriptor.idBinder().getAssocOneIdExpr(prefix, operator);
+    return targetDescriptor.idBinder().assocExpr(prefix, operator);
   }
 
   /**
@@ -503,7 +503,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
    */
   @Override
   public String assocIdInValueExpr(boolean not, int size) {
-    return targetDescriptor.idBinder().getIdInValueExpr(not, size);
+    return targetDescriptor.idBinder().idInValueExpr(not, size);
   }
 
   /**
@@ -511,7 +511,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
    */
   @Override
   public String assocIdInExpr(String prefix) {
-    return targetDescriptor.idBinder().getAssocIdInExpr(prefix);
+    return targetDescriptor.idBinder().assocInExpr(prefix);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinder.java
@@ -44,15 +44,6 @@ public interface IdBinder {
   Object readData(DataInput dataInput) throws IOException;
 
   /**
-   * Return the name(s) of the Id property(s). Comma delimited if there is more
-   * than one.
-   * <p>
-   * This can be used to include in a query.
-   * </p>
-   */
-  String getIdProperty();
-
-  /**
    * Return the Id BeanProperty.
    */
   STreeProperty getBeanProperty();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinder.java
@@ -46,7 +46,7 @@ public interface IdBinder {
   /**
    * Return the Id BeanProperty.
    */
-  STreeProperty getBeanProperty();
+  STreeProperty beanProperty();
 
   /**
    * Find a BeanProperty that is mapped to the database column.
@@ -63,9 +63,14 @@ public interface IdBinder {
    * Return the default order by that may need to be used if the query includes
    * a many property.
    */
-  String getDefaultOrderBy();
+  String orderBy();
 
-  String getOrderBy(String pathPrefix, boolean ascending);
+  String orderBy(String pathPrefix, boolean ascending);
+
+  /**
+   * Return the id values for a given bean.
+   */
+  Object[] values(EntityBean bean);
 
   /**
    * Return the values as an array of scalar bindable values.
@@ -77,8 +82,7 @@ public interface IdBinder {
    * Added primarily for Query.addWhere().add(Expr.idEq()) support.
    * </p>
    */
-  Object[] getBindValues(Object idValue);
-
+  Object[] bindValues(Object idValue);
 
   /**
    * For EmbeddedId convert the idValue into a simple map.
@@ -87,7 +91,7 @@ public interface IdBinder {
    * This is used to provide a simple JSON serializable version of the id value.
    * </p>
    */
-  Object getIdForJson(EntityBean idValue);
+  Object convertForJson(EntityBean idValue);
 
   /**
    * For EmbeddedId the value is assumed to be a Map and this is
@@ -99,12 +103,7 @@ public interface IdBinder {
    * This is used to provide a simple JSON serializable version of the id value.
    * </p>
    */
-  Object convertIdFromJson(Object value);
-
-  /**
-   * Return the id values for a given bean.
-   */
-  Object[] getIdValues(EntityBean bean);
+  Object convertFromJson(Object value);
 
   /**
    * Build a string of the logical expressions.
@@ -112,12 +111,12 @@ public interface IdBinder {
    * Typically used to build a id = ? string.
    * </p>
    */
-  String getAssocOneIdExpr(String prefix, String operator);
+  String assocExpr(String prefix, String operator);
 
   /**
    * Return the logical id in expression taking into account embedded id's.
    */
-  String getAssocIdInExpr(String prefix);
+  String assocInExpr(String prefix);
 
   /**
    * Binds an id value to a prepared statement.
@@ -132,27 +131,27 @@ public interface IdBinder {
   /**
    * Binds multiple id value to an update.
    */
-  void addIdInBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> ids);
+  void addBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> ids);
 
   /**
    * Binds multiple id value to a request.
    */
-  void addIdInBindValues(SpiExpressionRequest request, Collection<?> ids);
+  void addBindValues(SpiExpressionRequest request, Collection<?> ids);
 
   /**
    * Return the sql for binding the id using an IN clause.
    */
-  String getBindIdInSql(String baseTableAlias);
+  String bindInSql(String baseTableAlias);
 
   /**
    * Return the binding expression (like "?" or "(?,?)")for the Id.
    */
-  String getIdInValueExpr(boolean not, int size);
+  String idInValueExpr(boolean not, int size);
 
   /**
    * Same as getIdInValueExpr but for delete by id.
    */
-  String getIdInValueExprDelete(int size);
+  String idInValueExprDelete(int size);
 
   void buildRawSqlSelectChain(String prefix, List<String> selectChain);
 
@@ -181,7 +180,7 @@ public interface IdBinder {
    * Return the sql for binding the id to. This includes table alias and columns
    * that make up the id.
    */
-  String getBindIdSql(String baseTableAlias);
+  String bindEqSql(String baseTableAlias);
 
   /**
    * Cast or convert the Id value if necessary and optionally set it.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmbedded.java
@@ -90,11 +90,6 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public String getIdProperty() {
-    return embIdProperty.name();
-  }
-
-  @Override
   public void buildRawSqlSelectChain(String prefix, List<String> selectChain) {
     if (!idClass) {
       prefix = SplitName.add(prefix, embIdProperty.name());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmbedded.java
@@ -81,11 +81,11 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public BeanProperty getBeanProperty() {
+  public BeanProperty beanProperty() {
     return embIdProperty;
   }
 
-  public BeanDescriptor<?> getIdBeanDescriptor() {
+  public BeanDescriptor<?> descriptor() {
     return idDesc;
   }
 
@@ -115,12 +115,12 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public String getDefaultOrderBy() {
-    return getOrderBy(null, true);
+  public String orderBy() {
+    return orderBy(null, true);
   }
 
   @Override
-  public String getOrderBy(String pathPrefix, boolean ascending) {
+  public String orderBy(String pathPrefix, boolean ascending) {
     final StringBuilder sb = new StringBuilder(100);
     for (int i = 0; i < props.length; i++) {
       if (i > 0) {
@@ -140,17 +140,17 @@ public final class IdBinderEmbedded implements IdBinder {
     return sb.toString();
   }
 
-  public BeanProperty[] getProperties() {
+  public BeanProperty[] properties() {
     return props;
   }
 
   @Override
-  public String getIdInValueExprDelete(int size) {
+  public String idInValueExprDelete(int size) {
     if (size <= 0) {
       throw new IndexOutOfBoundsException("The size must be at least 1");
     }
     if (!idInExpandedForm) {
-      return getIdInValueExpr(false, size);
+      return idInValueExpr(false, size);
     }
     final StringBuilder sb = new StringBuilder(80);
     sb.append("(");
@@ -172,7 +172,7 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public String getIdInValueExpr(boolean not, int size) {
+  public String idInValueExpr(boolean not, int size) {
     if (size <= 0) {
       throw new IndexOutOfBoundsException("The size must be at least 1");
     }
@@ -199,12 +199,12 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public Object[] getIdValues(EntityBean bean) {
-    return getBindValues(embIdProperty.getValue(bean));
+  public Object[] values(EntityBean bean) {
+    return bindValues(embIdProperty.getValue(bean));
   }
 
   @Override
-  public Object[] getBindValues(Object value) {
+  public Object[] bindValues(Object value) {
     final EntityBean bean = (EntityBean) value;
     final Object[] bindValues = new Object[props.length];
     for (int i = 0; i < props.length; i++) {
@@ -217,7 +217,7 @@ public final class IdBinderEmbedded implements IdBinder {
    * Convert from embedded bean to Map.
    */
   @Override
-  public Object getIdForJson(EntityBean bean) {
+  public Object convertForJson(EntityBean bean) {
     final EntityBean ebValue = (EntityBean) embIdProperty.getValue(bean);
     final Map<String, Object> map = new LinkedHashMap<>();
     for (BeanProperty prop : props) {
@@ -231,7 +231,7 @@ public final class IdBinderEmbedded implements IdBinder {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public Object convertIdFromJson(Object value) {
+  public Object convertFromJson(Object value) {
     final Map<String, Object> map = (Map<String, Object>) value;
     final EntityBean idValue = idDesc.createEntityBean();
     for (BeanProperty prop : props) {
@@ -257,14 +257,14 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public void addIdInBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> values) {
+  public void addBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> values) {
     for (Object value : values) {
       bindId(sqlUpdate, value);
     }
   }
 
   @Override
-  public void addIdInBindValues(SpiExpressionRequest request, Collection<?> values) {
+  public void addBindValues(SpiExpressionRequest request, Collection<?> values) {
     for (Object value : values) {
       final EntityBean bean = (EntityBean) value;
       for (BeanProperty prop : props) {
@@ -335,7 +335,7 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public String getAssocIdInExpr(String prefix) {
+  public String assocInExpr(String prefix) {
     final StringBuilder sb = new StringBuilder(80);
     sb.append("(");
     for (int i = 0; i < props.length; i++) {
@@ -352,7 +352,7 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public String getAssocOneIdExpr(String prefix, String operator) {
+  public String assocExpr(String prefix, String operator) {
     final StringBuilder sb = new StringBuilder(100);
     for (int i = 0; i < props.length; i++) {
       if (i > 0) {
@@ -370,7 +370,7 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public String getBindIdSql(String baseTableAlias) {
+  public String bindEqSql(String baseTableAlias) {
     final StringBuilder sb = new StringBuilder(80);
     for (int i = 0; i < props.length; i++) {
       if (i > 0) {
@@ -385,7 +385,7 @@ public final class IdBinderEmbedded implements IdBinder {
   }
 
   @Override
-  public String getBindIdInSql(String baseTableAlias) {
+  public String bindInSql(String baseTableAlias) {
     if (idInExpandedForm) {
       return "";
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmpty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmpty.java
@@ -52,11 +52,6 @@ final class IdBinderEmpty implements IdBinder {
   }
 
   @Override
-  public String getIdProperty() {
-    return null;
-  }
-
-  @Override
   public BeanProperty findBeanProperty(String dbColumnName) {
     return null;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmpty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderEmpty.java
@@ -38,7 +38,7 @@ final class IdBinderEmpty implements IdBinder {
   }
 
   @Override
-  public String getOrderBy(String pathPrefix, boolean ascending) {
+  public String orderBy(String pathPrefix, boolean ascending) {
     return pathPrefix;
   }
 
@@ -47,7 +47,7 @@ final class IdBinderEmpty implements IdBinder {
   }
 
   @Override
-  public BeanProperty getBeanProperty() {
+  public BeanProperty beanProperty() {
     return null;
   }
 
@@ -62,58 +62,58 @@ final class IdBinderEmpty implements IdBinder {
   }
 
   @Override
-  public String getDefaultOrderBy() {
+  public String orderBy() {
     // this should never happen?
     return "";
   }
 
   @Override
-  public String getBindIdSql(String baseTableAlias) {
+  public String bindEqSql(String baseTableAlias) {
     return bindIdSql;
   }
 
   @Override
-  public String getAssocOneIdExpr(String prefix, String operator) {
+  public String assocExpr(String prefix, String operator) {
     return null;
   }
 
   @Override
-  public String getAssocIdInExpr(String prefix) {
+  public String assocInExpr(String prefix) {
     return null;
   }
 
   @Override
-  public String getIdInValueExprDelete(int size) {
-    return getIdInValueExpr(false, size);
+  public String idInValueExprDelete(int size) {
+    return idInValueExpr(false, size);
   }
 
   @Override
-  public String getIdInValueExpr(boolean not, int size) {
+  public String idInValueExpr(boolean not, int size) {
     return "";
   }
 
   @Override
-  public String getBindIdInSql(String baseTableAlias) {
+  public String bindInSql(String baseTableAlias) {
     return null;
   }
 
   @Override
-  public Object[] getIdValues(EntityBean bean) {
+  public Object[] values(EntityBean bean) {
     return null;
   }
 
   @Override
-  public Object[] getBindValues(Object idValue) {
+  public Object[] bindValues(Object idValue) {
     return new Object[]{idValue};
   }
 
   @Override
-  public Object getIdForJson(EntityBean bean) {
+  public Object convertForJson(EntityBean bean) {
     return null;
   }
 
   @Override
-  public Object convertIdFromJson(Object value) {
+  public Object convertFromJson(Object value) {
     return value;
   }
 
@@ -126,11 +126,11 @@ final class IdBinderEmpty implements IdBinder {
   }
 
   @Override
-  public void addIdInBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> ids) {
+  public void addBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> ids) {
   }
 
   @Override
-  public void addIdInBindValues(SpiExpressionRequest request, Collection<?> ids) {
+  public void addBindValues(SpiExpressionRequest request, Collection<?> ids) {
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
@@ -79,11 +79,6 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public String getIdProperty() {
-    return idProperty.name();
-  }
-
-  @Override
   public BeanProperty findBeanProperty(String dbColumnName) {
     if (dbColumnName.equalsIgnoreCase(idProperty.dbColumn())) {
       return idProperty;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
@@ -56,7 +56,7 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public String getOrderBy(String pathPrefix, boolean ascending) {
+  public String orderBy(String pathPrefix, boolean ascending) {
     StringBuilder sb = new StringBuilder();
     if (pathPrefix != null) {
       sb.append(pathPrefix).append(".");
@@ -74,7 +74,7 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public BeanProperty getBeanProperty() {
+  public BeanProperty beanProperty() {
     return idProperty;
   }
 
@@ -92,12 +92,12 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public String getDefaultOrderBy() {
+  public String orderBy() {
     return idProperty.name();
   }
 
   @Override
-  public String getBindIdInSql(String baseTableAlias) {
+  public String bindInSql(String baseTableAlias) {
     if (baseTableAlias == null) {
       return idProperty.dbColumn();
     } else {
@@ -106,7 +106,7 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public String getBindIdSql(String baseTableAlias) {
+  public String bindEqSql(String baseTableAlias) {
     if (baseTableAlias == null) {
       return bindIdSql;
     } else {
@@ -115,22 +115,22 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public Object[] getIdValues(EntityBean bean) {
+  public Object[] values(EntityBean bean) {
     return new Object[]{idProperty.getValue(bean)};
   }
 
   @Override
-  public Object[] getBindValues(Object idValue) {
+  public Object[] bindValues(Object idValue) {
     return new Object[]{idValue};
   }
 
   @Override
-  public String getIdInValueExprDelete(int size) {
-    return getIdInValueExpr(false, size);
+  public String idInValueExprDelete(int size) {
+    return idInValueExpr(false, size);
   }
 
   @Override
-  public String getIdInValueExpr(boolean not, int size) {
+  public String idInValueExpr(boolean not, int size) {
     if (size <= 0) {
       throw new IndexOutOfBoundsException("The size must be at least 1");
     }
@@ -138,24 +138,24 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public void addIdInBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> ids) {
+  public void addBindValues(DefaultSqlUpdate sqlUpdate, Collection<?> ids) {
     sqlUpdate.setParameter(new MultiValueWrapper(ids));
   }
 
   @Override
-  public void addIdInBindValues(SpiExpressionRequest request, Collection<?> values) {
+  public void addBindValues(SpiExpressionRequest request, Collection<?> values) {
     List<Object> copy = new ArrayList<>(values);
     copy.replaceAll(idValue -> convertSetId(idValue, null));
     request.addBindValue(new MultiValueWrapper(copy));
   }
 
   @Override
-  public Object getIdForJson(EntityBean bean) {
+  public Object convertForJson(EntityBean bean) {
     return idProperty.getValue(bean);
   }
 
   @Override
-  public Object convertIdFromJson(Object value) {
+  public Object convertFromJson(Object value) {
     // handle simple type conversion if required
     return convertId(value);
   }
@@ -208,11 +208,11 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public String getAssocOneIdExpr(String prefix, String operator) {
-    StringBuilder sb = new StringBuilder();
+  public String assocExpr(String prefix, String operator) {
+    StringBuilder sb = new StringBuilder(25);
     if (prefix != null) {
       sb.append(prefix);
-      sb.append(".");
+      sb.append('.');
     }
     sb.append(idProperty.name());
     sb.append(operator);
@@ -220,7 +220,7 @@ public final class IdBinderSimple implements IdBinder {
   }
 
   @Override
-  public String getAssocIdInExpr(String prefix) {
+  public String assocInExpr(String prefix) {
     StringBuilder sb = new StringBuilder();
     if (prefix != null) {
       sb.append(prefix);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/IdInExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/IdInExpression.java
@@ -66,7 +66,7 @@ public final class IdInExpression extends NonPrepareExpression implements IdInCo
       return;
     }
     // Bind the ID values including EmbeddedId and multiple ID
-    request.descriptor().idBinder().addIdInBindValues(request, idCollection);
+    request.descriptor().idBinder().addBindValues(request, idCollection);
   }
 
   /**
@@ -77,8 +77,8 @@ public final class IdInExpression extends NonPrepareExpression implements IdInCo
       request.append(SQL_FALSE); // append false for this stage
     } else {
       final BeanDescriptor<?> descriptor = request.descriptor();
-      request.property(descriptor.idBinder().getBindIdInSql(null));
-      request.append(descriptor.idBinder().getIdInValueExpr(false, idCollection.size()));
+      request.property(descriptor.idBinder().bindInSql(null));
+      request.append(descriptor.idBinder().idInValueExpr(false, idCollection.size()));
     }
   }
 
@@ -91,9 +91,9 @@ public final class IdInExpression extends NonPrepareExpression implements IdInCo
       final IdBinder idBinder = descriptor.idBinder();
       if (idBinder.isComplexId()) {
         request.parse(descriptor.idBinderInLHSSql());
-        request.append(idBinder.getIdInValueExpr(false, idCollection.size()));
+        request.append(idBinder.idInValueExpr(false, idCollection.size()));
       } else {
-        request.property(idBinder.getBeanProperty().name());
+        request.property(idBinder.beanProperty().name());
         request.appendInExpression(false, idCollection);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryOrderBy.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryOrderBy.java
@@ -59,7 +59,7 @@ final class CQueryOrderBy {
     if (beanProperty instanceof BeanPropertyAssoc<?>) {
       BeanPropertyAssoc<?> ap = (BeanPropertyAssoc<?>) beanProperty;
       IdBinder idBinder = ap.targetDescriptor().idBinder();
-      return idBinder.getOrderBy(el.elName(), p.isAscending());
+      return idBinder.orderBy(el.elName(), p.isAscending());
     }
     return p.toStringFormat();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeLoadBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeLoadBean.java
@@ -81,7 +81,7 @@ class SqlTreeLoadBean implements SqlTreeLoad {
       // if we have no property ask first children (in a distinct select with join)
       if (children.length == 0) {
         // expected to be a findIds query
-        return desc.idBinder().getBeanProperty();
+        return desc.idBinder().beanProperty();
       }
       return children[0].singleAttributeReader();
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
@@ -159,7 +159,7 @@ class SqlTreeNodeBean implements SqlTreeNode {
       lazyLoadParent.addSelectExported(ctx, prefix);
     }
     if (readId) {
-      appendSelectId(ctx, idBinder.getBeanProperty());
+      appendSelectId(ctx, idBinder.beanProperty());
     }
     for (STreeProperty property : properties) {
       if (!property.isAggregation()) {
@@ -201,7 +201,7 @@ class SqlTreeNodeBean implements SqlTreeNode {
       if (!subQuery && inheritInfo != null) {
         ctx.appendColumn(inheritInfo.getDiscriminatorColumn());
       }
-      appendSelectId(ctx, idBinder.getBeanProperty());
+      appendSelectId(ctx, idBinder.beanProperty());
     }
     appendSelect(ctx, subQuery, properties);
     for (SqlTreeNode child : children) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeManyRoot.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeManyRoot.java
@@ -30,7 +30,7 @@ final class SqlTreeNodeManyRoot extends SqlTreeNodeBean {
   @Override
   public void appendDistinctOn(DbSqlContext ctx, boolean subQuery) {
     ctx.pushTableAlias(prefix);
-    appendSelectId(ctx, idBinder.getBeanProperty());
+    appendSelectId(ctx, idBinder.beanProperty());
     ctx.popTableAlias();
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeRoot.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeRoot.java
@@ -45,7 +45,7 @@ final class SqlTreeNodeRoot extends SqlTreeNodeBean {
   public void appendDistinctOn(DbSqlContext ctx, boolean subQuery) {
     if (readId) {
       ctx.pushTableAlias(prefix);
-      appendSelectId(ctx, idBinder.getBeanProperty());
+      appendSelectId(ctx, idBinder.beanProperty());
       ctx.popTableAlias();
       super.appendDistinctOn(ctx, subQuery);
     }


### PR DESCRIPTION
To use idSelect(). Means we can remove getIdProperty()