### PR TITLE
Regression of #3133 with formula properties

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/MatchedImportedFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/MatchedImportedFactory.java
@@ -41,7 +41,7 @@ final class MatchedImportedFactory {
     }
     // match on property name
     for (BeanProperty beanProperty : desc.propertiesBaseScalar()) {
-      if (prop.name().equals(beanProperty.name())) {
+      if (!beanProperty.isFormula() && prop.name().equals(beanProperty.name())) {
         return new MatchedImportedScalar(prop, beanProperty);
       }
     }

--- a/ebean-test/src/test/java/org/tests/model/composite/DataWithFormula.java
+++ b/ebean-test/src/test/java/org/tests/model/composite/DataWithFormula.java
@@ -1,0 +1,65 @@
+package org.tests.model.composite;
+
+
+import io.ebean.annotation.Formula;
+import io.ebean.annotation.Index;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+
+public class DataWithFormula {
+
+  private static final long serialVersionUID = 1L;
+
+  @EmbeddedId
+  private DataWithFormulaKey id;
+
+
+  @Formula(select = "${ta}.meta_key")
+  private String metaKey;
+
+  @Formula(select = "${ta}.value_index")
+  private Integer valueIndex;
+
+  @ManyToOne
+  @JoinColumn(name = "main_id", insertable = false, nullable = false)
+  private DataWithFormulaMain main;
+
+  @Index
+  private String stringValue;
+
+  public DataWithFormulaKey getId() {
+    return id;
+  }
+
+  public void setId(DataWithFormulaKey id) {
+    this.id = id;
+  }
+
+  public String getMetaKey() {
+    return metaKey;
+  }
+
+  public void setMetaKey(String metaKey) {
+    this.metaKey = metaKey;
+  }
+
+  public Integer getValueIndex() {
+    return valueIndex;
+  }
+
+  public void setValueIndex(Integer valueIndex) {
+    this.valueIndex = valueIndex;
+  }
+
+  public String getStringValue() {
+    return stringValue;
+  }
+
+  public void setStringValue(String stringValue) {
+    this.stringValue = stringValue;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/composite/DataWithFormulaKey.java
+++ b/ebean-test/src/test/java/org/tests/model/composite/DataWithFormulaKey.java
@@ -1,0 +1,59 @@
+package org.tests.model.composite;
+
+import io.ebean.annotation.NotNull;
+import jakarta.persistence.Embeddable;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Embeddable
+public class DataWithFormulaKey {
+
+  private static final long serialVersionUID = 1L;
+
+  @NotNull
+  private UUID mainId;
+
+  @NotNull
+  private String metaKey = "";
+
+  @NotNull
+  private Integer valueIndex = 0;
+
+  public UUID getMainId() {
+    return mainId;
+  }
+
+  public void setMainId(UUID mainId) {
+    this.mainId = mainId;
+  }
+
+  public String getMetaKey() {
+    return metaKey;
+  }
+
+  public void setMetaKey(String metaKey) {
+    this.metaKey = metaKey;
+  }
+
+  public Integer getValueIndex() {
+    return valueIndex;
+  }
+
+  public void setValueIndex(Integer valueIndex) {
+    this.valueIndex = valueIndex;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DataWithFormulaKey that = (DataWithFormulaKey) o;
+    return Objects.equals(mainId, that.mainId) && Objects.equals(metaKey, that.metaKey) && Objects.equals(valueIndex, that.valueIndex);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mainId, metaKey, valueIndex);
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/composite/DataWithFormulaMain.java
+++ b/ebean-test/src/test/java/org/tests/model/composite/DataWithFormulaMain.java
@@ -1,0 +1,44 @@
+package org.tests.model.composite;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+public class DataWithFormulaMain {
+  @Id
+  private UUID id;
+
+  private String title;
+
+  @OneToMany(cascade = CascadeType.ALL, mappedBy = "main")
+  private List<DataWithFormula> metaData;
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public List<DataWithFormula> getMetaData() {
+    return metaData;
+  }
+
+  public void setMetaData(List<DataWithFormula> metaData) {
+    this.metaData = metaData;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/composite/TestDataWithFormula.java
+++ b/ebean-test/src/test/java/org/tests/model/composite/TestDataWithFormula.java
@@ -1,0 +1,43 @@
+package org.tests.model.composite;
+
+import io.ebean.DB;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class TestDataWithFormula extends BaseTestCase {
+
+  @Test
+  public void test1() {
+
+
+    DataWithFormulaMain main = new DataWithFormulaMain();
+    main.setId(UUID.randomUUID());
+    main.setTitle("Main");
+
+    DataWithFormulaKey key = new DataWithFormulaKey();
+    key.setMainId(main.getId());
+    key.setMetaKey("meta");
+    key.setValueIndex(42);
+    DataWithFormula data = new DataWithFormula();
+    data.setId(key);
+    data.setStringValue("SomeValue");
+    main.setMetaData(List.of(data));
+
+    LoggedSql.start();
+    DB.save(main);
+    List<String> sqls = LoggedSql.stop();
+
+    assertThat(sqls).hasSize(3);
+    assertThat(sqls.get(0)).contains("insert into data_with_formula_main (id, title) values (?,?);"); // main
+    assertThat(sqls.get(1)).contains("insert into data_with_formula (main_id, meta_key, value_index, string_value) values (?,?,?,?)"); // main
+    assertThat(sqls.get(2)).contains("-- bind");
+
+  }
+}


### PR DESCRIPTION
Hello Rob, we had found a regression due #3133

**Use case:**

We had the following dataModel in our application
```java
@Entity
public class DataMain {
  @Id  
  private UUID id; 
  private String title;
  @OneToMany(cascade = CascadeType.ALL, mappedBy = "main")
  private List<Data> metaData;
}

public class Data {
  private UUID mainId;
  private String metaKey;
  private Integer valueIndex;
  private String stringValue;
  @ManyToOne
  private DataMain main;
}
```
Logically, `Data` represents an attribute set on `DataMain`
So `DataMain` can have several attributes called `metaKey` and attributes with the same `metaKey` have a position (`valueIndex`)

Later we had the requirement, that it is guaranteed, that `mainId`, `metaKey` and `valueIndex` is unique.

So we were at the decision:
- to add a separate unique index on these 3 items 
- or extend the primary key.

We decided to extend the PK, as we think it is better for the DB than a separate index.
We did this in the way as it is implemented in the test. (Move mainId, metaKey + valueIndex to an embeddable object) and added some annotations, so that the mapping is handled correctly.

But now, we had a problem with existing code, as the properties for "metaKey" and "valueIndex" are only reachable over the embedded ID.

To be backwards compatible, we decided to add the old properties as `@Formula` that will compute directly on the DB field, so existing code can read them.

This works fine till commit #3155, issue #3133

It seems that MatchedImportedProperty will find the formula properties and then it produces a wrong insert statement:
```sql
insert into data_with_formula (main_id, ${}meta_key, ${}value_index, string_value) values (?,?,?,?)
```

This PR fixes ebean, so that we have no breaking change in our application.
Nevertheless, I would like to ask the question whether the decisions to model the data model this way or whether we did “bad things” here

Roland


