### PR TITLE
Refactor internal SpiEbeanServer API - transaction from SpiQuery

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiDtoQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiDtoQuery.java
@@ -61,9 +61,4 @@ public interface SpiDtoQuery<T> extends DtoQuery<T>, SpiSqlBinding {
    */
   SpiQuery<?> ormQuery();
 
-  /**
-   * Return the explicit transaction used to execute the query.
-   */
-  Transaction transaction();
-
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
@@ -372,24 +372,12 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
 
   <T> int update(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  List<SqlRow> findList(SpiSqlQuery query, Transaction transaction);
+  List<SqlRow> findList(SpiSqlQuery query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  void findEach(SpiSqlQuery query, Consumer<SqlRow> consumer, Transaction transaction);
+  void findEach(SpiSqlQuery query, Consumer<SqlRow> consumer);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  void findEachWhile(SpiSqlQuery query, Predicate<SqlRow> consumer, Transaction transaction);
+  void findEachWhile(SpiSqlQuery query, Predicate<SqlRow> consumer);
 
-  /**
-   * Deprecated migrate to using {@link SqlQuery#usingTransaction(Transaction)}.
-   */
   @Nullable
-  SqlRow findOne(SpiSqlQuery query, Transaction transaction);
+  SqlRow findOne(SpiSqlQuery query);
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
@@ -162,12 +162,12 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
    * the query has finished (if executing in a background thread).
    * </p>
    */
-  <A, T> List<A> findIdsWithCopy(SpiQuery<T> query, Transaction transaction);
+  <A, T> List<A> findIdsWithCopy(SpiQuery<T> query);
 
   /**
    * Execute the findCount query but without copying the query.
    */
-  <T> int findCountWithCopy(SpiQuery<T> query, Transaction transaction);
+  <T> int findCountWithCopy(SpiQuery<T> query);
 
   /**
    * Load a batch of Associated One Beans.
@@ -295,7 +295,7 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
   /**
    * Execute the underlying ORM query returning as a JDBC ResultSet to map to DTO beans.
    */
-  SpiResultSet findResultSet(SpiQuery<?> ormQuery, SpiTransaction transaction);
+  SpiResultSet findResultSet(SpiQuery<?> ormQuery);
 
   /**
    * Visit all the metrics (typically reporting them).
@@ -327,56 +327,25 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
    */
   SpiQueryBindCapture createQueryBindCapture(SpiQueryPlan queryPlan);
 
+  <T> boolean exists(SpiQuery<T> ormQuery);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> boolean exists(SpiQuery<T> ormQuery, Transaction transaction);
+  <T> int findCount(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> int findCount(SpiQuery<T> query, Transaction transaction);
+  <A, T> List<A> findIds(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <A, T> List<A> findIds(SpiQuery<T> query, Transaction transaction);
+  <T> QueryIterator<T> findIterate(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> QueryIterator<T> findIterate(SpiQuery<T> query, Transaction transaction);
+  <T> Stream<T> findStream(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> Stream<T> findStream(SpiQuery<T> query, Transaction transaction);
+  <T> void findEach(SpiQuery<T> query, Consumer<T> consumer);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> void findEach(SpiQuery<T> query, Consumer<T> consumer, Transaction transaction);
+  <T> void findEach(SpiQuery<T> query, int batch, Consumer<List<T>> consumer);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> void findEach(SpiQuery<T> query, int batch, Consumer<List<T>> consumer, Transaction t);
+  <T> void findEachWhile(SpiQuery<T> query, Predicate<T> consumer);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> void findEachWhile(SpiQuery<T> query, Predicate<T> consumer, Transaction transaction);
+  <T> List<Version<T>> findVersions(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> List<Version<T>> findVersions(SpiQuery<T> query, Transaction transaction);
-
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> List<T> findList(SpiQuery<T> query, Transaction transaction);
+  <T> List<T> findList(SpiQuery<T> query);
 
   <T> FutureRowCount<T> findFutureCount(SpiQuery<T> query);
 
@@ -384,51 +353,24 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
 
   <T> FutureList<T> findFutureList(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> PagedList<T> findPagedList(SpiQuery<T> query, Transaction transaction);
+  <T> PagedList<T> findPagedList(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> Set<T> findSet(SpiQuery<T> query, Transaction transaction);
+  <T> Set<T> findSet(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <K, T> Map<K, T> findMap(SpiQuery<T> query, Transaction transaction);
+  <K, T> Map<K, T> findMap(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <A, T> List<A> findSingleAttributeList(SpiQuery<T> query, Transaction transaction);
+  <A, T> List<A> findSingleAttributeList(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <A, T> Set<A> findSingleAttributeSet(SpiQuery<T> query, Transaction transaction);
+  <A, T> Set<A> findSingleAttributeSet(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
   @Nullable
-  <T> T findOne(SpiQuery<T> query, Transaction transaction);
+  <T> T findOne(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> Optional<T> findOneOrEmpty(SpiQuery<T> query, Transaction transaction);
+  <T> Optional<T> findOneOrEmpty(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> int delete(SpiQuery<T> query, Transaction transaction);
+  <T> int delete(SpiQuery<T> query);
 
-  /**
-   * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.
-   */
-  <T> int update(SpiQuery<T> query, Transaction transaction);
+  <T> int update(SpiQuery<T> query);
 
   /**
    * Deprecated migrate to using {@link Query#usingTransaction(Transaction)}.

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiSqlBinding.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiSqlBinding.java
@@ -1,9 +1,17 @@
 package io.ebeaninternal.api;
 
+import io.avaje.lang.Nullable;
+
 /**
  * SQL query binding (for SqlQuery and DtoQuery).
  */
 public interface SpiSqlBinding extends SpiCancelableQuery {
+
+  /**
+   * Return the transaction explicitly associated to the query.
+   */
+  @Nullable
+  SpiTransaction transaction();
 
   /**
    * Return true if this query should not use the read only data source.

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiSqlQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiSqlQuery.java
@@ -1,17 +1,10 @@
 package io.ebeaninternal.api;
 
-import io.avaje.lang.Nullable;
 import io.ebean.SqlQuery;
-import io.ebean.Transaction;
 
 /**
  * SQL query - Internal extension to SqlQuery.
  */
 public interface SpiSqlQuery extends SqlQuery, SpiSqlBinding {
 
-  /**
-   * Return the transaction explicitly associated to the query.
-   */
-  @Nullable
-  Transaction transaction();
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/AbstractSqlQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/AbstractSqlQueryRequest.java
@@ -33,10 +33,10 @@ public abstract class AbstractSqlQueryRequest implements CancelableQuery {
   /**
    * Create the BeanFindRequest.
    */
-  AbstractSqlQueryRequest(SpiEbeanServer server, SpiSqlBinding query, Transaction t) {
+  AbstractSqlQueryRequest(SpiEbeanServer server, SpiSqlBinding query) {
     this.server = server;
     this.query = query;
-    this.transaction = (SpiTransaction) t;
+    this.transaction = query.transaction();
     this.query.setCancelableQuery(this);
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -106,7 +106,7 @@ final class DefaultBeanLoader {
       query.setReadOnly(true);
     }
 
-    server.findOne(query, null);
+    server.findOne(query);
     if (beanCollection != null) {
       if (beanCollection.checkEmptyLazyLoad()) {
         if (log.isLoggable(DEBUG)) {
@@ -127,6 +127,7 @@ final class DefaultBeanLoader {
       throw new RuntimeException("Nothing in batch?");
     }
     final SpiQuery<?> query = server.createQuery(loadRequest.beanType());
+    query.usingTransaction(loadRequest.transaction());
     loadRequest.configureQuery(query);
     loadRequest.postLoad(executeQuery(loadRequest, query));
   }
@@ -139,12 +140,13 @@ final class DefaultBeanLoader {
       // MySql - we need a different transaction to execute the secondary query
       SpiTransaction extraTxn = server.createReadOnlyTransaction(query.tenantId(), query.isUseMaster());
       try {
-        return server.findList(query, extraTxn);
+        query.usingTransaction(extraTxn);
+        return server.findList(query);
       } finally {
         extraTxn.end();
       }
     } else {
-      return server.findList(query, loadRequest.transaction());
+      return server.findList(query);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1442,16 +1442,16 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Nullable
   @Override
-  public SqlRow findOne(SpiSqlQuery query, Transaction transaction) {
+  public SqlRow findOne(SpiSqlQuery query) {
     // no findId() method for SqlQuery...
     // a query that is expected to return either 0 or 1 rows
-    List<SqlRow> list = findList(query, transaction);
+    List<SqlRow> list = findList(query);
     return extractUnique(list);
   }
 
   @Override
-  public void findEach(SpiSqlQuery query, Consumer<SqlRow> consumer, Transaction transaction) {
-    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query, transaction);
+  public void findEach(SpiSqlQuery query, Consumer<SqlRow> consumer) {
+    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query);
     try {
       request.initTransIfRequired();
       request.findEach(consumer);
@@ -1461,8 +1461,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public void findEachWhile(SpiSqlQuery query, Predicate<SqlRow> consumer, Transaction transaction) {
-    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query, transaction);
+  public void findEachWhile(SpiSqlQuery query, Predicate<SqlRow> consumer) {
+    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query);
     try {
       request.initTransIfRequired();
       request.findEachWhile(consumer);
@@ -1472,8 +1472,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public List<SqlRow> findList(SpiSqlQuery query, Transaction transaction) {
-    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query, transaction);
+  public List<SqlRow> findList(SpiSqlQuery query) {
+    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query);
     try {
       request.initTransIfRequired();
       return request.findList();
@@ -1483,7 +1483,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   private <P> P executeSqlQuery(Function<RelationalQueryRequest, P> fun, SpiSqlQuery query) {
-    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query, query.transaction());
+    RelationalQueryRequest request = new RelationalQueryRequest(this, relationalQueryEngine, query);
     try {
       request.initTransIfRequired();
       return fun.apply(request);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1087,8 +1087,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   public <T> Set<T> findSet(SpiQuery<T> query) {
     SpiOrmQueryRequest request = buildQueryRequest(Type.SET, query);
     request.resetBeanCacheAutoMode(false);
-    SpiTransaction transaction = request.transaction();
-    if ((transaction == null || !transaction.isSkipCache()) && request.getFromBeanCache()) {
+    if (request.isGetAllFromBeanCache()) {
       // hit bean cache and got all results from cache
       return request.beanCacheHitsAsSet();
     }
@@ -1110,8 +1109,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   public <K, T> Map<K, T> findMap(SpiQuery<T> query) {
     SpiOrmQueryRequest request = buildQueryRequest(Type.MAP, query);
     request.resetBeanCacheAutoMode(false);
-    SpiTransaction transaction = request.transaction();
-    if ((transaction == null || !transaction.isSkipCache()) && request.getFromBeanCache()) {
+    if (request.isGetAllFromBeanCache()) {
       // hit bean cache and got all results from cache
       return request.beanCacheHitsAsMap();
     }
@@ -1422,8 +1420,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   private <T> List<T> findList(SpiQuery<T> query, boolean findOne) {
     SpiOrmQueryRequest<T> request = buildQueryRequest(Type.LIST, query);
     request.resetBeanCacheAutoMode(findOne);
-    SpiTransaction transaction = request.transaction();
-    if ((transaction == null || !transaction.isSkipCache()) && request.getFromBeanCache()) {
+    if (request.isGetAllFromBeanCache()) {
       // hit bean cache and got all results from cache
       return request.beanCacheHits();
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -441,7 +441,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
    */
   @Override
   public <T> CQuery<T> compileQuery(Type type, SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest<T> qr = createQueryRequest(type, query, transaction);
+    query.usingTransaction(transaction);
+    SpiOrmQueryRequest<T> qr = createQueryRequest(type, query);
     OrmQueryRequest<T> orm = (OrmQueryRequest<T>) qr;
     return cqueryEngine.buildQuery(orm);
   }
@@ -903,8 +904,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public SpiResultSet findResultSet(SpiQuery<?> ormQuery, SpiTransaction transaction) {
-    SpiOrmQueryRequest<?> request = createQueryRequest(ormQuery.type(), ormQuery, transaction);
+  public SpiResultSet findResultSet(SpiQuery<?> ormQuery) {
+    SpiOrmQueryRequest<?> request = createQueryRequest(ormQuery.type(), ormQuery);
     request.initTransIfRequired();
     return request.findResultSet();
   }
@@ -935,24 +936,26 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   public <T> T find(Class<T> beanType, Object id, @Nullable Transaction transaction) {
     Objects.requireNonNull(id);
-    Query<T> query = createQuery(beanType).setId(id);
-    return findId(query, transaction);
+    SpiQuery<T> query = createQuery(beanType);
+    query.usingTransaction(transaction);
+    query.setId(id);
+    return findId(query);
   }
 
-  <T> SpiOrmQueryRequest<T> createQueryRequest(Type type, Query<T> query, @Nullable Transaction transaction) {
-    SpiOrmQueryRequest<T> request = buildQueryRequest(type, query, transaction);
+  <T> SpiOrmQueryRequest<T> createQueryRequest(Type type, SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = buildQueryRequest(type, query);
     request.prepareQuery();
     return request;
   }
 
-  <T> SpiOrmQueryRequest<T> buildQueryRequest(Type type, Query<T> query, @Nullable Transaction transaction) {
-    SpiQuery<T> spiQuery = (SpiQuery<T>) query;
-    spiQuery.setType(type);
-    spiQuery.checkNamedParameters();
-    return buildQueryRequest(spiQuery, transaction);
+  <T> SpiOrmQueryRequest<T> buildQueryRequest(Type type, SpiQuery<T> query) {
+    query.setType(type);
+    query.checkNamedParameters();
+    return buildQueryRequest(query);
   }
 
-  private <T> SpiOrmQueryRequest<T> buildQueryRequest(SpiQuery<T> query, @Nullable Transaction transaction) {
+  private <T> SpiOrmQueryRequest<T> buildQueryRequest(SpiQuery<T> query) {
+    SpiTransaction transaction = query.transaction();
     if (transaction == null) {
       transaction = currentServerTransaction();
     }
@@ -973,7 +976,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     if (query.parentNode() == null) {
       query.setOrigin(createCallOrigin());
     }
-    return new OrmQueryRequest<>(this, queryEngine, query, (SpiTransaction) transaction);
+    return new OrmQueryRequest<>(this, queryEngine, query, transaction);
   }
 
   /**
@@ -981,8 +984,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
    */
   @Nullable
   @SuppressWarnings("unchecked")
-  private <T> T findIdCheckPersistenceContextAndCache(@Nullable Transaction transaction, SpiQuery<T> query, Object id) {
-    SpiTransaction t = (SpiTransaction) transaction;
+  private <T> T findIdCheckPersistenceContextAndCache(SpiQuery<T> query, Object id) {
+    SpiTransaction t = query.transaction();
     if (t == null) {
       t = currentServerTransaction();
     }
@@ -1028,18 +1031,17 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Nullable
   @SuppressWarnings("unchecked")
-  private <T> T findId(Query<T> query, @Nullable Transaction transaction) {
-    SpiQuery<T> spiQuery = (SpiQuery<T>) query;
-    spiQuery.setType(Type.BEAN);
-    if (SpiQuery.Mode.NORMAL == spiQuery.mode() && !spiQuery.isForceHitDatabase()) {
+  private <T> T findId(SpiQuery<T> query) {
+    query.setType(Type.BEAN);
+    if (SpiQuery.Mode.NORMAL == query.mode() && !query.isForceHitDatabase()) {
       // See if we can skip doing the fetch completely by getting the bean from the
       // persistence context or the bean cache
-      T bean = findIdCheckPersistenceContextAndCache(transaction, spiQuery, spiQuery.getId());
+      T bean = findIdCheckPersistenceContextAndCache(query, query.getId());
       if (bean != null) {
         return bean;
       }
     }
-    SpiOrmQueryRequest<T> request = buildQueryRequest(spiQuery, transaction);
+    SpiOrmQueryRequest<T> request = buildQueryRequest(query);
     request.prepareQuery();
     if (request.isUseDocStore()) {
       return docStore().find(request);
@@ -1053,22 +1055,19 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> Optional<T> findOneOrEmpty(SpiQuery<T> query, Transaction transaction) {
-    return Optional.ofNullable(findOne(query, transaction));
+  public <T> Optional<T> findOneOrEmpty(SpiQuery<T> query) {
+    return Optional.ofNullable(findOne(query));
   }
 
   @Nullable
   @Override
-  public <T> T findOne(SpiQuery<T> query, @Nullable Transaction transaction) {
+  public <T> T findOne(SpiQuery<T> query) {
     if (query.isFindById()) {
       // actually a find by Id query
-      return findId(query, transaction);
-    }
-    if (transaction == null) {
-      transaction = currentServerTransaction();
+      return findId(query);
     }
     // a query that is expected to return either 0 or 1 beans
-    List<T> list = findList(query, transaction, true);
+    List<T> list = findList(query, true);
     return extractUnique(list);
   }
 
@@ -1085,9 +1084,10 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public <T> Set<T> findSet(SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest request = buildQueryRequest(Type.SET, query, transaction);
+  public <T> Set<T> findSet(SpiQuery<T> query) {
+    SpiOrmQueryRequest request = buildQueryRequest(Type.SET, query);
     request.resetBeanCacheAutoMode(false);
+    SpiTransaction transaction = request.transaction();
     if ((transaction == null || !transaction.isSkipCache()) && request.getFromBeanCache()) {
       // hit bean cache and got all results from cache
       return request.beanCacheHitsAsSet();
@@ -1107,9 +1107,10 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
-  public <K, T> Map<K, T> findMap(SpiQuery<T> query, @Nullable Transaction transaction) {
-    SpiOrmQueryRequest request = buildQueryRequest(Type.MAP, query, transaction);
+  public <K, T> Map<K, T> findMap(SpiQuery<T> query) {
+    SpiOrmQueryRequest request = buildQueryRequest(Type.MAP, query);
     request.resetBeanCacheAutoMode(false);
+    SpiTransaction transaction = request.transaction();
     if ((transaction == null || !transaction.isSkipCache()) && request.getFromBeanCache()) {
       // hit bean cache and got all results from cache
       return request.beanCacheHitsAsMap();
@@ -1129,8 +1130,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Override
   @SuppressWarnings("unchecked")
-  public <A, T> List<A> findSingleAttributeList(SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = buildQueryRequest(Type.ATTRIBUTE, query, transaction);
+  public <A, T> List<A> findSingleAttributeList(SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = buildQueryRequest(Type.ATTRIBUTE, query);
     request.query().setSingleAttribute();
     request.prepareQuery();
     Object result = request.getFromQueryCache();
@@ -1147,8 +1148,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
 
   @Override
   @SuppressWarnings("unchecked")
-  public <A, T> Set<A> findSingleAttributeSet(SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = buildQueryRequest(Type.ATTRIBUTE_SET, query, transaction);
+  public <A, T> Set<A> findSingleAttributeSet(SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = buildQueryRequest(Type.ATTRIBUTE_SET, query);
     request.query().setSingleAttribute();
     request.prepareQuery();
     Object result = request.getFromQueryCache();
@@ -1164,16 +1165,16 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> int findCount(SpiQuery<T> query, @Nullable Transaction transaction) {
+  public <T> int findCount(SpiQuery<T> query) {
     if (!query.isDistinct()) {
       query = query.copy();
     }
-    return findCountWithCopy(query, transaction);
+    return findCountWithCopy(query);
   }
 
   @Override
-  public <T> int findCountWithCopy(SpiQuery<T> query, @Nullable Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.COUNT, query, transaction);
+  public <T> int findCountWithCopy(SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.COUNT, query);
     Integer result = request.getFromQueryCache();
     if (result != null) {
       return result;
@@ -1189,14 +1190,16 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   public boolean exists(Class<?> beanType, Object beanId, Transaction transaction) {
     final DefaultOrmQuery<?> query = createQuery(beanType);
+    query.usingTransaction(transaction);
     query.setId(beanId);
-    return !findIdsWithCopy(query, transaction).isEmpty();
+    return !findIdsWithCopy(query).isEmpty();
   }
 
   @Override
-  public <T> boolean exists(SpiQuery<T> ormQuery, Transaction transaction) {
-    Query<T> ormQueryCopy = ormQuery.copy().setMaxRows(1);
-    SpiOrmQueryRequest<?> request = createQueryRequest(Type.EXISTS, ormQueryCopy, transaction);
+  public <T> boolean exists(SpiQuery<T> ormQuery) {
+    SpiQuery<T> ormQueryCopy = ormQuery.copy();
+    ormQueryCopy.setMaxRows(1);
+    SpiOrmQueryRequest<?> request = createQueryRequest(Type.EXISTS, ormQueryCopy);
     List<Object> ids = request.getFromQueryCache();
     if (ids != null) {
       return !ids.isEmpty();
@@ -1210,14 +1213,14 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <A, T> List<A> findIds(SpiQuery<T> query, Transaction transaction) {
-    return findIdsWithCopy(query.copy(), transaction);
+  public <A, T> List<A> findIds(SpiQuery<T> query) {
+    return findIdsWithCopy(query.copy());
   }
 
   @SuppressWarnings("unchecked")
   @Override
-  public <A, T> List<A> findIdsWithCopy(SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest<?> request = createQueryRequest(Type.ID_LIST, query, transaction);
+  public <A, T> List<A> findIdsWithCopy(SpiQuery<T> query) {
+    SpiOrmQueryRequest<?> request = createQueryRequest(Type.ID_LIST, query);
     Object result = request.getFromQueryCache();
     if (result != null) {
       if (Boolean.FALSE.equals(request.query().isReadOnly())) {
@@ -1235,8 +1238,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> int delete(SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.DELETE, query, transaction);
+  public <T> int delete(SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.DELETE, query);
     try {
       request.initTransIfRequired();
       request.markNotQueryOnly();
@@ -1258,8 +1261,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> int update(SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.UPDATE, query, transaction);
+  public <T> int update(SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.UPDATE, query);
     try {
       request.initTransIfRequired();
       request.markNotQueryOnly();
@@ -1280,8 +1283,9 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
         transaction = (SpiTransaction) createTransaction();
         createdTransaction = true;
       }
+      copy.usingTransaction(transaction);
     }
-    var queryFuture = new QueryFutureRowCount<>(new CallableQueryCount<>(this, copy, transaction, createdTransaction));
+    var queryFuture = new QueryFutureRowCount<>(new CallableQueryCount<>(this, copy, createdTransaction));
     backgroundExecutor.execute(queryFuture.futureTask());
     return queryFuture;
   }
@@ -1297,8 +1301,9 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
         transaction = (SpiTransaction) createTransaction();
         createdTransaction = true;
       }
+      copy.usingTransaction(transaction);
     }
-    QueryFutureIds<T> queryFuture = new QueryFutureIds<>(new CallableQueryIds<>(this, copy, transaction, createdTransaction));
+    QueryFutureIds<T> queryFuture = new QueryFutureIds<>(new CallableQueryIds<>(this, copy, createdTransaction));
     backgroundExecutor.execute(queryFuture.futureTask());
     return queryFuture;
   }
@@ -1321,27 +1326,28 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
         transaction = (SpiTransaction) createTransaction();
         createdTransaction = true;
       }
+      spiQuery.usingTransaction(transaction);
     }
-    QueryFutureList<T> queryFuture = new QueryFutureList<>(new CallableQueryList<>(this, spiQuery, transaction, createdTransaction));
+    QueryFutureList<T> queryFuture = new QueryFutureList<>(new CallableQueryList<>(this, spiQuery, createdTransaction));
     backgroundExecutor.execute(queryFuture.futureTask());
     return queryFuture;
   }
 
   @Override
-  public <T> PagedList<T> findPagedList(SpiQuery<T> query, Transaction transaction) {
+  public <T> PagedList<T> findPagedList(SpiQuery<T> query) {
     int maxRows = query.getMaxRows();
     if (maxRows == 0) {
       throw new PersistenceException("maxRows must be specified for findPagedList() query");
     }
     if (query.isUseDocStore()) {
-      return docStore().findPagedList(createQueryRequest(Type.LIST, query, transaction));
+      return docStore().findPagedList(createQueryRequest(Type.LIST, query));
     }
     return new LimitOffsetPagedList<>(this, query);
   }
 
   @Override
-  public <T> QueryIterator<T> findIterate(SpiQuery<T> query, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query, transaction);
+  public <T> QueryIterator<T> findIterate(SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query);
     try {
       request.initTransIfRequired();
       return request.findIterate();
@@ -1352,8 +1358,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> Stream<T> findStream(SpiQuery<T> query, Transaction transaction) {
-    return toStream(findIterate(query, transaction));
+  public <T> Stream<T> findStream(SpiQuery<T> query) {
+    return toStream(findIterate(query));
   }
 
   private <T> Stream<T> toStream(QueryIterator<T> queryIterator) {
@@ -1361,8 +1367,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> void findEach(SpiQuery<T> query, Consumer<T> consumer, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query, transaction);
+  public <T> void findEach(SpiQuery<T> query, Consumer<T> consumer) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query);
     if (request.isUseDocStore()) {
       docStore().findEach(request, consumer);
       return;
@@ -1373,8 +1379,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> void findEach(SpiQuery<T> query, int batch, Consumer<List<T>> consumer, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query, transaction);
+  public <T> void findEach(SpiQuery<T> query, int batch, Consumer<List<T>> consumer) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query);
 //    if (request.isUseDocStore()) {
 //      docStore().findEach(request, consumer);
 //      return;
@@ -1385,8 +1391,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> void findEachWhile(SpiQuery<T> query, Predicate<T> consumer, Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query, transaction);
+  public <T> void findEachWhile(SpiQuery<T> query, Predicate<T> consumer) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.ITERATE, query);
     if (request.isUseDocStore()) {
       docStore().findEachWhile(request, consumer);
       return;
@@ -1397,8 +1403,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> List<Version<T>> findVersions(SpiQuery<T> query, @Nullable Transaction transaction) {
-    SpiOrmQueryRequest<T> request = createQueryRequest(Type.LIST, query, transaction);
+  public <T> List<Version<T>> findVersions(SpiQuery<T> query) {
+    SpiOrmQueryRequest<T> request = createQueryRequest(Type.LIST, query);
     try {
       request.initTransIfRequired();
       return request.findVersions();
@@ -1408,14 +1414,15 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public <T> List<T> findList(SpiQuery<T> query, Transaction transaction) {
-    return findList(query, transaction, false);
+  public <T> List<T> findList(SpiQuery<T> query) {
+    return findList(query, false);
   }
 
   @SuppressWarnings("unchecked")
-  private <T> List<T> findList(SpiQuery<T> query, @Nullable Transaction transaction, boolean findOne) {
-    SpiOrmQueryRequest<T> request = buildQueryRequest(Type.LIST, query, transaction);
+  private <T> List<T> findList(SpiQuery<T> query, boolean findOne) {
+    SpiOrmQueryRequest<T> request = buildQueryRequest(Type.LIST, query);
     request.resetBeanCacheAutoMode(findOne);
+    SpiTransaction transaction = request.transaction();
     if ((transaction == null || !transaction.isSkipCache()) && request.getFromBeanCache()) {
       // hit bean cache and got all results from cache
       return request.beanCacheHits();
@@ -2200,8 +2207,9 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     if (entityBean._ebean_getIntercept().isNew() && id != null) {
       // Primary Key is changeable only on new models - so skip check if we are not new
       SpiQuery<?> query = new DefaultOrmQuery<>(beanDesc, this, expressionFactory);
+      query.usingTransaction(transaction);
       query.setId(id);
-      if (findCount(query, transaction) > 0) {
+      if (findCount(query) > 0) {
         return Collections.singleton(idProperty);
       }
     }
@@ -2221,6 +2229,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   private Set<Property> checkUniqueness(EntityBean entityBean, BeanDescriptor<?> beanDesc, BeanProperty[] props, @Nullable Transaction transaction) {
     BeanProperty idProperty = beanDesc.idProperty();
     SpiQuery<?> query = new DefaultOrmQuery<>(beanDesc, this, expressionFactory);
+    query.usingTransaction(transaction);
     ExpressionList<?> exprList = query.where();
     if (!entityBean._ebean_getIntercept().isNew()) {
       // if model is not new, exclude ourself.
@@ -2233,7 +2242,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
       }
       exprList.eq(prop.name(), value);
     }
-    if (findCount(query, transaction) > 0) {
+    if (findCount(query) > 0) {
       Set<Property> ret = new LinkedHashSet<>();
       Collections.addAll(ret, props);
       return ret;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DtoQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DtoQueryRequest.java
@@ -33,7 +33,7 @@ public final class DtoQueryRequest<T> extends AbstractSqlQueryRequest {
   private DataReader dataReader;
 
   DtoQueryRequest(SpiEbeanServer server, DtoQueryEngine engine, SpiDtoQuery<T> query) {
-    super(server, query, query.transaction());
+    super(server, query);
     this.queryEngine = engine;
     this.query = query;
     query.obtainLocation();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DtoQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DtoQueryRequest.java
@@ -52,7 +52,8 @@ public final class DtoQueryRequest<T> extends AbstractSqlQueryRequest {
 
       query.setCancelableQuery(ormQuery);
       // execute the underlying ORM query returning the ResultSet
-      SpiResultSet result = server.findResultSet(ormQuery, transaction);
+      ormQuery.usingTransaction(transaction);
+      SpiResultSet result = server.findResultSet(ormQuery);
       this.pstmt = result.statement();
       this.sql = ormQuery.getGeneratedSql();
       setResultSet(result.resultSet(), ormQuery.queryPlanKey());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -61,6 +61,11 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   }
 
   @Override
+  public boolean isGetAllFromBeanCache() {
+    return (transaction == null || !transaction.isSkipCache()) && getFromBeanCache();
+  }
+
+  @Override
   public boolean isDeleteByStatement() {
     if (!transaction.isPersistCascade() || beanDescriptor.isDeleteByStatement()) {
       // plain delete by query

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/RelationalQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/RelationalQueryRequest.java
@@ -2,7 +2,7 @@ package io.ebeaninternal.server.core;
 
 import io.ebean.*;
 import io.ebeaninternal.api.SpiEbeanServer;
-import io.ebeaninternal.api.SpiSqlBinding;
+import io.ebeaninternal.api.SpiSqlQuery;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -22,8 +22,8 @@ public final class RelationalQueryRequest extends AbstractSqlQueryRequest {
   private int estimateCapacity;
   private int rows;
 
-  RelationalQueryRequest(SpiEbeanServer server, RelationalQueryEngine engine, SqlQuery q, Transaction t) {
-    super(server, (SpiSqlBinding) q, t);
+  RelationalQueryRequest(SpiEbeanServer server, RelationalQueryEngine engine, SpiSqlQuery q) {
+    super(server, q);
     this.queryEngine = engine;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
@@ -188,4 +188,8 @@ public interface SpiOrmQueryRequest<T> extends BeanQueryRequest<T>, DocQueryRequ
    */
   boolean isDeleteByStatement();
 
+  /**
+   * Return true if hitting bean cache and returning all beans from cache.
+   */
+  boolean isGetAllFromBeanCache();
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanCollectionHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanCollectionHelp.java
@@ -63,11 +63,6 @@ public interface BeanCollectionHelp<T> extends CQueryCollectionAdd<T> {
    */
   BeanCollection<T> createReference(EntityBean parentBean);
 
-//  /**
-//   * Refresh the List Set or Map.
-//   */
-//  void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean);
-
   /**
    * Apply the new refreshed BeanCollection to the appropriate property of the parent bean.
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanCollectionHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanCollectionHelp.java
@@ -63,10 +63,10 @@ public interface BeanCollectionHelp<T> extends CQueryCollectionAdd<T> {
    */
   BeanCollection<T> createReference(EntityBean parentBean);
 
-  /**
-   * Refresh the List Set or Map.
-   */
-  void refresh(SpiEbeanServer server, SpiQuery<?> query, Transaction t, EntityBean parentBean);
+//  /**
+//   * Refresh the List Set or Map.
+//   */
+//  void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean);
 
   /**
    * Apply the new refreshed BeanCollection to the appropriate property of the parent bean.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanListHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanListHelp.java
@@ -67,12 +67,6 @@ public class BeanListHelp<T> extends BaseCollectionHelp<T> {
     return beanList;
   }
 
-//  @Override
-//  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean) {
-//    BeanList<?> newBeanList = (BeanList<?>) server.findList(query);
-//    refresh(newBeanList, parentBean);
-//  }
-
   @Override
   public final void refresh(BeanCollection<?> bc, EntityBean parentBean) {
     BeanList<?> newBeanList = (BeanList<?>) bc;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanListHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanListHelp.java
@@ -67,11 +67,11 @@ public class BeanListHelp<T> extends BaseCollectionHelp<T> {
     return beanList;
   }
 
-  @Override
-  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, Transaction t, EntityBean parentBean) {
-    BeanList<?> newBeanList = (BeanList<?>) server.findList(query, t);
-    refresh(newBeanList, parentBean);
-  }
+//  @Override
+//  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean) {
+//    BeanList<?> newBeanList = (BeanList<?>) server.findList(query);
+//    refresh(newBeanList, parentBean);
+//  }
 
   @Override
   public final void refresh(BeanCollection<?> bc, EntityBean parentBean) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanMapHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanMapHelp.java
@@ -113,12 +113,6 @@ public class BeanMapHelp<T> extends BaseCollectionHelp<T> {
     return beanMap;
   }
 
-//  @Override
-//  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean) {
-//    BeanMap<?, ?> newBeanMap = (BeanMap<?, ?>) server.findMap(query);
-//    refresh(newBeanMap, parentBean);
-//  }
-
   @Override
   public final void refresh(BeanCollection<?> bc, EntityBean parentBean) {
     BeanMap<?, ?> newBeanMap = (BeanMap<?, ?>) bc;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanMapHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanMapHelp.java
@@ -113,11 +113,11 @@ public class BeanMapHelp<T> extends BaseCollectionHelp<T> {
     return beanMap;
   }
 
-  @Override
-  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, Transaction t, EntityBean parentBean) {
-    BeanMap<?, ?> newBeanMap = (BeanMap<?, ?>) server.findMap(query, t);
-    refresh(newBeanMap, parentBean);
-  }
+//  @Override
+//  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean) {
+//    BeanMap<?, ?> newBeanMap = (BeanMap<?, ?>) server.findMap(query);
+//    refresh(newBeanMap, parentBean);
+//  }
 
   @Override
   public final void refresh(BeanCollection<?> bc, EntityBean parentBean) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManySqlHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocManySqlHelp.java
@@ -127,6 +127,7 @@ class BeanPropertyAssocManySqlHelp<T> {
   List<Object> findIdsByParentId(Object parentId, Transaction t, boolean includeSoftDeletes, Set<Object> excludeDetailIds) {
     final SpiEbeanServer server = descriptor.ebeanServer();
     final SpiQuery<?> query = many.newQuery(server);
+    query.usingTransaction(t);
     many.bindParentIdEq(rawParentIdEQ(""), parentId, query);
     if (includeSoftDeletes) {
       query.setIncludeSoftDeletes();
@@ -135,17 +136,18 @@ class BeanPropertyAssocManySqlHelp<T> {
     if (excludeDetailIds != null && !excludeDetailIds.isEmpty()) {
       query.where().not(query.getExpressionFactory().idIn(excludeDetailIds));
     }
-    return server.findIds(query, t);
+    return server.findIds(query);
   }
 
   List<Object> findIdsByParentIdList(List<Object> parentIds, Transaction t, boolean includeSoftDeletes) {
     final SpiEbeanServer server = descriptor.ebeanServer();
     final SpiQuery<?> query = many.newQuery(server);
+    query.usingTransaction(t);
     many.bindParentIdsIn(rawParentIdIN("", parentIds.size()), parentIds, query);
     if (includeSoftDeletes) {
       query.setIncludeSoftDeletes();
     }
-    return server.findIds(query, t);
+    return server.findIds(query);
   }
 
   SpiSqlUpdate deleteByParentId(Object parentId) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -259,11 +259,12 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
     String rawWhere = deriveWhereParentIdSql(false);
     SpiEbeanServer server = server();
     SpiQuery<?> q = server.createQuery(type());
+    q.usingTransaction(t);
     bindParentIdEq(rawWhere, parentId, q);
     if (includeSoftDeletes) {
       q.setIncludeSoftDeletes();
     }
-    return server.findIds(q, t);
+    return server.findIds(q);
   }
 
   @Override
@@ -273,11 +274,12 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
     String expr = rawWhere + inClause;
     SpiEbeanServer server = server();
     SpiQuery<?> q = server.createQuery(type());
+    q.usingTransaction(t);
     bindParentIdsIn(expr, parentIds, q);
     if (includeSoftDeletes) {
       q.setIncludeSoftDeletes();
     }
-    return server.findIds(q, t);
+    return server.findIds(q);
   }
 
   void addFkey() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanSetHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanSetHelp.java
@@ -72,11 +72,11 @@ public class BeanSetHelp<T> extends BaseCollectionHelp<T> {
     return beanSet;
   }
 
-  @Override
-  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, Transaction t, EntityBean parentBean) {
-    BeanSet<?> newBeanSet = (BeanSet<?>) server.findSet(query, t);
-    refresh(newBeanSet, parentBean);
-  }
+//  @Override
+//  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean) {
+//    BeanSet<?> newBeanSet = (BeanSet<?>) server.findSet(query);
+//    refresh(newBeanSet, parentBean);
+//  }
 
   @Override
   public final void refresh(BeanCollection<?> bc, EntityBean parentBean) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanSetHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanSetHelp.java
@@ -72,12 +72,6 @@ public class BeanSetHelp<T> extends BaseCollectionHelp<T> {
     return beanSet;
   }
 
-//  @Override
-//  public final void refresh(SpiEbeanServer server, SpiQuery<?> query, EntityBean parentBean) {
-//    BeanSet<?> newBeanSet = (BeanSet<?>) server.findSet(query);
-//    refresh(newBeanSet, parentBean);
-//  }
-
   @Override
   public final void refresh(BeanCollection<?> bc, EntityBean parentBean) {
     BeanSet<?> newBeanSet = (BeanSet<?>) bc;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DeleteUnloadedForeignKeys.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DeleteUnloadedForeignKeys.java
@@ -50,7 +50,8 @@ final class DeleteUnloadedForeignKeys {
   void queryForeignKeys() {
 
     BeanDescriptor<?> descriptor = request.descriptor();
-    SpiQuery<?> q = (SpiQuery<?>) server.createQuery(descriptor.type());
+    SpiQuery<?> q = server.createQuery(descriptor.type());
+    q.usingTransaction(request.transaction());
 
     Object id = request.beanId();
 
@@ -71,7 +72,7 @@ final class DeleteUnloadedForeignKeys {
     if (t.isLogSummary()) {
       t.logSummary("-- Ebean fetching foreign key values for delete of {0} id:{1}", descriptor.name(), id);
     }
-    beanWithForeignKeys = (EntityBean) server.findOne(q, t);
+    beanWithForeignKeys = (EntityBean) server.findOne(q);
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/MergeHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/MergeHandler.java
@@ -92,7 +92,8 @@ final class MergeHandler {
       MergeNode node = buildNode(path);
       node.addSelectId(query);
     }
-    return (EntityBean) server.findOne(query, transaction);
+    query.usingTransaction(transaction);
+    return (EntityBean) server.findOne(query);
   }
 
   private MergeNode buildNode(String path) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DeleteHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DeleteHandler.java
@@ -33,9 +33,9 @@ final class DeleteHandler extends DmlHandler {
     SpiTransaction t = persistRequest.transaction();
     PreparedStatement pstmt;
     if (persistRequest.isBatched()) {
-      pstmt = getPstmtBatch(t, sql, persistRequest, false);
+      pstmt = pstmtBatch(t, sql, persistRequest, false);
     } else {
-      pstmt = getPstmt(t, sql, false);
+      pstmt = pstmt(t, sql, false);
     }
     dataBind = bind(pstmt);
     meta.bind(persistRequest, this);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DeleteMeta.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DeleteMeta.java
@@ -39,7 +39,7 @@ final class DeleteMeta extends BaseMeta {
   /**
    * Bind the request based on the concurrency mode.
    */
-  public void bind(PersistRequestBean<?> persist, DmlHandler bind) throws SQLException {
+  void bind(PersistRequestBean<?> persist, DmlHandler bind) throws SQLException {
     EntityBean bean = persist.entityBean();
     id.dmlBind(bind, bean);
     if (tenantId != null) {
@@ -54,7 +54,7 @@ final class DeleteMeta extends BaseMeta {
   /**
    * get or generate the sql based on the concurrency mode.
    */
-  public String getSql(PersistRequestBean<?> request) {
+  String getSql(PersistRequestBean<?> request) {
     if (id.isEmpty()) {
       throw new IllegalStateException("Can not deleteById on " + request.fullName() + " as no @Id property");
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
@@ -58,7 +58,7 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
   }
 
   @Override
-  public PersistRequestBean<?> getPersistRequest() {
+  public PersistRequestBean<?> persistRequest() {
     return persistRequest;
   }
 
@@ -233,7 +233,7 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
   /**
    * Check with useGeneratedKeys to get appropriate PreparedStatement.
    */
-  PreparedStatement getPstmt(SpiTransaction t, String sql, boolean genKeys) throws SQLException {
+  PreparedStatement pstmt(SpiTransaction t, String sql, boolean genKeys) throws SQLException {
     Connection conn = t.internalConnection();
     if (genKeys) {
       // the Id generated is always the first column
@@ -248,7 +248,7 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
   /**
    * Return a prepared statement taking into account batch requirements.
    */
-  PreparedStatement getPstmtBatch(SpiTransaction t, String sql, PersistRequestBean<?> request, boolean genKeys) throws SQLException {
+  PreparedStatement pstmtBatch(SpiTransaction t, String sql, PersistRequestBean<?> request, boolean genKeys) throws SQLException {
     BatchedPstmtHolder batch = t.batchControl().pstmtHolder();
     batchedPstmt = batch.batchedPstmt(sql);
     if (batchedPstmt != null) {
@@ -256,7 +256,7 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
       return batchedPstmt.statement(request);
     }
     batchedStatus = BATCHED_FIRST;
-    PreparedStatement stmt = getPstmt(t, sql, genKeys);
+    PreparedStatement stmt = pstmt(t, sql, genKeys);
     batchedPstmt = new BatchedPstmt(stmt, genKeys, sql, t);
     batch.addStmt(batchedPstmt, request);
     return stmt;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/GenerateDmlRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/GenerateDmlRequest.java
@@ -42,11 +42,11 @@ public final class GenerateDmlRequest {
     }
   }
 
-  int getBindColumnCount() {
+  int bindColumnCount() {
     return bindColumnCount;
   }
 
-  String getInsertBindBuffer() {
+  String insertBindBuffer() {
     return insertBindBuffer.toString();
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/InsertHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/InsertHandler.java
@@ -72,9 +72,9 @@ public final class InsertHandler extends DmlHandler {
     sql = meta.getSql(withId, persistRequest.isPublish());
     PreparedStatement pstmt;
     if (persistRequest.isBatched()) {
-      pstmt = getPstmtBatch(t, sql, persistRequest, useGeneratedKeys);
+      pstmt = pstmtBatch(t, sql, persistRequest, useGeneratedKeys);
     } else {
-      pstmt = getPstmt(t, sql, useGeneratedKeys);
+      pstmt = pstmt(t, sql, useGeneratedKeys);
     }
     dataBind = bind(pstmt);
     meta.bind(this, bean, withId, persistRequest.isPublish());
@@ -88,11 +88,10 @@ public final class InsertHandler extends DmlHandler {
    * Check with useGeneratedKeys to get appropriate PreparedStatement.
    */
   @Override
-  PreparedStatement getPstmt(SpiTransaction t, String sql, boolean useGeneratedKeys) throws SQLException {
+  PreparedStatement pstmt(SpiTransaction t, String sql, boolean useGeneratedKeys) throws SQLException {
     Connection conn = t.internalConnection();
     if (useGeneratedKeys) {
-      return conn.prepareStatement(sql, meta.getIdentityDbColumns());
-
+      return conn.prepareStatement(sql, meta.identityDbColumns());
     } else {
       return conn.prepareStatement(sql);
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/InsertMeta.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/InsertMeta.java
@@ -39,7 +39,7 @@ final class InsertMeta {
 
   InsertMeta(DatabasePlatform dbPlatform, BeanDescriptor<?> desc, Bindable shadowFKey, BindableId id, BindableList all) {
     this.platform = dbPlatform.platform();
-    this.discriminator = getDiscriminator(desc);
+    this.discriminator = discriminator(desc);
     this.id = id;
     this.all = all;
     this.allExcludeDraftOnly = all.excludeDraftOnly();
@@ -77,7 +77,7 @@ final class InsertMeta {
     }
   }
 
-  private static Bindable getDiscriminator(BeanDescriptor<?> desc) {
+  private static Bindable discriminator(BeanDescriptor<?> desc) {
     InheritInfo inheritInfo = desc.inheritInfo();
     return inheritInfo != null ? new BindableDiscriminator(inheritInfo) : null;
   }
@@ -89,7 +89,7 @@ final class InsertMeta {
     return concatenatedKey;
   }
 
-  String[] getIdentityDbColumns() {
+  String[] identityDbColumns() {
     return identityDbColumns;
   }
 
@@ -170,7 +170,7 @@ final class InsertMeta {
       allExcludeDraftOnly.dmlAppend(request);
     }
     request.append(") values (");
-    request.append(request.getInsertBindBuffer());
+    request.append(request.insertBindBuffer());
     request.append(")");
     return request.toString();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/UpdateHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/UpdateHandler.java
@@ -31,7 +31,7 @@ public final class UpdateHandler extends DmlHandler {
    */
   @Override
   public void bind() throws SQLException {
-    SpiUpdatePlan updatePlan = meta.getUpdatePlan(persistRequest);
+    SpiUpdatePlan updatePlan = meta.updatePlan(persistRequest);
     if (updatePlan.isEmptySetClause()) {
       emptySetClause = true;
       return;
@@ -41,9 +41,9 @@ public final class UpdateHandler extends DmlHandler {
     SpiTransaction t = persistRequest.transaction();
     PreparedStatement pstmt;
     if (persistRequest.isBatched()) {
-      pstmt = getPstmtBatch(t, sql, persistRequest, false);
+      pstmt = pstmtBatch(t, sql, persistRequest, false);
     } else {
-      pstmt = getPstmt(t, sql, false);
+      pstmt = pstmt(t, sql, false);
     }
     dataBind = bind(pstmt);
     meta.bind(persistRequest, this, updatePlan);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/UpdateMeta.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/UpdateMeta.java
@@ -44,11 +44,11 @@ final class UpdateMeta extends BaseMeta {
   /**
    * get or generate the sql based on the concurrency mode.
    */
-  SpiUpdatePlan getUpdatePlan(PersistRequestBean<?> request) {
-    return getDynamicUpdatePlan(request);
+  SpiUpdatePlan updatePlan(PersistRequestBean<?> request) {
+    return dynamicUpdatePlan(request);
   }
 
-  private SpiUpdatePlan getDynamicUpdatePlan(PersistRequestBean<?> persistRequest) {
+  private SpiUpdatePlan dynamicUpdatePlan(PersistRequestBean<?> persistRequest) {
     String key = persistRequest.updatePlanHash();
     // check if we can use a cached UpdatePlan
     BeanDescriptor<?> beanDescriptor = persistRequest.descriptor();
@@ -80,7 +80,7 @@ final class UpdateMeta extends BaseMeta {
     request.setUpdateSetMode();
     bindableList.dmlAppend(request);
 
-    if (request.getBindColumnCount() == 0) {
+    if (request.bindColumnCount() == 0) {
       // update properties must have been updatable=false
       // with the result that nothing is in the set clause
       return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableAssocOne.java
@@ -24,11 +24,6 @@ class BindableAssocOne implements Bindable {
   }
 
   @Override
-  public final String toString() {
-    return "BindableAssocOne " + assocOne;
-  }
-
-  @Override
   public final boolean isDraftOnly() {
     return assocOne.isDraftOnly();
   }
@@ -61,7 +56,7 @@ class BindableAssocOne implements Bindable {
       // which will require an additional update
       // register for post insert of assocBean
       // update of bean set importedId
-      request.getPersistRequest().deferredRelationship(assocBean, importedId, bean);
+      request.persistRequest().deferredRelationship(assocBean, importedId, bean);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableDiscriminator.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableDiscriminator.java
@@ -25,11 +25,6 @@ public final class BindableDiscriminator implements Bindable {
   }
 
   @Override
-  public String toString() {
-    return columnName + " = " + discValue;
-  }
-
-  @Override
   public boolean isDraftOnly() {
     return false;
   }
@@ -46,7 +41,6 @@ public final class BindableDiscriminator implements Bindable {
 
   @Override
   public void dmlBind(BindableRequest bindRequest, EntityBean bean) throws SQLException {
-
     bindRequest.bind(discValue, sqlType);
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableEmbedded.java
@@ -24,18 +24,12 @@ final class BindableEmbedded implements Bindable {
   }
 
   @Override
-  public String toString() {
-    return "BindableEmbedded " + embProp + " items:" + Arrays.toString(items);
-  }
-
-  @Override
   public boolean isDraftOnly() {
     return embProp.isDraftOnly();
   }
 
   @Override
   public void dmlAppend(GenerateDmlRequest request) {
-
     for (Bindable item : items) {
       item.dmlAppend(request);
     }
@@ -50,7 +44,6 @@ final class BindableEmbedded implements Bindable {
 
   @Override
   public void dmlBind(BindableRequest bindRequest, EntityBean bean) throws SQLException {
-
     // get the embedded bean
     EntityBean embBean = (EntityBean) embProp.getValue(bean);
     if (embBean == null) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableEncryptedProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableEncryptedProperty.java
@@ -24,11 +24,6 @@ final class BindableEncryptedProperty implements Bindable {
   }
 
   @Override
-  public String toString() {
-    return prop.toString();
-  }
-
-  @Override
   public boolean isDraftOnly() {
     return prop.isDraftOnly();
   }
@@ -42,18 +37,12 @@ final class BindableEncryptedProperty implements Bindable {
 
   @Override
   public void dmlAppend(GenerateDmlRequest request) {
-
     // columnName = AES_ENCRYPT(?,?)
     request.appendColumn(prop.dbColumn(), prop.dbBind());
   }
 
-
-  /**
-   * Bind a value in a Insert SET clause.
-   */
   @Override
   public void dmlBind(BindableRequest request, EntityBean bean) throws SQLException {
-
     Object value = null;
     if (bean != null) {
       value = prop.getValue(bean);
@@ -61,13 +50,11 @@ final class BindableEncryptedProperty implements Bindable {
 
     // get Encrypt key
     String encryptKeyValue = prop.encryptKey().getStringValue();
-
     if (!bindEncryptDataFirst) {
       // H2 encrypt function ... different parameter order
       request.bindNoLog(encryptKeyValue, Types.VARCHAR, prop.name() + "=****");
     }
     request.bindNoLog(value, prop);
-
     if (bindEncryptDataFirst) {
       // MySql, Postgres, Oracle
       request.bindNoLog(encryptKeyValue, Types.VARCHAR, prop.name() + "=****");

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableId.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableId.java
@@ -8,10 +8,8 @@ import io.ebeaninternal.server.core.PersistRequestBean;
  * Specifically if the concatenated id object is null on insert this can be
  * built from the matching ManyToOne associated beans. For example RoleUserId
  * embeddedId object could be built from the associated Role and User beans.
- * </p>
  * <p>
  * This is only attempted if the id is null when it gets to the insert.
- * </p>
  */
 public interface BindableId extends Bindable {
 
@@ -35,7 +33,6 @@ public interface BindableId extends Bindable {
    * <p>
    * Really only where there are ManyToOne assoc beans that make up the
    * primary key and the values can be got from those.
-   * </p>
    */
   boolean deriveConcatenatedId(PersistRequestBean<?> persist);
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableIdEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableIdEmbedded.java
@@ -49,11 +49,6 @@ final class BindableIdEmbedded implements BindableId {
     return null;
   }
 
-  @Override
-  public String toString() {
-    return embId + " props:" + Arrays.toString(props);
-  }
-
   /**
    * Does nothing for BindableId.
    */
@@ -94,18 +89,13 @@ final class BindableIdEmbedded implements BindableId {
         + " not have ManyToOne assoc beans matching the primary key columns?";
       throw new PersistenceException(m);
     }
-
     EntityBean bean = persist.entityBean();
-
     // create the new id
     EntityBean newId = (EntityBean) embId.createEmbeddedId();
-
     // populate it from the assoc one id values...
     for (MatchedImportedProperty match : matches) {
       match.populate(bean, newId);
     }
-
-    // support PropertyChangeSupport
     embId.setValueIntercept(bean, newId);
     return true;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableIdScalar.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableIdScalar.java
@@ -36,11 +36,6 @@ final class BindableIdScalar implements BindableId {
   }
 
   @Override
-  public String toString() {
-    return uidProp.toString();
-  }
-
-  @Override
   public boolean isDraftOnly() {
     return false;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableProperty.java
@@ -20,11 +20,6 @@ class BindableProperty implements Bindable {
   }
 
   @Override
-  public final String toString() {
-    return prop.toString();
-  }
-
-  @Override
   public final boolean isDraftOnly() {
     return prop.isDraftOnly();
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindablePropertyJsonInsert.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindablePropertyJsonInsert.java
@@ -18,9 +18,6 @@ final class BindablePropertyJsonInsert extends BindableProperty {
     this.propertyIndex = prop.propertyIndex();
   }
 
-  /**
-   * Normal binding of a property value from the bean.
-   */
   @Override
   public void dmlBind(BindableRequest request, EntityBean bean) throws SQLException {
     if (bean == null) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindablePropertyVersion.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindablePropertyVersion.java
@@ -46,7 +46,6 @@ final class BindablePropertyVersion implements Bindable {
    */
   @Override
   public void dmlBind(BindableRequest request, EntityBean bean) throws SQLException {
-
     // get prior version value from 'old values'
     Object value = bean._ebean_getIntercept().origValue(prop.propertyIndex());
     request.bind(value, prop);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableRequest.java
@@ -19,11 +19,9 @@ public interface BindableRequest {
    * Bind the value to a PreparedStatement.
    * <p>
    * Takes into account logicalType to dbType conversion if required.
-   * </p>
    * <p>
    * Returns the value that was bound (and was potentially converted from
    * logicalType to dbType.
-   * </p>
    */
   void bind(Object value, BeanProperty prop) throws SQLException;
 
@@ -45,7 +43,7 @@ public interface BindableRequest {
   /**
    * Return the original PersistRequest.
    */
-  PersistRequestBean<?> getPersistRequest();
+  PersistRequestBean<?> persistRequest();
 
   /**
    * Return the system current time in millis. This is expected to the same time used

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableUnidirectional.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableUnidirectional.java
@@ -16,7 +16,6 @@ import java.util.List;
  * <p>
  * This inserts the foreign key value that is retrieved from the id of the
  * parentBean.
- * </p>
  */
 public final class BindableUnidirectional implements Bindable {
 
@@ -28,11 +27,6 @@ public final class BindableUnidirectional implements Bindable {
     this.desc = desc;
     this.unidirectional = unidirectional;
     this.importedId = unidirectional.importedId();
-  }
-
-  @Override
-  public String toString() {
-    return "BindableShadowFKey " + unidirectional;
   }
 
   @Override
@@ -53,12 +47,11 @@ public final class BindableUnidirectional implements Bindable {
 
   @Override
   public void dmlBind(BindableRequest request, EntityBean bean) throws SQLException {
-    PersistRequestBean<?> persistRequest = request.getPersistRequest();
+    PersistRequestBean<?> persistRequest = request.persistRequest();
     Object parentBean = persistRequest.parentBean();
     if (parentBean == null) {
       Class<?> localType = desc.type();
       Class<?> targetType = unidirectional.targetType();
-
       String msg = "Error inserting bean [" + localType + "] with unidirectional relationship. ";
       msg += "For inserts you must use cascade save on the master bean [" + targetType + "].";
       throw new PersistenceException(msg);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/FactoryBaseProperties.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/FactoryBaseProperties.java
@@ -10,7 +10,6 @@ import java.util.List;
  * Add base properties to the BindableList for a bean type.
  * <p>
  * This excludes unique embedded and associated properties.
- * </p>
  */
 public final class FactoryBaseProperties {
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/FactoryEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/FactoryEmbedded.java
@@ -36,5 +36,4 @@ public final class FactoryEmbedded {
     }
   }
 
-
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/FactoryProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/FactoryProperty.java
@@ -10,7 +10,6 @@ import io.ebeaninternal.server.persist.dml.DmlMode;
  * <p>
  * Lob properties can be excluded and it creates BindablePropertyInsertGenerated
  * and BindablePropertyUpdateGenerated as required.
- * </p>
  */
 final class FactoryProperty {
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQuery.java
@@ -13,9 +13,9 @@ abstract class CallableQuery<T> {
   final SpiEbeanServer server;
   final Transaction transaction;
 
-  CallableQuery(SpiEbeanServer server, SpiQuery<T> query, Transaction t) {
+  CallableQuery(SpiEbeanServer server, SpiQuery<T> query) {
     this.server = server;
     this.query = query;
-    this.transaction = t;
+    this.transaction = query.transaction();
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryCount.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryCount.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.query;
 
-import io.ebean.Transaction;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiQuery;
 
@@ -17,8 +16,8 @@ public final class CallableQueryCount<T> extends CallableQuery<T> implements Cal
    * Note that the transaction passed in is always a new transaction solely to
    * find the row count so it must be cleaned up by this CallableQueryRowCount.
    */
-  public CallableQueryCount(SpiEbeanServer server, SpiQuery<T> query, Transaction t, boolean createdTransaction) {
-    super(server, query, t);
+  public CallableQueryCount(SpiEbeanServer server, SpiQuery<T> query, boolean createdTransaction) {
+    super(server, query);
     this.createdTransaction = createdTransaction;
   }
 
@@ -28,7 +27,7 @@ public final class CallableQueryCount<T> extends CallableQuery<T> implements Cal
   @Override
   public Integer call() {
     try {
-      return server.findCountWithCopy(query, transaction);
+      return server.findCountWithCopy(query);
     } finally {
       if (createdTransaction) {
         transaction.end();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryIds.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryIds.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.query;
 
-import io.ebean.Transaction;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiQuery;
 
@@ -14,8 +13,8 @@ public final class CallableQueryIds<T> extends CallableQuery<T> implements Calla
 
   private final boolean createdTransaction;
 
-  public CallableQueryIds(SpiEbeanServer server, SpiQuery<T> query, Transaction t, boolean createdTransaction) {
-    super(server, query, t);
+  public CallableQueryIds(SpiEbeanServer server, SpiQuery<T> query, boolean createdTransaction) {
+    super(server, query);
     this.createdTransaction = createdTransaction;
   }
 
@@ -28,7 +27,7 @@ public final class CallableQueryIds<T> extends CallableQuery<T> implements Calla
     // this way the same query instance is available to the
     // QueryFutureIds (as so has access to the List before it is done)
     try {
-      return server.findIdsWithCopy(query, transaction);
+      return server.findIdsWithCopy(query);
     } finally {
       if (createdTransaction) {
         transaction.end();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryList.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.query;
 
-import io.ebean.Transaction;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiQuery;
 
@@ -14,8 +13,8 @@ public final class CallableQueryList<T> extends CallableQuery<T> implements Call
 
   private final boolean createdTransaction;
 
-  public CallableQueryList(SpiEbeanServer server, SpiQuery<T> query, Transaction t, boolean createdTransaction) {
-    super(server, query, t);
+  public CallableQueryList(SpiEbeanServer server, SpiQuery<T> query, boolean createdTransaction) {
+    super(server, query);
     this.createdTransaction = createdTransaction;
   }
 
@@ -25,7 +24,7 @@ public final class CallableQueryList<T> extends CallableQuery<T> implements Call
   @Override
   public List<T> call() {
     try {
-      return server.findList(query, transaction);
+      return server.findList(query);
     } finally {
       if (createdTransaction) {
         transaction.end();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/LimitOffsetPagedList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/LimitOffsetPagedList.java
@@ -57,7 +57,7 @@ public final class LimitOffsetPagedList<T> implements PagedList<T> {
     lock.lock();
     try {
       if (list == null) {
-        list = server.findList(query, null);
+        list = server.findList(query);
       }
       return list;
     } finally {
@@ -99,7 +99,7 @@ public final class LimitOffsetPagedList<T> implements PagedList<T> {
       if (foregroundTotalRowCount > -1) return foregroundTotalRowCount;
 
       // just using foreground thread
-      foregroundTotalRowCount = server.findCount(query, null);
+      foregroundTotalRowCount = server.findCount(query);
       return foregroundTotalRowCount;
     } finally {
       lock.unlock();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
@@ -5,10 +5,7 @@ import io.ebean.DtoQuery;
 import io.ebean.ProfileLocation;
 import io.ebean.QueryIterator;
 import io.ebean.Transaction;
-import io.ebeaninternal.api.BindParams;
-import io.ebeaninternal.api.SpiDtoQuery;
-import io.ebeaninternal.api.SpiEbeanServer;
-import io.ebeaninternal.api.SpiQuery;
+import io.ebeaninternal.api.*;
 import io.ebeaninternal.server.dto.DtoBeanDescriptor;
 import io.ebeaninternal.server.dto.DtoMappingRequest;
 import io.ebeaninternal.server.dto.DtoQueryPlan;
@@ -39,7 +36,7 @@ public final class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQue
   private String label;
   private ProfileLocation profileLocation;
   private final BindParams bindParams = new BindParams();
-  private Transaction transaction;
+  private SpiTransaction transaction;
 
   /**
    * Create given an underlying ORM query.
@@ -85,7 +82,7 @@ public final class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQue
 
   @Override
   public DtoQuery<T> usingTransaction(Transaction transaction) {
-    this.transaction = transaction;
+    this.transaction = (SpiTransaction) transaction;
     return this;
   }
 
@@ -227,7 +224,7 @@ public final class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQue
   }
 
   @Override
-  public Transaction transaction() {
+  public SpiTransaction transaction() {
     return transaction;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1419,22 +1419,22 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
 
   @Override
   public final int delete() {
-    return server.delete(this, transaction);
+    return server.delete(this);
   }
 
   @Override
   public final int delete(Transaction transaction) {
-    return server.delete(this, transaction);
+    return server.delete(this);
   }
 
   @Override
   public final int update() {
-    return server.update(this, transaction);
+    return server.update(this);
   }
 
   @Override
   public final int update(Transaction transaction) {
-    return server.update(this, transaction);
+    return server.update(this);
   }
 
   @Override
@@ -1442,12 +1442,12 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     // a copy of this query is made in the server
     // as the query needs to modified (so we modify
     // the copy rather than this query instance)
-    return server.findIds(this, transaction);
+    return server.findIds(this);
   }
 
   @Override
   public final boolean exists() {
-    return server.exists(this, transaction);
+    return server.exists(this);
   }
 
   @Override
@@ -1455,38 +1455,38 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     // a copy of this query is made in the server
     // as the query needs to modified (so we modify
     // the copy rather than this query instance)
-    return server.findCount(this, transaction);
+    return server.findCount(this);
   }
 
   @Override
   public final void findEachWhile(Predicate<T> consumer) {
-    server.findEachWhile(this, consumer, transaction);
+    server.findEachWhile(this, consumer);
   }
 
   @Override
   public final void findEach(Consumer<T> consumer) {
-    server.findEach(this, consumer, transaction);
+    server.findEach(this, consumer);
   }
 
   @Override
   public final void findEach(int batch, Consumer<List<T>> consumer) {
-    server.findEach(this, batch, consumer, transaction);
+    server.findEach(this, batch, consumer);
   }
 
   @Override
   public final QueryIterator<T> findIterate() {
-    return server.findIterate(this, transaction);
+    return server.findIterate(this);
   }
 
   @Override
   public final Stream<T> findStream() {
-    return server.findStream(this, transaction);
+    return server.findStream(this);
   }
 
   @Override
   public final List<Version<T>> findVersions() {
     this.temporalMode = TemporalMode.VERSIONS;
-    return server.findVersions(this, transaction);
+    return server.findVersions(this);
   }
 
   @Override
@@ -1497,33 +1497,33 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
     this.temporalMode = TemporalMode.VERSIONS;
     this.versionsStart = start;
     this.versionsEnd = end;
-    return server.findVersions(this, transaction);
+    return server.findVersions(this);
   }
 
   @Override
   public final List<T> findList() {
-    return server.findList(this, transaction);
+    return server.findList(this);
   }
 
   @Override
   public final Set<T> findSet() {
-    return server.findSet(this, transaction);
+    return server.findSet(this);
   }
 
   @Override
   public final <K> Map<K, T> findMap() {
-    return server.findMap(this, transaction);
+    return server.findMap(this);
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public final <A> List<A> findSingleAttributeList() {
-    return server.findSingleAttributeList(this, transaction);
+    return server.findSingleAttributeList(this);
   }
 
   @Override
   public final <A> Set<A> findSingleAttributeSet() {
-    return server.findSingleAttributeSet(this, transaction);
+    return server.findSingleAttributeSet(this);
   }
 
   @Override
@@ -1534,12 +1534,12 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
 
   @Override
   public final T findOne() {
-    return server.findOne(this, transaction);
+    return server.findOne(this);
   }
 
   @Override
   public final Optional<T> findOneOrEmpty() {
-    return server.findOneOrEmpty(this, transaction);
+    return server.findOneOrEmpty(this);
   }
 
   @Override
@@ -1559,7 +1559,7 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
 
   @Override
   public final PagedList<T> findPagedList() {
-    return server.findPagedList(this, transaction);
+    return server.findPagedList(this);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
@@ -6,6 +6,7 @@ import io.ebean.*;
 import io.ebeaninternal.api.BindParams;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiSqlQuery;
+import io.ebeaninternal.api.SpiTransaction;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +29,7 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   private int timeout;
   private int bufferFetchSizeHint;
   private final BindParams bindParams = new BindParams();
-  private Transaction transaction;
+  private SpiTransaction transaction;
 
   /**
    * Additional supply a query detail object.
@@ -39,13 +40,13 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   }
 
   @Override
-  public Transaction transaction() {
+  public SpiTransaction transaction() {
     return transaction;
   }
 
   @Override
   public SqlQuery usingTransaction(Transaction transaction) {
-    this.transaction = transaction;
+    this.transaction = (SpiTransaction) transaction;
     return this;
   }
 
@@ -61,22 +62,22 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   }
 
   private void transaction(Transaction transaction) {
-    this.transaction = transaction;
+    this.transaction = (SpiTransaction) transaction;
   }
 
   @Override
   public void findEach(Consumer<SqlRow> consumer) {
-    server.findEach(this, consumer, transaction);
+    server.findEach(this, consumer);
   }
 
   @Override
   public void findEachWhile(Predicate<SqlRow> consumer) {
-    server.findEachWhile(this, consumer, transaction);
+    server.findEachWhile(this, consumer);
   }
 
   @Override
   public List<SqlRow> findList() {
-    return server.findList(this, transaction);
+    return server.findList(this);
   }
 
   @Override
@@ -86,7 +87,7 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
 
   @Override
   public SqlRow findOne() {
-    return server.findOne(this, transaction);
+    return server.findOne(this);
   }
 
   @Override

--- a/ebean-core/src/test/java/io/ebeaninternal/server/core/OrmQueryRequestTestHelper.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/core/OrmQueryRequestTestHelper.java
@@ -11,8 +11,9 @@ public class OrmQueryRequestTestHelper {
   /**
    * Create and return a OrmQueryRequest for the given query.
    */
+  @SuppressWarnings("unchecked")
   public static <T> OrmQueryRequest<T> queryRequest(Query<T> query) {
-    return (OrmQueryRequest<T>) defaultServer.createQueryRequest(SpiQuery.Type.LIST, query, null);
+    return (OrmQueryRequest<T>) defaultServer.createQueryRequest(SpiQuery.Type.LIST, (SpiQuery<? extends Object>) query);
   }
 
 }

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
@@ -706,20 +706,20 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public List<SqlRow> findList(SpiSqlQuery query, Transaction transaction) {
+  public List<SqlRow> findList(SpiSqlQuery query) {
     return null;
   }
 
   @Override
-  public void findEach(SpiSqlQuery query, Consumer<SqlRow> consumer, Transaction transaction) {
+  public void findEach(SpiSqlQuery query, Consumer<SqlRow> consumer) {
   }
 
   @Override
-  public void findEachWhile(SpiSqlQuery query, Predicate<SqlRow> consumer, Transaction transaction) {
+  public void findEachWhile(SpiSqlQuery query, Predicate<SqlRow> consumer) {
   }
 
   @Override
-  public SqlRow findOne(SpiSqlQuery query, Transaction transaction) {
+  public SqlRow findOne(SpiSqlQuery query) {
     return null;
   }
 

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
@@ -229,7 +229,7 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public <T> int delete(SpiQuery<T> query, Transaction t) {
+  public <T> int delete(SpiQuery<T> query) {
     return 0;
   }
 
@@ -239,7 +239,7 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public <T> int update(SpiQuery<T> query, Transaction transaction) {
+  public <T> int update(SpiQuery<T> query) {
     return 0;
   }
 
@@ -256,17 +256,17 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public <T> List<Version<T>> findVersions(SpiQuery<T> query, Transaction transaction) {
+  public <T> List<Version<T>> findVersions(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <A, T> List<A> findIdsWithCopy(SpiQuery<T> query, Transaction t) {
+  public <A, T> List<A> findIdsWithCopy(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <T> int findCountWithCopy(SpiQuery<T> query, Transaction t) {
+  public <T> int findCountWithCopy(SpiQuery<T> query) {
     return 0;
   }
 
@@ -453,7 +453,7 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public SpiResultSet findResultSet(SpiQuery<?> ormQuery, SpiTransaction transaction) {
+  public SpiResultSet findResultSet(SpiQuery<?> ormQuery) {
     return null;
   }
 
@@ -604,7 +604,7 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public <T> boolean exists(SpiQuery<T> ormQuery, Transaction transaction) {
+  public <T> boolean exists(SpiQuery<T> ormQuery) {
     return false;
   }
 
@@ -619,39 +619,39 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public <T> int findCount(SpiQuery<T> query, Transaction transaction) {
+  public <T> int findCount(SpiQuery<T> query) {
     return 0;
   }
 
   @Override
-  public <A, T> List<A> findIds(SpiQuery<T> query, Transaction transaction) {
+  public <A, T> List<A> findIds(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <T> QueryIterator<T> findIterate(SpiQuery<T> query, Transaction transaction) {
+  public <T> QueryIterator<T> findIterate(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <T> Stream<T> findStream(SpiQuery<T> query, Transaction transaction) {
+  public <T> Stream<T> findStream(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <T> void findEach(SpiQuery<T> query, Consumer<T> consumer, Transaction transaction) {
+  public <T> void findEach(SpiQuery<T> query, Consumer<T> consumer) {
   }
 
   @Override
-  public <T> void findEach(SpiQuery<T> query, int batch, Consumer<List<T>> consumer, Transaction t) {
+  public <T> void findEach(SpiQuery<T> query, int batch, Consumer<List<T>> consumer) {
   }
 
   @Override
-  public <T> void findEachWhile(SpiQuery<T> query, Predicate<T> consumer, Transaction transaction) {
+  public <T> void findEachWhile(SpiQuery<T> query, Predicate<T> consumer) {
   }
 
   @Override
-  public <T> List<T> findList(SpiQuery<T> query, Transaction transaction) {
+  public <T> List<T> findList(SpiQuery<T> query) {
     return null;
   }
 
@@ -671,37 +671,37 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public <T> PagedList<T> findPagedList(SpiQuery<T> query, Transaction transaction) {
+  public <T> PagedList<T> findPagedList(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <T> Set<T> findSet(SpiQuery<T> query, Transaction transaction) {
+  public <T> Set<T> findSet(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <K, T> Map<K, T> findMap(SpiQuery<T> query, Transaction transaction) {
+  public <K, T> Map<K, T> findMap(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <A, T> List<A> findSingleAttributeList(SpiQuery<T> query, Transaction transaction) {
+  public <A, T> List<A> findSingleAttributeList(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <A, T> Set<A> findSingleAttributeSet(SpiQuery<T> query, Transaction transaction) {
+  public <A, T> Set<A> findSingleAttributeSet(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <T> T findOne(SpiQuery<T> query, Transaction transaction) {
+  public <T> T findOne(SpiQuery<T> query) {
     return null;
   }
 
   @Override
-  public <T> Optional<T> findOneOrEmpty(SpiQuery<T> query, Transaction transaction) {
+  public <T> Optional<T> findOneOrEmpty(SpiQuery<T> query) {
     return null;
   }
 

--- a/ebean-test/src/test/java/org/tests/cache/TestBeanCache.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestBeanCache.java
@@ -122,7 +122,7 @@ public class TestBeanCache extends BaseTestCase {
 
     ServerCacheStatistics statistics = beanCache.statistics(true);
     assertThat(statistics.getHitCount()).isEqualTo(0);
-    assertThat(statistics.getMissCount()).isEqualTo(2);
+    assertThat(statistics.getMissCount()).isEqualTo(0);
     assertThat(statistics.getPutCount()).isEqualTo(2);
   }
 

--- a/ebean-test/src/test/java/org/tests/delete/TestDeleteByQuery.java
+++ b/ebean-test/src/test/java/org/tests/delete/TestDeleteByQuery.java
@@ -20,6 +20,7 @@ public class TestDeleteByQuery extends BaseTestCase {
     DB.save(u1);
   }
 
+  @IgnorePlatform(Platform.MYSQL)
   @Test
   void maxDelete_expect_singleDeleteStatement() {
     LoggedSql.start();


### PR DESCRIPTION
Originally the API took explicit transactions but then the API changed toward query.usingTransaction(), which means the SpiQuery holds the explicit transaction.

This change is to update the SpiEbeanServer API to reflect that it can get explicit transaction from SpiQuery.transaction() rather than pass transaction around.

Doing this also identified a small bug where L2 cache could be hit when it should not after there is some update on the transaction (hence the adjustment to the test TestBeanCache missCount)