### PR TITLE
Change loadMode to be 'safer' (for Grafana etc). e.g. change "(+lazy) " to "__lazy"

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanRequest.java
@@ -111,7 +111,7 @@ public final class LoadBeanRequest extends LoadRequest {
   }
 
   private String mode() {
-    return lazy ? "+lazy" : loadBuffer.isCache() ? "+cache" : "+query";
+    return lazy ? "lazy" : loadBuffer.isCache() ? "cache" : "query";
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
@@ -101,7 +101,7 @@ public final class LoadManyRequest extends LoadRequest {
     query.setLazyLoadForParents(many);
     many.addWhereParentIdIn(query, parentIdList(server), loadContext.isUseDocStore());
     query.setPersistenceContext(loadContext.persistenceContext());
-    query.setLoadDescription(lazy ? "+lazy" : "+query", description());
+    query.setLoadDescription(lazy ? "lazy" : "query", description());
     if (lazy) {
       query.setLazyLoadBatchSize(loadContext.batchSize());
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.api;
 
+import io.avaje.lang.Nullable;
 import io.ebean.CacheMode;
 import io.ebean.CountDistinctOrder;
 import io.ebean.ExpressionList;
@@ -339,7 +340,7 @@ public interface SpiQuery<T> extends Query<T>, SpiQueryFetch, TxnProfileEventCod
   /**
    * Set the on a secondary query given the label, relativePath and profile location of the parent query.
    */
-  void setProfilePath(String label, String relativePath, ProfileLocation profileLocation);
+  void setProfilePath(String label, String relativePath, @Nullable ProfileLocation profileLocation);
 
   /**
    * Set the query mode.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -82,9 +82,9 @@ final class DefaultBeanLoader {
       // populate a new collection
       BeanCollection<?> emptyCollection = many.createEmpty(parentBean);
       many.setValue(parentBean, emptyCollection);
-      query.setLoadDescription("+refresh", null);
+      query.setLoadDescription("refresh", null);
     } else {
-      query.setLoadDescription("+lazy", null);
+      query.setLoadDescription("lazy", null);
     }
 
     query.select(parentDesc.idBinder().idSelect());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadBaseContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadBaseContext.java
@@ -52,8 +52,13 @@ abstract class DLoadBaseContext {
   void setLabel(SpiQuery<?> query) {
     String label = parent.planLabel();
     if (label != null) {
-      query.setProfilePath(label, fullPath + "__" + query.loadMode(), parent.profileLocation());
+      query.setProfilePath(label, pathMode(query), parent.profileLocation());
     }
+  }
+
+  private String pathMode(SpiQuery<?> query) {
+    final var loadMode = query.loadMode();
+    return fullPath == null ? '_' + loadMode : fullPath + "__" + loadMode;
   }
 
   PersistenceContext persistenceContext() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadBaseContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadBaseContext.java
@@ -52,7 +52,7 @@ abstract class DLoadBaseContext {
   void setLabel(SpiQuery<?> query) {
     String label = parent.planLabel();
     if (label != null) {
-      query.setProfilePath(label, fullPath + "(" + query.loadMode() + ")", parent.profileLocation());
+      query.setProfilePath(label, fullPath + "__" + query.loadMode(), parent.profileLocation());
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1,6 +1,7 @@
 package io.ebeaninternal.server.querydefn;
 
 import io.avaje.lang.NonNullApi;
+import io.avaje.lang.Nullable;
 import io.ebean.*;
 import io.ebean.bean.CallOrigin;
 import io.ebean.bean.ObjectGraphNode;
@@ -245,9 +246,9 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
   }
 
   @Override
-  public final void setProfilePath(String label, String relativePath, ProfileLocation profileLocation) {
+  public final void setProfilePath(String label, String relativePath, @Nullable ProfileLocation profileLocation) {
     this.profileLocation = profileLocation;
-    this.label = ((profileLocation == null) ? label : profileLocation.label()) + "_" + relativePath;
+    this.label = (profileLocation == null ? label : profileLocation.label()) + '_' + relativePath;
   }
 
   @Override


### PR DESCRIPTION
The loadMode ends up as a suffix to some query metrics.

For example "foo.findIt_baz(+lazy)", and the (+lazy) part isn't safe/friendly to tools like Grafana. So change to instead of (+lazy) use __lazy.