### PR TITLE
Add filterManyRaw() and Deprecate filterMany( <string expressions> )

### DIFF
--- a/ebean-api/src/main/java/io/ebean/ExpressionList.java
+++ b/ebean-api/src/main/java/io/ebean/ExpressionList.java
@@ -508,6 +508,8 @@ public interface ExpressionList<T> {
   ExpressionList<T> filterMany(String manyProperty);
 
   /**
+   * Deprecated for removal - migrate to filterManyRaw()
+   * <p>
    * Add filter expressions to the many property.
    *
    * <pre>{@code
@@ -524,7 +526,28 @@ public interface ExpressionList<T> {
    * @param expressions  Filter expressions with and, or and ? or ?1 type bind parameters
    * @param params       Bind parameters used in the expressions
    */
+  @Deprecated(forRemoval = true)
   ExpressionList<T> filterMany(String manyProperty, String expressions, Object... params);
+
+  /**
+   * Add filter expressions for the many path. The expressions can include SQL functions if
+   * desired and the property names are translated to column names.
+   * <p>
+   * The expressions can contain placeholders for bind values using <code>?</code> or <code>?1</code> style.
+   *
+   * <pre>{@code
+   *
+   *     new QCustomer()
+   *       .name.startsWith("Postgres")
+   *       .contacts.filterMany("status = ? and firstName like ?", Contact.Status.NEW, "Rob%")
+   *       .findList();
+   *
+   * }</pre>
+   *
+   * @param rawExpressions The raw expressions which can include ? and ?1 style bind parameter placeholders
+   * @param params The parameter values to bind
+   */
+  ExpressionList<T> filterManyRaw(String manyProperty, String rawExpressions, Object... params);
 
   /**
    * Specify specific properties to fetch on the main/root bean (aka partial

--- a/ebean-api/src/main/java/io/ebean/ExpressionList.java
+++ b/ebean-api/src/main/java/io/ebean/ExpressionList.java
@@ -539,7 +539,7 @@ public interface ExpressionList<T> {
    *
    *     new QCustomer()
    *       .name.startsWith("Postgres")
-   *       .contacts.filterMany("status = ? and firstName like ?", Contact.Status.NEW, "Rob%")
+   *       .contacts.filterManyRaw("status = ? and firstName like ?", Contact.Status.NEW, "Rob%")
    *       .findList();
    *
    * }</pre>

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/DefaultExpressionList.java
@@ -445,6 +445,11 @@ public class DefaultExpressionList<T> implements SpiExpressionList<T> {
   }
 
   @Override
+  public ExpressionList<T> filterManyRaw(String manyProperty, String rawExpression, Object... params) {
+    return query.filterMany(manyProperty).raw(rawExpression, params);
+  }
+
+  @Override
   public Query<T> withLock(Query.LockType lockType) {
     return query.withLock(lockType);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/JunctionExpression.java
@@ -318,6 +318,11 @@ final class JunctionExpression<T> implements SpiJunction<T>, SpiExpression, Expr
   }
 
   @Override
+  public ExpressionList<T> filterManyRaw(String manyProperty, String rawExpression, Object... params) {
+    throw new IllegalStateException("filterMany not allowed on Junction expression list");
+  }
+
+  @Override
   public Query<T> usingTransaction(Transaction transaction) {
     return exprList.usingTransaction(transaction);
   }

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
@@ -188,6 +188,8 @@ public abstract class TQAssocBean<T, R, QB> extends TQAssoc<T, R> {
   }
 
   /**
+   * Deprecated for removal - migrate to filterManyRaw()
+   * <p>
    * Apply a filter when fetching these beans.
    * <p>
    * The expressions can use any valid Ebean expression and contain
@@ -215,8 +217,32 @@ public abstract class TQAssocBean<T, R, QB> extends TQAssoc<T, R> {
    * @param expressions The expressions including and, or, not etc with ? and ?1 bind params.
    * @param params      The bind parameter values
    */
+  @Deprecated(forRemoval = true)
   public final R filterMany(String expressions, Object... params) {
     expr().filterMany(_name, expressions, params);
+    return _root;
+  }
+
+  /**
+   * Add filter expressions for the many path. The expressions can include SQL functions if
+   * desired and the property names are translated to column names.
+   * <p>
+   * The expressions can contain placeholders for bind values using <code>?</code> or <code>?1</code> style.
+   *
+   * <pre>{@code
+   *
+   *     new QCustomer()
+   *       .name.startsWith("Shrek")
+   *       .contacts.filterMany("status = ? and firstName like ?", Contact.Status.NEW, "Rob%")
+   *       .findList();
+   *
+   * }</pre>
+   *
+   * @param rawExpressions The raw expressions which can include ? and ?1 style bind parameter placeholders
+   * @param params The parameter values to bind
+   */
+  public final R filterManyRaw(String rawExpressions, Object... params) {
+    expr().filterManyRaw(_name, rawExpressions, params);
     return _root;
   }
 

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
@@ -233,7 +233,7 @@ public abstract class TQAssocBean<T, R, QB> extends TQAssoc<T, R> {
    *
    *     new QCustomer()
    *       .name.startsWith("Shrek")
-   *       .contacts.filterMany("status = ? and firstName like ?", Contact.Status.NEW, "Rob%")
+   *       .contacts.filterManyRaw("status = ? and firstName like ?", Contact.Status.NEW, "Rob%")
    *       .findList();
    *
    * }</pre>

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -281,6 +281,41 @@ public class QCustomerTest {
   }
 
   @Test
+  void filterManySeparateQuery() {
+    Customer cust = new Customer();
+    cust.setName("filterManySeparateQuery");
+    cust.setStatus(Customer.Status.GOOD);
+    cust.save();
+
+    var q = new QCustomer()
+      .select(FGCustomerContacts)
+      .contacts.filterManyRaw("firstName like ?", "R%")
+      .contacts.filterMany(c -> c.firstName.startsWith("R")) // same as filterManyRaw() expression
+      .setMaxRows(10) // force the ToMany path to be in a separate secondary query
+      .query();
+
+    q.findList();
+    assertThat(q.getGeneratedSql()).isEqualTo("select t0.id, t0.name from be_customer t0 limit 10");
+  }
+
+  @Test
+  void filterManySingleQuery() {
+    Customer cust = new Customer();
+    cust.setName("filterManySingleQuery");
+    cust.setStatus(Customer.Status.GOOD);
+    cust.save();
+
+    var q = new QCustomer()
+      .select(FGCustomerContacts)
+      .contacts.filterManyRaw("firstName like ?", "R%")
+      .contacts.filterMany(c -> c.firstName.startsWith("R")) // same as filterManyRaw() expression
+      .query();
+
+    q.findList();
+    assertThat(q.getGeneratedSql()).isEqualTo("select t0.id, t0.name from be_customer t0 limit 10");
+  }
+
+  @Test
   public void testIdIn() {
 
     List<Integer> ids = new ArrayList<>();

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -312,7 +312,7 @@ public class QCustomerTest {
       .query();
 
     q.findList();
-    assertThat(q.getGeneratedSql()).isEqualTo("select t0.id, t0.name from be_customer t0 limit 10");
+    assertThat(q.getGeneratedSql()).contains(" from be_customer t0 left join be_contact t1 on t1.customer_id = t0.id where t1.first_name like ? and t1.first_name like ");
   }
 
   @Test


### PR DESCRIPTION
The filterMany( <string expressions> ) uses the language parser which ultimately will we probably remove in ebean 15.x

Code can migrate to filterManyRaw() instead or better yet change to use the improved query beans filterMany( <closure> ) option that will be included in this same ebean release.