### PR TITLE
Change semantic of userObjects in nested transaction

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/ScopeTrans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/ScopeTrans.java
@@ -3,6 +3,8 @@ package io.ebeaninternal.api;
 import io.ebean.TxScope;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Used internally to handle the scoping of transactions for methods.
@@ -46,6 +48,11 @@ public final class ScopeTrans {
    */
   private boolean nestedCommit;
   private boolean nestedUseSavepoint;
+
+  /**
+   * The UserObjects when using in nested transactions.
+   */
+  private Map<String, Object> userObjects;
 
   public ScopeTrans(boolean rollbackOnChecked, boolean created, SpiTransaction transaction, TxScope txScope) {
     this.rollbackOnChecked = rollbackOnChecked;
@@ -218,4 +225,17 @@ public final class ScopeTrans {
     return e instanceof RuntimeException || rollbackOnChecked;
   }
 
+  public void putUserObject(String name, Object value) {
+    if (userObjects == null) {
+      userObjects = new HashMap<>();
+    }
+    userObjects.put(name, value);
+  }
+
+  public Object getUserObject(String name) {
+    if (userObjects == null) {
+      return null;
+    }
+    return userObjects.get(name);
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
@@ -2,7 +2,6 @@ package io.ebeaninternal.api;
 
 import io.ebeaninternal.server.transaction.TransactionScopeManager;
 import io.ebeaninternal.server.util.ArrayStack;
-
 import jakarta.persistence.PersistenceException;
 
 /**
@@ -171,6 +170,33 @@ public final class ScopedTransaction extends SpiTransactionProxy {
    */
   public Exception caughtThrowable(Exception e) {
     return current.caughtThrowable(e);
+  }
+
+  /**
+   * New user objects are always written to the current ScopeTrans.
+   */
+  @Override
+  public void putUserObject(String name, Object value) {
+    current.putUserObject(name, value);
+  }
+
+  /**
+   * Returns the userObject in the stack, Herew we search
+   * the stack and return the first found userObject
+   */
+  @Override
+  public Object getUserObject(String name) {
+    Object obj = current.getUserObject(name);
+    if (obj != null) {
+      return obj;
+    }
+    for (ScopeTrans trans : stack) {
+      obj = trans.getUserObject(name);
+      if (obj != null) {
+        return obj;
+      }
+    }
+    return transaction.getUserObject(name);
   }
 
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/util/ArrayStack.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/util/ArrayStack.java
@@ -2,12 +2,13 @@ package io.ebeaninternal.server.util;
 
 import java.util.ArrayList;
 import java.util.EmptyStackException;
+import java.util.Iterator;
 import java.util.List;
 
 /**
  * Stack based on ArrayList.
  */
-public class ArrayStack<E> {
+public class ArrayStack<E> implements Iterable<E> {
 
   private final List<E> list;
 
@@ -88,5 +89,10 @@ public class ArrayStack<E> {
 
   public boolean contains(E o) {
     return list.contains(o);
+  }
+
+  @Override
+  public Iterator<E> iterator() {
+    return list.iterator();
   }
 }


### PR DESCRIPTION
Hello Rob,
I want to discuss, if this change makes sense.

We often use `Transaction.putUserObject` to store some context information and use it in TransactionCallbacks
With the last PR, we discovered, that this does not work how we thought, when nested transactions are use.

We expected that user objects are stored at the current scope. So after a try/finally block, the information is gone, but it seems, if there is a transaction open, that the objects are stored at the upper most transaction.

Please take a look at this PR, which will change the behaviour, how userObjects are stored.

Roland