### PR TITLE
BUG: Using a subquery with idEq or setId is missing the bind value

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPredicates.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPredicates.java
@@ -21,10 +21,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static java.lang.System.Logger.Level.WARNING;
 
@@ -303,7 +300,20 @@ public final class CQueryPredicates {
    * Return the bind values for the where expression.
    */
   public List<Object> whereExprBindValues() {
-    return where == null ? Collections.emptyList() : where.bindValues();
+    if (idValue == null && where == null) {
+      return Collections.emptyList();
+    }
+    if (where == null) {
+      return List.of(idValue);
+    }
+    if (idValue == null) {
+      return where.bindValues();
+    }
+
+    List<Object> bindValues = new ArrayList<>();
+    bindValues.add(idValue);
+    bindValues.addAll(where.bindValues());
+    return Collections.unmodifiableList(bindValues);
   }
 
   /**

--- a/ebean-test/src/test/java/org/tests/query/TestQuerySubquery.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQuerySubquery.java
@@ -1,0 +1,115 @@
+package org.tests.query;
+
+import io.ebean.DB;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Order;
+import org.tests.model.basic.Person;
+import org.tests.model.basic.ResetBasicData;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestQuerySubquery extends BaseTestCase {
+
+    private Long robId;
+
+    @BeforeEach
+    public void setup() {
+        ResetBasicData.reset();
+
+        Person rob = new Person();
+        rob.setName("Rob");
+        rob.setSurname("Test");
+        DB.save(rob);
+        robId = rob.getId();
+
+        DB.getDefault().pluginApi().cacheManager().clearAll();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        DB.delete(Person.class, robId);
+    }
+
+    @Test
+    public void testWithoutSubquery() {
+
+        Person contact = DB.find(Person.class)
+                .where()
+                .idEq(robId)
+                .findOne();
+
+        LoggedSql.start();
+        List<Order> orders = DB.find(Order.class)
+                .alias("t0")
+                .where()
+                .eq("customer.name", contact.getName())
+                .findList();
+
+        assertThat(orders).hasSize(3);
+        assertThat(LoggedSql.stop())
+                .hasSize(1)
+                .first().asString()
+                .contains("--bind("+ contact.getName() + ")")
+                .contains("kcustomer_id where t1.name = ?");
+    }
+
+    @Test
+    public void testEqSubqueryWithIdEq() {
+        LoggedSql.start();
+        List<Order> orders = DB.find(Order.class)
+                .alias("t0")
+                .where()
+                .eq("customer.name", DB.find(Person.class).select("name").where().idEq(robId).query())
+                .findList();
+
+        assertThat(orders).hasSize(3);
+        assertThat(LoggedSql.stop())
+                .hasSize(1)
+                .first().asString()
+                .contains("--bind("+ robId + ")")
+                .contains("name = (select t0.NAME");
+    }
+
+    @Test
+    public void testEqSubqueryWithSetId() {
+        LoggedSql.start();
+
+        List<Order> orders = DB.find(Order.class)
+                .alias("t0")
+                .where()
+                .eq("customer.name", DB.find(Person.class).select("name").setId(robId))
+                .findList();
+
+        assertThat(orders).hasSize(3);
+        assertThat(LoggedSql.stop())
+                .hasSize(1)
+                .first().asString()
+                .contains("--bind("+ robId + ")")
+                .contains("name = (select t0.NAME");
+    }
+
+    @Test
+    public void testEqSubqueryWithEqId() {
+        LoggedSql.start();
+
+        List<Order> orders = DB.find(Order.class)
+                .alias("t0")
+                .where()
+                .eq("customer.name", DB.find(Person.class).select("name").where().eq("id", robId).query())
+                .findList();
+
+        assertThat(orders).hasSize(3);
+        assertThat(LoggedSql.stop())
+                .hasSize(1)
+                .first().asString()
+                .contains("--bind("+ robId + ")")
+                .contains("name = (select t0.NAME");
+    }
+
+}


### PR DESCRIPTION
We found that using a subquery with `idEq` or `setId` does not set the bind value correctly. The issue seems to be that `whereExprBindValue` does not include the id when it is set resulting in an Exception because of a missing parameter. With this fix we include the id when the predicate returns the bind values.

We have also found another problem that when the "control test" (using `eq("id"...`) runs first, the statement seems to work in the other tests, however the logged sql bind is empty. Running the tests individually presents you with the properly failing statement. This behaviour seems to be an issue in the ebean-datasource, because the same `PreparedStatement` is being reused including (!) its set parameters. @rPraml has provided a individual test and fix for that: https://github.com/ebean-orm/ebean-datasource/pull/75