### PR TITLE
[12x] Backport of fix for #3173 BeanSet init(), initClear() and BeanMap

### DIFF
--- a/ebean-api/src/main/java/io/ebean/common/BeanSet.java
+++ b/ebean-api/src/main/java/io/ebean/common/BeanSet.java
@@ -117,7 +117,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
     try {
       if (set == null) {
         if (!disableLazyLoad && modifyListening) {
-          lazyLoadCollection(true);
+          lazyLoadCollection(false);
         } else {
           set = new LinkedHashSet<>();
         }
@@ -134,7 +134,7 @@ public final class BeanSet<E> extends AbstractBeanCollection<E> implements Set<E
         if (disableLazyLoad) {
           set = new LinkedHashSet<>();
         } else {
-          lazyLoadCollection(true);
+          lazyLoadCollection(false);
         }
       }
     } finally {

--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
@@ -97,8 +97,12 @@ public final class LoadManyRequest extends LoadRequest {
     // potentially changes the joins, selected properties, cache mode
     loadContext.configureQuery(query);
     if (onlyIds) {
-      // lazy loading invoked via clear() and removeAll()
-      query.select(many.targetIdProperty());
+      String mapKey = many.mapKey();
+      if (mapKey != null) {
+        query.select(mapKey);
+      } else {
+        query.select(many.targetIdProperty());
+      }
     }
     return query;
   }


### PR DESCRIPTION
- BeanSet init() and initClear() load with onlyIds false because the expectation is that with BeanSet the equals/hashCode implementation can use a property
- BeanMap lazy loading, include the mapKey if defined in the lazy loading query