### PR TITLE
Add Query bean filterMany() taking a closure

### DIFF
--- a/ebean-api/src/main/java/io/ebean/ExpressionFactory.java
+++ b/ebean-api/src/main/java/io/ebean/ExpressionFactory.java
@@ -37,6 +37,11 @@ import java.util.Map;
 public interface ExpressionFactory {
 
   /**
+   * Return a new ExpressionList.
+   */
+  <T> ExpressionList<T> expressionList();
+
+  /**
    * Path exists - for the given path in a JSON document.
    */
   Expression jsonExists(String propertyName, String path);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionFactory.java
@@ -37,6 +37,11 @@ public class DefaultExpressionFactory implements SpiExpressionFactory {
   }
 
   @Override
+  public <T> ExpressionList<T> expressionList() {
+    return new DefaultExpressionList<>(this);
+  }
+
+  @Override
   public Expression textMatch(String propertyName, String search, Match options) {
     return new TextMatchExpression(propertyName, search, options);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -56,6 +56,10 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
     this.parentExprList = parentExprList;
   }
 
+  protected DefaultExpressionList(ExpressionFactory expr) {
+    this(null, expr, null, new ArrayList<>());
+  }
+
   private DefaultExpressionList() {
     this(null, null, null, new ArrayList<>());
   }
@@ -112,10 +116,8 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
    * <p>
    * If this is the Top level "text" expressions then it detects if explicit or implicit Bool Should, Must etc is required
    * to wrap the expressions.
-   * </p>
    * <p>
    * If implicit Bool is required SHOULD is used.
-   * </p>
    */
   @Override
   public void writeDocQuery(DocQueryContext context) throws IOException {

--- a/ebean-querybean/pom.xml
+++ b/ebean-querybean/pom.xml
@@ -107,7 +107,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:13.17.1</tile>
+            <tile>io.ebean.tile:enhancement:13.21.1-beta</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
@@ -136,6 +136,13 @@ public abstract class TQRootBean<T, R> {
     this.query = null;
   }
 
+  /** Construct for FilterMany */
+  protected TQRootBean(ExpressionList<T> filter) {
+    this.query = null;
+    this.whereStack = new ArrayStack<>();
+    whereStack.push(filter);
+  }
+
   /**
    * Return the fetch group.
    */

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -21,9 +21,7 @@ interface Constants {
   String DBNAME = "io.ebean.annotation.DbName";
 
   String TQROOTBEAN = "io.ebean.typequery.TQRootBean";
-  String TQASSOC = "io.ebean.typequery.TQAssoc";
   String TQASSOCBEAN = "io.ebean.typequery.TQAssocBean";
-  String TQPROPERTY = "io.ebean.typequery.TQProperty";
   String TYPEQUERYBEAN = "io.ebean.typequery.TypeQueryBean";
   String DATABASE = "io.ebean.Database";
   String DB = "io.ebean.DB";
@@ -37,4 +35,7 @@ interface Constants {
 
   String AVAJE_LANG_NULLABLE = "io.avaje.lang.Nullable";
   String JAVA_COLLECTION = "java.util.Collection";
+  String EXPRESSIONLIST = "io.ebean.ExpressionList";
+  String EXPR = "io.ebean.Expr";
+  String CONSUMER = "java.util.function.Consumer";
 }

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -361,20 +361,8 @@ class ProcessingContext implements Constants {
    */
   private PropertyType createPropertyTypeAssoc(String fullName) {
     String[] split = Split.split(fullName);
-    String propertyName = "QAssoc" + split[1];
-    String packageName = packageAppend(split[0]);
-    return new PropertyTypeAssoc(propertyName, packageName);
-  }
-
-  /**
-   * Prepend the package to the suffix taking null into account.
-   */
-  private String packageAppend(String origPackage) {
-    if (origPackage == null) {
-      return "query.assoc";
-    } else {
-      return origPackage + "." + "query.assoc";
-    }
+    String propertyName = "Q" + split[1] + ".Assoc";
+    return new PropertyTypeAssoc(propertyName);
   }
 
   /**

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -114,7 +114,6 @@ public class Processor extends AbstractProcessor implements Constants {
     try {
       SimpleQueryBeanWriter beanWriter = new SimpleQueryBeanWriter((TypeElement) element, processingContext);
       beanWriter.writeRootBean();
-      beanWriter.writeAssocBean();
     } catch (Throwable e) {
       e.printStackTrace();
       processingContext.logError(element, "Error generating query beans: " + e);

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/PropertyMeta.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/PropertyMeta.java
@@ -31,14 +31,12 @@ class PropertyMeta {
   }
 
   void writeFieldDefn(Append writer, String shortName, boolean assoc) {
-
     writer.append("  public ");
     writer.append(getTypeDefn(shortName, assoc));
     writer.append(" ").append(name).append(";");
   }
 
   void writeFieldAliasDefn(Append writer, String shortName) {
-
     writer.append("    public static ");
     writer.append(getTypeDefn(shortName, false));
     writer.append(" ").append(name).append(" = _alias.").append(name).append(";");

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/PropertyTypeAssoc.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/PropertyTypeAssoc.java
@@ -8,19 +8,12 @@ import java.util.Set;
 class PropertyTypeAssoc extends PropertyType {
 
   /**
-   * The package name for this associated query bean.
-   */
-  private final String assocPackage;
-
-  /**
    * Construct given the associated bean type name and package.
    *
    * @param qAssocTypeName the associated bean type name.
-   * @param assocPackage   the associated bean package.
    */
-  PropertyTypeAssoc(String qAssocTypeName, String assocPackage) {
+  PropertyTypeAssoc(String qAssocTypeName) {
     super(qAssocTypeName);
-    this.assocPackage = assocPackage;
   }
 
   /**
@@ -28,7 +21,7 @@ class PropertyTypeAssoc extends PropertyType {
    */
   @Override
   void addImports(Set<String> allImports) {
-    allImports.add(assocPackage + "." + propertyType);
+    // do nothing
   }
 
 }


### PR DESCRIPTION
### reason-for-version-bump

- The query bean generation is different [assoc query beans are inner classes]
- Requires ebean-agent enhancement changes to support this

----

On the generated QContact assoc query bean this adds a method like:

```java
public final R filterMany(Consumer<QContact> apply)
```

... which handles the detail of creating the query bean, passing it to the consumer [to add our predicates/expressions], and then extract the ExpressionList [which is added to the filter many expression list].


This means we can do:
```java
new QCustomer()
  .contacts.filterMany(c -> c.firstName.startsWith("r"))
```

Instead of:
```java
var contactsFilter = 
  new QContact()
    .firstName.startsWith("r")
    .getExpressionList();

new QCustomer()
  .contacts.filterMany(contactsFilter)

```


**Notes:**
Query beans also generate a "Assoc" query bean that is used for the relationships. That is, there are really 2 query beans per entity type - a "root" query bean which is the ones we use explicitly + a "assoc" query bean which are the ones we use implicitly when we navigate the *ToOne and *ToMany relationships.

Previously the "Assoc" query beans were generated into a `.query.assoc` package. With this change the "assoc" query beans are instead generated as an inner class of the [root/main] query bean.

Moving the "Assoc" query beans to be inner classes allows this change where we generate this additional filterMany() that takes a closure i.e. `filterMany(Consumer<QContact>)`. The whole point of this is to simplify the use of filterMany using type safe query beans expressions.

Note: This change to the generated query beans needs a change to the ebean-agent enhancement.



**The expected benefits are:**
- expected to be easier to use and learn
- slightly more efficient as the query bean [e.g. QContact] used in the filterMany() to add the filter many expressions is created for this task and only initialises the ExpressionList and not the other parts of the query.
