### PR TITLE
[Draft] FIX broken test for DB2

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -41,8 +41,8 @@ import io.ebeanservice.docstore.api.mapping.DocMappingBuilder;
 import io.ebeanservice.docstore.api.mapping.DocPropertyMapping;
 import io.ebeanservice.docstore.api.mapping.DocPropertyOptions;
 import io.ebeanservice.docstore.api.support.DocStructure;
-
 import jakarta.persistence.PersistenceException;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -1189,7 +1189,7 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
     switch (dbType) {
       case DbPlatformType.JSON:
       case DbPlatformType.JSONB:
-        return dbLength == 0; // must be analog to DbPlatformTypeMapping.lookup
+        return dbLength == 0 || dbLength > 255; // must be analog to DbPlatformTypeMapping.lookup
       case DbPlatformType.JSONBlob:
       case DbPlatformType.JSONClob:
         return true;


### PR DESCRIPTION
Hello @rbygrave,

this fixes the 
```
TestJsonMapBasic.whereManyPredicateDb2:76 » Persistence Query threw SQLException:DB2 SQL Error: SQLCODE=-134, SQLSTATE=42907
```

I've bisected and it was introduced by this commit: https://github.com/ebean-orm/ebean/commit/11c9bdfc6f987aef48e6b9712106fa17161854bb because it changes `EBasicJsonMap.content` property from `@DbJson` to
```java
  @DbJson(length = 5000)
  Map<String, Object> content;
```

The problem is, that a field with value of length 5000 is no longer detected as lob. And lob fields are not allowed in DB2 distinct queries...
We've added a workaround for this some time ago: #2511 
Unfortunately, the detection mechanism is not precise enough. So as quick workaround (!) I added to the "isDbLob" a check if the `dbLength > 255`

I'm not happy with this check, because there is also a "use best type detection" here: #3107 so that lengths > 4000 are mapped to lob instead to varchar.

So from DB2 perspective, it would be better to use `dbLength > 4000` as fix ?

I could either refactor the whole "unselectLobs" code to "unselectLobsForDb2". "isDbLob" -> "isDb2Lob" ans so on. So I can use hard coded values.
(All in all, distincts and lobs are very annoying in DB2 and it seems that this is really only needed for DB2 and maybe Oracle? - see comment [here](https://github.com/ebean-orm/ebean/blob/7ba6e5f67d5d3b420d75d9647cb0c9e96e43656d/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java#L758))

OR

I find a way to determine the exact DDL type from a BeanProperty, but this is not easily to determine, because it is hidden in "renderDbType" and so on.

in short words, the easiest fix would be to assume that a DbJson is a lob if `dbLength > 4000`. What do you think about this?

cheers
Roland




