### PR TITLE
dep: Bump avaje-config to 3.12 - supports AWS AppConfig & Dynamic Logback

### DIFF
--- a/ebean-api/pom.xml
+++ b/ebean-api/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
-      <version>3.11</version>
+      <version>3.12</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This version of avaje-config supports using AWS AppConfig as a configuration source (via avaje-aws-appconfig). It also supports dynamic changing Logback logging levels (via avaje-dynamic-logback).