### PR TITLE
Remove deprecated database.commitTransaction(), migrate to transaction.commit()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DB.java
+++ b/ebean-api/src/main/java/io/ebean/DB.java
@@ -267,55 +267,6 @@ public final class DB {
   }
 
   /**
-   * Deprecated for removal migrate using try-with-resources and commit on the transaction itself.
-   * <p>
-   * Commit the current transaction.
-   */
-  @Deprecated(forRemoval = true)
-  public static void commitTransaction() {
-    getDefault().commitTransaction();
-  }
-
-  /**
-   * Deprecated for removal migrate to using try-with-resources and rollback on the transaction itself.
-   * <p>
-   * Rollback the current transaction.
-   */
-  @Deprecated(forRemoval = true)
-  public static void rollbackTransaction() {
-    getDefault().rollbackTransaction();
-  }
-
-  /**
-   * If the current transaction has already been committed do nothing otherwise
-   * rollback the transaction.
-   * <p>
-   * It is preferable to use <em>try with resources</em> rather than this.
-   * <p>
-   * Useful to put in a finally block to ensure the transaction is ended, rather
-   * than a rollbackTransaction() in each catch block.
-   * <p>
-   * Code example:
-   *
-   * <pre>{@code
-   *   DB.beginTransaction();
-   *   try {
-   *     // do some fetching and or persisting
-   *
-   *     // commit at the end
-   *     DB.commitTransaction();
-   *
-   *   } finally {
-   *     // if commit didn't occur then rollback the transaction
-   *     DB.endTransaction();
-   *   }
-   * }</pre>
-   */
-  public static void endTransaction() {
-    getDefault().endTransaction();
-  }
-
-  /**
    * Mark the current transaction as rollback only.
    */
   public static void setRollbackOnly() {

--- a/ebean-api/src/main/java/io/ebean/Database.java
+++ b/ebean-api/src/main/java/io/ebean/Database.java
@@ -667,49 +667,6 @@ public interface Database {
   void flush();
 
   /**
-   * Deprecated for removal migrate using try-with-resources and commit on the transaction itself.
-   * <p>
-   * Commit the current transaction.
-   */
-  @Deprecated(forRemoval = true)
-  void commitTransaction();
-
-  /**
-   * Deprecated for removal migrate to using try-with-resources and rollback on the transaction itself.
-   * <p>
-   * Rollback the current transaction.
-   */
-  @Deprecated(forRemoval = true)
-  void rollbackTransaction();
-
-  /**
-   * If the current transaction has already been committed do nothing otherwise
-   * rollback the transaction.
-   * <p>
-   * Useful to put in a finally block to ensure the transaction is ended, rather
-   * than a rollbackTransaction() in each catch block.
-   * <p>
-   * Code example:
-   * <p>
-   * <pre>{@code
-   *
-   *   database.beginTransaction();
-   *   try {
-   *     // do some fetching and or persisting ...
-   *
-   *     // commit at the end
-   *     database.commitTransaction();
-   *
-   *   } finally {
-   *     // if commit didn't occur then rollback the transaction
-   *     database.endTransaction();
-   *   }
-   *
-   * }</pre>
-   */
-  void endTransaction();
-
-  /**
    * Refresh the values of a bean.
    * <p>
    * Note that this resets OneToMany and ManyToMany properties so that if they

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
@@ -87,6 +87,11 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
   SpiTransactionManager transactionManager();
 
   /**
+   * End the current transaction if it is active.
+   */
+  void endTransaction();
+
+  /**
    * Return all the descriptors.
    */
   List<BeanDescriptor<?>> descriptors();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -757,16 +757,6 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   }
 
   @Override
-  public void commitTransaction() {
-    currentTransaction().commit();
-  }
-
-  @Override
-  public void rollbackTransaction() {
-    currentTransaction().rollback();
-  }
-
-  @Override
   public void endTransaction() {
     Transaction transaction = transactionManager.inScope();
     if (transaction != null) {

--- a/ebean-test/src/test/java/io/ebean/xtest/base/TransactionalTestCase.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/TransactionalTestCase.java
@@ -1,5 +1,6 @@
 package io.ebean.xtest.base;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import org.junit.jupiter.api.AfterEach;
@@ -18,15 +19,17 @@ import org.tests.model.basic.ResetBasicData;
  */
 public abstract class TransactionalTestCase extends BaseTestCase {
 
+  private Transaction transaction;
+
   @BeforeEach
   public void startTransaction() {
     ResetBasicData.reset();
-    DB.beginTransaction();
+    transaction = DB.beginTransaction();
   }
 
   @AfterEach
   public void endTransaction() {
-    DB.rollbackTransaction();
-    DB.endTransaction();
+    transaction.rollback();
+    transaction.end();
   }
 }

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiEbeanServer.java
@@ -579,14 +579,6 @@ public class TDSpiEbeanServer extends TDSpiServer implements SpiEbeanServer {
   }
 
   @Override
-  public void commitTransaction() {
-  }
-
-  @Override
-  public void rollbackTransaction() {
-  }
-
-  @Override
   public void endTransaction() {
   }
 

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiServer.java
@@ -223,21 +223,6 @@ public class TDSpiServer implements SpiServer {
   }
 
   @Override
-  public void commitTransaction() {
-
-  }
-
-  @Override
-  public void rollbackTransaction() {
-
-  }
-
-  @Override
-  public void endTransaction() {
-
-  }
-
-  @Override
   public void refresh(Object bean) {
 
   }

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/transaction/DefaultTransactionThreadLocalTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/transaction/DefaultTransactionThreadLocalTest.java
@@ -79,9 +79,7 @@ public class DefaultTransactionThreadLocalTest extends BaseTestCase {
   @ForPlatform({Platform.H2})
   @Test
   public void end_withoutActiveTransaction_isFine() {
-
     assertNull(DB.currentTransaction());
-    DB.endTransaction();
   }
 
   @ForPlatform({Platform.H2})

--- a/ebean-test/src/test/java/org/tests/basic/TestDynamicUpdate.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestDynamicUpdate.java
@@ -1,5 +1,6 @@
 package org.tests.basic;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.BeanState;
 import io.ebean.DB;
@@ -36,13 +37,11 @@ public class TestDynamicUpdate extends BaseTestCase {
 
     server.save(b2);
 
-    server.beginTransaction();
-    try {
+    try (Transaction txn = server.beginTransaction()) {
       EMain b3 = server.find(EMain.class, b.getId());
       assertEquals("ABC", b3.getEmbeddable().getDescription());
-    } finally {
-      server.endTransaction();
     }
+
     EMain b4 = server.find(EMain.class, b.getId());
     b4.setName("bbb");
     b4.getEmbeddable().setDescription("123");

--- a/ebean-test/src/test/java/org/tests/basic/TestInheritRef.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestInheritRef.java
@@ -1,5 +1,6 @@
 package org.tests.basic;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import org.junit.jupiter.api.Test;
@@ -17,8 +18,7 @@ public class TestInheritRef extends BaseTestCase {
   @Test
   public void testAssocOne() {
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       DB.createUpdate(Vehicle.class, "delete from vehicle");
 
       Car c = new Car();
@@ -52,9 +52,6 @@ public class TestInheritRef extends BaseTestCase {
 
       assertEquals(1, found);
       assertTrue(foundTruck.getCapacity() == 20D);
-
-    } finally {
-      DB.rollbackTransaction();
     }
   }
 }

--- a/ebean-test/src/test/java/org/tests/basic/TestPersistenceContext.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestPersistenceContext.java
@@ -47,10 +47,9 @@ public class TestPersistenceContext extends BaseTestCase {
     // implicit transaction with its own persistence context
     Order oBefore = DB.find(Order.class, 1);
     // start a persistence context
-    DB.beginTransaction();
 
     Order order;
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       order = DB.find(Order.class, 1);
       // not the same instance ...as a different persistence context
       assertNotSame(order, oBefore);
@@ -63,9 +62,6 @@ public class TestPersistenceContext extends BaseTestCase {
       // all the same instance
       assertSame(order, o2);
       assertSame(order, o3);
-
-    } finally {
-      DB.endTransaction();
     }
 
     // implicit transaction with its own persistence context
@@ -74,8 +70,7 @@ public class TestPersistenceContext extends BaseTestCase {
     assertNotSame(oAfter, order);
 
     // start a persistence context
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       Order testOrder = ResetBasicData.createOrderCustAndOrder("testPC");
       Integer id = testOrder.getCustomer().getId();
       Integer orderId = testOrder.getId();
@@ -94,9 +89,6 @@ public class TestPersistenceContext extends BaseTestCase {
 
       assertEquals(customer.getId(), customer2.getId());
       assertSame(customer, customer2);
-
-    } finally {
-      DB.endTransaction();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/cache/TestCacheInterceptSaveWhenLazyLoaded.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestCacheInterceptSaveWhenLazyLoaded.java
@@ -1,5 +1,6 @@
 package org.tests.cache;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import org.junit.jupiter.api.Test;
@@ -26,8 +27,7 @@ public class TestCacheInterceptSaveWhenLazyLoaded extends BaseTestCase {
     order.setCustomer(customer);
     DB.save(order);
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
 
       Order foundOrder = DB.find(Order.class)
         .where().eq("id", order.getId())
@@ -47,9 +47,6 @@ public class TestCacheInterceptSaveWhenLazyLoaded extends BaseTestCase {
 
       assertSame(foundOrder, order1);
       assertTrue(DB.beanState(foundOrder).isDirty());
-
-    } finally {
-      DB.endTransaction();
     }
 
     // cleanup

--- a/ebean-test/src/test/java/org/tests/genkey/TestGeneratedKeys.java
+++ b/ebean-test/src/test/java/org/tests/genkey/TestGeneratedKeys.java
@@ -1,6 +1,7 @@
 package org.tests.genkey;
 
 import io.ebean.DB;
+import io.ebean.Transaction;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.TOne;
 
@@ -19,12 +20,10 @@ public class TestGeneratedKeys {
     c1.setName("Two");
     c1.setDescription("Test Gen Key Two");
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       DB.save(c);
       DB.save(c1);
-    } finally {
-      DB.commitTransaction();
+      txn.commit();
     }
     Integer id = c.getId();
     assertNotNull(id);

--- a/ebean-test/src/test/java/org/tests/level/test/ManyToManyTest.java
+++ b/ebean-test/src/test/java/org/tests/level/test/ManyToManyTest.java
@@ -1,5 +1,6 @@
 package org.tests.level.test;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import org.junit.jupiter.api.Test;
@@ -19,8 +20,7 @@ public class ManyToManyTest extends BaseTestCase {
   @Test
   public void test() {
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       Level4 i = new Level4("i");
       Level4 ii = new Level4("ii");
       Level4 iii = new Level4("iii");
@@ -92,9 +92,6 @@ public class ManyToManyTest extends BaseTestCase {
         .findList();
 
       validateObjectGraph(i, ii, iii, one, two, x1, x2, x3, x4, x5, things);
-
-    } finally {
-      DB.endTransaction();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/model/basic/xtra/TestDeleteUnloadedChildren.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/xtra/TestDeleteUnloadedChildren.java
@@ -54,7 +54,6 @@ public class TestDeleteUnloadedChildren extends BaseTestCase {
 
   @Test
   public void testCascadeDelete2() {
-
     init();
 
     try (Transaction txn = DB.beginTransaction()) {
@@ -68,18 +67,14 @@ public class TestDeleteUnloadedChildren extends BaseTestCase {
 
   @Test
   public void testCascadeDelete3() {
-
     init();
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       EdExtendedParent extendedParent = DB.find(EdExtendedParent.class).where()
         .eq("name", "My second computer").findOne();
       extendedParent.getChildren().size();
       DB.delete(extendedParent);
-      DB.commitTransaction();
-    } finally {
-      DB.endTransaction();
+      txn.commit();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenFlushThenUpdate.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenFlushThenUpdate.java
@@ -49,7 +49,7 @@ public class TestInsertBatchThenFlushThenUpdate extends BaseTestCase {
       // nothing flushed yet
       assertThat(LoggedSql.start()).isEmpty();
 
-      DB.commitTransaction();
+      txn.commit();
 
       // insert statements for EdExtendedParent
       List<String> loggedSql2 = LoggedSql.start();

--- a/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenUpdate.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchThenUpdate.java
@@ -44,7 +44,7 @@ public class TestInsertBatchThenUpdate extends BaseTestCase {
       parent.setName("MyDesk");
       DB.save(parent);
 
-      DB.commitTransaction();
+      txn.commit();
 
       // insert statements for EdExtendedParent
       List<String> loggedSql = LoggedSql.stop();
@@ -87,7 +87,7 @@ public class TestInsertBatchThenUpdate extends BaseTestCase {
       DB.save(parent);
 
       // flush
-      DB.commitTransaction();
+      txn.commit();
 
       // insert statements for EdExtendedParent
       List<String> loggedSql = LoggedSql.stop();

--- a/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchWithDifferentRootTypes.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/xtra/TestInsertBatchWithDifferentRootTypes.java
@@ -58,7 +58,7 @@ public class TestInsertBatchWithDifferentRootTypes extends BaseTestCase {
       // insert statements for EdParent
       List<String> loggedSql1 = LoggedSql.start();
 
-      DB.commitTransaction();
+      txn.commit();
 
       assertEquals(0, loggedSql1.size());
 

--- a/ebean-test/src/test/java/org/tests/persistencecontext/TestPersistenceContextOnUpdateDuringTxn.java
+++ b/ebean-test/src/test/java/org/tests/persistencecontext/TestPersistenceContextOnUpdateDuringTxn.java
@@ -1,5 +1,6 @@
 package org.tests.persistencecontext;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Database;
@@ -12,12 +13,9 @@ public class TestPersistenceContextOnUpdateDuringTxn extends BaseTestCase {
 
   @Test
   public void test() {
-
     Database server = DB.getDefault();
 
-    server.beginTransaction();
-    try {
-
+    try (Transaction txn = server.beginTransaction()) {
       EBasic bean1 = new EBasic();
       bean1.setName("hello");
 
@@ -33,11 +31,7 @@ public class TestPersistenceContextOnUpdateDuringTxn extends BaseTestCase {
       EBasic loadedEntity = server.find(EBasic.class, bean1.getId());
 
       assertThat(loadedEntity.getName()).isEqualTo("hello-changed");
-
-    } finally {
-      server.endTransaction();
     }
-
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/persistencecontext/TestPersistenceContextQueryScope.java
+++ b/ebean-test/src/test/java/org/tests/persistencecontext/TestPersistenceContextQueryScope.java
@@ -1,5 +1,6 @@
 package org.tests.persistencecontext;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import org.junit.jupiter.api.Test;
@@ -21,8 +22,7 @@ public class TestPersistenceContextQueryScope extends BaseTestCase {
 
     //DB.cacheManager().setCaching(EBasicVer.class, true);
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       EBasicVer bean1 = DB.find(EBasicVer.class, bean.getId());
 
       // do an update of the name in the DB
@@ -65,10 +65,7 @@ public class TestPersistenceContextQueryScope extends BaseTestCase {
       assertEquals("second", bean3.getName());
       DB.delete(bean3);
 
-      DB.commitTransaction();
-
-    } finally {
-      DB.endTransaction();
+      txn.commit();
     }
   }
 }

--- a/ebean-test/src/test/java/org/tests/query/TestConnectionCloseOnSqlerr.java
+++ b/ebean-test/src/test/java/org/tests/query/TestConnectionCloseOnSqlerr.java
@@ -1,5 +1,6 @@
 package org.tests.query;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Query;
@@ -50,22 +51,17 @@ public class TestConnectionCloseOnSqlerr extends BaseTestCase {
 
     try {
       for (int i = 0; i < 100; i++) {
-        DB.beginTransaction();
-        try {
+        try (Transaction txn = DB.beginTransaction()) {
           Query<Customer> q0 = DB.find(Customer.class).where().icontains("namexxx", "Rob")
             .query();
 
           q0.findList();
-          DB.commitTransaction();
+          txn.commit();
         } catch (Exception e) {
           if (e.getMessage().contains("Unsuccessfully waited")) {
             fail("No connections found while only one thread is running. (after " + i + " queries)");
           } else {
             e.printStackTrace();
-          }
-        } finally {
-          if (DB.currentTransaction().isActive()) {
-            DB.rollbackTransaction();
           }
         }
       }

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindPagedList.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindPagedList.java
@@ -219,8 +219,7 @@ public class TestQueryFindPagedList extends BaseTestCase {
     // kinda not normal but just wrap in a transaction to assert
     // the background fetch does not occur (which explicitly creates
     // its own transaction) ... so a bit naughty with the test here
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
 
       List<Order> orders = pagedList.getList();
       int totalRowCount = pagedList.getTotalCount();
@@ -238,12 +237,8 @@ public class TestQueryFindPagedList extends BaseTestCase {
       String secTxn = loggedSql.get(1).substring(0, 10);
 
       assertEquals(firstTxn, secTxn);
-
-    } finally {
-      DB.endTransaction();
     }
   }
-
 
   @Test
   public void test_usingAlias() {

--- a/ebean-test/src/test/java/org/tests/query/finder/TestCustomerFinder.java
+++ b/ebean-test/src/test/java/org/tests/query/finder/TestCustomerFinder.java
@@ -84,15 +84,10 @@ public class TestCustomerFinder extends BaseTestCase {
 
   @Test
   public void currentTransaction() {
-
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       Transaction t1 = DB.currentTransaction();
       Transaction t2 = Customer.find.currentTransaction();
       assertThat(t2).isSameAs(t1);
-
-    } finally {
-      DB.endTransaction();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/query/joins/TestDisjunctWhereOuterJoin.java
+++ b/ebean-test/src/test/java/org/tests/query/joins/TestDisjunctWhereOuterJoin.java
@@ -1,9 +1,10 @@
 package org.tests.query.joins;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Expr;
 import io.ebean.Query;
+import io.ebean.Transaction;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.Test;
 import org.tests.basic.one2one.Wheel;
 import org.tests.model.basic.MRole;
@@ -18,8 +19,7 @@ public class TestDisjunctWhereOuterJoin extends BaseTestCase {
   @Test
   public void test() {
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
 
       MRole r1 = new MRole();
       r1.setRoleName("role1B");
@@ -63,8 +63,6 @@ public class TestDisjunctWhereOuterJoin extends BaseTestCase {
       assertSqlOuterJoins(sql);
       assertThat(sql).contains(".role_name = ?");
 
-    } finally {
-      DB.rollbackTransaction();
     }
   }
 
@@ -76,7 +74,7 @@ public class TestDisjunctWhereOuterJoin extends BaseTestCase {
       .eq("roles.roleid", roleid)
       .endOr().query();
 
-      query.findList();
+    query.findList();
 
     String sql = sqlOf(query);
     assertSqlOuterJoins(sql);
@@ -85,19 +83,16 @@ public class TestDisjunctWhereOuterJoin extends BaseTestCase {
 
   @Test
   public void testSelectOneToOneDisjunction() {
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       Query<Wheel> query = DB.find(Wheel.class)
-              .select("id")
-              .where().or()
-              .ge("tire.id", 100)
-              .lt("tire.id", 100)
-              .endOr().query();
+        .select("id")
+        .where().or()
+        .ge("tire.id", 100)
+        .lt("tire.id", 100)
+        .endOr().query();
       query.findList();
       String sql = sqlOf(query);
       assertThat(sql).contains("join");
-    } finally {
-      DB.rollbackTransaction();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/query/other/TestManyLazyLoadingQuery.java
+++ b/ebean-test/src/test/java/org/tests/query/other/TestManyLazyLoadingQuery.java
@@ -1,5 +1,6 @@
 package org.tests.query.other;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebeaninternal.api.SpiEbeanServer;
@@ -44,8 +45,7 @@ public class TestManyLazyLoadingQuery extends BaseTestCase {
 
 
     // start transaction to keep PC going to lazy query
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       DB.find(Order.class, 1);
 
       SpiQuery<?> query0 = (SpiQuery<?>) DB.find(OrderDetail.class);
@@ -57,9 +57,6 @@ public class TestManyLazyLoadingQuery extends BaseTestCase {
       query0.findList();
       assertThat(query0.getGeneratedSql()).contains(" from o_order_detail t0 where (t0.order_id) ");
       platformAssertIn(query0.getGeneratedSql(), "where (t0.order_id)");
-
-    } finally {
-      DB.endTransaction();
     }
 
     List<OrderDetail> details = DB.find(OrderDetail.class)

--- a/ebean-test/src/test/java/org/tests/transaction/TestBatchPersistCascade.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestBatchPersistCascade.java
@@ -62,8 +62,7 @@ public class TestBatchPersistCascade extends BaseTestCase {
 
     List<UTMaster> list = server.find(UTMaster.class).fetch("details").findList();
 
-    Transaction txn = server.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       txn.setBatchMode(true);
       txn.setBatchOnCascade(true);
 
@@ -103,11 +102,8 @@ public class TestBatchPersistCascade extends BaseTestCase {
 
       logger.info("commit ------------ ");
 
-      server.commitTransaction();
-    } finally {
-      server.endTransaction();
+      txn.commit();
     }
-
   }
 
   private UTDetail createUTDetail(String master, int count) {

--- a/ebean-test/src/test/java/org/tests/transaction/TestDeleteFromPersistenceContext.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestDeleteFromPersistenceContext.java
@@ -1,5 +1,6 @@
 package org.tests.transaction;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebeaninternal.api.SpiTransaction;
@@ -19,9 +20,8 @@ public class TestDeleteFromPersistenceContext extends BaseTestCase {
     EBasicVer bean = new EBasicVer("Please Delete Me");
     DB.save(bean);
 
-    SpiTransaction transaction = (SpiTransaction) DB.beginTransaction();
-    try {
-
+    try (Transaction txn = DB.beginTransaction()) {
+      SpiTransaction spiTransaction = (SpiTransaction)txn;
       EBasicVer bean2 = DB.find(EBasicVer.class, bean.getId());
       assertNotSame(bean, bean2);
 
@@ -29,18 +29,15 @@ public class TestDeleteFromPersistenceContext extends BaseTestCase {
       // same instance from PersistenceContext
       assertSame(bean2, bean3);
 
-      Object bean4 = transaction.persistenceContext().get(EBasicVer.class, bean.getId());
+      Object bean4 = spiTransaction.persistenceContext().get(EBasicVer.class, bean.getId());
       assertSame(bean2, bean4);
 
       DB.delete(bean2);
 
-      Object bean5 = transaction.persistenceContext().get(EBasicVer.class, bean.getId());
+      Object bean5 = spiTransaction.persistenceContext().get(EBasicVer.class, bean.getId());
       assertNull(bean5);
 
-      DB.commitTransaction();
-
-    } finally {
-      DB.endTransaction();
+      txn.commit();
     }
 
     EBasicVer bean6 = DB.find(EBasicVer.class).where().eq("id", bean.getId()).findOne();

--- a/ebean-test/src/test/java/org/tests/transaction/TestNestedSubTransaction.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestNestedSubTransaction.java
@@ -37,8 +37,7 @@ public class TestNestedSubTransaction extends BaseTestCase {
       try (Transaction txn1 = server.beginTransaction()) {
         bean.setName("x2");
         server.save(bean);
-        //txn1.commit();
-        server.commitTransaction();
+        txn1.commit();
       }
 
       EBasic fresh = server.find(EBasic.class, bean.getId());
@@ -48,8 +47,7 @@ public class TestNestedSubTransaction extends BaseTestCase {
       try (Transaction txn2 = server.beginTransaction()) {
         bean.setName("barney");
         DB.save(bean);
-        //txn2.commit();
-        server.commitTransaction();
+        txn2.commit();
       }
 
       fresh = server.find(EBasic.class)

--- a/ebean-test/src/test/java/org/tests/transaction/TestStatelessUpdateClearPC.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestStatelessUpdateClearPC.java
@@ -1,5 +1,6 @@
 package org.tests.transaction;
 
+import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import org.junit.jupiter.api.Test;
@@ -12,10 +13,7 @@ public class TestStatelessUpdateClearPC extends BaseTestCase {
 
   @Test
   public void test() {
-
-
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       EBasic newUser = new EBasic();
       newUser.setName("any@email.com");
       DB.save(newUser);
@@ -32,8 +30,6 @@ public class TestStatelessUpdateClearPC extends BaseTestCase {
 
       EBasic loadedUser = DB.find(EBasic.class, newUser.getId());
       assertEquals("anyNew@email.com", loadedUser.getName());
-    } finally {
-      DB.rollbackTransaction();
     }
   }
 }

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionCallback.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionCallback.java
@@ -31,11 +31,8 @@ public class TestTransactionCallback extends BaseTestCase {
     assertEquals(0, countPreRollback);
     assertEquals(0, countPostRollback);
 
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       DB.register(new MyCallback());
-    } finally {
-      DB.rollbackTransaction();
     }
 
     assertEquals(1, countPreCommit);

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionalNotSupports.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionalNotSupports.java
@@ -32,8 +32,7 @@ public class TestTransactionalNotSupports extends BaseTestCase {
   public void withOuterTransaction_expect_currentTransaction_null_and_originalTxnRestored() {
 
     outerTxn = null;
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       currentTxn = DB.currentTransaction();
       assertNotNull(currentTxn);
       new SomeTransactionalWithNotSupported().doStuff();
@@ -44,8 +43,6 @@ public class TestTransactionalNotSupports extends BaseTestCase {
       // the original transaction was restored
       Transaction restored = DB.currentTransaction();
       assertSame(currentTxn, restored);
-    } finally {
-      DB.endTransaction();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionalRequired.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionalRequired.java
@@ -40,8 +40,7 @@ public class TestTransactionalRequired extends BaseTestCase {
   public void withOuterBegin() {
 
     outerTxn = null;
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       currentTxn = DB.currentTransaction();
       assertNotNull(currentTxn);
       new OuterTransactionalWithRequired().doOuter();
@@ -51,8 +50,6 @@ public class TestTransactionalRequired extends BaseTestCase {
       assertSame(currentTxn, restored);
       assertSame(currentTxn, innerTxn);
       assertSame(currentTxn, outerTxn);
-    } finally {
-      DB.endTransaction();
     }
 
     assertNull(DB.currentTransaction());

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionalRequiresNew.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionalRequiresNew.java
@@ -68,11 +68,8 @@ public class TestTransactionalRequiresNew extends BaseTestCase {
     Database server = server();
     try(Transaction txn = server.beginTransaction()) {
       String txnName = txn.toString();
-      DB.beginTransaction(TxScope.requiresNew());
-      try {
-        DB.commitTransaction();
-      } finally {
-        DB.endTransaction();
+      try (Transaction txn2 = DB.beginTransaction(TxScope.requiresNew())) {
+        txn2.commit();
       }
       assertThat(txn.toString()).isEqualTo(txnName);
     }
@@ -83,11 +80,8 @@ public class TestTransactionalRequiresNew extends BaseTestCase {
     Database server = server();
     try (Transaction txn = server.beginTransaction()) {
       String txnName = txn.toString();
-      server.beginTransaction(TxScope.requiresNew());
-      try {
-        server.commitTransaction();
-      } finally {
-        server.endTransaction();
+      try (Transaction txn2 = server.beginTransaction(TxScope.requiresNew())) {
+        txn2.commit();
       }
       assertThat(txn.toString()).isEqualTo(txnName);
     }
@@ -98,11 +92,8 @@ public class TestTransactionalRequiresNew extends BaseTestCase {
     Database server = server();
     try (Transaction txn = server.beginTransaction()) {
       String txnName = txn.toString();
-      Transaction txn2 = DB.beginTransaction(TxScope.requiresNew());
-      try {
+      try (Transaction txn2 = DB.beginTransaction(TxScope.requiresNew())) {
         txn2.commit();
-      } finally {
-        txn2.end();
       }
       assertThat(txn.toString()).isEqualTo(txnName);
     }

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionalSupports.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionalSupports.java
@@ -33,12 +33,9 @@ public class TestTransactionalSupports extends BaseTestCase {
   public void withOuterTransaction_expect_currentTransactionAvailable() {
 
     outerTxn = null;
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       new SomeTransactionalWithSupports().doStuff();
       assertNotNull(outerTxn);
-    } finally {
-      DB.endTransaction();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/update/TestSqlUpdateInTxn.java
+++ b/ebean-test/src/test/java/org/tests/update/TestSqlUpdateInTxn.java
@@ -177,9 +177,7 @@ public class TestSqlUpdateInTxn extends BaseTestCase {
     assertEquals("foo3", log4.getDescription());
     assertEquals("mod1", log4.getModifiedDescription());
 
-
-    DB.beginTransaction();
-    try {
+    try (Transaction txn = DB.beginTransaction()) {
       SqlUpdate update = DB.sqlUpdate(updateDml);
       update.setParameter("desc", "foo4");
       update.setParameter("id", id);
@@ -189,9 +187,7 @@ public class TestSqlUpdateInTxn extends BaseTestCase {
       updateMod.setParameter("desc", "mod2");
       updateMod.execute();
 
-      DB.commitTransaction();
-    } finally {
-      DB.endTransaction();
+      txn.commit();
     }
     AuditLog log5 = DB.find(AuditLog.class, log.getId());
     assertEquals("foo4", log5.getDescription());


### PR DESCRIPTION
Remove the deprecated methods:
- DB.commitTransaction()
- DB.rollbackTransaction()
- DB.endTransaction()
- database.commitTransaction()
- database.rollbackTransaction()
- database.endTransaction()

Migrate to using try-with-resources and transaction.commit(), transaction.rollback()