### PR TITLE
Failing Tests with CustomerFindController

### DIFF
--- a/ebean-test/src/test/java/org/tests/model/basic/CustomerFindController.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/CustomerFindController.java
@@ -1,0 +1,35 @@
+package org.tests.model.basic;
+
+import io.ebean.bean.BeanCollection;
+import io.ebean.event.BeanFindController;
+import io.ebean.event.BeanQueryRequest;
+
+/**
+ * @author Noemi Praml, FOCONIS AG
+ */
+public class CustomerFindController implements BeanFindController  {
+  @Override
+  public boolean isRegisterFor(Class<?> cls) {
+    return Customer.class.isAssignableFrom(cls);
+  }
+
+  @Override
+  public boolean isInterceptFind(BeanQueryRequest<?> request) {
+    return false;
+  }
+
+  @Override
+  public <T> T find(BeanQueryRequest<T> request) {
+    return null;
+  }
+
+  @Override
+  public boolean isInterceptFindMany(BeanQueryRequest<?> request) {
+    return false;
+  }
+
+  @Override
+  public <T> BeanCollection<T> findMany(BeanQueryRequest<T> request) {
+    return null;
+  }
+}


### PR DESCRIPTION
Hello @rob-bygrave,

we discovered an issue with BeanFindController and findSingleAttribute queries.
If there is a BeanFindController, every property is selected in [DefaultServer.BuildQueryRequest](https://github.com/ebean-orm/ebean/blob/master/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java#L964). The produced queries and the results are wrong:

```
TestQuerySingleAttribute.distinctWithFetch:329
Expecting actual:
  "select distinct t0.status, t0.name, t0.smallnote, t0.anniversary, t0.cretime, t0.updtime, t0.version, t0.shipping_address_id, t1.city from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id"
to contain:
  "select distinct t1.city from o_customer t0 left join o_address t1 on t1.id = t0.billing_address_id"

TestQuerySingleAttribute.findSingleWithFetch:402
Expecting ArrayList:
  [NEW, NEW, ACTIVE, ACTIVE, NEW, NEW, NEW, NEW, NEW, NEW]
to contain:
  ["Auckland"]
but could not find the following element(s):
  ["Auckland"]
```

Can you tell me why will all properties from t0 be selected when there is a BeanFindController present?
FYI: we use a BeanFindController with postProcess/postProcessMany and the other methods return the default (false or null) values.

Kind regards,
Noemi