### PR TITLE
Bump parent to 3.11 with compiler arg -proc:full for change with JDK 22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>3.10</version>
+    <version>3.11</version>
   </parent>
 
   <groupId>io.ebean</groupId>


### PR DESCRIPTION
JDK 22 changes such that annotation processors are not found by default on the classpath. As such they either need to be explicitly registered with the compiler (e.g. maven-compiler-plugin) or use -proc:full