### PR TITLE
Expose betweenProperties on query bean

### DIFF
--- a/ebean-querybean/src/main/java/io/ebean/typequery/PBaseComparable.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/PBaseComparable.java
@@ -305,6 +305,14 @@ public abstract class PBaseComparable<R, T> extends PBaseValueEqual<R, T> {
   }
 
   /**
+   * Between - value between this property and another property
+   */
+  public final R betweenProperties(Query.Property<T> highProperty, T value) {
+    expr().betweenProperties(_name, highProperty.toString(), value);
+    return _root;
+  }
+
+  /**
    * Greater than.
    *
    * @param value the bind value


### PR DESCRIPTION
Hello @rbygrave,

As I'm moving from expression list to query bean, I noticed that we don't expose a convenient api to do `betweenProperties` on query bean. Given that similar api `inRangeWith` and `inRangeWith` are exposed on query bean, I thought it might be acceptable to expose `betweenProperties` as well. What are your thoughts on this?

Thank you for your time.