### PR TITLE
#3313 Ability to configure fetch batch size when using FetchGroups and query beans

### DIFF
--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
@@ -108,6 +108,18 @@ public abstract class TQAssocBean<T, R, QB> extends TQAssoc<T, R> {
     return fetchWithProperties(FETCH_DEFAULT, properties);
   }
 
+
+  /**
+   * Fetch this association with config for the type of fetch and the specified properties.
+   *
+   * @param config Fetch configuration to define the type of fetch to use
+   * @param properties The properties to fetch
+   */
+  @SafeVarargs @SuppressWarnings("varargs")
+  public final R fetch(FetchConfig config, TQProperty<QB,?>... properties) {
+    return fetchWithProperties(config, properties);
+  }
+
   /**
    * Eagerly fetch this association using a 'query join' loading the specified properties.
    */


### PR DESCRIPTION
We can do this currently using string paths and properties, this adds support for doing this when using query beans and strong types

```java
  private static final FetchGroup<Customer> FETCHGROUP_CustomerWithContacts = QCustomer.forFetchGroup()
    .select(cu.name, cu.phoneNumber)
    .contacts.fetch(FetchConfig.ofQuery(1000), co.firstName, co.lastName, co.email)
    .buildFetchGroup();


    new QCustomer()
      .select(FETCHGROUP_CustomerWithContacts)
      .findList();

```