### PR TITLE
FIX: nested NOT_SUPPORTED transaction with an inner REQUIRES transaction

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -28,8 +28,8 @@ import io.ebeaninternal.server.profile.TimedProfileLocationRegistry;
 import io.ebeanservice.docstore.api.DocStoreTransaction;
 import io.ebeanservice.docstore.api.DocStoreUpdateProcessor;
 import io.ebeanservice.docstore.api.DocStoreUpdates;
-
 import jakarta.persistence.PersistenceException;
+
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -174,13 +174,6 @@ public class TransactionManager implements SpiTransactionManager {
   @Override
   public final SpiTransaction active() {
     return scopeManager.active();
-  }
-
-  /**
-   * Return the current active transaction as a scoped transaction.
-   */
-  private ScopedTransaction activeScoped() {
-    return (ScopedTransaction) scopeManager.active();
   }
 
   /**
@@ -499,7 +492,7 @@ public class TransactionManager implements SpiTransactionManager {
    */
   public final ScopedTransaction beginScopedTransaction(TxScope txScope) {
     txScope = initTxScope(txScope);
-    ScopedTransaction txnContainer = activeScoped();
+    ScopedTransaction txnContainer = (ScopedTransaction) inScope();
 
     boolean setToScope;
     boolean nestedSavepoint;


### PR DESCRIPTION
Hello Rob, we discovered a strange behaviour, when using NOT_SUPPORTED transaction.

We have some import code in our application Our use case is as follow:

```java
try (Transaction txn1 = DB.beginTransaction()) {
      ImportStatus status = DB.find(ImportStatus.class).forUpdate()...findOne(); // find status entity and place lock

      try (Transaction txn2 = DB.beginTransaction(TxScope.notSupported())) {
        // pause current transaction and run import without an active txn
        runImport();
        txn2.commit(); // not really neccessary, it's the NO_TRANSACTION
        status.setSuccess(true);
      } catch (Throwable t) {
        status.setSuccess(false);
      }
      DB.save(status)
}
```
This works fine, as long the "runImport" will not open new transactions. In this case, the next `DB.beginTransaction()` will not detect the open stack of `txn1` and `txn2` and will effectively overwrite the existing txnContainer.
