### PR TITLE
In version 13.22 if the entity definition is in a different package, …

### DIFF
--- a/ebean-querybean/src/test/java/org/example/domain/OtherMain.java
+++ b/ebean-querybean/src/test/java/org/example/domain/OtherMain.java
@@ -1,0 +1,18 @@
+package org.example.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import org.example.domain.other.OtherBean;
+
+@SuppressWarnings("unused")
+@Entity
+public class OtherMain {
+
+  @Id
+  long id;
+
+  @ManyToOne
+  OtherBean other;
+
+}

--- a/ebean-querybean/src/test/java/org/example/domain/other/OtherBean.java
+++ b/ebean-querybean/src/test/java/org/example/domain/other/OtherBean.java
@@ -1,0 +1,13 @@
+package org.example.domain.other;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@SuppressWarnings("unused")
+@Entity
+public class OtherBean {
+
+  @Id
+  long id;
+  String name;
+}

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -362,7 +362,8 @@ class ProcessingContext implements Constants {
   private PropertyType createPropertyTypeAssoc(String fullName) {
     String[] split = Split.split(fullName);
     String propertyName = "Q" + split[1] + ".Assoc";
-    return new PropertyTypeAssoc(propertyName);
+    String importName = split[0] + ".query.Q" + split[1];
+    return new PropertyTypeAssoc(propertyName, importName);
   }
 
   /**

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/PropertyTypeAssoc.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/PropertyTypeAssoc.java
@@ -7,13 +7,17 @@ import java.util.Set;
  */
 class PropertyTypeAssoc extends PropertyType {
 
+  private final String importName;
+
   /**
    * Construct given the associated bean type name and package.
    *
    * @param qAssocTypeName the associated bean type name.
+   * @param importName the import for the Assoc bean.
    */
-  PropertyTypeAssoc(String qAssocTypeName) {
+  PropertyTypeAssoc(String qAssocTypeName, String importName) {
     super(qAssocTypeName);
+    this.importName = importName;
   }
 
   /**
@@ -21,7 +25,7 @@ class PropertyTypeAssoc extends PropertyType {
    */
   @Override
   void addImports(Set<String> allImports) {
-    // do nothing
+    allImports.add(importName);
   }
 
 }


### PR DESCRIPTION
…the generated query bean cannot resolve the symbol erro