### PR TITLE
Make Jackson a transitive dependency of ebean-jackson-mapper

### DIFF
--- a/ebean-jackson-mapper/pom.xml
+++ b/ebean-jackson-mapper/pom.xml
@@ -22,14 +22,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
So jackson-core and jackson-databind are both transitive dependencies of ebean-jackson-mapper.