### PR TITLE
NEW: Allow control of jsonwrite-loadedprops

### DIFF
--- a/ebean-api/src/main/java/io/ebean/text/json/JsonWriteOptions.java
+++ b/ebean-api/src/main/java/io/ebean/text/json/JsonWriteOptions.java
@@ -22,6 +22,8 @@ public class JsonWriteOptions {
 
   protected JsonConfig.Include include;
 
+  protected boolean includeLoadedImplicit = true;
+
   protected Map<String, JsonWriteBeanVisitor<?>> visitorMap;
 
   /**
@@ -71,6 +73,20 @@ public class JsonWriteOptions {
    */
   public void setInclude(JsonConfig.Include include) {
     this.include = include;
+  }
+
+  /**
+   * Should loaded properties be included implicit, if no other fetch path is specified (default = true).
+   */
+  public boolean isIncludeLoadedImplicit() {
+    return includeLoadedImplicit;
+  }
+
+  /**
+   * Set include loaded properties implicit (default = true).
+   */
+  public void setIncludeLoadedImplicit(boolean includeLoadedImplicit) {
+    this.includeLoadedImplicit = includeLoadedImplicit;
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/json/DJsonContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/json/DJsonContext.java
@@ -402,7 +402,13 @@ public final class DJsonContext implements SpiJsonContext {
   private WriteJson createWriteJson(JsonGenerator gen, JsonWriteOptions options) {
     FetchPath pathProps = (options == null) ? null : options.getPathProperties();
     Map<String, JsonWriteBeanVisitor<?>> visitors = (options == null) ? null : options.getVisitorMap();
-    return new WriteJson(server, gen, pathProps, visitors, determineObjectMapper(options), determineInclude(options));
+    return new WriteJson(server,
+      gen,
+      pathProps,
+      visitors,
+      determineObjectMapper(options),
+      determineInclude(options),
+      options == null || options.isIncludeLoadedImplicit());
   }
 
   private <T> void toJsonFromCollection(Collection<T> collection, String key, JsonGenerator gen, JsonWriteOptions options) throws IOException {
@@ -490,4 +496,5 @@ public final class DJsonContext implements SpiJsonContext {
     JsonConfig.Include include = options.getInclude();
     return (include != null) ? include : defaultInclude;
   }
+
 }

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/WriteJsonDirtyTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/WriteJsonDirtyTest.java
@@ -43,7 +43,7 @@ public class WriteJsonDirtyTest {
     JsonFactory jsonFactory = new JsonFactory();
     JsonGenerator generator = jsonFactory.createGenerator(writer);
 
-    WriteJson writeJson = new WriteJson(server, generator, null, null, null, null);
+    WriteJson writeJson = new WriteJson(server, generator, null, null, null, null, true);
     descriptor.jsonWriteDirty(writeJson, entityBean, dirtyProperties);
 
     generator.flush();

--- a/ebean-test/src/test/java/org/tests/json/include/TestJsonImplicitLoaded.java
+++ b/ebean-test/src/test/java/org/tests/json/include/TestJsonImplicitLoaded.java
@@ -1,0 +1,41 @@
+package org.tests.json.include;
+
+import io.ebean.DB;
+import io.ebean.FetchPath;
+import io.ebean.annotation.Transactional;
+import io.ebean.config.JsonConfig;
+import io.ebean.text.PathProperties;
+import io.ebean.text.json.JsonWriteOptions;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Contact;
+import org.tests.model.basic.ResetBasicData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJsonImplicitLoaded {
+
+  @Test
+  @Transactional
+  public void testToBeanToJson() throws Exception {
+    ResetBasicData.reset();
+
+
+    FetchPath path = PathProperties.parse("*");
+    Contact bean = DB.find(Contact.class).setId(1).apply(path).findOne();
+
+    JsonWriteOptions options = new JsonWriteOptions();
+    options.setInclude(JsonConfig.Include.NON_NULL);
+    options.setPathProperties(path);
+    options.setIncludeLoadedImplicit(false);
+
+    String asJson = DB.json().toJson(bean, options);
+    assertThat(asJson).contains("customer\":{\"id\":1}"); // hold only ID
+
+    bean.getCustomer().getName(); // lazy-load bean;
+    asJson = DB.json().toJson(bean, options);
+    assertThat(asJson).contains("customer\":{\"id\":1}"); // expect the same result
+
+
+  }
+
+}


### PR DESCRIPTION
We have the following use case:

We want to convert a model to JSON, exactly, we want to convert the first level of an object graph.

We need the IDs of refrenced objects, but we do not need (and **must not** provide) any additional data. 
(The data we do not want to expose can contain secret informations: e.g. password hashes)

For example, when serializing a `Contact` then we expect all properties from contact, but only the ID from `Customer`:

```json
{
  "id":1,
  "firstName":"Jim1",
  "lastName":"Cricket",
  "isMember":false,
  "customer":{"id":1},
  "cretime":"2024-02-29T13:03:10.378Z",
  "updtime":"2024-02-29T13:03:10.378Z"
}
```
So we hoped a simple `PathProperties.parse("*")`  This works fine, as long the "customer" bean is not loaded. 
But if the bean is loaded, the result looks different, and the json contains all properties in customer.
(the presence in persistence-context and also in the bean-cache seems to affect the json output)

In our case, the data at our rest-api was a bit non deterministic, depending of the cache state of the reference bean.

I've tracked down the problem to [isIncludeProperty](https://github.com/ebean-orm/ebean/blob/master/ebean-core/src/main/java/io/ebeaninternal/server/json/WriteJson.java#L504) as the fallback is to check if the property is loaded if no explicit path is configured for a certain graph path.

This PR allows to change this behaviour, so that only the ID is written.

@rbygrave maybe you have a better idea about naming or solving our issue?

cheers
Roland

