### PR TITLE
ADD: DB2 supports select .. for update queries

### DIFF
--- a/ebean-test/src/test/java/org/tests/basic/TestQueryForUpdate.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestQueryForUpdate.java
@@ -27,14 +27,14 @@ public class TestQueryForUpdate extends BaseTestCase {
     try (final Transaction transaction = DB.beginTransaction()) {
       query = DB.find(Customer.class)
         .forUpdate()
-        .order().desc("id");
+        .orderBy().desc("id");
 
       query.findList();
     }
 
     if (isSqlServer()) {
       assertThat(sqlOf(query)).contains("with (updlock)");
-    } else if (!isDb2()){
+    } else {
       assertThat(sqlOf(query)).contains("for update");
     }
   }
@@ -48,21 +48,21 @@ public class TestQueryForUpdate extends BaseTestCase {
       query = DB.find(Customer.class)
         .forUpdate()
         .setMaxRows(3)
-        .order().desc("id");
+        .orderBy().desc("id");
 
       query.findList();
     }
 
     if (isSqlServer()) {
       assertThat(sqlOf(query)).contains("with (updlock)");
-    } else if (!isOracle() && !isDb2()) {
+    } else if (!isOracle()) {
       // Oracle does not support FOR UPDATE with FETCH
       assertThat(sqlOf(query)).contains("for update");
     }
   }
 
   @Test
-  @ForPlatform({Platform.H2, Platform.ORACLE, Platform.POSTGRES, Platform.SQLSERVER, Platform.MYSQL, Platform.MARIADB})
+  @ForPlatform({Platform.H2, Platform.ORACLE, Platform.POSTGRES, Platform.SQLSERVER, Platform.MYSQL, Platform.MARIADB, Platform.DB2})
   public void testForUpdate_when_alreadyInPCAsReference() {
     ResetBasicData.reset();
     Order o0 = DB.find(Order.class).orderBy("id").setMaxRows(1).findOne();
@@ -96,7 +96,7 @@ public class TestQueryForUpdate extends BaseTestCase {
   }
 
   @Test
-  @ForPlatform({Platform.H2, Platform.ORACLE, Platform.POSTGRES, Platform.SQLSERVER, Platform.MYSQL, Platform.MARIADB})
+  @ForPlatform({Platform.H2, Platform.ORACLE, Platform.POSTGRES, Platform.SQLSERVER, Platform.MYSQL, Platform.MARIADB, Platform.DB2})
   public void testForUpdate_when_alreadyInPCAsReference_usingLock() {
     ResetBasicData.reset();
     Order o0 = DB.find(Order.class).orderBy("id").setMaxRows(1).findOne();
@@ -131,7 +131,7 @@ public class TestQueryForUpdate extends BaseTestCase {
   }
 
   @Test
-  @ForPlatform({Platform.H2, Platform.ORACLE, Platform.POSTGRES, Platform.SQLSERVER, Platform.MYSQL, Platform.MARIADB})
+  @ForPlatform({Platform.H2, Platform.ORACLE, Platform.POSTGRES, Platform.SQLSERVER, Platform.MYSQL, Platform.MARIADB, Platform.DB2})
   public void testForUpdate_when_alreadyInPC() {
 
     EBasic basic = new EBasic("initialValue");
@@ -193,7 +193,7 @@ public class TestQueryForUpdate extends BaseTestCase {
 
     Query<Customer> query = DB.find(Customer.class)
       .forUpdateNoWait()
-      .order().desc("id");
+      .orderBy().desc("id");
 
     query.findList();
     if (isOracle()) {
@@ -219,7 +219,7 @@ public class TestQueryForUpdate extends BaseTestCase {
       Query<Customer> query = DB.find(Customer.class)
         .forUpdateNoWait()
         .setMaxRows(1)
-        .order().desc("id");
+        .orderBy().desc("id");
 
       List<Customer> list = query.findList();
       Customer first = list.get(0);

--- a/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
+++ b/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
@@ -1,6 +1,7 @@
 package io.ebean.platform.db2;
 
 import io.ebean.BackgroundExecutor;
+import io.ebean.Query;
 import io.ebean.annotation.Platform;
 import io.ebean.config.dbplatform.*;
 
@@ -53,4 +54,9 @@ public abstract class BaseDB2Platform extends DatabasePlatform {
     return new DB2SequenceIdGenerator(be, ds, seqName, sequenceBatchSize);
   }
 
+  @Override
+  protected String withForUpdate(String sql, Query.LockWait lockWait, Query.LockType lockType) {
+    // NOWAIT and SKIP LOCKED not supported with Db2
+    return sql + " for update";
+  }
 }


### PR DESCRIPTION
Hello @rob-bygrave ,

I've implemented the select - for update structure for DB2.

IBM documentation of select - for update: https://www.ibm.com/docs/en/db2/11.5?topic=statement-update-clause
nowait & skip locked are only for update queries: https://www.ibm.com/docs/en/db2/11.5?topic=statements-update#sdx-synid_nowait

Can you please take a look at it?

Kind regards
Noemi