### PR TITLE
Change default persistBatchSize from 20 to 100 (as a better default value)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -236,7 +236,7 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
    */
   private PersistBatch persistBatchOnCascade = PersistBatch.INHERIT;
 
-  private int persistBatchSize = 20;
+  private int persistBatchSize = 100;
 
   private EnumType defaultEnumType = EnumType.ORDINAL;
 

--- a/ebean-test/src/test/java/org/tests/iud/TestPersistCascade.java
+++ b/ebean-test/src/test/java/org/tests/iud/TestPersistCascade.java
@@ -35,11 +35,9 @@ public class TestPersistCascade extends BaseTestCase {
       assertThat(sql.get(23)).contains("insert into pcf_city");
       assertSqlBind(sql, 24, 26);
       assertThat(sql.get(28)).contains("insert into pcf_event");
-      assertSqlBind(sql, 29, 48);
-      assertThat(sql.get(50)).contains("insert into pcf_event");
-      assertSqlBind(sql, 51, 70);
-      assertThat(sql.get(72)).contains("insert into pcf_event");
-      assertSqlBind(sql, 73, 87);
+      assertSqlBind(sql, 29, 128);
+      assertThat(sql.get(130)).contains("insert into pcf_event");
+      assertSqlBind(sql, 131, 150);
     }
 
     country.deletePermanent();


### PR DESCRIPTION
This is the batch size used with PreparedStatement executeBatch() with batched inserts, updates and deletes. 20 is really on the low side and bumping this default to 100 seems good and right.

This value is defined in DatabaseConfig.