### PR TITLE
Use querybean-generator via provided scope rather than maven compiler plugin

### DIFF
--- a/ebean-querybean/pom.xml
+++ b/ebean-querybean/pom.xml
@@ -88,23 +88,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>querybean-generator</artifactId>
+      <version>13.23.0-jakarta</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>io.ebean</groupId>
-              <artifactId>querybean-generator</artifactId>
-              <version>13.23.0-jakarta</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
       <!-- Enhancement -->
       <plugin>
         <groupId>io.repaint.maven</groupId>

--- a/ebean-redis/pom.xml
+++ b/ebean-redis/pom.xml
@@ -61,23 +61,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>querybean-generator</artifactId>
+      <version>13.23.0-jakarta</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>io.ebean</groupId>
-              <artifactId>querybean-generator</artifactId>
-              <version>13.23.0-jakarta</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>io.repaint.maven</groupId>
         <artifactId>tiles-maven-plugin</artifactId>

--- a/tests/test-java16/pom.xml
+++ b/tests/test-java16/pom.xml
@@ -41,22 +41,16 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>querybean-generator</artifactId>
+      <version>13.23.0-jakarta</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>io.ebean</groupId>
-              <artifactId>querybean-generator</artifactId>
-              <version>13.23.0-jakarta</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
 
       <plugin>
         <groupId>io.repaint.maven</groupId>


### PR DESCRIPTION
This is because when releasing both jakarta and javax versions these need to have their versions adjusted