### PR TITLE
Explicit annotation processors required with JDK 22

### DIFF
--- a/ebean-querybean/pom.xml
+++ b/ebean-querybean/pom.xml
@@ -69,13 +69,6 @@
 
     <dependency>
       <groupId>io.ebean</groupId>
-      <artifactId>querybean-generator</artifactId>
-      <version>13.23.0-jakarta</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
       <version>13.23.0-jakarta</version>
       <scope>test</scope>
@@ -103,7 +96,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <compilerArgument>-proc:full</compilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.ebean</groupId>
+              <artifactId>querybean-generator</artifactId>
+              <version>13.23.0-jakarta</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <!-- Enhancement -->

--- a/ebean-redis/pom.xml
+++ b/ebean-redis/pom.xml
@@ -42,13 +42,6 @@
 
     <dependency>
       <groupId>io.ebean</groupId>
-      <artifactId>querybean-generator</artifactId>
-      <version>13.23.0-jakarta</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
       <version>13.23.0-jakarta</version>
       <scope>test</scope>
@@ -72,7 +65,19 @@
 
   <build>
     <plugins>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.ebean</groupId>
+              <artifactId>querybean-generator</artifactId>
+              <version>13.23.0-jakarta</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.repaint.maven</groupId>
         <artifactId>tiles-maven-plugin</artifactId>

--- a/tests/test-java16/pom.xml
+++ b/tests/test-java16/pom.xml
@@ -52,7 +52,7 @@
             <path>
               <groupId>io.ebean</groupId>
               <artifactId>querybean-generator</artifactId>
-              <version>13.22.0</version>
+              <version>13.22.0-jakarta</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
JDK 22 changes such that annotation processors are not found by default on the classpath. As such they either need to be explicitly registered with the compiler (e.g. maven-compiler-plugin) or use -proc:full