### PR TITLE
Auto commit transactions after a certain amount of inserts/updates

### DIFF
--- a/ebean-api/src/main/java/io/ebean/Transaction.java
+++ b/ebean-api/src/main/java/io/ebean/Transaction.java
@@ -555,4 +555,13 @@ public interface Transaction extends AutoCloseable {
    * Get an object added with {@link #putUserObject(String, Object)}.
    */
   Object getUserObject(String name);
+
+  /**
+   * Sets the maximum transaction size. After this amount of inserts/updates or sql/orm calls,
+   * the transaction performs an autocommit.
+   * This prevents having huge transactions, which consumes a lot of log space.
+   * Note: saving an object graph could produce more than one insert/update statement,
+   * but this increases the transaction size only by one.
+   */
+  void setMaxTransactionSize(int maxTransactionSize);
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransaction.java
@@ -357,4 +357,9 @@ public interface SpiTransaction extends Transaction {
    */
   void postRollback(Throwable cause);
 
+  /**
+   * Performs a commit and continue, if necessary. This can be done every 1000 updates or so.
+   */
+  void commitAndContinueIfNecessary();
+
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
@@ -53,8 +53,18 @@ public abstract class SpiTransactionProxy implements SpiTransaction {
   }
 
   @Override
+  public void setMaxTransactionSize(int maxTransactionSize) {
+    transaction.setMaxTransactionSize(maxTransactionSize);
+  }
+
+  @Override
   public void commitAndContinue() {
     transaction.commitAndContinue();
+  }
+
+  @Override
+  public void commitAndContinueIfNecessary() {
+    transaction.commitAndContinueIfNecessary();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/BeanRequest.java
@@ -49,6 +49,8 @@ public abstract class BeanRequest {
   public void commitTransIfRequired() {
     if (createdTransaction) {
       server.commitTransaction();
+    } else {
+      transaction.commitAndContinueIfNecessary();
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -503,11 +503,21 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
     manager.collectMetricReadOnly((System.nanoTime() - startNanos) / 1000L);
   }
 
+  @Override
+  public void setMaxTransactionSize(int maxTransactionSize) {
+
+  }
+
   /**
-   * Perform a commit, fire callbacks and notify l2 cache etc.
-   * <p>
-   * This leaves the transaction active and expects another commit
-   * to occur later (which closes the underlying connection etc).
+   * Do nothing.
+   */
+  @Override
+  public void commitAndContinueIfNecessary() {
+    // do nothing
+  }
+
+  /**
+   * Do nothing.
    */
   @Override
   public void commitAndContinue() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
@@ -68,6 +68,16 @@ final class NoTransaction implements SpiTransaction {
   }
 
   @Override
+  public void setMaxTransactionSize(int maxTransactionSize) {
+
+  }
+
+  @Override
+  public void commitAndContinueIfNecessary() {
+    // do nothing
+  }
+
+  @Override
   public void commitAndContinue() {
     // do nothing
   }


### PR DESCRIPTION
Hello @rbygrave I would need feedback to this PR:

**Problem**
Our application creates huge transactions when importing certain data.
On DB2 we ran into the "Transaction log is full problem" (Sqlcode: -964, Sqlstate: 57011)

As temporary solution, the DBA tuned the log settings for this DB (increased LOGFILSIZ from 1024 to 80000, reduced LOGPRIMARY from 16 to 5 and increased LOGSECOND from 22 to 50)
They also told us, that they do not want to increase this to such high values, as they cannot guarantee a defined RPO, because the log files may not be archived in time.

**Suggested solution**
The advice of the DBA was to do imports in smaller transactions. We checked the `Transaction.commitAndContine()` function and this seems to do the job.

Unfortunately, this method has to be called in the application code (e.g. always after 1000 save's)
This would need a lot refactoring in our application. Also doing it without a transaction (and use only implicit) is not a good option, as this kills the performance

This PR adds a feature, that "commitAndContinue" is called from time to time.
My idea was, to set a `maxTransactionSize` and after that, the transaction will commit and continue.

**Questions**
- what is a good metric for `size`. The best unit would be size in bytes, but it is extremely difficult to compute this
- so I think, we should count the beans that were saved. Here is also the problem, that saving a simple bean counts the same as saving a complex object graph
- is `commitTransIfRequired` the correct place.
- currently, also non dirty beans will be counted.

**Further thoughts**
I think it is not a good idea, to count inserts/batch binds and do a commitAndContinue after a fixed amount of inserts (this means, if the transaction is then rollbacked, the "half" of the dependant beans could be saved.

Should we estimate the amount of data, that the transaction holds or should we be conservative here and set the max transaction size to <= 1000 beans, so that we are far away from the actual database limit

Rob, maybe you can drop a comment, if it is worth to contine the work on this idea or if there is a different approach to solve the issue.