### PR TITLE
Support native-image via querybean-generator

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -237,7 +237,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
     this.owner = owner;
     this.multiValueSupported = owner.isMultiValueSupported();
     this.entityType = deploy.getEntityType();
-    this.properties = deploy.getProperties();
+    this.properties = deploy.propertyNames();
     this.name = InternString.intern(deploy.getName());
     this.baseTableAlias = "t0";
     this.fullName = InternString.intern(deploy.getFullName());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocManys.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocManys.java
@@ -213,9 +213,9 @@ final class AnnotationAssocManys extends AnnotationAssoc {
 
     int sortOrder = 0;
     if (!prop.getManyType().isMap()) {
-      elementDescriptor.setProperties(new String[]{"value"});
+      elementDescriptor.setPropertyNames(new String[]{"value"});
     } else {
-      elementDescriptor.setProperties(new String[]{"key", "value"});
+      elementDescriptor.setPropertyNames(new String[]{"key", "value"});
       String dbKeyColumn = "mkey";
       MapKeyColumn mapKeyColumn = get(prop, MapKeyColumn.class);
       if (mapKeyColumn != null) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/properties/BeanPropertiesReader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/properties/BeanPropertiesReader.java
@@ -1,7 +1,5 @@
 package io.ebeaninternal.server.properties;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,34 +9,14 @@ import java.util.Map;
 public final class BeanPropertiesReader {
 
   private final Map<String, Integer> propertyIndexMap = new HashMap<>();
-  private final String[] props;
 
-  public BeanPropertiesReader(Class<?> clazz) {
-    this.props = getProperties(clazz);
+  public BeanPropertiesReader(String[] props) {
     for (int i = 0; i < props.length; i++) {
       propertyIndexMap.put(props[i], i);
     }
   }
 
-  public String[] getProperties() {
-    return props;
-  }
-
-  @Override
-  public String toString() {
-    return Arrays.toString(props);
-  }
-
-  public Integer getPropertyIndex(String property) {
+  public Integer propertyIndex(String property) {
     return propertyIndexMap.get(property);
-  }
-
-  private String[] getProperties(Class<?> clazz) {
-    try {
-      Field field = clazz.getField("_ebean_props");
-      return (String[]) field.get(null);
-    } catch (Exception e) {
-      throw new IllegalStateException("Error getting _ebean_props field on type " + clazz, e);
-    }
   }
 }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/deploy/parse/AnnotationClassTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/deploy/parse/AnnotationClassTest.java
@@ -7,6 +7,7 @@ import io.ebeaninternal.server.deploy.generatedproperty.GeneratedPropertyFactory
 import io.ebeaninternal.server.deploy.meta.DeployBeanDescriptor;
 import io.ebeaninternal.server.type.DefaultTypeManager;
 import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Customer;
 
 import java.util.Collections;
 
@@ -47,7 +48,7 @@ public class AnnotationClassTest {
   private AnnotationClass createAnnotationClass(DatabaseConfig config) {
     DeployUtil deployUtil = new DeployUtil(new DefaultTypeManager(config, new BootupClasses()), config);
 
-    DeployBeanInfo deployBeanInfo = new DeployBeanInfo(deployUtil, new DeployBeanDescriptor<>(null, null, null));
+    DeployBeanInfo deployBeanInfo = new DeployBeanInfo(deployUtil, new DeployBeanDescriptor<>(null, Customer.class, null));
     ReadAnnotationConfig readAnnotationConfig = new ReadAnnotationConfig(new GeneratedPropertyFactory(true, new DatabaseConfig(), Collections.emptyList()), "","", new DatabaseConfig());
     return new AnnotationClass(deployBeanInfo, readAnnotationConfig);
   }

--- a/kotlin-querybean-generator/pom.xml
+++ b/kotlin-querybean-generator/pom.xml
@@ -144,7 +144,7 @@
           <source>11</source>
           <target>11</target>
           <!-- Turn off annotation processing for building -->
-          <compilerArgument>-proc:none</compilerArgument>
+          <compilerArgs>-proc:none</compilerArgs>
         </configuration>
       </plugin>
 

--- a/querybean-generator/pom.xml
+++ b/querybean-generator/pom.xml
@@ -31,7 +31,7 @@
           <source>11</source>
           <target>11</target>
           <!-- Turn off annotation processing for building -->
-          <compilerArgument>-proc:none</compilerArgument>
+          <compilerArgs>-proc:none</compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -475,6 +475,11 @@ class ProcessingContext implements Constants {
     return createMetaInfWriter(METAINF_MANIFEST);
   }
 
+  FileObject createNativeImageWriter(String name) throws IOException {
+    String nm = "META-INF/native-image/" + name + "/reflect-config.json";
+    return createMetaInfWriter(nm);
+  }
+
   FileObject createMetaInfWriter(String target) throws IOException {
     return filer.createResource(StandardLocation.CLASS_OUTPUT, "", target);
   }

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
@@ -4,6 +4,7 @@ import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -38,6 +39,7 @@ class SimpleModuleInfoWriter {
     writer.close();
     writeServicesFile();
     writeManifestFile();
+    writeNativeImageFile();
   }
 
   private void writeServicesFile() {
@@ -48,9 +50,7 @@ class SimpleModuleInfoWriter {
         writer.write(factoryFullName);
         writer.close();
       }
-
     } catch (IOException e) {
-      e.printStackTrace();
       processingContext.logError(null, "Failed to write services file " + e.getMessage());
     }
   }
@@ -68,9 +68,7 @@ class SimpleModuleInfoWriter {
           writer.close();
         }
       }
-
     } catch (IOException e) {
-      e.printStackTrace();
       processingContext.logError(null, "Failed to write services file " + e.getMessage());
     }
   }
@@ -84,10 +82,41 @@ class SimpleModuleInfoWriter {
     return builder.delete(builder.lastIndexOf("\n"), builder.length()).append('\n').toString();
   }
 
+  private void writeNativeImageFile() {
+    try {
+      Set<String> allEntities = new LinkedHashSet<>(processingContext.getDbEntities());
+      for (Set<String> value : processingContext.getOtherDbEntities().values()) {
+        allEntities.addAll(value);
+      }
+
+      if (!allEntities.isEmpty()) {
+        FileObject jfo = processingContext.createNativeImageWriter(factoryPackage + ".ebean-entity");
+        if (jfo != null) {
+          boolean first = true;
+          Writer writer = jfo.openWriter();
+          writer.write("[");
+          for (String entity : allEntities) {
+            if (first) {
+              first = false;
+            } else {
+              writer.write(",");
+            }
+            writer.write("\n  {\"name\": \"");
+            writer.write(entity);
+            writer.write("\", \"allDeclaredConstructors\": true, \"allDeclaredFields\": true}");
+          }
+          writer.write("\n]\n");
+          writer.write("\n");
+          writer.close();
+        }
+      }
+    } catch (IOException e) {
+      processingContext.logError(null, "Failed to write services file " + e.getMessage());
+    }
+  }
+
   private void writePackage() {
-
     writer.append("package %s;", factoryPackage).eol().eol();
-
     writer.append("import java.util.ArrayList;").eol();
     writer.append("import java.util.Collections;").eol();
     writer.append("import java.util.List;").eol();
@@ -125,7 +154,6 @@ class SimpleModuleInfoWriter {
   }
 
   private void writeStartClass() {
-
     buildAtContextModule(writer);
 
     writer.append("public class %s implements EntityClassRegister {", factoryShortName).eol().eol();


### PR DESCRIPTION
When using `querybean-generator` this will generate a `reflect-config.json` for each entity bean.

This is because ebean uses reflection to read properties from the entity beans and create an initial prototype entity bean.