### PR TITLE
#3337 Fix querybean-generation to not import the entity bean type

### DIFF
--- a/ebean-querybean/src/test/java/org/example/domain/Alias.java
+++ b/ebean-querybean/src/test/java/org/example/domain/Alias.java
@@ -1,0 +1,14 @@
+package org.example.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+@Entity
+public class Alias {
+
+  @Id
+  long id;
+  @Version
+  long version;
+}

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -2,9 +2,8 @@ package io.ebean.querybean.generator;
 
 interface Constants {
 
-  String AT_GENERATED = "@Generated(\"io.ebean.querybean.kotlin-generator\")";
-  String AT_TYPEQUERYBEAN = "@TypeQueryBean(\"v1\")";
-  String GENERATED = "io.ebean.typequery.Generated";
+  String AT_GENERATED = "@io.ebean.typequery.Generated(\"io.ebean.querybean.kotlin-generator\")";
+  String AT_TYPEQUERYBEAN = "@io.ebean.typequery.TypeQueryBean(\"v1\")";
 
   String MAPPED_SUPERCLASS = "jakarta.persistence.MappedSuperclass";
   String DISCRIMINATOR_VALUE = "jakarta.persistence.DiscriminatorValue";
@@ -19,16 +18,9 @@ interface Constants {
   String DBJSONB = "io.ebean.annotation.DbJsonB";
   String DBNAME = "io.ebean.annotation.DbName";
 
-  String TQROOTBEAN = "io.ebean.typequery.TQRootBean";
   String TQASSOC = "io.ebean.typequery.TQAssoc";
   String TQASSOCBEAN = "io.ebean.typequery.TQAssocBean";
   String TQPROPERTY = "io.ebean.typequery.TQProperty";
-  String TYPEQUERYBEAN = "io.ebean.typequery.TypeQueryBean";
-  String DATABASE = "io.ebean.Database";
-  String DB = "io.ebean.DB";
-  String FETCHGROUP = "io.ebean.FetchGroup";
-  String QUERY = "io.ebean.Query";
-  String TRANSACTION = "io.ebean.Transaction";
 
   String MODULEINFO = "io.ebean.config.ModuleInfo";
   String METAINF_MANIFEST = "META-INF/ebean-generated-info.mf";

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
@@ -3,17 +3,7 @@ package io.ebean.querybean.generator;
 class KotlinLangAdapter implements LangAdapter {
 
   @Override
-  public void beginClass(Append writer, String shortName) {
-    writer.append("class Q%s : TQRootBean<%1$s, Q%1$s> {", shortName).eol();
-  }
-
-  @Override
-  public void beginAssocClass(Append writer, String shortName, String origShortName) {
-//    writer.append("class Q%s<R> : TQAssocBean<%s,R> {", shortName, origShortName).eol();
-  }
-
-  @Override
-  public void alias(Append writer, String shortName) {
+  public void alias(Append writer, String shortName, String fullName) {
     writer.append("  companion object {").eol();
     writer.append("    /**").eol();
     writer.append("     * shared 'Alias' instance used to provide").eol();
@@ -25,7 +15,7 @@ class KotlinLangAdapter implements LangAdapter {
     writer.append("     * Return a query bean used to build a FetchGroup.").eol();
     writer.append("     */").eol();
     writer.append("    fun forFetchGroup(): Q%s {", shortName).eol();
-    writer.append("      return Q%s(FetchGroup.queryFor(%s::class.java));", shortName, shortName).eol();
+    writer.append("      return Q%s(io.ebean.FetchGroup.queryFor(%s::class.java));", shortName, fullName).eol();
     writer.append("    }").eol();
     writer.append("  }").eol().eol();
   }
@@ -59,31 +49,31 @@ class KotlinLangAdapter implements LangAdapter {
   }
 
   @Override
-  public void rootBeanConstructor(Append writer, String shortName, String dbName) {
+  public void rootBeanConstructor(Append writer, String shortName, String dbName, String fullName) {
     String name = (dbName == null) ? "default" : dbName;
     writer.append("  /**").eol();
     writer.append("   * Construct using the %s Database.", name).eol();
     writer.append("   */").eol();
     if (dbName == null) {
-      writer.append("  constructor() : super(%s::class.java)", shortName).eol().eol();
+      writer.append("  constructor() : super(%s::class.java)", fullName).eol().eol();
     } else {
-      writer.append("  constructor() : super(%s::class.java, DB.byName(\"%s\"))", shortName, dbName).eol().eol();
+      writer.append("  constructor() : super(%s::class.java, io.ebean.DB.byName(\"%s\"))", fullName, dbName).eol().eol();
     }
 
     writer.append("  /**").eol();
     writer.append("   * Construct with a given Transaction.", name).eol();
     writer.append("   */").eol();
     if (dbName == null) {
-      writer.append("  constructor(transaction: Transaction) : super(%s::class.java, transaction)", shortName).eol().eol();
+      writer.append("  constructor(transaction: io.ebean.Transaction) : super(%s::class.java, transaction)", fullName).eol().eol();
     } else {
-      writer.append("  constructor(transaction: Transaction) : super(%s::class.java, DB.byName(\"%s\"), transaction)", shortName, dbName).eol().eol();
+      writer.append("  constructor(transaction: io.ebean.Transaction) : super(%s::class.java, io.ebean.DB.byName(\"%s\"), transaction)", fullName, dbName).eol().eol();
     }
 
     writer.eol();
     writer.append("  /**").eol();
     writer.append("   * Construct with a given Database.").eol();
     writer.append("   */").eol();
-    writer.append("  constructor(database: Database) : super(%s::class.java, database)", shortName).eol().eol();
+    writer.append("  constructor(database: io.ebean.Database) : super(%s::class.java, database)", fullName).eol().eol();
 
     writer.append("  /**").eol();
     writer.append("   * Construct for Alias.").eol();
@@ -93,7 +83,7 @@ class KotlinLangAdapter implements LangAdapter {
     writer.append("  /**").eol();
     writer.append("   * Private constructor for FetchGroup building.").eol();
     writer.append("   */").eol();
-    writer.append("  private constructor(fetchGroupQuery: Query<%s>) : super(fetchGroupQuery)", shortName).eol();
+    writer.append("  private constructor(fetchGroupQuery: io.ebean.Query<%s>) : super(fetchGroupQuery)", fullName).eol();
 
     writer.eol();
     writer.append("  /** Return a copy of the query. */").eol();

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/LangAdapter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/LangAdapter.java
@@ -2,13 +2,10 @@ package io.ebean.querybean.generator;
 
 public interface LangAdapter {
 
-  void beginClass(Append writer, String shortName);
 
-  void beginAssocClass(Append writer, String shortName, String origShortName);
+  void alias(Append writer, String shortName, String beanFullName);
 
-  void alias(Append writer, String shortName);
-
-  void rootBeanConstructor(Append writer, String shortName, String dbName);
+  void rootBeanConstructor(Append writer, String shortName, String dbName, String beanFullName);
 
   void assocBeanConstructor(Append writer, String shortName);
 

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
@@ -91,7 +91,6 @@ class SimpleModuleInfoWriter {
     writer.append("import java.util.ArrayList;").eol();
     writer.append("import java.util.Collections;").eol();
     writer.append("import java.util.List;").eol();
-    writer.append("import %s;", Constants.GENERATED).eol();
     writer.eol();
     writer.append("import io.ebean.config.ModuleInfo;").eol();
     writer.append("import io.ebean.config.EntityClassRegister;").eol();

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -123,21 +123,10 @@ class SimpleQueryBeanWriter {
   }
 
   private void gatherPropertyDetails() {
-    importTypes.add(Constants.GENERATED);
-    importTypes.add(beanFullName);
-    importTypes.add(Constants.TQROOTBEAN);
-    importTypes.add(Constants.TYPEQUERYBEAN);
-    importTypes.add(Constants.DATABASE);
-    importTypes.add(Constants.FETCHGROUP);
-    importTypes.add(Constants.QUERY);
-    importTypes.add(Constants.TRANSACTION);
     if (implementsInterface != null) {
       implementsInterfaceFullName = implementsInterface.getQualifiedName().toString();
       boolean nested = implementsInterface.getNestingKind().isNested();
       implementsInterfaceShortName = Util.shortName(nested, implementsInterfaceFullName);
-    }
-    if (dbName != null) {
-      importTypes.add(Constants.DB);
     }
     addClassProperties();
   }
@@ -230,12 +219,6 @@ class SimpleQueryBeanWriter {
    * Prepare the imports for writing assoc bean.
    */
   private void prepareAssocBeanImports() {
-
-    importTypes.remove(Constants.DB);
-    importTypes.remove(Constants.TQROOTBEAN);
-    importTypes.remove(Constants.DATABASE);
-    importTypes.remove(Constants.FETCHGROUP);
-    importTypes.remove(Constants.QUERY);
     if (embeddable) {
       importTypes.add(Constants.TQASSOC);
     } else {
@@ -266,7 +249,6 @@ class SimpleQueryBeanWriter {
    * Write constructors.
    */
   private void writeConstructors() {
-
     if (writingAssocBean) {
       writeAssocBeanFetch();
       writeAssocBeanConstructor();
@@ -279,7 +261,7 @@ class SimpleQueryBeanWriter {
    * Write the constructors for 'root' type query bean.
    */
   private void writeRootBeanConstructor() {
-    lang().rootBeanConstructor(writer, shortName, dbName);
+    lang().rootBeanConstructor(writer, shortName, dbName, beanFullName);
   }
 
   private void writeAssocBeanFetch() {
@@ -315,7 +297,6 @@ class SimpleQueryBeanWriter {
    * Write constructor for 'assoc' type query bean.
    */
   private void writeAssocBeanConstructor() {
-
     lang().assocBeanConstructor(writer, shortName);
   }
 
@@ -344,11 +325,10 @@ class SimpleQueryBeanWriter {
       writer.append(Constants.AT_GENERATED).eol();
       writer.append(Constants.AT_TYPEQUERYBEAN).eol();
       if (embeddable) {
-        writer.append("class Q%s<R> : TQAssoc<%s,R> {", shortName, shortInnerName).eol();
+        writer.append("class Q%s<R> : TQAssoc<%s,R> {", shortName, beanFullName).eol();
       } else {
-        writer.append("class Q%s<R> : TQAssocBean<%s,R,Q%s> {", shortName, shortInnerName, origShortName).eol();
+        writer.append("class Q%s<R> : TQAssocBean<%s,R,Q%s> {", shortName, beanFullName, origShortName).eol();
       }
-
     } else {
       writer.append("/**").eol();
       writer.append(" * Query bean for %s.", shortName).eol();
@@ -357,7 +337,7 @@ class SimpleQueryBeanWriter {
       writer.append(" */").eol();
       writer.append(Constants.AT_GENERATED).eol();
       writer.append(Constants.AT_TYPEQUERYBEAN).eol();
-      lang().beginClass(writer, shortName);
+      writer.append("class Q%s : io.ebean.typequery.TQRootBean<%s, Q%s> {", shortName, beanFullName, shortName).eol();
     }
 
     writer.eol();
@@ -365,7 +345,7 @@ class SimpleQueryBeanWriter {
 
   private void writeAlias() {
     if (!writingAssocBean) {
-      lang().alias(writer, shortName);
+      lang().alias(writer, shortName, beanFullName);
     }
   }
 

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -70,7 +70,6 @@ class SimpleQueryBeanWriter {
   }
 
   private void gatherPropertyDetails() {
-    importTypes.add(beanFullName);
     if (implementsInterface != null) {
       String implementsInterfaceFullName = implementsInterface.getQualifiedName().toString();
       boolean nested = implementsInterface.getNestingKind().isNested();
@@ -146,7 +145,7 @@ class SimpleQueryBeanWriter {
     writer.append("   * }</pre>").eol();
     writer.append("   */").eol();
     writer.append("  public static Q%s forFetchGroup() {", shortName).eol();
-    writer.append("    return new Q%s(io.ebean.FetchGroup.queryFor(%s.class));", shortName, shortName).eol();
+    writer.append("    return new Q%s(io.ebean.FetchGroup.queryFor(%s.class));", shortName, beanFullName).eol();
     writer.append("  }").eol();
     writer.eol();
 
@@ -154,9 +153,9 @@ class SimpleQueryBeanWriter {
     writer.append("  /** Construct using the %s Database */", name).eol();
     writer.append("  public Q%s() {", shortName).eol();
     if (dbName == null) {
-      writer.append("    super(%s.class);", shortName).eol();
+      writer.append("    super(%s.class);", beanFullName).eol();
     } else {
-      writer.append("    super(%s.class, io.ebean.DB.byName(\"%s\"));", shortName, dbName).eol();
+      writer.append("    super(%s.class, io.ebean.DB.byName(\"%s\"));", beanFullName, dbName).eol();
     }
     writer.append("  }").eol();
     writer.eol();
@@ -164,16 +163,16 @@ class SimpleQueryBeanWriter {
     writer.append("  /** Construct with a given transaction */").eol();
     writer.append("  public Q%s(io.ebean.Transaction transaction) {", shortName).eol();
     if (dbName == null) {
-      writer.append("    super(%s.class, transaction);", shortName).eol();
+      writer.append("    super(%s.class, transaction);", beanFullName).eol();
     } else {
-      writer.append("    super(%s.class, io.ebean.DB.byName(\"%s\"), transaction);", shortName, dbName).eol();
+      writer.append("    super(%s.class, io.ebean.DB.byName(\"%s\"), transaction);", beanFullName, dbName).eol();
     }
     writer.append("  }").eol();
 
     writer.eol();
     writer.append("  /** Construct with a given Database */").eol();
     writer.append("  public Q%s(io.ebean.Database database) {", shortName).eol();
-    writer.append("    super(%s.class, database);", shortName).eol();
+    writer.append("    super(%s.class, database);", beanFullName).eol();
     writer.append("  }").eol();
     writer.eol();
 
@@ -185,13 +184,13 @@ class SimpleQueryBeanWriter {
 
     writer.eol();
     writer.append("  /** Private constructor for FetchGroup building */").eol();
-    writer.append("  private Q%s(io.ebean.Query<%s> fetchGroupQuery) {", shortName, shortName).eol();
+    writer.append("  private Q%s(io.ebean.Query<%s> fetchGroupQuery) {", shortName, beanFullName).eol();
     writer.append("    super(fetchGroupQuery);").eol();
     writer.append("  }").eol();
 
     writer.eol();
     writer.append("  /** Private constructor for filterMany */").eol();
-    writer.append("  private Q%s(io.ebean.ExpressionList<%s> filter) {", shortName, shortName).eol();
+    writer.append("  private Q%s(io.ebean.ExpressionList<%s> filter) {", shortName, beanFullName).eol();
     writer.append("    super(filter);").eol();
     writer.append("  }").eol();
 
@@ -224,7 +223,7 @@ class SimpleQueryBeanWriter {
       writer.append("public final class Q%s {", shortName).eol();
     } else {
       writer.append(Constants.AT_TYPEQUERYBEAN).eol();
-      writer.append("public final class Q%s extends io.ebean.typequery.TQRootBean<%1$s,Q%1$s> {", shortName).eol();
+      writer.append("public final class Q%s extends io.ebean.typequery.TQRootBean<%s,Q%s> {", shortName, beanFullName, shortName).eol();
     }
     writer.eol();
   }
@@ -263,9 +262,9 @@ class SimpleQueryBeanWriter {
     writer.append("  ").append(Constants.AT_GENERATED).eol();
     writer.append("  ").append(Constants.AT_TYPEQUERYBEAN).eol();
     if (embeddable) {
-      writer.append("  public static final class Assoc<R> extends io.ebean.typequery.TQAssoc<%s,R> {", shortInnerName).eol();
+      writer.append("  public static final class Assoc<R> extends io.ebean.typequery.TQAssoc<%s,R> {", beanFullName).eol();
     } else {
-      writer.append("  public static final class Assoc<R> extends io.ebean.typequery.TQAssocBean<%s,R,Q%s> {", shortName, shortInnerName).eol();
+      writer.append("  public static final class Assoc<R> extends io.ebean.typequery.TQAssocBean<%s,R,Q%s> {", beanFullName, shortInnerName).eol();
     }
     for (PropertyMeta property : properties) {
       writer.append("  ");

--- a/tests/test-kotlin/pom.xml
+++ b/tests/test-kotlin/pom.xml
@@ -15,9 +15,9 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
 
-    <ebean-maven-plugin.version>13.13.0</ebean-maven-plugin.version>
-    <kotlin.version>1.8.10</kotlin.version>
-    <jackson.version>2.12.1</jackson.version>
+    <ebean-maven-plugin.version>14.0.0</ebean-maven-plugin.version>
+    <kotlin.version>1.9.22</kotlin.version>
+    <jackson.version>2.16.1</jackson.version>
   </properties>
 
   <dependencies>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.12</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>
@@ -91,7 +91,8 @@
                 <annotationProcessorPath>
                   <groupId>io.ebean</groupId>
                   <artifactId>kotlin-querybean-generator</artifactId>
-                  <version>13.14.0</version>
+<!--                  <artifactId>querybean-generator</artifactId>-->
+                  <version>14.0.0</version>
                 </annotationProcessorPath>
               </annotationProcessorPaths>
             </configuration>


### PR DESCRIPTION
Use the full canonical name of the entity bean in the generated code.