### PR TITLE
InTuples literal mode - don't cache ebean compiled query plan

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/CQueryPlanKey.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/CQueryPlanKey.java
@@ -6,6 +6,11 @@ package io.ebeaninternal.api;
 public interface CQueryPlanKey {
 
   /**
+   * Return true if the query plan should be cached.
+   */
+  boolean useCache();
+
+  /**
    * Used by read audit such that we can log read audit entries without the full sql
    * (which would make the read audit logs verbose).
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1503,7 +1503,9 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   }
 
   public void queryPlan(CQueryPlanKey key, CQueryPlan plan) {
-    queryPlanCache.put(key, plan);
+    if (key.useCache()) {
+      queryPlanCache.put(key, plan);
+    }
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -612,9 +612,9 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
     }
     for (SpiExpression expr : list) {
       expr.queryPlanHash(builder);
-      builder.append(",");
+      builder.append(',');
     }
-    builder.append("]");
+    builder.append(']');
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/InTuplesExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/InTuplesExpression.java
@@ -66,7 +66,7 @@ final class InTuplesExpression extends AbstractExpression {
     if (maxInBinding == 0) {
       return 5000 / propertyCount;
     }
-    return Math.min((maxInBinding / propertyCount) - 200, 5000);
+    return (maxInBinding / propertyCount) - 200;
   }
 
   @Override
@@ -159,19 +159,19 @@ final class InTuplesExpression extends AbstractExpression {
    */
   @Override
   public void queryPlanHash(StringBuilder builder) {
+    if (literalMode) {
+      builder.delete(0, builder.length());
+      builder.append("$NoCache/").append(UUID.randomUUID()).append('/');
+      return;
+    }
     if (not) {
       builder.append("Not");
     }
     builder.append("InTuple[");
-    if (literalMode) {
-      builder.append(UUID.randomUUID());
-    } else {
-      for (String property : properties) {
-        builder.append(property).append("-");
-      }
-      builder.append(entries.size());
+    for (String property : properties) {
+      builder.append(property).append("-");
     }
-    builder.append("]");
+    builder.append(entries.size()).append(']');
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/NativeSqlQueryPlanKey.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/NativeSqlQueryPlanKey.java
@@ -19,6 +19,11 @@ public class NativeSqlQueryPlanKey implements CQueryPlanKey {
   }
 
   @Override
+  public boolean useCache() {
+    return true;
+  }
+
+  @Override
   public CQueryPlanKey withDeleteByIds() {
     throw new IllegalStateException("Not allowed");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/RawSqlQueryPlanKey.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/RawSqlQueryPlanKey.java
@@ -25,6 +25,11 @@ final class RawSqlQueryPlanKey implements CQueryPlanKey {
   }
 
   @Override
+  public boolean useCache() {
+    return true;
+  }
+
+  @Override
   public CQueryPlanKey withDeleteByIds() {
     throw new IllegalStateException("Not allowed");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1047,13 +1047,13 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     if (temporalMode != SpiQuery.TemporalMode.CURRENT) {
       sb.append("/tm").append(temporalMode.ordinal());
       if (versionsStart != null) {
-        sb.append("v");
+        sb.append('v');
       }
     }
     if (forUpdate != null) {
       sb.append("/fu").append(forUpdate.ordinal());
       if (lockType != null) {
-        sb.append("t").append(lockType.ordinal());
+        sb.append('t').append(lockType.ordinal());
       }
     }
     if (id != null) {
@@ -1092,27 +1092,27 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     if (detail != null) {
       sb.append("/d[");
       detail.queryPlanHash(sb);
-      sb.append("]");
+      sb.append(']');
     }
     if (bindParams != null) {
       sb.append("/b[");
       bindParams.buildQueryPlanHash(sb);
-      sb.append("]");
+      sb.append(']');
     }
     if (whereExpressions != null) {
       sb.append("/w[");
       whereExpressions.queryPlanHash(sb);
-      sb.append("]");
+      sb.append(']');
     }
     if (havingExpressions != null) {
       sb.append("/h[");
       havingExpressions.queryPlanHash(sb);
-      sb.append("]");
+      sb.append(']');
     }
     if (updateProperties != null) {
       sb.append("/u[");
       updateProperties.buildQueryPlanHash(sb);
-      sb.append("]");
+      sb.append(']');
     }
     return sb.toString();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryPlanKey.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryPlanKey.java
@@ -33,6 +33,11 @@ final class OrmQueryPlanKey implements CQueryPlanKey {
   }
 
   @Override
+  public boolean useCache() {
+    return !description.startsWith("$NoCache");
+  }
+
+  @Override
   public String partialKey() {
     return description;
   }

--- a/ebean-test/src/test/java/org/tests/model/aggregation/TestInTuplesWithLocalDate.java
+++ b/ebean-test/src/test/java/org/tests/model/aggregation/TestInTuplesWithLocalDate.java
@@ -81,9 +81,11 @@ class TestInTuplesWithLocalDate extends BaseTestCase {
     assertThat(sql).hasSize(2);
     assertThat(sql.get(0)).contains("where (t0.edate,t0.hours) in ((?,?),(?,?),(?,?),(?,?),(?,?)) and t1.name = ?");
     if (isMySql()) {
-      assertThat(sql.get(1)).contains("where (t0.edate,t0.hours) in (({d '2023-08-16'},0),({d '2023-08-16'},100),({d '2023-08-16'},101)");
+      assertThat(sql.get(1)).contains("where (t0.edate,t0.hours) in (({d '2023-08-16'},0),({d '2023-08-16'},100),({d '2023-08-16'},101),(");
+    } else if (isPostgresCompatible()) {
+      assertThat(sql.get(1)).contains("where (t0.edate,t0.hours) in ((?,?),(?,?),(?,?),(");
     } else {
-      assertThat(sql.get(1)).contains("where (t0.edate,t0.hours) in ((date '2023-08-16',0),(date '2023-08-16',100),(date '2023-08-16',101)");
+      assertThat(sql.get(1)).contains("where (t0.edate,t0.hours) in ((date '2023-08-16',0),(date '2023-08-16',100),(date '2023-08-16',101),(");
     }
 
     DB.deleteAll(allStats);

--- a/ebean-test/src/test/java/org/tests/model/aggregation/TestInTuplesWithLocalDate.java
+++ b/ebean-test/src/test/java/org/tests/model/aggregation/TestInTuplesWithLocalDate.java
@@ -2,8 +2,10 @@ package org.tests.model.aggregation;
 
 import io.ebean.DB;
 import io.ebean.InTuples;
+import io.ebean.annotation.Platform;
 import io.ebean.test.LoggedSql;
 import io.ebean.xtest.BaseTestCase;
+import io.ebean.xtest.IgnorePlatform;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -15,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TestInTuplesWithLocalDate extends BaseTestCase {
 
+  @IgnorePlatform({Platform.SQLSERVER, Platform.DB2})
   @Test
   void inTuples_localDate() {
     DOrg org = new DOrg("inTuple");

--- a/platforms/postgres/src/main/java/io/ebean/platform/postgres/PostgresPlatform.java
+++ b/platforms/postgres/src/main/java/io/ebean/platform/postgres/PostgresPlatform.java
@@ -28,6 +28,7 @@ public class PostgresPlatform extends DatabasePlatform {
   public PostgresPlatform() {
     super();
     this.platform = Platform.POSTGRES;
+    this.maxInBinding = 32_000; // technically 32_767
     this.supportsNativeIlike = true;
     this.supportsDeleteTableAlias = true;
     this.selectCountWithAlias = true;

--- a/platforms/sqlite/src/main/java/io/ebean/platform/sqlite/SQLitePlatform.java
+++ b/platforms/sqlite/src/main/java/io/ebean/platform/sqlite/SQLitePlatform.java
@@ -13,6 +13,7 @@ public class SQLitePlatform extends DatabasePlatform {
   public SQLitePlatform() {
     super();
     this.platform = Platform.SQLITE;
+    this.maxInBinding = 800; // technically 999
     this.dbIdentity.setIdType(IdType.IDENTITY);
     this.dbIdentity.setSupportsGetGeneratedKeys(false);
     this.dbIdentity.setSupportsSequence(false);


### PR DESCRIPTION
- Don't cache ebean compiled query plan when InTuples goes into literal mode
- Postgres maxInBinding = 32_000;
- SQLite maxInBinding = 800;
- Note that not caching the compiled query plan means that metrics visitor isn't going to see it, we lose collection of that query execution metric. We might need a plan to fix this later.