### PR TITLE
Map.clear() on a @OneToMany orphanRemoval=true invokes 1+N queries du…

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
@@ -111,7 +111,12 @@ public final class LoadManyRequest extends LoadRequest {
     loadContext.configureQuery(query);
     if (onlyIds) {
       // lazy loading invoked via clear() and removeAll()
-      query.select(many.targetIdProperty());
+      String mapKey = many.mapKey();
+      if (mapKey != null) {
+        query.select(mapKey);
+      } else {
+        query.select(many.targetIdProperty());
+      }
     }
     return query;
   }

--- a/ebean-test/src/test/java/org/tests/sets/TestO2MMap.java
+++ b/ebean-test/src/test/java/org/tests/sets/TestO2MMap.java
@@ -37,42 +37,42 @@ class TestO2MMap {
     assertThat(sql.get(1)).contains("select t0.department_id, t0.id, t0.code, t0.name, t0.department_id from map_emp t0 where (t0.department_id)");
   }
 
-//  @Test
-//  void beanSet_when_clear_thenAddSave() {
-//
-//    final MapDepart department = new MapDepart("clearAndAdd");
-//    final MapEmp employee0 = new MapEmp("Init1", "Code0");
-//    final MapEmp employee1 = new MapEmp("Init2", "Code1");
-//    department.addEmployee(employee0);
-//    department.addEmployee(employee1);
-//    DB.save(department);
-//
-//    LoggedSql.start();
-//
-//    MapDepart dept = DB.find(MapDepart.class, department.getId());
-//
-//    List<String> sql = LoggedSql.collect();
-//    assertThat(sql).hasSize(1);
-//    assertThat(sql.get(0)).contains("select t0.id, t0.name from map_depart t0 where t0.id = ?");
-//
-//    Map<String, MapEmp> employees = dept.employees();
-//    employees.clear();
-//
-//    sql = LoggedSql.collect();
-//    assertThat(sql).hasSize(1);
-//    assertThat(sql.get(0)).contains("select t0.department_id, t0.id, t0.code from map_emp t0 where (t0.department_id)");
-//
-//    final MapEmp employee2 = new MapEmp("After1", "Code3");
-//    dept.addEmployee(employee2);
-//
-//    DB.save(dept);
-//
-//    sql = LoggedSql.collect();
-//    assertThat(sql).hasSize(5);
-//    assertThat(sql.get(0)).contains("delete from map_emp where id=?");
-//    assertThat(sql.get(1)).contains(" -- bind");
-//    assertThat(sql.get(2)).contains(" -- bind");
-//    assertThat(sql.get(3)).contains("insert into map_emp (code, name, department_id) values (?,?,?)");
-//    assertThat(sql.get(4)).contains(" -- bind");
-//  }
+  @Test
+  void beanMap_when_clear_thenAddSave() {
+
+    final MapDepart department = new MapDepart("clearAndAdd");
+    final MapEmp employee0 = new MapEmp("Init1", "Code0");
+    final MapEmp employee1 = new MapEmp("Init2", "Code1");
+    department.addEmployee(employee0);
+    department.addEmployee(employee1);
+    DB.save(department);
+
+    LoggedSql.start();
+
+    MapDepart dept = DB.find(MapDepart.class, department.getId());
+
+    List<String> sql = LoggedSql.collect();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("select t0.id, t0.name from map_depart t0 where t0.id = ?");
+
+    Map<String, MapEmp> employees = dept.employees();
+    employees.clear();
+
+    sql = LoggedSql.collect();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("select t0.department_id, t0.id, t0.code from map_emp t0 where (t0.department_id)");
+
+    final MapEmp employee2 = new MapEmp("After1", "Code3");
+    dept.addEmployee(employee2);
+
+    DB.save(dept);
+
+    sql = LoggedSql.collect();
+    assertThat(sql).hasSize(5);
+    assertThat(sql.get(0)).contains("delete from map_emp where id=?");
+    assertThat(sql.get(1)).contains(" -- bind");
+    assertThat(sql.get(2)).contains(" -- bind");
+    assertThat(sql.get(3)).contains("insert into map_emp (code, name, department_id) values (?,?,?)");
+    assertThat(sql.get(4)).contains(" -- bind");
+  }
 }


### PR DESCRIPTION
…e to MapKey

The fix is for LoadManyRequest to detect when a MapKey is on the collection and include that in the lazy loading query (to avoid the N queries invoked)

Also a follow up to #3173 