### PR TITLE
dep: Bump ebean-datasource to 8.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>13.11.1</ebean-migration.version>
     <ebean-test-containers.version>7.3</ebean-test-containers.version>
-    <ebean-datasource.version>8.11</ebean-datasource.version>
+    <ebean-datasource.version>8.12</ebean-datasource.version>
     <ebean-agent.version>14.0.0</ebean-agent.version>
     <ebean-maven-plugin.version>14.0.0</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>


### PR DESCRIPTION
This adds the option to register a JVM shutdown hook (which we generally will not use with ebean as the ebean io.ebean.Database shutdown wants to shutdown the DataSource after any background tasks have completed).

This also adds an experimental feature for use with AWS Lambda to check for old idle connections due to lambda suspension.