### PR TITLE
Change SQL log to include executeBatch() via BatchedPstmt

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchedPstmt.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchedPstmt.java
@@ -84,6 +84,9 @@ public final class BatchedPstmt implements SpiProfileTransactionEvent {
    */
   private void flushStatementBatch() throws SQLException {
     final int[] rows = pstmt.executeBatch();
+    if (transaction.isLogSql()) {
+      transaction.logSql(" -- executeBatch() size:{0} sql:{1}", rows.length, sql);
+    }
     if (rows.length != list.size()) {
       throw new IllegalStateException("Invalid state on executeBatch, rows:" + rows.length + " != " + list.size());
     }
@@ -153,6 +156,9 @@ public final class BatchedPstmt implements SpiProfileTransactionEvent {
   private void executeAndCheckRowCounts() throws SQLException {
     try {
       results = pstmt.executeBatch();
+      if (transaction.isLogSql()) {
+        transaction.logSql(" -- executeBatch() size:{0} sql:{1}", results.length, sql);
+      }
       if (results.length != list.size()) {
         throw new SQLException("Invalid state on executeBatch, rows:" + results.length + " != " + list.size());
       }

--- a/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServer_deleteAllByIdTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServer_deleteAllByIdTest.java
@@ -33,7 +33,7 @@ class EbeanServer_deleteAllByIdTest extends BaseTestCase {
     assertNotNull(bean2.getId());
 
     List<String> loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(4);
+    assertThat(loggedSql).hasSize(5);
     assertThat(loggedSql.get(0)).contains("insert into e_basicver");
     assertSqlBind(loggedSql, 1, 3);
 

--- a/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServer_saveAllTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServer_saveAllTest.java
@@ -28,7 +28,7 @@ public class EbeanServer_saveAllTest extends BaseTestCase {
 
     // assert
     List<String> loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(4);
+    assertThat(loggedSql).hasSize(5);
     assertThat(loggedSql.get(0)).contains("insert into e_basicver (");
     assertThat(loggedSql.get(0)).contains("name, description, other, last_update) values (");
 
@@ -50,7 +50,7 @@ public class EbeanServer_saveAllTest extends BaseTestCase {
     DB.deleteAll(someBeans);
 
     loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(4);
+    assertThat(loggedSql).hasSize(5);
     assertThat(loggedSql.get(0)).contains("delete from e_basicver where id=?");
   }
 
@@ -125,7 +125,7 @@ public class EbeanServer_saveAllTest extends BaseTestCase {
 
     // assert
     List<String> loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(4);
+    assertThat(loggedSql).hasSize(5);
     assertThat(loggedSql.get(0)).contains("insert into e_basicver (");
     assertThat(loggedSql.get(0)).contains("name, description, other, last_update) values (");
 
@@ -151,7 +151,7 @@ public class EbeanServer_saveAllTest extends BaseTestCase {
       txn.commit();
     }
     loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(4);
+    assertThat(loggedSql).hasSize(5);
     assertThat(loggedSql.get(0)).contains("delete from e_basicver where id=?");
   }
 

--- a/ebean-test/src/test/java/org/tests/basic/TestDeleteCascadingOneToMany.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestDeleteCascadingOneToMany.java
@@ -27,12 +27,12 @@ class TestDeleteCascadingOneToMany extends BaseTestCase {
     DB.delete(a0);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(6);
     assertThat(sql.get(0)).contains("select t0.id from section t0 where article_id=?");
     assertThat(sql.get(1)).contains("select t0.id from sub_section t0 where (section_id)"); // in | any
     assertThat(sql.get(2)).contains("delete from section where id"); // in | any
     assertThat(sql.get(3)).contains(" -- bind");
-    assertThat(sql.get(4)).contains("delete from article where id=? and version=?");
+    assertThat(sql.get(5)).contains("delete from article where id=? and version=?");
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/basic/delete/TestDeleteCascadeById.java
+++ b/ebean-test/src/test/java/org/tests/basic/delete/TestDeleteCascadeById.java
@@ -40,25 +40,30 @@ class TestDeleteCascadeById extends BaseTestCase {
 
     DB.delete(o);
     List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(6);
+    assertThat(sql).hasSize(8);
     assertThat(sql.get(0)).contains("select t0.id from o_order_detail t0 where order_id=?");
     assertThat(sql.get(1)).contains("delete from o_order_detail where id");
     assertThat(sql.get(2)).contains("-- bind(Array[3]");
     assertThat(sql.get(3)).contains("delete from or_order_ship where order_id = ?");
     assertThat(sql.get(4)).contains("-- bind(");
-    assertThat(sql.get(5)).contains("delete from o_order where id=? and updtime=?");
+    assertThat(sql.get(5)).contains("-- executeBatch");
+    assertThat(sql.get(6)).contains("-- executeBatch");
+    assertThat(sql.get(7)).contains("delete from o_order where id=? and updtime=?");
 
     DB.delete(cust);
     sql = LoggedSql.stop();
-    assertThat(sql).hasSize(9);
+    assertThat(sql).hasSize(12);
     assertThat(sql.get(0)).contains("select t0.id from contact t0 where customer_id=");
     assertThat(sql.get(1)).contains("delete from contact_note where (contact_id)");
     assertThat(sql.get(2)).contains(" -- bind(Array[3]=");
     assertThat(sql.get(3)).contains("delete from contact where id");
     assertThat(sql.get(4)).contains(" -- bind(Array[3]");
-    assertThat(sql.get(5)).contains("delete from o_customer where id=? and version=?");
-    assertThat(sql.get(6)).contains("delete from o_address where id=? and updtime=?");
-    assertThat(sql.get(7)).contains(" -- bind(");
-    assertThat(sql.get(8)).contains(" -- bind(");
+    assertThat(sql.get(5)).contains(" -- executeBatch");
+    assertThat(sql.get(6)).contains(" -- executeBatch");
+    assertThat(sql.get(7)).contains("delete from o_customer where id=? and version=?");
+    assertThat(sql.get(8)).contains("delete from o_address where id=? and updtime=?");
+    assertThat(sql.get(9)).contains(" -- bind(");
+    assertThat(sql.get(10)).contains(" -- bind(");
+    assertThat(sql.get(11)).contains(" -- executeBatch");
   }
 }

--- a/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
+++ b/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
@@ -100,7 +100,7 @@ public class TestBatchInsertFlush extends BaseTestCase {
       assertSql(sql.get(0)).contains("insert into t_atable_thatisrelatively");
       assertSql(sql.get(1)).contains("-- bind(");
       // detail
-      assertThat(sql.get(3)).contains("insert into t_detail_with_other_namexxxyy");
+      assertThat(sql.get(4)).contains("insert into t_detail_with_other_namexxxyy");
 
       assertThat(((SpiTransaction) transaction).label()).isEqualTo("TestBatchInsertFlush.no_cascade");
 
@@ -205,7 +205,7 @@ public class TestBatchInsertFlush extends BaseTestCase {
     assertThat(LoggedSql.collect()).isEmpty();
     Integer id = b1.getId();
     assertNotNull(id);
-    assertThat(LoggedSql.collect()).hasSize(3);
+    assertThat(LoggedSql.collect()).hasSize(4);
 
     EBasicVer b3 = new EBasicVer("b3");
     server.save(b3);
@@ -231,7 +231,7 @@ public class TestBatchInsertFlush extends BaseTestCase {
       assertThat(LoggedSql.collect()).isEmpty();
       Integer id = b1.getId();
       assertNotNull(id);
-      assertThat(LoggedSql.collect()).hasSize(3);
+      assertThat(LoggedSql.collect()).hasSize(4);
 
       EBasicVer b3 = new EBasicVer("b3");
       server.save(b3, txn);
@@ -298,7 +298,7 @@ public class TestBatchInsertFlush extends BaseTestCase {
       server.save(b3, txn);
 
       txn.commit();
-      assertThat(LoggedSql.collect()).hasSize(5);
+      assertThat(LoggedSql.collect()).hasSize(7);
 
     } finally {
       txn.end();

--- a/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertWithInitialisedCollection.java
+++ b/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertWithInitialisedCollection.java
@@ -40,7 +40,7 @@ public class TestBatchInsertWithInitialisedCollection extends BaseTestCase {
     }
 
     List<String> loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(4);
+    assertThat(loggedSql).hasSize(5);
     assertThat(loggedSql.get(0)).contains("insert into o_cached_bean (");
     assertThat(loggedSql.get(0)).contains("name) values (?");
   }

--- a/ebean-test/src/test/java/org/tests/cascade/TestMultiCascadeBatch.java
+++ b/ebean-test/src/test/java/org/tests/cascade/TestMultiCascadeBatch.java
@@ -55,12 +55,15 @@ public class TestMultiCascadeBatch extends BaseTestCase {
 
     assertThat(list).hasSize(3);
 
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertSql(sql.get(0)).contains("insert into site (id, name");
     assertSql(sql.get(1)).contains("insert into site (id, name");
     assertSqlBind(sql.get(2));
-    assertThat(sql.get(3)).contains("insert into site (id, name");
-    assertSqlBind(sql.get(4));
+    assertThat(sql.get(3)).contains(" -- executeBatch");
+    assertThat(sql.get(4)).contains("insert into site (id, name");
+    assertSqlBind(sql.get(5));
+    assertThat(sql.get(6)).contains(" -- executeBatch");
+
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/cascade/TestOrderedList.java
+++ b/ebean-test/src/test/java/org/tests/cascade/TestOrderedList.java
@@ -77,7 +77,7 @@ public class TestOrderedList extends BaseTestCase {
     DB.save(fresh);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(7);
+    assertThat(sql).hasSize(8);
     assertSql(sql.get(0)).contains("update om_ordered_master set name=?, version=?");
     assertSql(sql.get(1)).contains("update om_ordered_detail set version=?, sort_order=? where id=? and version=?");
 
@@ -86,7 +86,7 @@ public class TestOrderedList extends BaseTestCase {
     DB.save(fresh);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("update om_ordered_master set name=?, version=? where id=? and version=?; -- bind(m1-mod3");
     assertSql(sql.get(1)).contains("update om_ordered_detail set name=?, version=?, sort_order=? where id=? and version=?");
     assertThat(sql.get(2)).contains("bind(was 1,3,2,");
@@ -94,10 +94,10 @@ public class TestOrderedList extends BaseTestCase {
     DB.delete(fresh);
 
     sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("delete from om_ordered_detail where master_id = ?");
     assertSqlBind(sql.get(1));
-    assertSql(sql.get(2)).contains("delete from om_ordered_master where id=? and version=?");
+    assertSql(sql.get(3)).contains("delete from om_ordered_master where id=? and version=?");
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/cascade/TestOrphanCollectionReplacement.java
+++ b/ebean-test/src/test/java/org/tests/cascade/TestOrphanCollectionReplacement.java
@@ -20,20 +20,20 @@ class TestOrphanCollectionReplacement extends BaseTestCase {
     long parentId = setup(1000); // can be handled by statement for SqlServer
     List<String> sql = doUpdate(parentId, name -> !"c0".equals(name));
     if (isH2() || isPostgresCompatible()) { // using deleted=true vs deleted=1
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(6);
       assertThat(sql.get(0)).contains("update coone_many set deleted=true where coone_id = ? and not ( id ");
       assertThat(sql.get(1)).contains(" -- bind(");
-      assertThat(sql.get(2)).contains("insert into coone_many (coone_id, name, deleted) values (?,?,?)");
-      assertThat(sql.get(3)).contains(" -- bind(");
+      assertThat(sql.get(3)).contains("insert into coone_many (coone_id, name, deleted) values (?,?,?)");
+      assertThat(sql.get(4)).contains(" -- bind(");
     }
 
     if (isSqlServer()) {
       // statement mode
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(6);
       assertThat(sql.get(0)).contains("update coone_many set deleted=1 where coone_id = ? and not ( id ");
       assertThat(sql.get(1)).contains(" -- bind(");
-      assertThat(sql.get(2)).contains("insert into coone_many (id, coone_id, name, deleted) values (?,?,?,?)");
-      assertThat(sql.get(3)).contains(" -- bind(");
+      assertThat(sql.get(3)).contains("insert into coone_many (id, coone_id, name, deleted) values (?,?,?,?)");
+      assertThat(sql.get(4)).contains(" -- bind(");
     }
     COOne fetchedUser2 = DB.find(COOne.class, parentId);
     requireNonNull(fetchedUser2);
@@ -51,14 +51,14 @@ class TestOrphanCollectionReplacement extends BaseTestCase {
     List<String> sql = doUpdate(parentId, name -> !"c0".equals(name));
     if (isH2() || isPostgresCompatible()) { // using deleted=true vs deleted=1
       // CHECKME: H2 would not require the batch mode here and could theoretically do it in fewer statements
-      assertThat(sql).hasSize(5);
+      assertThat(sql).hasSize(7);
       assertThat(sql.get(0)).contains("select t0.id from coone_many t0 where coone_id=? and t0.deleted = false and t0.deleted = false; --bind");
       if (isH2()) {
         assertThat(sql.get(1)).contains("update coone_many set deleted=true where id  in (?)");
       }
       assertThat(sql.get(2)).contains(" -- bind(");
-      assertThat(sql.get(3)).contains("insert into coone_many (coone_id, name, deleted) values (?,?,?)");
-      assertThat(sql.get(4)).contains(" -- bind(");
+      assertThat(sql.get(4)).contains("insert into coone_many (coone_id, name, deleted) values (?,?,?)");
+      assertThat(sql.get(5)).contains(" -- bind(");
     }
 
     if (isSqlServer()) {
@@ -86,15 +86,15 @@ class TestOrphanCollectionReplacement extends BaseTestCase {
     List<String> sql = doUpdate(parentId, name -> Integer.parseInt(name.substring(1)) >= 2500);
     if (isH2()) { // using deleted=true vs deleted=1
       // CHECKME: H2 would not require the batch mode here and could theoretically do it in fewer statements
-      assertThat(sql).hasSize(8);
+      assertThat(sql).hasSize(11);
       assertThat(sql.get(0)).contains("select t0.id from coone_many t0 where coone_id=? and t0.deleted = false and t0.deleted = false; --bind"); // find all Ids
       assertThat(sql.get(1)).contains("update coone_many set deleted=true where id  in (?,?,?");
       assertThat(sql.get(2)).contains(" -- bind(Array[1000]="); // update first 1000
       assertThat(sql.get(3)).contains(" -- bind(Array[1000]="); // update second 1000
       assertThat(sql.get(4)).contains("update coone_many set deleted=true where id  in (?,?,?");
       assertThat(sql.get(5)).contains(" -- bind(Array[500]="); // update last 500
-      assertThat(sql.get(6)).contains("insert into coone_many (coone_id, name, deleted) values (?,?,?)");
-      assertThat(sql.get(7)).contains(" -- bind(");
+      assertThat(sql.get(8)).contains("insert into coone_many (coone_id, name, deleted) values (?,?,?)");
+      assertThat(sql.get(9)).contains(" -- bind(");
     }
     if (isPostgresCompatible()) {
       assertThat(sql).hasSize(7);

--- a/ebean-test/src/test/java/org/tests/cascade/TestPrivateOwned.java
+++ b/ebean-test/src/test/java/org/tests/cascade/TestPrivateOwned.java
@@ -71,7 +71,7 @@ public class TestPrivateOwned extends BaseTestCase {
     DB.save(m0);
 
     List<String> loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(2);
+    assertThat(loggedSql).hasSize(3);
     assertThat(loggedSql.get(0)).contains("delete from t_detail_with_other_namexxxyy where id=?");
     assertSqlBind(loggedSql.get(1));
 

--- a/ebean-test/src/test/java/org/tests/ddl/TestForeignKeyModes.java
+++ b/ebean-test/src/test/java/org/tests/ddl/TestForeignKeyModes.java
@@ -79,10 +79,10 @@ public class TestForeignKeyModes extends BaseTestCase {
     DB.delete(none);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("delete from dfk_none_via_mto_m_dfk_one where dfk_none_via_mto_m_id = ?");
     assertSqlBind(sql.get(1));
-    assertSql(sql.get(2)).contains("delete from dfk_none_via_mto_m where id=?");
+    assertSql(sql.get(3)).contains("delete from dfk_none_via_mto_m where id=?");
   }
 
   @IgnorePlatform(Platform.NUODB)

--- a/ebean-test/src/test/java/org/tests/delete/TestDeleteCascadeWithListener.java
+++ b/ebean-test/src/test/java/org/tests/delete/TestDeleteCascadeWithListener.java
@@ -28,11 +28,11 @@ public class TestDeleteCascadeWithListener extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(6);
+      assertThat(sql).hasSize(7);
       assertSql(sql.get(0)).contains("select t0.id from dc_detail t0 where master_id=?");
       assertSql(sql.get(1)).contains("delete from dc_detail where id=?");
       assertSqlBind(sql, 2, 4);
-      assertThat(sql.get(5)).contains("delete from dc_master where id=? and version=?");
+      assertThat(sql.get(6)).contains("delete from dc_master where id=? and version=?");
     }
     awaitListenerPropagation();
 

--- a/ebean-test/src/test/java/org/tests/inheritance/TestInheritanceOrderColumn.java
+++ b/ebean-test/src/test/java/org/tests/inheritance/TestInheritanceOrderColumn.java
@@ -32,7 +32,7 @@ public class TestInheritanceOrderColumn extends BaseTestCase {
     LoggedSql.start();
     DB.save(master);
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     // Some platforms insert ids and others don't need to...
     assertSql(trimId(sql, 1))
       .contains("insert into ordered_parent (order_master_inheritance_id, dtype, common_name, ordered_aname, sort_order) values");
@@ -53,7 +53,7 @@ public class TestInheritanceOrderColumn extends BaseTestCase {
     LoggedSql.start();
     DB.save(result);
     sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertThat(sql.get(0)).contains("update ordered_parent set sort_order=? where id=?");
 
     result = DB.find(OrderMasterInheritance.class).findOne();

--- a/ebean-test/src/test/java/org/tests/iud/TestPersistCascade.java
+++ b/ebean-test/src/test/java/org/tests/iud/TestPersistCascade.java
@@ -30,16 +30,16 @@ public class TestPersistCascade extends BaseTestCase {
       assertSql(sql.get(0)).contains("insert into pcf_country");
       assertSql(sql.get(1)).contains("insert into pcf_person");
       assertSqlBind(sql, 2, 7);
-      assertThat(sql.get(8)).contains("insert into pcf_calendar");
-      assertSqlBind(sql, 9, 20);
-      assertThat(sql.get(21)).contains("insert into pcf_city");
-      assertSqlBind(sql, 22, 24);
-      assertThat(sql.get(25)).contains("insert into pcf_event");
-      assertSqlBind(sql, 26, 45);
-      assertThat(sql.get(46)).contains("insert into pcf_event");
-      assertSqlBind(sql, 47, 66);
-      assertThat(sql.get(67)).contains("insert into pcf_event");
-      assertSqlBind(sql, 68, 87);
+      assertThat(sql.get(9)).contains("insert into pcf_calendar");
+      assertSqlBind(sql, 10, 21);
+      assertThat(sql.get(23)).contains("insert into pcf_city");
+      assertSqlBind(sql, 24, 26);
+      assertThat(sql.get(28)).contains("insert into pcf_event");
+      assertSqlBind(sql, 29, 48);
+      assertThat(sql.get(50)).contains("insert into pcf_event");
+      assertSqlBind(sql, 51, 70);
+      assertThat(sql.get(72)).contains("insert into pcf_event");
+      assertSqlBind(sql, 73, 87);
     }
 
     country.deletePermanent();

--- a/ebean-test/src/test/java/org/tests/m2m/TestM2MDeleteNoCascade.java
+++ b/ebean-test/src/test/java/org/tests/m2m/TestM2MDeleteNoCascade.java
@@ -75,12 +75,14 @@ public class TestM2MDeleteNoCascade extends BaseTestCase {
     DB.update(user);
 
     final List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertSql(sql.get(0)).contains("update mnoc_user set user_name=?, version=? where user_id=? and version=?");
     assertSql(sql.get(1)).contains("delete from mnoc_user_mnoc_role where mnoc_user_user_id = ?");
     assertSqlBind(sql.get(2));
     assertThat(sql.get(3)).contains("insert into mnoc_user_mnoc_role (mnoc_user_user_id, mnoc_role_role_id) values (?, ?)");
     assertSqlBind(sql.get(4));
+    assertThat(sql.get(5)).contains("-- executeBatch");
+    assertThat(sql.get(6)).contains("-- executeBatch");
   }
 
   @Test
@@ -107,10 +109,10 @@ public class TestM2MDeleteNoCascade extends BaseTestCase {
     }
 
     final List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(8);
+    assertThat(sql).hasSize(12);
     assertSql(sql.get(0)).contains("delete from mnoc_user_mnoc_role where mnoc_user_user_id = ?");
-    assertThat(sql.get(4)).contains("delete from mnoc_user_mnoc_role where mnoc_user_user_id = ?");
-    assertSql(sql.get(2)).contains("delete from mnoc_user where user_id=? and version=?");
-    assertThat(sql.get(6)).contains("delete from mnoc_user where user_id=? and version=?");
+    assertThat(sql.get(6)).contains("delete from mnoc_user_mnoc_role where mnoc_user_user_id = ?");
+    assertSql(sql.get(3)).contains("delete from mnoc_user where user_id=? and version=?");
+    assertThat(sql.get(9)).contains("delete from mnoc_user where user_id=? and version=?");
   }
 }

--- a/ebean-test/src/test/java/org/tests/merge/TestMergeBasic.java
+++ b/ebean-test/src/test/java/org/tests/merge/TestMergeBasic.java
@@ -63,10 +63,10 @@ public class TestMergeBasic extends BaseTestCase {
       assertThat(sql.get(3)).contains("insert into uutwo (id, name, notes, version, master_id) values (?,?,?,?,?)");
       assertThat(sql.get(4)).contains("-- bind(");
       assertThat(sql.get(5)).contains("-- bind(");
-      assertThat(sql.get(6)).contains("update uutwo set name=?, notes=?, version=?, master_id=? where id=? and version=?");
-      assertThat(sql.get(7)).contains("-- bind(");
+      assertThat(sql.get(7)).contains("update uutwo set name=?, notes=?, version=?, master_id=? where id=? and version=?");
       assertThat(sql.get(8)).contains("-- bind(");
       assertThat(sql.get(9)).contains("-- bind(");
+      assertThat(sql.get(10)).contains("-- bind(");
 
     } else {
       assertThat(sql.get(3)).contains("insert into uutwo (id, name, notes, version, master_id) values (?,?,?,?,?);");
@@ -111,8 +111,8 @@ public class TestMergeBasic extends BaseTestCase {
       assertThat(sql.get(3)).contains("insert into uutwo (id, name, notes, version, master_id) values (?,?,?,?,?)");
       assertThat(sql.get(4)).contains("-- bind(");
       assertThat(sql.get(5)).contains("-- bind(");
-      assertThat(sql.get(6)).contains("update uutwo set name=?, notes=?, version=?, master_id=? where id=? and version=?");
-      assertThat(sql.get(9)).contains("-- bind(");
+      assertThat(sql.get(7)).contains("update uutwo set name=?, notes=?, version=?, master_id=? where id=? and version=?");
+      assertThat(sql.get(10)).contains("-- bind(");
 
     } else {
       assertThat(sql.get(3)).contains("insert into uutwo (id, name, notes, version, master_id) values (?,?,?,?,?);");

--- a/ebean-test/src/test/java/org/tests/merge/TestMergeCustomer.java
+++ b/ebean-test/src/test/java/org/tests/merge/TestMergeCustomer.java
@@ -92,11 +92,11 @@ public class TestMergeCustomer extends BaseTestCase {
     server().merge(mCustomer, options);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(6);
     assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
     assertSql(sql.get(1)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
     assertSqlBind(sql, 2, 3);
-    assertThat(sql.get(4)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
+    assertThat(sql.get(5)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
   }
 
   @Test
@@ -121,13 +121,13 @@ public class TestMergeCustomer extends BaseTestCase {
     server().merge(mCustomer, options);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(6);
+    assertThat(sql).hasSize(8);
     assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
     assertSql(sql.get(1)).contains("insert into maddress (id, street, city, version) values (?,?,?,?)");
     assertSqlBind(sql.get(2));
-    assertThat(sql.get(3)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
-    assertSqlBind(sql.get(4));
-    assertThat(sql.get(5)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
+    assertThat(sql.get(4)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
+    assertSqlBind(sql.get(5));
+    assertThat(sql.get(7)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
   }
 
   @Test
@@ -154,16 +154,16 @@ public class TestMergeCustomer extends BaseTestCase {
     server().merge(mCustomer, options);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(7);
+    assertThat(sql).hasSize(9);
     assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
 
     // Additional check to see if the address with the unknown UUID is 'insert' or 'update'
     assertSql(sql.get(1)).contains("select t0.id from maddress t0 where t0.id = ?");
     assertSql(sql.get(2)).contains("insert into maddress (id, street, city, version) values (?,?,?,?)");
     assertSqlBind(sql.get(3));
-    assertThat(sql.get(4)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
-    assertSqlBind(sql.get(5));
-    assertThat(sql.get(6)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
+    assertThat(sql.get(5)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
+    assertSqlBind(sql.get(6));
+    assertThat(sql.get(8)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
   }
 
   @Test
@@ -212,12 +212,12 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(20);
+      assertThat(sql).hasSize(26);
     }
     assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id where t0.id = ?");
     assertSql(sql.get(1)).contains("delete from mcontact_message where contact_id = ?");
-    assertThat(sql.get(3)).contains("delete from mcontact where id=?");
-    assertThat(sql.get(19)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
+    assertThat(sql.get(4)).contains("delete from mcontact where id=?");
+    assertThat(sql.get(25)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
   }
 
 
@@ -238,12 +238,12 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(20);
+      assertThat(sql).hasSize(26);
     }
     assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id where t0.id = ?");
     assertSql(sql.get(1)).contains("delete from mcontact_message where contact_id = ?");
-    assertThat(sql.get(3)).contains("delete from mcontact where id=?");
-    assertThat(sql.get(19)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
+    assertThat(sql.get(4)).contains("delete from mcontact where id=?");
+    assertThat(sql.get(25)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
   }
 
   @Test
@@ -276,17 +276,17 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(16);
+      assertThat(sql).hasSize(20);
       assertSql(sql.get(0)).contains("select t0.id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id where t0.id = ?");
       assertSql(sql.get(1)).contains("delete from mcontact_message where contact_id = ?");
-      assertThat(sql.get(3)).contains("delete from mcontact where id=?");
-      assertThat(sql.get(7)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
+      assertThat(sql.get(4)).contains("delete from mcontact where id=?");
+      assertThat(sql.get(9)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
     }
 
     if (isPersistBatchOnCascade()) {
-      assertThat(sql.get(8)).contains("insert into mcontact");
-      assertThat(sql.get(9)).contains("-- bind(");
-      assertThat(sql.get(11)).contains("update mcontact set email=?, first_name=?, last_name=?, version=?, customer_id=? where id=? and version=?");
+      assertThat(sql.get(10)).contains("insert into mcontact");
+      assertThat(sql.get(11)).contains("-- bind(");
+      assertThat(sql.get(14)).contains("update mcontact set email=?, first_name=?, last_name=?, version=?, customer_id=? where id=? and version=?");
     } else {
       assertThat(sql.get(6)).contains("update mcontact set email=?, first_name=?, last_name=?, version=?, customer_id=? where id=? and version=?");
       assertThat(sql.get(7)).contains("update mcontact set email=?, first_name=?, last_name=?, version=?, customer_id=? where id=? and version=?");
@@ -323,15 +323,15 @@ public class TestMergeCustomer extends BaseTestCase {
         assertSql(sql.get(1)).contains("select t0.contact_id, t0.id from mcontact_message t0 where (t0.contact_id) in (?,?,?,?,?,?,?,?,?,?)");
       }
       assertSql(sql.get(2)).contains("delete from mcontact_message where contact_id = ?");
-      assertThat(sql.get(4)).contains("delete from mcontact where id=?");
-      assertThat(sql.get(5)).contains("delete from mcontact_message where contact_id = ?");
-      assertThat(sql.get(7)).contains("delete from mcontact where id=?");
+      assertThat(sql.get(5)).contains("delete from mcontact where id=?");
+      assertThat(sql.get(6)).contains("delete from mcontact_message where contact_id = ?");
+      assertThat(sql.get(9)).contains("delete from mcontact where id=?");
 
-      assertThat(sql.get(8)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
-      assertThat(sql.get(13)).contains("update mcontact set email=?, first_name=?, last_name=?, version=?, customer_id=? where id=? and version=?");
-      assertSqlBind(sql, 14, 17);
-      assertThat(sql.get(18)).contains("update mcontact_message set title=?, subject=?, notes=?, version=?, contact_id=? where id=? and version=?");
-      assertSqlBind(sql, 19, 22);
+      assertThat(sql.get(10)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
+      assertThat(sql.get(17)).contains("update mcontact set email=?, first_name=?, last_name=?, version=?, customer_id=? where id=? and version=?");
+      assertSqlBind(sql, 18, 21);
+      assertThat(sql.get(23)).contains("update mcontact_message set title=?, subject=?, notes=?, version=?, contact_id=? where id=? and version=?");
+      assertSqlBind(sql, 24, 29);
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/merge/TestMergeM2M.java
+++ b/ebean-test/src/test/java/org/tests/merge/TestMergeM2M.java
@@ -41,11 +41,12 @@ public class TestMergeM2M extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(6);
+      assertThat(sql).hasSize(7);
       assertSql(sql.get(0)).contains("select");
       assertSql(sql.get(1)).contains("insert into mmachine");
       assertSql(sql.get(2)).contains("insert into mmachine_mgroup");
       assertSqlBind(sql, 3, 5);
+      assertSql(sql.get(6)).contains(" -- executeBatch");
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("select");
@@ -66,13 +67,13 @@ public class TestMergeM2M extends BaseTestCase {
     DB.merge(m1, options);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(9);
+    assertThat(sql).hasSize(11);
     assertSql(sql.get(0)).contains("select");
     assertSql(sql.get(1)).contains("delete from mmachine_mgroup");
     assertSqlBind(sql, 2, 4);
 
-    assertThat(sql.get(5)).contains("insert into mmachine_mgroup");
-    assertSqlBind(sql, 6, 7);
-    assertThat(sql.get(8)).contains("update mmachine");
+    assertThat(sql.get(6)).contains("insert into mmachine_mgroup");
+    assertSqlBind(sql, 7, 8);
+    assertThat(sql.get(10)).contains("update mmachine");
   }
 }

--- a/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenFlushThenUpdate.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenFlushThenUpdate.java
@@ -41,7 +41,7 @@ public class TestInsertBatchThenFlushThenUpdate extends BaseTestCase {
       txn.flush();
 
       List<String> loggedSql1 = LoggedSql.start();
-      assertThat(loggedSql1).hasSize(4);
+      assertThat(loggedSql1).hasSize(6);
 
       parent.setName("MyDesk");
       DB.save(parent);
@@ -53,7 +53,7 @@ public class TestInsertBatchThenFlushThenUpdate extends BaseTestCase {
 
       // insert statements for EdExtendedParent
       List<String> loggedSql2 = LoggedSql.start();
-      assertThat(loggedSql2).hasSize(2);
+      assertThat(loggedSql2).hasSize(3);
       assertThat(loggedSql2.get(0)).contains(" update td_parent ");
     }
   }

--- a/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenUpdate.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenUpdate.java
@@ -48,10 +48,10 @@ public class TestInsertBatchThenUpdate extends BaseTestCase {
 
       // insert statements for EdExtendedParent
       List<String> loggedSql = LoggedSql.stop();
-      assertThat(loggedSql).hasSize(6);
+      assertThat(loggedSql).hasSize(9);
       assertThat(loggedSql.get(0)).contains("insert into td_parent");
-      assertThat(loggedSql.get(2)).contains("insert into td_child ");
-      assertThat(loggedSql.get(4)).contains("update td_parent set parent_name=? where parent_id=?");
+      assertThat(loggedSql.get(3)).contains("insert into td_child ");
+      assertThat(loggedSql.get(6)).contains("update td_parent set parent_name=? where parent_id=?");
     }
   }
 
@@ -91,9 +91,9 @@ public class TestInsertBatchThenUpdate extends BaseTestCase {
 
       // insert statements for EdExtendedParent
       List<String> loggedSql = LoggedSql.stop();
-      assertThat(loggedSql).hasSize(4);
+      assertThat(loggedSql).hasSize(6);
       assertThat(loggedSql.get(0)).contains("insert into td_parent");
-      assertThat(loggedSql.get(2)).contains("insert into td_child ");
+      assertThat(loggedSql.get(3)).contains("insert into td_child ");
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchWithDifferentRootTypes.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchWithDifferentRootTypes.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestInsertBatchWithDifferentRootTypes extends BaseTestCase {
@@ -63,8 +64,7 @@ public class TestInsertBatchWithDifferentRootTypes extends BaseTestCase {
 
       // insert statements for EdExtendedParent
       List<String> loggedSql2 = LoggedSql.start();
-      assertEquals(7, loggedSql2.size());
-
+      assertThat(loggedSql2).hasSize(10);
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/model/composite/TestData2WithFormula.java
+++ b/ebean-test/src/test/java/org/tests/model/composite/TestData2WithFormula.java
@@ -31,10 +31,10 @@ class TestData2WithFormula extends BaseTestCase {
     DB.save(main);
     List<String> sqls = LoggedSql.stop();
 
-    assertThat(sqls).hasSize(3);
+    assertThat(sqls).hasSize(4);
     assertThat(sqls.get(0)).contains("insert into data2_with_formula_main (id, title) values (?,?);"); // main
     assertThat(sqls.get(1)).contains("insert into data2_with_formula (main_id, meta_key, value_index, string_value) values (?,?,?,?)"); // main
     assertThat(sqls.get(2)).contains("-- bind");
-
+    assertThat(sqls.get(3)).contains("-- executeBatch");
   }
 }

--- a/ebean-test/src/test/java/org/tests/model/composite/TestDataWithFormula.java
+++ b/ebean-test/src/test/java/org/tests/model/composite/TestDataWithFormula.java
@@ -30,7 +30,7 @@ class TestDataWithFormula extends BaseTestCase {
     DB.save(main);
     List<String> sqls = LoggedSql.stop();
 
-    assertThat(sqls).hasSize(3);
+    assertThat(sqls).hasSize(4);
     assertThat(sqls.get(0)).contains("insert into data_with_formula_main (id, title) values (?,?);"); // main
     assertThat(sqls.get(1)).contains("insert into data_with_formula (main_id, meta_key, value_index, string_value) values (?,?,?,?)"); // main
     assertThat(sqls.get(2)).contains("-- bind");

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/EcmPersonTest.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/EcmPersonTest.java
@@ -31,7 +31,7 @@ public class EcmPersonTest extends BaseTestCase {
 
     final List<String> sql = LoggedSql.stop();
 
-    assertThat(sql).hasSize(4);
+    assertThat(sql).hasSize(5);
     assertSql(sql.get(0)).contains("insert into ecm_person ");
     assertSql(sql.get(1)).contains("insert into ecm_person_phone_numbers ");
     assertSql(sql.get(2)).contains("-- bind");

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/EcsPersonTest.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/EcsPersonTest.java
@@ -30,7 +30,7 @@ public class EcsPersonTest extends BaseTestCase {
 
     final List<String> sql = LoggedSql.stop();
 
-    assertThat(sql).hasSize(4);
+    assertThat(sql).hasSize(5);
     assertSql(sql.get(0)).contains("insert into ecs_person ");
     assertSql(sql.get(1)).contains("insert into ecs_person_phone ");
     assertSql(sql.get(2)).contains("-- bind");

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasic.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasic.java
@@ -28,7 +28,7 @@ class TestElementCollectionBasic extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     assertThat(eventLog()).containsOnly("preInsert", "postInsert");
-    assertThat(sql).hasSize(4);
+    assertThat(sql).hasSize(5);
 
     final EcPerson found = DB.find(EcPerson.class)
       .setId(person.getId())
@@ -66,10 +66,11 @@ class TestElementCollectionBasic extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("insert into ec_person");
       assertSql(sql.get(1)).contains("insert into ec_person_phone");
       assertSqlBind(sql, 2, 3);
+      assertThat(sql.get(4)).contains("-- executeBatch");
     } else {
       assertThat(sql).hasSize(3);
       assertSql(sql.get(0)).contains("insert into ec_person");
@@ -148,7 +149,7 @@ class TestElementCollectionBasic extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(2);
+    assertThat(sql).hasSize(3);
     assertSql(sql.get(0)).contains("update ec_person");
 
     assertThat(eventLog()).containsExactly("preUpdate", "postUpdate");
@@ -163,12 +164,12 @@ class TestElementCollectionBasic extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("update ec_person set name=?, version=? where id=? and version=?");
       assertSql(sql.get(1)).contains("delete from ec_person_phone where owner_id=?");
       assertSqlBind(sql.get(2));
-      assertThat(sql.get(3)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
-      assertSqlBind(sql, 4, 6);
+      assertThat(sql.get(4)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
+      assertSqlBind(sql, 5, 7);
 
     } else {
       assertThat(sql).hasSize(5);
@@ -194,12 +195,12 @@ class TestElementCollectionBasic extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(9);
+    assertThat(sql).hasSize(12);
     assertSql(sql.get(0)).contains("update ec_person set name=?, version=? where id=? and version=?");
-    assertSql(sql.get(2)).contains("delete from ec_person_phone where owner_id=?");
-    assertSqlBind(sql, 3);
-    assertThat(sql.get(4)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
-    assertSqlBind(sql, 5, 8);
+    assertSql(sql.get(3)).contains("delete from ec_person_phone where owner_id=?");
+    assertSqlBind(sql, 4);
+    assertThat(sql.get(6)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
+    assertSqlBind(sql, 7, 10);
 
     assertThat(eventLog()).containsExactly("preUpdate", "postUpdate");
 
@@ -226,11 +227,11 @@ class TestElementCollectionBasic extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(8);
+    assertThat(sql).hasSize(10);
     assertSql(sql.get(0)).contains("delete from ec_person_phone where owner_id=?");
     assertSqlBind(sql, 1);
-    assertSql(sql.get(2)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
-    assertSqlBind(sql, 3, 7);
+    assertSql(sql.get(3)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
+    assertSqlBind(sql, 4, 8);
 
     assertThat(eventLog()).containsExactly("preUpdate", "postUpdate");
 
@@ -243,11 +244,11 @@ class TestElementCollectionBasic extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(9);
+      assertThat(sql).hasSize(11);
       assertSql(sql.get(0)).contains("delete from ec_person_phone where owner_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
-      assertSqlBind(sql, 3, 8);
+      assertSql(sql.get(3)).contains("insert into ec_person_phone (owner_id,phone) values (?,?)");
+      assertSqlBind(sql, 4, 9);
 
     } else {
       assertThat(sql).hasSize(7);

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicCache.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicCache.java
@@ -43,8 +43,8 @@ public class TestElementCollectionBasicCache extends BaseTestCase {
 
     sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
-      assertSqlBind(sql, 4, 6);
+      assertThat(sql).hasSize(9);
+      assertSqlBind(sql, 5, 7);
     } else {
       assertThat(sql).hasSize(5);
     }
@@ -69,7 +69,7 @@ public class TestElementCollectionBasicCache extends BaseTestCase {
 
     sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7); // cache hit
+      assertThat(sql).hasSize(9); // cache hit
     } else {
       assertThat(sql).hasSize(5); // cache hit
     }

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMap.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMap.java
@@ -25,10 +25,11 @@ public class TestElementCollectionBasicMap extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("insert into ecm_person");
       assertSql(sql.get(1)).contains("insert into ecm_person_phone");
       assertSqlBind(sql, 2, 3);
+      assertSql(sql.get(4)).contains(" -- executeBatch");
     } else {
       assertThat(sql).hasSize(3);
       assertSql(sql.get(0)).contains("insert into ecm_person");
@@ -107,12 +108,12 @@ public class TestElementCollectionBasicMap extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("update ecm_person set name=?, version=? where id=? and version=?");
       assertSql(sql.get(1)).contains("delete from ecm_person_phone_numbers where ecm_person_id=?");
       assertSqlBind(sql.get(2));
-      assertThat(sql.get(3)).contains("insert into ecm_person_phone_numbers (ecm_person_id,type,phnum) values (?,?,?)");
-      assertSqlBind(sql, 4, 6);
+      assertThat(sql.get(4)).contains("insert into ecm_person_phone_numbers (ecm_person_id,type,phnum) values (?,?,?)");
+      assertSqlBind(sql, 5, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("update ecm_person set name=?, version=? where id=? and version=?");
@@ -142,11 +143,11 @@ public class TestElementCollectionBasicMap extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("delete from ecm_person_phone_numbers where ecm_person_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ecm_person_phone_numbers (ecm_person_id,type,phnum) values (?,?,?)");
-      assertSqlBind(sql, 3, 6);
+      assertSql(sql.get(3)).contains("insert into ecm_person_phone_numbers (ecm_person_id,type,phnum) values (?,?,?)");
+      assertSqlBind(sql, 4, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("delete from ecm_person_phone_numbers where ecm_person_id=?");

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMapAsLob.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMapAsLob.java
@@ -23,7 +23,7 @@ public class TestElementCollectionBasicMapAsLob extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("insert into ecmc_person");
       assertSql(sql.get(1)).contains("insert into ecmc_person_phone");
       assertSqlBind(sql, 2, 3);

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMapCache.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMapCache.java
@@ -45,8 +45,8 @@ public class TestElementCollectionBasicMapCache extends BaseTestCase {
 
     sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
-      assertSqlBind(sql, 4, 6);
+      assertThat(sql).hasSize(9);
+      assertSqlBind(sql, 5, 7);
     } else {
       assertThat(sql).hasSize(5);
     }
@@ -73,8 +73,8 @@ public class TestElementCollectionBasicMapCache extends BaseTestCase {
 
     sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(5); // cache hit
-      assertSqlBind(sql, 3, 4);
+      assertThat(sql).hasSize(7); // cache hit
+      assertSqlBind(sql, 4, 5);
     } else {
       assertThat(sql).hasSize(3); // cache hit
     }

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicSet.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicSet.java
@@ -23,7 +23,7 @@ class TestElementCollectionBasicSet extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("insert into ecs_person");
       assertSql(sql.get(1)).contains("insert into ecs_person_phone");
       assertSqlBind(sql, 2, 3);
@@ -104,12 +104,12 @@ class TestElementCollectionBasicSet extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("update ecs_person set name=?, version=? where id=? and version=?");
       assertSql(sql.get(1)).contains("delete from ecs_person_phone where ecs_person_id=?");
       assertSqlBind(sql.get(2));
-      assertThat(sql.get(3)).contains("insert into ecs_person_phone (ecs_person_id,phone) values (?,?)");
-      assertSqlBind(sql, 4, 6);
+      assertThat(sql.get(4)).contains("insert into ecs_person_phone (ecs_person_id,phone) values (?,?)");
+      assertSqlBind(sql, 5, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("update ecs_person set name=?, version=? where id=? and version=?");
@@ -139,11 +139,11 @@ class TestElementCollectionBasicSet extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("delete from ecs_person_phone where ecs_person_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ecs_person_phone (ecs_person_id,phone) values (?,?)");
-      assertSqlBind(sql, 3, 6);
+      assertSql(sql.get(3)).contains("insert into ecs_person_phone (ecs_person_id,phone) values (?,?)");
+      assertSqlBind(sql, 4, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("delete from ecs_person_phone where ecs_person_id=?");

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionCascadeMultiple.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionCascadeMultiple.java
@@ -41,8 +41,8 @@ public class TestElementCollectionCascadeMultiple extends BaseTestCase {
     assertThat(sql.get(8)).contains("-- bind");
     assertThat(sql.get(9)).contains("insert into ec_top_ecs_person");
     assertThat(sql.get(10)).contains("-- bind");
-    assertThat(sql.get(11)).contains("-- executeBatch() rows:2 sql:insert into ecs_person_phone");
-    assertThat(sql.get(12)).contains("-- executeBatch() rows:1 sql:insert into ec_top_ecs_person");
+    assertThat(sql.get(11)).contains("-- executeBatch() size:2 sql:insert into ecs_person_phone");
+    assertThat(sql.get(12)).contains("-- executeBatch() size:1 sql:insert into ec_top_ecs_person");
   }
 
   @Transactional(batchSize = 20)

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionCascadeMultiple.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionCascadeMultiple.java
@@ -29,17 +29,20 @@ public class TestElementCollectionCascadeMultiple extends BaseTestCase {
     save(top);
 
     final List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(9);
+    assertThat(sql).hasSize(13);
 
     assertSql(sql.get(0)).contains("insert into ecs_person");
     assertSql(sql.get(1)).contains("-- bind");
-    assertSql(sql.get(2)).contains("insert into ec_top");
-    assertThat(sql.get(3)).contains("-- bind");
-    assertThat(sql.get(4)).contains("insert into ecs_person_phone");
-    assertThat(sql.get(5)).contains("-- bind");
-    assertThat(sql.get(6)).contains("-- bind");
-    assertThat(sql.get(7)).contains("insert into ec_top_ecs_person");
+    assertThat(sql.get(2)).contains("-- executeBatch");
+    assertSql(sql.get(3)).contains("insert into ec_top");
+    assertThat(sql.get(4)).contains("-- bind");
+    assertThat(sql.get(6)).contains("insert into ecs_person_phone");
+    assertThat(sql.get(7)).contains("-- bind");
     assertThat(sql.get(8)).contains("-- bind");
+    assertThat(sql.get(9)).contains("insert into ec_top_ecs_person");
+    assertThat(sql.get(10)).contains("-- bind");
+    assertThat(sql.get(11)).contains("-- executeBatch() rows:2 sql:insert into ecs_person_phone");
+    assertThat(sql.get(12)).contains("-- executeBatch() rows:1 sql:insert into ec_top_ecs_person");
   }
 
   @Transactional(batchSize = 20)

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedList.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedList.java
@@ -23,7 +23,7 @@ public class TestElementCollectionEmbeddedList extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("insert into ecbl_person");
       assertSql(sql.get(1)).contains("insert into ecbl_person_phone_numbers");
       assertSqlBind(sql, 2, 3);
@@ -103,12 +103,12 @@ public class TestElementCollectionEmbeddedList extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("update ecbl_person set name=?, version=? where id=? and version=?");
       assertSql(sql.get(1)).contains("delete from ecbl_person_phone_numbers where person_id=?");
       assertSqlBind(sql.get(2));
-      assertThat(sql.get(3)).contains("insert into ecbl_person_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
-      assertSqlBind(sql, 4, 6);
+      assertThat(sql.get(4)).contains("insert into ecbl_person_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
+      assertSqlBind(sql, 5, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("update ecbl_person set name=?, version=? where id=? and version=?");
@@ -138,11 +138,11 @@ public class TestElementCollectionEmbeddedList extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("delete from ecbl_person_phone_numbers where person_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ecbl_person_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
-      assertSqlBind(sql, 3, 6);
+      assertSql(sql.get(3)).contains("insert into ecbl_person_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
+      assertSqlBind(sql, 4, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("delete from ecbl_person_phone_numbers where person_id=?");

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedListCache.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedListCache.java
@@ -48,11 +48,11 @@ class TestElementCollectionEmbeddedListCache extends BaseTestCase {
 
     sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(5); // update of collection only
+      assertThat(sql).hasSize(7); // update of collection only
       assertSql(sql.get(0)).contains("delete from ecbl_person_phone_numbers where person_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ecbl_person_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
-      assertSqlBind(sql, 3, 4);
+      assertSql(sql.get(3)).contains("insert into ecbl_person_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
+      assertSqlBind(sql, 4, 5);
     } else {
       assertThat(sql).hasSize(3); // update of collection only
       assertSql(sql.get(0)).contains("delete from ecbl_person_phone_numbers where person_id=?");
@@ -77,7 +77,7 @@ class TestElementCollectionEmbeddedListCache extends BaseTestCase {
     DB.save(three);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
 
     EcblPerson four = DB.find(EcblPerson.class)
       .setId(person.getId())

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedListCache2.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedListCache2.java
@@ -49,11 +49,11 @@ class TestElementCollectionEmbeddedListCache2 extends BaseTestCase {
 
     sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(5); // update of collection only
+      assertThat(sql).hasSize(7); // update of collection only
       assertSql(sql.get(0)).contains("delete from ecbl_person2_phone_numbers where person_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ecbl_person2_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
-      assertSqlBind(sql, 3, 4);
+      assertSql(sql.get(3)).contains("insert into ecbl_person2_phone_numbers (person_id,country_code,area,phnum) values (?,?,?,?)");
+      assertSqlBind(sql, 4, 5);
     } else {
       assertThat(sql).hasSize(3); // update of collection only
       assertSql(sql.get(0)).contains("delete from ecbl_person2_phone_numbers where person_id=?");
@@ -77,7 +77,7 @@ class TestElementCollectionEmbeddedListCache2 extends BaseTestCase {
     DB.save(three);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
 
     EcblPerson2 four = DB.find(EcblPerson2.class)
       .setId(person.getId())

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedMap.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedMap.java
@@ -24,10 +24,11 @@ public class TestElementCollectionEmbeddedMap extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(4);
+      assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("insert into ecbm_person");
       assertSql(sql.get(1)).contains("insert into ecbm_person_phone_numbers");
       assertSqlBind(sql, 2, 3);
+      assertThat(sql.get(4)).contains(" -- executeBatch");
     } else {
       assertThat(sql).hasSize(3);
       assertSql(sql.get(0)).contains("insert into ecbm_person");
@@ -96,11 +97,11 @@ public class TestElementCollectionEmbeddedMap extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("update ecbm_person set name=?, version=? where id=? and version=?");
       assertSql(sql.get(1)).contains("delete from ecbm_person_phone_numbers where person_id=?");
-      assertThat(sql.get(3)).contains("insert into ecbm_person_phone_numbers (person_id,mkey,country_code,area,phnum)");
-      assertSqlBind(sql, 4, 6);
+      assertThat(sql.get(4)).contains("insert into ecbm_person_phone_numbers (person_id,mkey,country_code,area,phnum)");
+      assertSqlBind(sql, 5, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("update ecbm_person set name=?, version=? where id=? and version=?");
@@ -130,11 +131,11 @@ public class TestElementCollectionEmbeddedMap extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(9);
       assertSql(sql.get(0)).contains("delete from ecbm_person_phone_numbers where person_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ecbm_person_phone_numbers (person_id,mkey,country_code,area,phnum) values (?,?,?,?,?)");
-      assertSqlBind(sql, 3, 6);
+      assertSql(sql.get(3)).contains("insert into ecbm_person_phone_numbers (person_id,mkey,country_code,area,phnum) values (?,?,?,?,?)");
+      assertSqlBind(sql, 4, 7);
     } else {
       assertThat(sql).hasSize(5);
       assertSql(sql.get(0)).contains("delete from ecbm_person_phone_numbers where person_id=?");

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedMapCache.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedMapCache.java
@@ -49,11 +49,11 @@ public class TestElementCollectionEmbeddedMapCache extends BaseTestCase {
 
     sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(5); // update of collection only
+      assertThat(sql).hasSize(7); // update of collection only
       assertSql(sql.get(0)).contains("delete from ecbm_person_phone_numbers where person_id=?");
       assertSqlBind(sql.get(1));
-      assertSql(sql.get(2)).contains("insert into ecbm_person_phone_numbers (person_id,mkey,country_code,area,phnum) values (?,?,?,?,?)");
-      assertSqlBind(sql, 3, 4);
+      assertSql(sql.get(3)).contains("insert into ecbm_person_phone_numbers (person_id,mkey,country_code,area,phnum) values (?,?,?,?,?)");
+      assertSqlBind(sql, 4, 5);
     } else {
       assertThat(sql).hasSize(4); // update of collection only
       assertSql(sql.get(0)).contains("delete from ecbm_person_phone_numbers where person_id=?");
@@ -79,7 +79,7 @@ public class TestElementCollectionEmbeddedMapCache extends BaseTestCase {
     DB.save(three);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
 
     EcbmPerson four = DB.find(EcbmPerson.class)
       .setId(person.getId())

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneOrphanRemove.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneOrphanRemove.java
@@ -33,21 +33,23 @@ public class TestOneToOneOrphanRemove extends BaseTestCase {
     DB.save(jack);
 
     List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertSql(sql.get(0)).contains("delete from oto_cust_address where aid=? and version=?");
     assertSqlBind(sql.get(1));
-    assertSql(sql.get(2)).contains("update oto_cust set version=? where cid=? and version=?");
-    assertThat(sql.get(3)).contains("insert into oto_cust_address ");
-    assertThat(sql.get(4)).contains("-- bind(");
+    assertThat(sql.get(2)).contains("-- executeBatch");
+    assertSql(sql.get(3)).contains("update oto_cust set version=? where cid=? and version=?");
+    assertThat(sql.get(4)).contains("insert into oto_cust_address ");
+    assertThat(sql.get(5)).contains("-- bind(");
 
     jack.setAddress(null);
     DB.save(jack);
 
     sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("delete from oto_cust_address where aid=? and version=?");
     assertSqlBind(sql.get(1));
-    assertSql(sql.get(2)).contains("update oto_cust set version=? where cid=? and version=?");
+    assertThat(sql.get(2)).contains("-- executeBatch");
+    assertSql(sql.get(3)).contains("update oto_cust set version=? where cid=? and version=?");
 
     OtoCustAddress foundAddress = DB.find(OtoCustAddress.class, address2.getAid());
     assertThat(foundAddress).isNull();

--- a/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneOrphanStringId.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/TestOneToOneOrphanStringId.java
@@ -25,10 +25,10 @@ public class TestOneToOneOrphanStringId extends BaseTestCase {
     DB.save(b);
 
     List<String> update = LoggedSql.collect();
-    assertThat(update).hasSize(3);
+    assertThat(update).hasSize(4);
     assertThat(update.get(0)).contains("insert into oto_aone");
     assertSqlBind(update.get(1));
-    assertThat(update.get(2)).contains("update oto_atwo set aone_id=? where id=?");
+    assertThat(update.get(3)).contains("update oto_atwo set aone_id=? where id=?");
 
     DB.delete(b);
 
@@ -51,10 +51,10 @@ public class TestOneToOneOrphanStringId extends BaseTestCase {
     DB.save(b);
 
     List<String> inserts = LoggedSql.collect();
-    assertThat(inserts).hasSize(3);
+    assertThat(inserts).hasSize(4);
     assertThat(inserts.get(0)).contains("insert into oto_aone");
     assertSqlBind(inserts.get(1));
-    assertThat(inserts.get(2)).contains("insert into oto_atwo");
+    assertThat(inserts.get(3)).contains("insert into oto_atwo");
 
     DB.delete(b);
 
@@ -82,12 +82,12 @@ public class TestOneToOneOrphanStringId extends BaseTestCase {
     DB.save(b);
 
     List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertSql(sql.get(0)).contains("insert into oto_aone");
     assertSqlBind(sql.get(1));
-    assertSql(sql.get(2)).contains("update oto_atwo set aone_id=? where id=?");
-    assertThat(sql.get(3)).contains("delete from oto_aone where id=?");
-    assertSqlBind(sql.get(4));
+    assertSql(sql.get(3)).contains("update oto_atwo set aone_id=? where id=?");
+    assertThat(sql.get(4)).contains("delete from oto_aone where id=?");
+    assertSqlBind(sql.get(5));
 
     DB.delete(b);
 

--- a/ebean-test/src/test/java/org/tests/model/onetoone/album/DeleteById_SoftDelete_Tests.java
+++ b/ebean-test/src/test/java/org/tests/model/onetoone/album/DeleteById_SoftDelete_Tests.java
@@ -204,7 +204,7 @@ public class DeleteById_SoftDelete_Tests extends BaseTestCase {
     DB.deleteAll(beans);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     if (isPersistBatchOnCascade()) {
       assertSql(sql.get(0)).contains("update cover set deleted=? where id=?");
     } else {
@@ -223,7 +223,7 @@ public class DeleteById_SoftDelete_Tests extends BaseTestCase {
     DB.deleteAll(beans);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     if (isPersistBatchOnCascade()) {
       assertSql(sql.get(0)).contains("update cover set deleted=? where id=?");
     }
@@ -246,7 +246,7 @@ public class DeleteById_SoftDelete_Tests extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     if (isPersistBatchOnCascade()) {
       assertSql(sql.get(0)).contains("update cover set deleted=? where id=?");
     }
@@ -266,7 +266,7 @@ public class DeleteById_SoftDelete_Tests extends BaseTestCase {
     DB.deleteAllPermanent(beans);
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("delete from cover where id=?");
   }
 
@@ -284,7 +284,7 @@ public class DeleteById_SoftDelete_Tests extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("delete from cover where id=?");
   }
 

--- a/ebean-test/src/test/java/org/tests/model/orphanremoval/TestOrphanRemoveO2M.java
+++ b/ebean-test/src/test/java/org/tests/model/orphanremoval/TestOrphanRemoveO2M.java
@@ -30,7 +30,7 @@ public class TestOrphanRemoveO2M extends BaseTestCase {
     assertThat(DB.find(OrpDetail.class, "d1")).isNull();
     assertThat(DB.find(OrpDetail.class, "d2")).isNull();
 
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("delete from orp_detail where id=?");
     assertSqlBind(sql, 1, 2);
   }

--- a/ebean-test/src/test/java/org/tests/model/site/TestTreeModel.java
+++ b/ebean-test/src/test/java/org/tests/model/site/TestTreeModel.java
@@ -25,10 +25,10 @@ public class TestTreeModel extends BaseTestCase {
     grandparent.save();
 
     final List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertSql(sql.get(0)).contains("insert into tree_entity");
     assertSql(sql.get(1)).contains("insert into tree_entity");
-    assertThat(sql.get(3)).contains("insert into tree_entity");
+    assertThat(sql.get(4)).contains("insert into tree_entity");
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/o2m/StatefulO2MSoftDelete.java
+++ b/ebean-test/src/test/java/org/tests/o2m/StatefulO2MSoftDelete.java
@@ -36,8 +36,8 @@ public class StatefulO2MSoftDelete extends BaseTestCase {
     var updateSql = LoggedSql.stop();
     updateSql.forEach(sql -> assertThat(sql).doesNotContain("delete from workflow_entity"));
     if (isH2()) {
-      assertThat(updateSql.get(4)).contains("update workflow_operation_entity set deleted=true where workflow_id = ?");
-      assertThat(updateSql.get(6)).contains("update workflow_entity set when_modified=?, deleted=? where id=?");
+      assertThat(updateSql.get(5)).contains("update workflow_operation_entity set deleted=true where workflow_id = ?");
+      assertThat(updateSql.get(8)).contains("update workflow_entity set when_modified=?, deleted=? where id=?");
     }
   }
 }

--- a/ebean-test/src/test/java/org/tests/o2m/TestOneToManyStatelessUpdateResultsInSoftDelete.java
+++ b/ebean-test/src/test/java/org/tests/o2m/TestOneToManyStatelessUpdateResultsInSoftDelete.java
@@ -141,7 +141,7 @@ class TestOneToManyStatelessUpdateResultsInSoftDelete extends BaseTestCase {
     DB.save(goodsAfterInsert);
     var sql = LoggedSql.collect();
     if (isH2() || isPostgresCompatible()) { // using deleted=true vs deleted=1
-      assertThat(sql).hasSize(2);
+      assertThat(sql).hasSize(3);
       assertThat(sql.get(0)).contains("update workflow_operation_entity set deleted=true where workflow_id = ?");
     }
 
@@ -166,14 +166,14 @@ class TestOneToManyStatelessUpdateResultsInSoftDelete extends BaseTestCase {
     sql = LoggedSql.collect();
     assertThat(sql).isNotEmpty();
     if (isH2() || isPostgresCompatible()) { // using deleted=true vs deleted=1
-      assertThat(sql).hasSize(7);
+      assertThat(sql).hasSize(10);
       assertThat(sql.get(0)).contains("update workflow_entity set when_modified=? where id=?");
       assertThat(sql.get(1)).contains(" -- bind(");
-      assertThat(sql.get(2)).contains("update workflow_operation_entity set deleted=true where workflow_id = ?");
-      assertThat(sql.get(3)).contains(" -- bind(");
-      assertThat(sql.get(4)).contains("insert into workflow_operation_entity (name, version, when_created, when_modified");
-      assertThat(sql.get(5)).contains(" -- bind(");
-      assertThat(sql.get(6)).contains("update goods_entity set when_modified=?, workflow_entity_id=? where id=?");
+      assertThat(sql.get(3)).contains("update workflow_operation_entity set deleted=true where workflow_id = ?");
+      assertThat(sql.get(4)).contains(" -- bind(");
+      assertThat(sql.get(6)).contains("insert into workflow_operation_entity (name, version, when_created, when_modified");
+      assertThat(sql.get(7)).contains(" -- bind(");
+      assertThat(sql.get(9)).contains("update goods_entity set when_modified=?, workflow_entity_id=? where id=?");
     }
 
     var ops = workflow.getOperations();
@@ -218,12 +218,12 @@ class TestOneToManyStatelessUpdateResultsInSoftDelete extends BaseTestCase {
 
     var sql = LoggedSql.collect();
     if (isH2() || isPostgresCompatible()) { // using deleted=true vs deleted=1
-      assertThat(sql).hasSize(5);
+      assertThat(sql).hasSize(7);
       assertThat(sql.get(0)).contains("update workflow_entity set when_modified=? where id=?");
       assertThat(sql.get(1)).contains(" -- bind(");
-      assertThat(sql.get(2)).contains("update workflow_operation_entity set deleted=true where workflow_id = ?");
-      assertThat(sql.get(3)).contains(" -- bind(");
-      assertThat(sql.get(4)).contains("update goods_entity set when_modified=?, workflow_entity_id=? where id=?");
+      assertThat(sql.get(3)).contains("update workflow_operation_entity set deleted=true where workflow_id = ?");
+      assertThat(sql.get(4)).contains(" -- bind(");
+      assertThat(sql.get(6)).contains("update goods_entity set when_modified=?, workflow_entity_id=? where id=?");
     }
 
     try (var writer = new StringWriter()) {
@@ -296,12 +296,12 @@ class TestOneToManyStatelessUpdateResultsInSoftDelete extends BaseTestCase {
     assertThat(sql).isNotEmpty();
     assertThat(sql.get(0)).contains("delete from attachment where goods_entity_id = ?");
     assertThat(sql.get(1)).contains(" -- bind(");
-    assertThat(sql.get(2)).contains("insert into attachment (id, goods_entity_id, name, ");
-    assertThat(sql.get(3)).contains(" -- bind(");
+    assertThat(sql.get(3)).contains("insert into attachment (id, goods_entity_id, name, ");
     assertThat(sql.get(4)).contains(" -- bind(");
+    assertThat(sql.get(5)).contains(" -- bind(");
     if (isH2() || isPostgresCompatible() || isMySql()) { // i.e. using identity, not using sequence
-      assertThat(sql.get(5)).contains("insert into attachment (goods_entity_id, name,");
-      assertThat(sql.get(6)).contains(" -- bind(");
+      assertThat(sql.get(6)).contains("insert into attachment (goods_entity_id, name,");
+      assertThat(sql.get(7)).contains(" -- bind(");
     }
 
     persistedGoods = DB.find(GoodsEntity.class, goods.getId());
@@ -328,13 +328,13 @@ class TestOneToManyStatelessUpdateResultsInSoftDelete extends BaseTestCase {
     assertThat(sql.get(1)).contains(" -- bind(");
     assertThat(sql.get(2)).contains(" -- bind(");
     assertThat(sql.get(3)).contains(" -- bind(");
-    assertThat(sql.get(4)).contains("insert into attachment (id, goods_entity_id, name,");
-    assertThat(sql.get(5)).contains(" -- bind(");
+    assertThat(sql.get(5)).contains("insert into attachment (id, goods_entity_id, name,");
     assertThat(sql.get(6)).contains(" -- bind(");
+    assertThat(sql.get(7)).contains(" -- bind(");
     if (isH2() || isPostgresCompatible()) { // using identity, not using sequence
-      assertThat(sql).hasSize(9);
-      assertThat(sql.get(7)).contains("insert into attachment (goods_entity_id, name, ");
-      assertThat(sql.get(8)).contains(" -- bind(");
+      assertThat(sql).hasSize(12);
+      assertThat(sql.get(8)).contains("insert into attachment (goods_entity_id, name, ");
+      assertThat(sql.get(9)).contains(" -- bind(");
     }
 
     var persistedGoods2 = DB.find(GoodsEntity.class, goods.getId());

--- a/ebean-test/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTable.java
+++ b/ebean-test/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTable.java
@@ -38,7 +38,7 @@ public class TestOneToManyJoinTable extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(3);
+      assertThat(sql).hasSize(4);
       assertSql(sql.get(0)).contains("insert into troop_monkey (troop_pid, monkey_mid) values (?, ?)");
       assertSqlBind(sql, 1, 2);
 
@@ -96,14 +96,14 @@ public class TestOneToManyJoinTable extends BaseTestCase {
     List<String> sql = LoggedSql.collect();
 
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(13);
+      assertThat(sql).hasSize(16);
       assertSql(sql.get(0)).contains("insert into trainer ");
       assertSql(sql.get(1)).contains("insert into monkey ");
       assertSqlBind(sql, 2, 4);
-      assertThat(sql.get(5)).contains("update monkey set food_preference=?, version=? where mid=? and version=?");
-      assertThat(sql.get(6)).contains("-- bind(");
-      assertThat(sql.get(7)).contains("insert into trainer_monkey ");
-      assertSqlBind(sql, 8, 12);
+      assertThat(sql.get(6)).contains("update monkey set food_preference=?, version=? where mid=? and version=?");
+      assertThat(sql.get(7)).contains("-- bind(");
+      assertThat(sql.get(9)).contains("insert into trainer_monkey ");
+      assertSqlBind(sql, 10, 14);
 
     } else {
       assertThat(sql).hasSize(10);

--- a/ebean-test/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableInheritance.java
+++ b/ebean-test/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableInheritance.java
@@ -35,20 +35,20 @@ public class TestOneToManyJoinTableInheritance extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
 
-    assertThat(sql).hasSize(11);
+    assertThat(sql).hasSize(14);
     assertSql(sql.get(0)).contains("insert into class_super ");
     if (idType() == IdType.IDENTITY) {
       assertSql(sql.get(1)).contains("-- bind(ClassA)");
       assertSql(sql.get(2)).contains("-- bind(ClassB)");
     }
-    assertThat(sql.get(3)).contains("insert into monkey ");
+    assertThat(sql.get(4)).contains("insert into monkey ");
     if (idType() == IdType.IDENTITY) {
-      assertThat(sql.get(4)).contains("-- bind(Sim");
-      assertThat(sql.get(5)).contains("-- bind(Tim");
-      assertThat(sql.get(6)).contains("-- bind(Uim");
-      assertThat(sql.get(7)).contains("insert into class_super_monkey (class_super_sid, monkey_mid) values (?, ?)");
+      assertThat(sql.get(5)).contains("-- bind(Sim");
+      assertThat(sql.get(6)).contains("-- bind(Tim");
+      assertThat(sql.get(7)).contains("-- bind(Uim");
+      assertThat(sql.get(9)).contains("insert into class_super_monkey (class_super_sid, monkey_mid) values (?, ?)");
     }
-    assertSqlBind(sql, 8, 10);
+    assertSqlBind(sql, 10, 12);
 
     ClassA dbA = DB.find(ClassA.class, 1);
     ClassB dbB = DB.find(ClassB.class, 2);

--- a/ebean-test/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableNoTableName.java
+++ b/ebean-test/src/test/java/org/tests/o2m/jointable/TestOneToManyJoinTableNoTableName.java
@@ -38,7 +38,7 @@ public class TestOneToManyJoinTableNoTableName extends BaseTestCase {
 
     List<String> sql = LoggedSql.collect();
     if (isPersistBatchOnCascade()) {
-      assertThat(sql).hasSize(3);
+      assertThat(sql).hasSize(4);
       assertSql(sql.get(0)).contains("insert into mkeygroup_monkey (mkeygroup_pid, monkey_mid) values (?, ?)");
       assertSqlBind(sql, 1, 2);
     } else {

--- a/ebean-test/src/test/java/org/tests/order/TestOrderColumn.java
+++ b/ebean-test/src/test/java/org/tests/order/TestOrderColumn.java
@@ -100,7 +100,7 @@ class TestOrderColumn extends TransactionalTestCase {
     LoggedSql.start();
     DB.save(result);
     final List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
 
     assertThat(sql.get(0)).contains("update order_toy set title=?, sort_order=? where id=?");
     assertThat(sql.get(1)).contains("bind(tt10");
@@ -138,10 +138,10 @@ class TestOrderColumn extends TransactionalTestCase {
     DB.save(result);
     final List<String> sql = LoggedSql.stop();
 
-    assertThat(sql).hasSize(4);
+    assertThat(sql).hasSize(6);
     assertSql(sql.get(0)).contains("delete from order_toy where id=?");
-    assertSql(sql.get(2)).contains("update order_toy set sort_order=? where id=?");
-    assertSql(sql.get(3)).contains("bind(2,");
+    assertSql(sql.get(3)).contains("update order_toy set sort_order=? where id=?");
+    assertSql(sql.get(4)).contains("bind(2,");
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/sets/TestO2MMap.java
+++ b/ebean-test/src/test/java/org/tests/sets/TestO2MMap.java
@@ -68,11 +68,11 @@ class TestO2MMap {
     DB.save(dept);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertThat(sql.get(0)).contains("delete from map_emp where id=?");
     assertThat(sql.get(1)).contains(" -- bind");
     assertThat(sql.get(2)).contains(" -- bind");
-    assertThat(sql.get(3)).contains("insert into map_emp (code, name, department_id) values (?,?,?)");
-    assertThat(sql.get(4)).contains(" -- bind");
+    assertThat(sql.get(4)).contains("insert into map_emp (code, name, department_id) values (?,?,?)");
+    assertThat(sql.get(5)).contains(" -- bind");
   }
 }

--- a/ebean-test/src/test/java/org/tests/sets/TestO2MMap2.java
+++ b/ebean-test/src/test/java/org/tests/sets/TestO2MMap2.java
@@ -67,7 +67,7 @@ class TestO2MMap2 {
     DB.save(dept);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(2);
+    assertThat(sql).hasSize(3);
     assertThat(sql.get(0)).contains("insert into map_emp2 (code, name, department_id) values (?,?,?)");
     assertThat(sql.get(1)).contains(" -- bind");
   }

--- a/ebean-test/src/test/java/org/tests/sets/TestO2MSet.java
+++ b/ebean-test/src/test/java/org/tests/sets/TestO2MSet.java
@@ -60,11 +60,12 @@ class TestO2MSet {
     DB.save(dept);
 
     sql = LoggedSql.collect();
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertThat(sql.get(0)).contains("delete from o2_memp where id=?");
     assertThat(sql.get(1)).contains(" -- bind");
     assertThat(sql.get(2)).contains(" -- bind");
-    assertThat(sql.get(3)).contains("insert into o2_memp (id, code, name, department_id) values (?,?,?,?)");
-    assertThat(sql.get(4)).contains(" -- bind");
+    assertThat(sql.get(3)).contains("-- executeBatch");
+    assertThat(sql.get(4)).contains("insert into o2_memp (id, code, name, department_id) values (?,?,?,?)");
+    assertThat(sql.get(5)).contains(" -- bind");
   }
 }

--- a/ebean-test/src/test/java/org/tests/softdelete/TestSoftDeleteStatelessUpdate.java
+++ b/ebean-test/src/test/java/org/tests/softdelete/TestSoftDeleteStatelessUpdate.java
@@ -40,7 +40,7 @@ public class TestSoftDeleteStatelessUpdate extends BaseTestCase {
     DB.update(upd);
 
     List<String> sql = LoggedSql.collect();
-    assertThat(sql).hasSize(6);
+    assertThat(sql).hasSize(8);
     assertSql(sql.get(0)).contains("update esd_master set name=? where id=?");
     if (isPlatformBooleanNative()) {
       assertSql(sql.get(1)).contains("update esd_detail set deleted=true where master_id = ? and not");

--- a/ebean-test/src/test/java/org/tests/transaction/TestBatchModelFlush.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestBatchModelFlush.java
@@ -72,7 +72,7 @@ public class TestBatchModelFlush extends BaseTestCase {
 
     // DEBUG io.ebean.SUM - txn[1001] BatchControl flush [MnyB:100 i:2, Role:101 i:2, MnyTopic:102 i:2]
 
-    assertThat(sql).hasSize(9);
+    assertThat(sql).hasSize(12);
 
     // first saved to batch - (depth 100)
     assertSql(sql.get(0)).contains("insert into mny_b");
@@ -81,14 +81,14 @@ public class TestBatchModelFlush extends BaseTestCase {
       assertSql(sql.get(2)).contains(" -- bind(BatchMultipleTop_1");
     }
     // second saved to batch - (depth 101)
-    assertThat(sql.get(3)).contains("insert into mt_role");
-    assertThat(sql.get(4)).contains(" -- bind(");
+    assertThat(sql.get(4)).contains("insert into mt_role");
     assertThat(sql.get(5)).contains(" -- bind(");
+    assertThat(sql.get(6)).contains(" -- bind(");
     // third saved to batch - (depth 102)
-    assertThat(sql.get(6)).contains("insert into mny_topic");
+    assertThat(sql.get(8)).contains("insert into mny_topic");
     if (idType() == IdType.IDENTITY) {
-      assertThat(sql.get(7)).contains(" -- bind(MnyTopic_0");
-      assertThat(sql.get(8)).contains(" -- bind(MnyTopic_1");
+      assertThat(sql.get(9)).contains(" -- bind(MnyTopic_0");
+      assertThat(sql.get(10)).contains(" -- bind(MnyTopic_1");
     }
 
     DB.delete(t0);

--- a/ebean-test/src/test/java/org/tests/transparentpersist/TestTransparentPersist.java
+++ b/ebean-test/src/test/java/org/tests/transparentpersist/TestTransparentPersist.java
@@ -48,11 +48,11 @@ public class TestTransparentPersist extends BaseTestCase {
     EBasicVer found = DB.find(EBasicVer.class, newBean.getId());
     assertThat(found.getName()).isEqualTo("make it dirty - auto save");
 
-    assertThat(sql).hasSize(4);
+    assertThat(sql).hasSize(6);
     assertThat(sql.get(0)).contains("insert into e_basicver");
     assertThat(sql.get(1)).contains(" -- bind(");
-    assertThat(sql.get(2)).contains("update e_basicver set name=?, last_update=? where id=? and last_update=?");
-    assertThat(sql.get(3)).contains(" -- bind(");
+    assertThat(sql.get(3)).contains("update e_basicver set name=?, last_update=? where id=? and last_update=?");
+    assertThat(sql.get(4)).contains(" -- bind(");
 
     DB.delete(found);
   }
@@ -248,17 +248,18 @@ public class TestTransparentPersist extends BaseTestCase {
     assertThat(checkOrder.getCustomer().getName()).isEqualTo("newCust CascadePersist");
     assertThat(checkOrder.getShipments().size()).isEqualTo(1);
 
-    assertThat(sql).hasSize(10);
+    assertThat(sql).hasSize(14);
     assertSql(sql.get(0)).contains("select t0.id, t0.status, t0.order_date");
     assertThat(sql.get(1)).contains("insert into o_customer");
     assertThat(sql.get(2)).contains(" -- bind(");
-    assertThat(sql.get(3)).contains("update o_order set updtime=?, kcustomer_id=? where id=? and updtime=?");
-    assertThat(sql.get(4)).contains(" -- bind(");
-    assertSql(sql.get(5)).contains("select t0.order_id, t0.id, t0.ship_time, t0.cretime, t0.updtime, t0.version, t0.order_id from or_order_ship");
-    assertThat(sql.get(6)).contains("delete from or_order_ship");
-    assertThat(sql.get(7)).contains(" -- bind(");
-    assertThat(sql.get(8)).contains("insert into or_order_ship");
+    assertThat(sql.get(3)).contains(" -- executeBatch");
+    assertThat(sql.get(4)).contains("update o_order set updtime=?, kcustomer_id=? where id=? and updtime=?");
+    assertThat(sql.get(5)).contains(" -- bind(");
+    assertSql(sql.get(7)).contains("select t0.order_id, t0.id, t0.ship_time, t0.cretime, t0.updtime, t0.version, t0.order_id from or_order_ship");
+    assertThat(sql.get(8)).contains("delete from or_order_ship");
     assertThat(sql.get(9)).contains(" -- bind(");
+    assertThat(sql.get(11)).contains("insert into or_order_ship");
+    assertThat(sql.get(12)).contains(" -- bind(");
 
     DB.delete(checkOrder);
     DB.delete(Customer.class, checkOrder.getCustomer().getId());

--- a/ebean-test/src/test/java/org/tests/update/TestSqlUpdateInTxn.java
+++ b/ebean-test/src/test/java/org/tests/update/TestSqlUpdateInTxn.java
@@ -62,7 +62,7 @@ public class TestSqlUpdateInTxn extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.stop();
-    assertThat(sql).hasSize(3);
+    assertThat(sql).hasSize(4);
     assertSql(sql.get(0)).contains("update audit_log set description = description where id = ?");
     assertSqlBind(sql, 1, 2);
   }

--- a/ebean-test/src/test/java/org/tests/update/TestStatelessUpdate.java
+++ b/ebean-test/src/test/java/org/tests/update/TestStatelessUpdate.java
@@ -347,12 +347,14 @@ public class TestStatelessUpdate extends TransactionalTestCase {
     DB.update(updateCustomer);
     final List<String> sql = LoggedSql.stop();
 
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertThat(sql.get(0)).contains("update o_customer set updtime=? where id=?");
     assertThat(sql.get(1)).contains("insert into contact");
     assertThat(sql.get(2)).contains(" -- bind(");
-    assertThat(sql.get(3)).contains("update contact set last_name=?, customer_id=? where id=?");
-    assertThat(sql.get(4)).contains(" -- bind(");
+    assertThat(sql.get(3)).contains(" -- executeBatch");
+    assertThat(sql.get(4)).contains("update contact set last_name=?, customer_id=? where id=?");
+    assertThat(sql.get(5)).contains(" -- bind(");
+    assertThat(sql.get(6)).contains(" -- executeBatch");
 
     // assert
     Customer assCustomer = DB.find(Customer.class, customer.getId());
@@ -402,12 +404,13 @@ public class TestStatelessUpdate extends TransactionalTestCase {
     DB.update(updateCustomer);
     final List<String> sql = LoggedSql.stop();
 
-    assertThat(sql).hasSize(5);
+    assertThat(sql).hasSize(7);
     assertThat(sql.get(0)).contains("update o_customer set updtime=? where id=?");
     assertThat(sql.get(1)).contains("insert into contact");
     assertThat(sql.get(2)).contains(" -- bind(");
-    assertThat(sql.get(3)).contains("update contact set last_name=?, customer_id=? where id=?");
-    assertThat(sql.get(4)).contains(" -- bind(");
+    assertThat(sql.get(3)).contains(" -- executeBatch");
+    assertThat(sql.get(4)).contains("update contact set last_name=?, customer_id=? where id=?");
+    assertThat(sql.get(5)).contains(" -- bind(");
 
     // assert
     Customer assCustomer = DB.find(Customer.class, customer.getId());


### PR DESCRIPTION
This adds:
```java
transaction.logSql(" -- executeBatch() size:{0} sql:{1}", rows.length, sql);
```
... into BatchedPstmt.

The reason for doing this is that when we turn on SQL logging via `io.ebean.SQL` `DEBUG` and we are using JDBC batch, then we see in the log the:
- SQL that was prepared
- The bind values per `PreparedStatement.addBatch()`
- ... but not the `PreparedStatement.executeBatch()`

Adding this into the SQL log I think makes it obvious when the `executeBatch()` is actually executed.  Generally this might not add much value to people reading the logs but on the other hand it might help people relate the log to the actual JDBC API calls being made.