### PR TITLE
Add read only database configuration/builder option

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
+++ b/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
@@ -1054,6 +1054,14 @@ public interface DatabaseBuilder {
   DatabaseBuilder setSkipDataSourceCheck(boolean skipDataSourceCheck);
 
   /**
+   * Set to true if this database is used in a read only way.
+   * <p>
+   * The DataSource and read-only DataSource are expected to be the same
+   * and use readOnly=true and autoCommit=true.
+   */
+  DatabaseBuilder readOnlyDatabase(boolean readOnlyDatabase);
+
+  /**
    * Set a DataSource.
    */
   default DatabaseBuilder dataSource(DataSource dataSource) {
@@ -2606,6 +2614,14 @@ public interface DatabaseBuilder {
      * Return true if the startup DataSource check should be skipped.
      */
     boolean skipDataSourceCheck();
+
+    /**
+     * Return true if this database is used in a read only way.
+     * <p>
+     * The DataSource and read-only DataSource are expected to be the same
+     * and use readOnly=true and autoCommit=true.
+     */
+    boolean readOnlyDatabase();
 
     /**
      * Return the DataSource.

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -304,6 +304,8 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
 
   private boolean skipDataSourceCheck;
 
+  private boolean readOnlyDatabase;
+
   /**
    * The data source (if programmatically provided).
    */
@@ -1341,6 +1343,17 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
   public DatabaseConfig setSkipDataSourceCheck(boolean skipDataSourceCheck) {
     this.skipDataSourceCheck = skipDataSourceCheck;
     return this;
+  }
+
+  @Override
+  public DatabaseBuilder readOnlyDatabase(boolean readOnlyDatabase) {
+    this.readOnlyDatabase = readOnlyDatabase;
+    return this;
+  }
+
+  @Override
+  public boolean readOnlyDatabase() {
+    return readOnlyDatabase;
   }
 
   @Override

--- a/ebean-test/src/test/java/org/tests/readonly/PostgresReadOnlyDatabaseTest.java
+++ b/ebean-test/src/test/java/org/tests/readonly/PostgresReadOnlyDatabaseTest.java
@@ -1,0 +1,119 @@
+package org.tests.readonly;
+
+import io.ebean.Database;
+import io.ebean.DatabaseBuilder;
+import io.ebean.Transaction;
+import io.ebean.annotation.Transactional;
+import io.ebean.datasource.DataSourceBuilder;
+import io.ebean.test.containers.PostgresContainer;
+import io.ebeaninternal.api.SpiTransaction;
+import jakarta.persistence.PersistenceException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.UTDetail;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PostgresReadOnlyDatabaseTest {
+
+  private static Database readDb;
+
+  @BeforeAll
+  static void beforeAll() {
+    readDb = setupReadOnlyDatabase();
+  }
+
+  @Test
+  void insertPreventedInReadOnlyTransaction() {
+    assertThatThrownBy(() -> {
+      try (Transaction transaction = readDb.beginTransaction()) {
+        UTDetail u0 = new UTDetail("u0", 45, 3D);
+        readDb.save(u0);
+      }
+    }).isInstanceOf(PersistenceException.class)
+      .hasMessageContaining("ERROR: cannot execute INSERT in a read-only transaction");
+  }
+
+  @Test
+  void queryInExplicitTransaction() {
+    try (Transaction transaction = readDb.beginTransaction()) {
+      List<UTDetail> list = readDb.find(UTDetail.class).findList();
+      assertThat(list).hasSize(2);
+      assertThat(transaction.isReadOnly()).isTrue();
+      transaction.commit(); // autoCommit=true but this is still allowed
+    }
+  }
+
+  @Test
+  void queryInImplicitTransaction() {
+    List<UTDetail> list = readDb.find(UTDetail.class).findList();
+    assertThat(list).hasSize(2);
+  }
+
+  // Requires .register(true).defaultDatabase(true) ... when running this test
+  @Disabled
+  @Test
+  void queryInReadOnlyTransactional() {
+    readOnlyTransactional();
+    transactionalOnlyContainingQueries();
+  }
+
+  @Transactional(readOnly = true)
+  void readOnlyTransactional() {
+    List<UTDetail> list = readDb.find(UTDetail.class).findList();
+    assertThat(list).hasSize(2);
+
+    SpiTransaction current = (SpiTransaction) Transaction.current();
+    assertThat(current.isReadOnly()).isTrue();
+  }
+
+  @Transactional
+  void transactionalOnlyContainingQueries() {
+    List<UTDetail> list = readDb.find(UTDetail.class).findList();
+    assertThat(list).hasSize(2);
+
+    SpiTransaction current = (SpiTransaction) Transaction.current();
+    assertThat(current.isReadOnly()).isTrue();
+  }
+
+  private static Database setupReadOnlyDatabase() {
+    PostgresContainer.builder("15")
+      .dbName("readonly_test")
+      .build()
+      .start();
+
+    var dataSourceBuilder = DataSourceBuilder.create()
+      .username("readonly_test")
+      .password("test")
+      .url("jdbc:postgresql://localhost:6432/readonly_test");
+
+    var writeDb = databaseBuilder(dataSourceBuilder)
+      .ddlGenerate(true)
+      .ddlRun(true)
+      .build();
+
+    writeDb.truncate(UTDetail.class);
+    writeDb.save(new UTDetail("u0", 45, 3D));
+    writeDb.save(new UTDetail("u1", 42, 5D));
+
+    return databaseBuilder(dataSourceBuilder)
+      .readOnlyDatabase(true)
+      // register + default required for the tests using @Transactional
+      // .register(true).defaultDatabase(true)
+      .build();
+  }
+
+  private static DatabaseBuilder databaseBuilder(DataSourceBuilder dataSourceBuilder) {
+    return Database.builder()
+      .name("ro_test")
+      .dataSourceBuilder(dataSourceBuilder)
+      .ddlExtra(false)
+      .defaultDatabase(false)
+      .register(false)
+      .addClass(UTDetail.class);
+  }
+}


### PR DESCRIPTION
When using DatabaseBuilder.readOnlyDatabase(true) then ebean will:
- Set the DataSourceBuilder to use autoCommit=true and readOnly=true
- Use the same DataSource instance for both dataSource and readOnlyDataSource

This is to simplify the setup/configuration for creating a Database that will only have read-only use.

Note that readOnly=true is a JDBC hint and for example H2 database effectively ignores that hint where as Postgres will enforce the read-only true nature.