### PR TITLE
Add support for literal mode for InTuples with lots of entries

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiExpressionRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiExpressionRequest.java
@@ -32,6 +32,11 @@ public interface SpiExpressionRequest {
   SpiOrmQueryRequest<?> queryRequest();
 
   /**
+   * Return the underling buffer.
+   */
+  StringBuilder buffer();
+
+  /**
    * Append to the expression sql without any parsing.
    */
   SpiExpressionRequest append(String expression);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionRequest.java
@@ -110,6 +110,11 @@ public final class DefaultExpressionRequest implements SpiExpressionRequest {
     return queryRequest;
   }
 
+  @Override
+  public StringBuilder buffer() {
+    return sql;
+  }
+
   /**
    * Append text the underlying sql expression.
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/InLiterals.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/InLiterals.java
@@ -1,0 +1,73 @@
+package io.ebeaninternal.server.expression;
+
+import io.ebean.annotation.Platform;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Adds values as literals to SQL string.
+ */
+interface InLiterals {
+
+  /**
+   * Add the value as a SQL literal to the buffer.
+   */
+  void append(StringBuilder buffer, Object value);
+
+  /**
+   * Return the InLiterals for the type of the given value.
+   */
+  static InLiterals of(Object val, Platform platform) {
+    if (val instanceof Number) {
+      return NumLiteral.INSTANCE;
+    }
+    if (val instanceof String || val instanceof UUID) {
+      return StrLiteral.INSTANCE;
+    }
+    if (val instanceof LocalDate) {
+      return platform.base() == Platform.MYSQL ? DateEscapeLiteral.INSTANCE : DateLiteral.INSTANCE;
+    }
+    throw new UnsupportedOperationException();
+  }
+
+  final class NumLiteral implements InLiterals {
+
+    static NumLiteral INSTANCE = new NumLiteral();
+
+    @Override
+    public void append(StringBuilder buffer, Object value) {
+      buffer.append(value);
+    }
+  }
+
+  final class StrLiteral implements InLiterals {
+
+    static StrLiteral INSTANCE = new StrLiteral();
+
+    @Override
+    public void append(StringBuilder buffer, Object value) {
+      buffer.append('\'').append(value).append('\'');
+    }
+  }
+
+  final class DateLiteral implements InLiterals {
+
+    static DateLiteral INSTANCE = new DateLiteral();
+
+    @Override
+    public void append(StringBuilder buffer, Object value) {
+      buffer.append("date ").append('\'').append(value).append('\'');
+    }
+  }
+
+  final class DateEscapeLiteral implements InLiterals {
+
+    static DateEscapeLiteral INSTANCE = new DateEscapeLiteral();
+
+    @Override
+    public void append(StringBuilder buffer, Object value) {
+      buffer.append("{d '").append(value).append("'}");
+    }
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/InTuplesExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/InTuplesExpression.java
@@ -1,6 +1,8 @@
 package io.ebeaninternal.server.expression;
 
 import io.ebean.InTuples;
+import io.ebean.annotation.Platform;
+import io.ebean.event.BeanQueryRequest;
 import io.ebean.service.SpiInTuples;
 import io.ebeaninternal.api.BindValuesKey;
 import io.ebeaninternal.api.NaturalKeyQueryData;
@@ -8,23 +10,63 @@ import io.ebeaninternal.api.SpiExpression;
 import io.ebeaninternal.api.SpiExpressionRequest;
 
 import java.util.List;
+import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
-
 
 final class InTuplesExpression extends AbstractExpression {
 
   private final boolean not;
   private final String[] properties;
   private final List<Object[]> entries;
+  private InLiterals[] literals;
+  private boolean literalMode;
 
   InTuplesExpression(InTuples pairs, boolean not) {
     super("");
-    SpiInTuples inTuples = (SpiInTuples)pairs;
+    SpiInTuples inTuples = (SpiInTuples) pairs;
     this.properties = inTuples.properties();
     // the entries might be modified on cache hit.
     this.entries = inTuples.entries();
     this.not = not;
+  }
+
+  @Override
+  public void prepareExpression(BeanQueryRequest<?> request) {
+    if (entries.size() > 50) {
+      // check if this should go into literal mode
+      final int maxInBinding = request.database().pluginApi().databasePlatform().maxInBinding();
+      final int threshold = literalThreshold(maxInBinding, properties.length);
+      if (entries.size() > threshold) {
+        literals = initLiterals(request.database().platform());
+        literalMode = literals != null;
+      }
+    }
+  }
+
+  private InLiterals[] initLiterals(Platform platform) {
+    try {
+      Object[] firstData = entries.get(0);
+      final InLiterals[] literals = new InLiterals[firstData.length];
+      for (int i = 0; i < firstData.length; i++) {
+        literals[i] = InLiterals.of(firstData[i], platform);
+      }
+      return literals;
+    } catch (UnsupportedOperationException e) {
+      // one of the value types is not supported as a SQL literal
+      // so stick to binding only
+      return null;
+    }
+  }
+
+  /**
+   * Return the threshold in number of entries before literal mode is used.
+   */
+  static int literalThreshold(int maxInBinding, int propertyCount) {
+    if (maxInBinding == 0) {
+      return 5000 / propertyCount;
+    }
+    return Math.min((maxInBinding / propertyCount) - 200, 5000);
   }
 
   @Override
@@ -39,6 +81,9 @@ final class InTuplesExpression extends AbstractExpression {
 
   @Override
   public void addBindValues(SpiExpressionRequest request) {
+    if (literalMode) {
+      return;
+    }
     for (Object[] entry : entries) {
       for (Object value : entry) {
         requireNonNull(value);
@@ -61,6 +106,33 @@ final class InTuplesExpression extends AbstractExpression {
       request.property(properties[i]);
     }
     request.append(") in (");
+    if (literalMode) {
+      addSqlLiterals(request);
+    } else {
+      addSqlBinding(request);
+    }
+    request.append(")");
+  }
+
+  private void addSqlLiterals(SpiExpressionRequest request) {
+    final var buffer = request.buffer();
+    for (int i = 0; i < entries.size(); i++) {
+      if (i > 0) {
+        buffer.append(',');
+      }
+      buffer.append('(');
+      Object[] values = entries.get(i);
+      for (int v = 0; v < values.length; v++) {
+        if (v > 0) {
+          buffer.append(',');
+        }
+        literals[v].append(buffer, values[v]);
+      }
+      buffer.append(')');
+    }
+  }
+
+  private void addSqlBinding(SpiExpressionRequest request) {
     final String eb = entryBinding();
     for (int i = 0; i < entries.size(); i++) {
       if (i > 0) {
@@ -68,7 +140,6 @@ final class InTuplesExpression extends AbstractExpression {
       }
       request.append(eb);
     }
-    request.append(")");
   }
 
   private String entryBinding() {
@@ -92,10 +163,15 @@ final class InTuplesExpression extends AbstractExpression {
       builder.append("Not");
     }
     builder.append("InTuple[");
-    for (String property : properties) {
-      builder.append(property).append("-");
+    if (literalMode) {
+      builder.append(UUID.randomUUID());
+    } else {
+      for (String property : properties) {
+        builder.append(property).append("-");
+      }
+      builder.append(entries.size());
     }
-    builder.append(entries.size()).append("]");
+    builder.append("]");
   }
 
   @Override

--- a/ebean-core/src/test/java/io/ebeaninternal/server/expression/InLiteralsTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/expression/InLiteralsTest.java
@@ -1,0 +1,58 @@
+package io.ebeaninternal.server.expression;
+
+import io.ebean.annotation.Platform;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InLiteralsTest {
+
+  private static String using(Object value) {
+    return using(value, Platform.GENERIC);
+  }
+
+  private static String using(Object value, Platform platform) {
+    InLiterals litInt = InLiterals.of(value, platform);
+    StringBuilder sb = new StringBuilder();
+    litInt.append(sb, value);
+    return sb.toString();
+  }
+
+  @Test
+  void of_numbers() {
+    assertThat(using(42)).isEqualTo("42");
+    assertThat(using(42d)).isEqualTo("42.0");
+    assertThat(using(42L)).isEqualTo("42");
+    assertThat(using(new BigDecimal("42.34"))).isEqualTo("42.34");
+    assertThat(using(new BigInteger("42"))).isEqualTo("42");
+    assertThat(using(Integer.valueOf(42))).isEqualTo("42");
+    assertThat(using(Long.valueOf(42))).isEqualTo("42");
+  }
+
+  @Test
+  void of_str() {
+    assertThat(using("hi")).isEqualTo("'hi'");
+    assertThat(using("there")).isEqualTo("'there'");
+  }
+
+  @Test
+  void of_uuid() {
+    UUID uuid = UUID.randomUUID();
+    assertThat(using(uuid)).isEqualTo("'" + uuid + "'");
+  }
+
+  @Test
+  void of_localDate() {
+    assertThat(using(LocalDate.of(2023, 3, 7))).isEqualTo("date '2023-03-07'");
+  }
+
+  @Test
+  void of_localDate_mysql() {
+    assertThat(using(LocalDate.of(2023, 3, 7), Platform.MYSQL)).isEqualTo("{d '2023-03-07'}");
+  }
+}

--- a/ebean-core/src/test/java/io/ebeaninternal/server/expression/InTuplesExpressionTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/expression/InTuplesExpressionTest.java
@@ -1,0 +1,51 @@
+package io.ebeaninternal.server.expression;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InTuplesExpressionTest {
+
+  @Test
+  void literalThreshold_maxInBindingZero_2properties() {
+    int threshold = InTuplesExpression.literalThreshold(0, 2);
+    assertThat(threshold).isEqualTo(2500);
+  }
+
+  @Test
+  void literalThreshold_maxInBindingZero_3properties() {
+    int threshold = InTuplesExpression.literalThreshold(0, 3);
+    assertThat(threshold).isEqualTo(1666);
+  }
+
+  @Test
+  void literalThreshold_maxInBindingZero_4properties() {
+    int threshold = InTuplesExpression.literalThreshold(0, 4);
+    assertThat(threshold).isEqualTo(1250);
+  }
+
+  @Test
+  void literalThreshold_sqlServer_2properties() {
+    int threshold = InTuplesExpression.literalThreshold(2000, 2);
+    assertThat(threshold).isEqualTo(800);
+  }
+
+  @Test
+  void literalThreshold_sqlServer_3properties() {
+    int threshold = InTuplesExpression.literalThreshold(2000, 3);
+    assertThat(threshold).isEqualTo(466);
+  }
+
+  @Test
+  void literalThreshold_sqlServer_4properties() {
+    int threshold = InTuplesExpression.literalThreshold(2000, 4);
+    assertThat(threshold).isEqualTo(300);
+  }
+
+  @Test
+  void literalThreshold_5000() {
+    int threshold = InTuplesExpression.literalThreshold(5000, 2);
+    assertThat(threshold).isEqualTo(2300);
+  }
+
+}

--- a/ebean-core/src/test/java/io/ebeaninternal/server/expression/TDSpiExpressionRequest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/expression/TDSpiExpressionRequest.java
@@ -44,6 +44,11 @@ public class TDSpiExpressionRequest implements SpiExpressionRequest {
   }
 
   @Override
+  public StringBuilder buffer() {
+    return sql;
+  }
+
+  @Override
   public SpiExpressionRequest append(String expression) {
     sql.append(expression);
     return this;

--- a/ebean-test/src/test/java/org/tests/model/aggregation/TestAggregationTopLevel.java
+++ b/ebean-test/src/test/java/org/tests/model/aggregation/TestAggregationTopLevel.java
@@ -1,9 +1,9 @@
 package org.tests.model.aggregation;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Query;
 import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -163,7 +163,8 @@ public class TestAggregationTopLevel extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
-    assertSql(sql.get(0)).contains("select t0.edate, sum(t0.total_kms), sum(t0.hours), t1.id, t1.name from d_machine_stats t0 join dmachine t1 on t1.id = t0.machine_id where t0.edate > ? group by t0.edate, t1.id, t1.name having sum(t0.hours) > ?");  }
+    assertSql(sql.get(0)).contains("select t0.edate, sum(t0.total_kms), sum(t0.hours), t1.id, t1.name from d_machine_stats t0 join dmachine t1 on t1.id = t0.machine_id where t0.edate > ? group by t0.edate, t1.id, t1.name having sum(t0.hours) > ?");
+  }
 
 
   @Test
@@ -269,7 +270,6 @@ public class TestAggregationTopLevel extends BaseTestCase {
 
     assertThat(sqlOf(query)).contains("select t0.id, t0.name, t1.edate, max(t1.rate), sum(t1.total_kms) from dmachine t0 left join d_machine_stats t1 on t1.machine_id = t0.id where t0.name = ? group by t0.id, t0.name, t1.edate order by t0.id");
   }
-
 
   public static void loadData() {
 

--- a/ebean-test/src/test/java/org/tests/model/aggregation/TestInTuplesWithLocalDate.java
+++ b/ebean-test/src/test/java/org/tests/model/aggregation/TestInTuplesWithLocalDate.java
@@ -1,0 +1,94 @@
+package org.tests.model.aggregation;
+
+import io.ebean.DB;
+import io.ebean.InTuples;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestInTuplesWithLocalDate extends BaseTestCase {
+
+  @Test
+  void inTuples_localDate() {
+    DOrg org = new DOrg("inTuple");
+    org.save();
+
+    var machine = new DMachine(org, "inTuple");
+    machine.save();
+
+    LocalDate date = LocalDate.of(2023,8,16);
+
+    var allStats = new ArrayList<DMachineStats>();
+    for (int i = 0; i < 8; i++) {
+      DMachineStats stats = new DMachineStats(machine, date);
+
+      long offset = i;
+      stats.setHours(offset * 3);
+      stats.setTotalKms(offset * 100);
+      stats.setCost(BigDecimal.valueOf(offset * 50));
+      stats.setRate(BigDecimal.valueOf(offset * 2));
+      allStats.add(stats);
+      if (i > 2) {
+        date = date.plusDays(1);
+      }
+    }
+
+    DB.saveAll(allStats);
+
+    LocalDate today = LocalDate.of(2023,8,16);
+
+    var in = InTuples.of("date", "hours")
+      .add(today, 0)
+      .add(today, 3)
+      .add(today, 9)
+      .add(today.plusDays(1), 12)
+      .add(today.plusDays(2), 15);
+
+
+    LoggedSql.start();
+
+    List<DMachineStats> result = DB.find(DMachineStats.class)
+      .where()
+      .inTuples(in)
+      .eq("machine.name", "inTuple")
+      .findList();
+
+    assertThat(result).hasSize(5);
+
+    var in2 = InTuples.of("date", "hours")
+      .add(today, 0);
+
+    for (int i = 0; i < 3_000; i++) {
+      in2.add(today, 100 + i);
+    }
+
+    List<DMachineStats> result2 = DB.find(DMachineStats.class)
+      .where()
+      .inTuples(in2)
+      //.raw("(t0.edate,t0.hours) in ((date '2023-08-16',0),(date '2023-08-16',100))")
+      .eq("machine.name", "inTuple")
+      .findList();
+
+    List<String> sql = LoggedSql.stop();
+
+    assertThat(sql).hasSize(2);
+    assertThat(sql.get(0)).contains("where (t0.edate,t0.hours) in ((?,?),(?,?),(?,?),(?,?),(?,?)) and t1.name = ?");
+    if (isMySql()) {
+      assertThat(sql.get(1)).contains("where (t0.edate,t0.hours) in (({d '2023-08-16'},0),({d '2023-08-16'},100),({d '2023-08-16'},101)");
+    } else {
+      assertThat(sql.get(1)).contains("where (t0.edate,t0.hours) in ((date '2023-08-16',0),(date '2023-08-16',100),(date '2023-08-16',101)");
+    }
+
+    DB.deleteAll(allStats);
+    DB.delete(machine);
+    DB.delete(org);
+  }
+
+}


### PR DESCRIPTION
So as to not exceed the limit on bind values, the InTuples expression can go into literal mode where it uses literal values for supported types - Numbers, Strings, UUID, and LocalDate.