### PR TITLE
Follow up #3173 - Change BeanSet clear() to lazy load ALL properties

### DIFF
--- a/ebean-api/src/main/java/io/ebean/common/BeanSet.java
+++ b/ebean-api/src/main/java/io/ebean/common/BeanSet.java
@@ -119,7 +119,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
     try {
       if (set == null) {
         if (!disableLazyLoad && modifyListening) {
-          lazyLoadCollection(true);
+          lazyLoadCollection(false);
         } else {
           set = new LinkedHashSet<>();
         }

--- a/ebean-test/src/test/java/org/tests/sets/TestO2MSet.java
+++ b/ebean-test/src/test/java/org/tests/sets/TestO2MSet.java
@@ -51,10 +51,8 @@ class TestO2MSet {
     employees.clear();
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(3);
-    assertThat(sql.get(0)).contains("select t0.department_id, t0.id from o2_memp t0 where (t0.department_id)");
-    assertThat(sql.get(1)).contains("select t0.id, t0.code, t0.name, t0.department_id from o2_memp t0 where t0.id = ?");
-    assertThat(sql.get(2)).contains("select t0.id, t0.code, t0.name, t0.department_id from o2_memp t0 where t0.id = ?");
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("select t0.department_id, t0.id, t0.code, t0.name, t0.department_id from o2_memp t0 where (t0.department_id)");
 
     final O2MEmp employee2 = new O2MEmp("After1", "Code3");
     employees.add(employee2);


### PR DESCRIPTION
Scenario:
set.clear() on a Set with orphanRemoval = true


Currently the clear() invokes lazy loads only fetching the Id properties but this is problematic when the entity bean in the Set has a hashcode/equals implementation as it results in 1 + N queries.  That is, for orphan removal it is identifying the beans that are going to be deleted and when doing that (with only the Id property fetched) the hashcode/equals implementation is invoked and that then invokes lazy loading N times where N is the number of elements in the collection that is being cleared.

To avoid the 1+N lazy loading queries instead the clear() invokes lazy loading that includes **_ALL_** the properties such that equals/hashcode implementation does not itself invoke lazy loading.

To be awesome, ebean would detect the properties that are used in hashcode/equals implementation and only fetch the Id property and those properties involved in the hashcode/equals for this case (rather than all properties). This might be a future optimisation that we could pursue using the entity bean enhancement to detect those properties used in the hashcode/equals.