### PR TITLE
use glassfish jaxb instead of old com.sun jaxb

### DIFF
--- a/ebean-ddl-generator/pom.xml
+++ b/ebean-ddl-generator/pom.xml
@@ -54,9 +54,9 @@
       <version>4.0.0</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>4.0.0</version>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>4.0.3</version>
       <scope>runtime</scope>
     </dependency>
     <!-- JAKARTA-DEPENDENCY-END -->

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -91,9 +91,9 @@
       <version>4.0.0</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>4.0.0</version>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>4.0.3</version>
       <scope>runtime</scope>
     </dependency>
     <!-- JAKARTA-DEPENDENCY-END -->


### PR DESCRIPTION
Hello Rob, as we are using ebean with spring 3 + jakarta in our application, we noted, that we will bundle the old jaxb-impl and the glassfish jaxb-runtime.

I did not spot out the exact difference, but https://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-impl is called `Old JAXB Runtime module` - so I think it is not recommended to use any more.

I also do not know, if the glassfish-jaxb runs in javax mode. Maybe the dependency in ebean-ddl-generator could be removed completely and the user has to provide one of the two libraries.