### PR TITLE
Refactor extract DbExpressionRequest interface for db platform specific expressions

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiExpressionRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiExpressionRequest.java
@@ -3,13 +3,14 @@ package io.ebeaninternal.api;
 import io.ebeaninternal.server.core.SpiOrmQueryRequest;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.expression.platform.DbExpressionHandler;
+import io.ebeaninternal.server.expression.platform.DbExpressionRequest;
 
 import java.util.List;
 
 /**
  * Request object used for gathering expression sql and bind values.
  */
-public interface SpiExpressionRequest {
+public interface SpiExpressionRequest extends DbExpressionRequest {
 
   /**
    * Return the DB specific handler for JSON and ARRAY expressions.
@@ -34,11 +35,13 @@ public interface SpiExpressionRequest {
   /**
    * Append to the expression sql without any parsing.
    */
+  @Override
   SpiExpressionRequest append(String expression);
 
   /**
    * Append to the expression sql without any parsing.
    */
+  @Override
   SpiExpressionRequest append(char c);
 
   /**
@@ -47,6 +50,7 @@ public interface SpiExpressionRequest {
    * This is a fast path case when expression is a bean property path and falls back to using parse()
    * when that isn't the case.
    */
+  @Override
   SpiExpressionRequest property(String expression);
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/BaseDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/BaseDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.BitwiseOp;
 
 /**
@@ -9,7 +8,7 @@ import io.ebeaninternal.server.expression.BitwiseOp;
 abstract class BaseDbExpression implements DbExpressionHandler {
 
   @Override
-  public void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
+  public void bitwise(DbExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
     final String bitOp = bitOp(operator);
     request.append('(').property(propName).append(' ').append(bitOp).append(" ? ").append(compare).append(" ?)");
   }
@@ -28,7 +27,7 @@ abstract class BaseDbExpression implements DbExpressionHandler {
   /**
    * Common alternative where the bitwise operation is a function (specifically bitand is used - H2 and Oracle).
    */
-  protected void bitwiseFunction(SpiExpressionRequest request, String propName, BitwiseOp operator, String compare) {
+  protected void bitwiseFunction(DbExpressionRequest request, String propName, BitwiseOp operator, String compare) {
     final String funcName = functionName(operator);
     request.append(funcName).append('(').property(propName).append(", ?) ").append(compare).append(" ?");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/BasicDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/BasicDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.Op;
 
 /**
@@ -9,17 +8,17 @@ import io.ebeaninternal.server.expression.Op;
 class BasicDbExpression extends BaseDbExpression {
 
   @Override
-  public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
+  public void json(DbExpressionRequest request, String propName, String path, Op operator, Object value) {
     throw new RuntimeException("JSON expressions only supported on Postgres and Oracle");
   }
 
   @Override
-  public void arrayContains(SpiExpressionRequest request, String propName, boolean contains, Object... values) {
+  public void arrayContains(DbExpressionRequest request, String propName, boolean contains, Object... values) {
     throw new RuntimeException("ARRAY expressions only supported on Postgres");
   }
 
   @Override
-  public void arrayIsEmpty(SpiExpressionRequest request, String propName, boolean empty) {
+  public void arrayIsEmpty(DbExpressionRequest request, String propName, boolean empty) {
     throw new RuntimeException("ARRAY expressions only supported on Postgres");
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionHandler.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.BitwiseOp;
 import io.ebeaninternal.server.expression.Op;
 
@@ -12,22 +11,22 @@ public interface DbExpressionHandler {
   /**
    * Write the db platform specific json expression.
    */
-  void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value);
+  void json(DbExpressionRequest request, String propName, String path, Op operator, Object value);
 
   /**
    * Add SQL for ARRAY CONTAINS expression.
    */
-  void arrayContains(SpiExpressionRequest request, String propName, boolean contains, Object... values);
+  void arrayContains(DbExpressionRequest request, String propName, boolean contains, Object... values);
 
   /**
    * Add SQL for ARRAY IS EMPTY expression.
    */
-  void arrayIsEmpty(SpiExpressionRequest request, String propName, boolean empty);
+  void arrayIsEmpty(DbExpressionRequest request, String propName, boolean empty);
 
   /**
    * Add the bitwise expression.
    */
-  void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match);
+  void bitwise(DbExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match);
 
   /**
    * Performs a "CONCAT" operation for that platform.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/DbExpressionRequest.java
@@ -1,0 +1,22 @@
+package io.ebeaninternal.server.expression.platform;
+
+/**
+ * Request building the expression sql.
+ */
+public interface DbExpressionRequest {
+
+  /**
+   * Append to the expression sql without any parsing.
+   */
+  DbExpressionRequest append(String expression);
+
+  /**
+   * Append to the expression sql without any parsing.
+   */
+  DbExpressionRequest append(char c);
+
+  /**
+   * Append to the expression sql with logical property parsing to db columns with logical path prefix.
+   */
+  DbExpressionRequest property(String expression);
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/H2DbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/H2DbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.BitwiseOp;
 
 /**
@@ -9,7 +8,7 @@ import io.ebeaninternal.server.expression.BitwiseOp;
 final class H2DbExpression extends BasicDbExpression {
 
   @Override
-  public void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
+  public void bitwise(DbExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
     final String funcName = functionName(operator);
     request.append(funcName).append('(').property(propName).append(", cast(? as long)) ").append(compare).append(" cast(? as long)");
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/HanaDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/HanaDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.BitwiseOp;
 import io.ebeaninternal.server.expression.Op;
 
@@ -10,17 +9,17 @@ import io.ebeaninternal.server.expression.Op;
 final class HanaDbExpression extends BaseDbExpression {
 
   @Override
-  public void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
+  public void bitwise(DbExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
     bitwiseFunction(request, propName, operator, compare);
   }
 
   @Override
-  public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
+  public void json(DbExpressionRequest request, String propName, String path, Op operator, Object value) {
     request.append("json_value(").property(propName).append(", '$.").append(path).append("')").append(operator.bind());
   }
 
   @Override
-  public void arrayIsEmpty(SpiExpressionRequest request, String propName, boolean empty) {
+  public void arrayIsEmpty(DbExpressionRequest request, String propName, boolean empty) {
     request.append("cardinality(").property(propName).append(')');
     if (empty) {
       request.append(" = 0");
@@ -41,7 +40,7 @@ final class HanaDbExpression extends BaseDbExpression {
   }
 
   @Override
-  public void arrayContains(SpiExpressionRequest request, String propName, boolean contains, Object... values) {
+  public void arrayContains(DbExpressionRequest request, String propName, boolean contains, Object... values) {
     for (int i = 0; i < values.length; i++) {
       if (i > 0) {
         request.append(" and ");

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/MariaDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/MariaDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.Op;
 
 /**
@@ -9,7 +8,7 @@ import io.ebeaninternal.server.expression.Op;
 final class MariaDbExpression extends BasicDbExpression {
 
   @Override
-  public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
+  public void json(DbExpressionRequest request, String propName, String path, Op operator, Object value) {
     request.append('(').property(propName).append(" ->> '$.").append(path).append("')").append(operator.bind());
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/MySqlDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/MySqlDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.Op;
 
 /**
@@ -9,7 +8,7 @@ import io.ebeaninternal.server.expression.Op;
 final class MySqlDbExpression extends BasicDbExpression {
 
   @Override
-  public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
+  public void json(DbExpressionRequest request, String propName, String path, Op operator, Object value) {
     request.append('(').property(propName).append(" ->> '$.").append(path).append("')").append(operator.bind());
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/OracleDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/OracleDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.BitwiseOp;
 import io.ebeaninternal.server.expression.Op;
 
@@ -15,7 +14,7 @@ final class OracleDbExpression extends BaseDbExpression {
   }
 
   @Override
-  public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
+  public void json(DbExpressionRequest request, String propName, String path, Op operator, Object value) {
     if (operator == Op.EXISTS) {
       request.append("json_exists(").property(propName).append(", '$.").append(path).append("')");
     } else if (operator == Op.NOT_EXISTS) {
@@ -26,17 +25,17 @@ final class OracleDbExpression extends BaseDbExpression {
   }
 
   @Override
-  public void bitwise(SpiExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
+  public void bitwise(DbExpressionRequest request, String propName, BitwiseOp operator, long flags, String compare, long match) {
     bitwiseFunction(request, propName, operator, compare);
   }
 
   @Override
-  public void arrayContains(SpiExpressionRequest request, String propName, boolean contains, Object... values) {
+  public void arrayContains(DbExpressionRequest request, String propName, boolean contains, Object... values) {
     throw new IllegalStateException("ARRAY expressions not supported on Oracle");
   }
 
   @Override
-  public void arrayIsEmpty(SpiExpressionRequest request, String propName, boolean empty) {
+  public void arrayIsEmpty(DbExpressionRequest request, String propName, boolean empty) {
     throw new IllegalStateException("ARRAY expressions not supported on Oracle");
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/PostgresDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/PostgresDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.Op;
 
 /**
@@ -14,7 +13,7 @@ final class PostgresDbExpression extends BaseDbExpression {
   }
 
   @Override
-  public void json(SpiExpressionRequest request, String propName, String path, Op operator, Object value) {
+  public void json(DbExpressionRequest request, String propName, String path, Op operator, Object value) {
     String[] paths = path.split("\\.");
     if (paths.length == 1) {
       // (t0.content ->> 'title') = 'Some value'
@@ -34,7 +33,7 @@ final class PostgresDbExpression extends BaseDbExpression {
   }
 
   @Override
-  public void arrayContains(SpiExpressionRequest request, String propName, boolean contains, Object... values) {
+  public void arrayContains(DbExpressionRequest request, String propName, boolean contains, Object... values) {
     if (!contains) {
       request.append("not (");
     }
@@ -49,7 +48,7 @@ final class PostgresDbExpression extends BaseDbExpression {
   }
 
   @Override
-  public void arrayIsEmpty(SpiExpressionRequest request, String propName, boolean empty) {
+  public void arrayIsEmpty(DbExpressionRequest request, String propName, boolean empty) {
     request.append("coalesce(cardinality(").property(propName).append("),0)");
     if (empty) {
       request.append(" = 0");

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/SqlServerDbExpression.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/platform/SqlServerDbExpression.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.expression.platform;
 
-import io.ebeaninternal.api.SpiExpressionRequest;
 import io.ebeaninternal.server.expression.Op;
 
 /**
@@ -9,19 +8,19 @@ import io.ebeaninternal.server.expression.Op;
 final class SqlServerDbExpression extends BaseDbExpression {
 
   @Override
-  public void json(final SpiExpressionRequest request, final String propName,
+  public void json(final DbExpressionRequest request, final String propName,
                    final String path, final Op operator, final Object value) {
     request.append("json_value(").property(propName).append(", '$.").append(path).append("')").append(operator.bind());
   }
 
   @Override
-  public void arrayContains(final SpiExpressionRequest request, final String propName,
+  public void arrayContains(final DbExpressionRequest request, final String propName,
                             final boolean contains, final Object... values) {
     throw new RuntimeException("ARRAY expressions not supported on Microsoft SQL Server");
   }
 
   @Override
-  public void arrayIsEmpty(final SpiExpressionRequest request, final String propName, final boolean empty) {
+  public void arrayIsEmpty(final DbExpressionRequest request, final String propName, final boolean empty) {
     throw new RuntimeException("ARRAY expressions not supported on Microsoft SQL Server");
   }
 }


### PR DESCRIPTION
This provides a simpler DbExpressionRequest interface for db platform specific expression adapters (rather than the SpiExpressionRequest which has more features that we don't wish to expose to those expression adapters.