### PR TITLE
feat: Add includeLabelInSql configuration option to include query label as inline comment in generated sql select

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
+++ b/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
@@ -2210,6 +2210,15 @@ public interface DatabaseBuilder {
   DatabaseBuilder setLoadModuleInfo(boolean loadModuleInfo);
 
   /**
+   * Set if generated SQL SELECT should include the query label as an
+   * inline SQL comment (to help reference back from the SQL to the code
+   * that executed the query.
+   *
+   * @param includeLabelInSql When true include a SQL inline comment in generated SELECT queries.
+   */
+  DatabaseConfig includeLabelInSql(boolean includeLabelInSql);
+
+  /**
    * Set the naming convention to apply to metrics names.
    */
   default DatabaseBuilder metricNaming(Function<String, String> metricNaming) {
@@ -3103,6 +3112,12 @@ public interface DatabaseBuilder {
      * scanning to find and register entity classes.
      */
     boolean isLoadModuleInfo();
+
+    /**
+     * Return true if generated sql select query should include an inline sql comment with the
+     * query label or profile location label.
+     */
+    boolean isIncludeLabelInSql();
 
     /**
      * Return the naming convention to apply to metrics names.

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -126,6 +126,12 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
   private boolean loadModuleInfo = true;
 
   /**
+   * When true then include a sql comment in generated SELECT queries with the query
+   * label or profile location label.
+   */
+  private boolean includeLabelInSql;
+
+  /**
    * Interesting classes such as entities, embedded, ScalarTypes,
    * Listeners, Finders, Controllers, AttributeConverters etc.
    */
@@ -2133,6 +2139,7 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
     readOnlyDatabase = p.getBoolean("readOnlyDatabase", readOnlyDatabase);
     autoPersistUpdates = p.getBoolean("autoPersistUpdates", autoPersistUpdates);
     loadModuleInfo = p.getBoolean("loadModuleInfo", loadModuleInfo);
+    includeLabelInSql = p.getBoolean("includeLabelInSql", includeLabelInSql);
     maxCallStack = p.getInt("maxCallStack", maxCallStack);
     dumpMetricsOnShutdown = p.getBoolean("dumpMetricsOnShutdown", dumpMetricsOnShutdown);
     dumpMetricsOptions = p.get("dumpMetricsOptions", dumpMetricsOptions);
@@ -2547,6 +2554,11 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
     return loadModuleInfo;
   }
 
+  @Override
+  public boolean isIncludeLabelInSql() {
+    return includeLabelInSql;
+  }
+
   /**
    * @deprecated - migrate to {@link #isLoadModuleInfo()}.
    */
@@ -2560,6 +2572,12 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
   @Override
   public DatabaseConfig setLoadModuleInfo(boolean loadModuleInfo) {
     this.loadModuleInfo = loadModuleInfo;
+    return this;
+  }
+
+  @Override
+  public DatabaseConfig includeLabelInSql(boolean includeLabelInSql) {
+    this.includeLabelInSql = includeLabelInSql;
     return this;
   }
 

--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/DatabasePlatform.java
@@ -769,4 +769,11 @@ public class DatabasePlatform {
   public boolean supportsNativeJavaTime() {
     return supportsNativeJavaTime;
   }
+
+  public String inlineSqlComment(String label) {
+    if (label == null) {
+      return "";
+    }
+    return "/* " + label + " */ ";
+  }
 }

--- a/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
+++ b/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
@@ -76,6 +76,7 @@ class DatabaseConfigTest {
     props.setProperty("skipDataSourceCheck", "true");
     props.setProperty("readOnlyDatabase", "true");
     props.setProperty("lengthCheck", "ON");
+    props.setProperty("includeLabelInSql", "true");
 
     props.setProperty("queryPlan.enable", "true");
     props.setProperty("queryPlan.thresholdMicros", "10000");
@@ -96,6 +97,7 @@ class DatabaseConfigTest {
     assertTrue(settings.isLoadModuleInfo());
     assertTrue(settings.skipDataSourceCheck());
     assertTrue(settings.readOnlyDatabase());
+    assertTrue(settings.isIncludeLabelInSql());
     assertThat(settings.getLengthCheck()).isEqualTo(LengthCheck.ON);
 
     assertTrue(settings.isIdGeneratorAutomatic());
@@ -181,6 +183,7 @@ class DatabaseConfigTest {
     assertEquals(10000L, config.getQueryPlanCaptureMaxTimeMillis());
     assertEquals(10, config.getQueryPlanCaptureMaxCount());
     assertThat(config.getLengthCheck()).isEqualTo(LengthCheck.OFF);
+    assertFalse(config.isIncludeLabelInSql());
 
     config.setLoadModuleInfo(false);
     assertFalse(config.isAutoLoadModuleInfo());

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -622,14 +622,9 @@ final class CQueryBuilder {
       }
       final var profileLocation = query.profileLocation();
       if (profileLocation != null) {
-        return dbPlatform.inlineSqlComment(trimLabel(profileLocation.label()));
+        return dbPlatform.inlineSqlComment(profileLocation.label());
       }
       return "";
-    }
-
-    private String trimLabel(String label) {
-      int pos = label.indexOf(':');
-      return pos == -1 ? label : label.substring(0, pos);
     }
 
     private void appendFrom() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -1,9 +1,6 @@
 package io.ebeaninternal.server.query;
 
-import io.ebean.CountDistinctOrder;
-import io.ebean.Query;
-import io.ebean.RawSql;
-import io.ebean.RawSqlBuilder;
+import io.ebean.*;
 import io.ebean.annotation.Platform;
 import io.ebean.config.dbplatform.DatabasePlatform;
 import io.ebean.config.dbplatform.SqlLimitRequest;
@@ -52,11 +49,13 @@ final class CQueryBuilder {
   private final CQueryDraftSupport draftSupport;
   private final DatabasePlatform dbPlatform;
   private final boolean selectCountWithColumnAlias;
+  private final boolean includeLabelInSql;
 
   /**
    * Create the SqlGenSelect.
    */
-  CQueryBuilder(DatabasePlatform dbPlatform, Binder binder, CQueryHistorySupport historySupport, CQueryDraftSupport draftSupport) {
+  CQueryBuilder(DatabaseBuilder.Settings config, DatabasePlatform dbPlatform, Binder binder, CQueryHistorySupport historySupport, CQueryDraftSupport draftSupport) {
+    this.includeLabelInSql = config.isIncludeLabelInSql();
     this.dbPlatform = dbPlatform;
     this.binder = binder;
     this.draftSupport = draftSupport;
@@ -596,7 +595,7 @@ final class CQueryBuilder {
     }
 
     private void appendSelectDistinct() {
-      sb.append("select ");
+      sb.append("select ").append(inlineSqlComment());
       if (distinct && !countSingleAttribute) {
         if (request.isInlineCountDistinct()) {
           sb.append("count(");
@@ -607,6 +606,30 @@ final class CQueryBuilder {
           sb.append("on (").append(distinctOn).append(") ");
         }
       }
+    }
+
+    private String inlineSqlComment() {
+      if (!includeLabelInSql) {
+        return "";
+      }
+      SpiQuery.Type type = query.type();
+      if (type == SpiQuery.Type.SQ_EX || type == SpiQuery.Type.SQ_EXISTS) {
+        return "";
+      }
+      final var label = query.label();
+      if (label != null) {
+        return dbPlatform.inlineSqlComment(label);
+      }
+      final var profileLocation = query.profileLocation();
+      if (profileLocation != null) {
+        return dbPlatform.inlineSqlComment(trimLabel(profileLocation.label()));
+      }
+      return "";
+    }
+
+    private String trimLabel(String label) {
+      int pos = label.indexOf(':');
+      return pos == -1 ? label : label.substring(0, pos);
     }
 
     private void appendFrom() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -44,7 +44,7 @@ public final class CQueryEngine {
     this.defaultFetchSizeFindList = config.getJdbcFetchSizeFindList();
     this.forwardOnlyHintOnFindIterate = dbPlatform.forwardOnlyHintOnFindIterate();
     this.historySupport = new CQueryHistorySupport(dbPlatform.historySupport(), asOfTableMapping, config.getAsOfSysPeriod());
-    this.queryBuilder = new CQueryBuilder(dbPlatform, binder, historySupport, new CQueryDraftSupport(draftTableMap));
+    this.queryBuilder = new CQueryBuilder(config, dbPlatform, binder, historySupport, new CQueryDraftSupport(draftTableMap));
   }
 
   public int forwardOnlyFetchSize() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
@@ -250,6 +250,9 @@ public final class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQue
   @Override
   public DtoQuery<T> setLabel(String label) {
     this.label = label;
+    if (ormQuery != null) {
+      ormQuery.setLabel(label);
+    }
     return this;
   }
 

--- a/ebean-querybean/src/test/java/org/querytest/MyInnerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/MyInnerTest.java
@@ -68,9 +68,9 @@ class MyInnerTest {
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(4);
-    assertThat(sql.get(0)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.one = ?;");
-    assertThat(sql.get(1)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.description = ?;");
-    assertThat(sql.get(2)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.description = ?;");
-    assertThat(sql.get(3)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.one > ? and t0.one >= ? and t0.one < ? and t0.one <= ? and t0.id > ?;");
+    assertThat(sql.get(0)).contains("select /* MyInnerTest.insert_and_find:36 */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.one = ?;");
+    assertThat(sql.get(1)).contains("select /* MyInnerTest.insert_and_find:43 */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.description = ?;");
+    assertThat(sql.get(2)).contains("select /* MyInnerTest.insert_and_find:54 */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.description = ?;");
+    assertThat(sql.get(3)).contains("select /* MyInnerTest.insert_and_find:65 */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.one > ? and t0.one >= ? and t0.one < ? and t0.one <= ? and t0.id > ?;");
   }
 }

--- a/ebean-querybean/src/test/java/org/querytest/MyInnerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/MyInnerTest.java
@@ -68,9 +68,9 @@ class MyInnerTest {
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(4);
-    assertThat(sql.get(0)).contains("select t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.one = ?;");
-    assertThat(sql.get(1)).contains("select t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.description = ?;");
-    assertThat(sql.get(2)).contains("select t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.description = ?;");
-    assertThat(sql.get(3)).contains("select t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.one > ? and t0.one >= ? and t0.one < ? and t0.one <= ? and t0.id > ?;");
+    assertThat(sql.get(0)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.one = ?;");
+    assertThat(sql.get(1)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.description = ?;");
+    assertThat(sql.get(2)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.description = ?;");
+    assertThat(sql.get(3)).contains("select /* MyInnerTest.insert_and_find */ t0.id, t0.one, t0.id, t0.one, t0.description from my_inner t0 where t0.id < ? and t0.one > ? and t0.one >= ? and t0.one < ? and t0.one <= ? and t0.id > ?;");
   }
 }

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerAndOrTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerAndOrTest.java
@@ -62,6 +62,7 @@ public class QCustomerAndOrTest {
   @Test
   public void testOrWithExists() {
     QCustomer query = Customer.find.typed()
+      .setLabel("hiLabel")
       .alias("_cust")
       .or()
       .name.eq("Superman")
@@ -72,12 +73,12 @@ public class QCustomerAndOrTest {
         .query()
       )
       .endOr()
-      .select(QCustomer.alias().id);
+      .select(QCustomer.Alias.id);
 
     query.findList();
 
     assertThat(query.getGeneratedSql()).isEqualTo(
-      "select _cust.id from be_customer _cust where (" +
+      "select /* hiLabel */ _cust.id from be_customer _cust where (" +
         "_cust.name = ? or exists (select 1 from be_contact contact where " +
         "contact.first_name = ? and contact.customer_id = _cust.id))"
     );

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -284,7 +284,7 @@ public class QCustomerTest {
       .query();
 
     q.findList();
-    assertThat(q.getGeneratedSql()).isEqualTo("select t0.id, t0.name, t1.id, t1.first_name, t1.last_name from be_customer t0 left join be_contact t1 on t1.customer_id = t0.id where t1.first_name like ? escape'|' and t1.email is not null order by t0.id");
+    assertThat(q.getGeneratedSql()).isEqualTo("select /* QCustomerTest.filterMany */ t0.id, t0.name, t1.id, t1.first_name, t1.last_name from be_customer t0 left join be_contact t1 on t1.customer_id = t0.id where t1.first_name like ? escape'|' and t1.email is not null order by t0.id");
   }
 
   @Test
@@ -296,7 +296,7 @@ public class QCustomerTest {
       .query();
 
     q.findList();
-    assertThat(q.getGeneratedSql()).isEqualTo("select t0.id, t0.name, t1.id, t1.first_name, t1.last_name from be_customer t0 left join be_contact t1 on t1.customer_id = t0.id where t1.first_name like ? escape'|' order by t0.id");
+    assertThat(q.getGeneratedSql()).isEqualTo("select /* QCustomerTest.filterManySingle */ t0.id, t0.name, t1.id, t1.first_name, t1.last_name from be_customer t0 left join be_contact t1 on t1.customer_id = t0.id where t1.first_name like ? escape'|' order by t0.id");
   }
 
   @Test

--- a/ebean-querybean/src/test/java/org/querytest/QOrderTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QOrderTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static io.ebean.StdOperators.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class QOrderTest {
+class QOrderTest {
 
   private static final QCustomer cu = QCustomer.alias();
 
@@ -89,12 +89,12 @@ public class QOrderTest {
 
     final List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(2);
-    assertThat(sql.get(0)).contains("select t0.id, t0.name, t0.phone_number from be_customer t0");
-    assertThat(sql.get(1)).contains("select t0.customer_id, t0.id, t0.first_name, t0.last_name, t0.email from be_contact t0 where");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.fetchQueryWithBatch */ t0.id, t0.name, t0.phone_number from be_customer t0");
+    assertThat(sql.get(1)).contains("select /* QOrderTest.fetchQueryWithBatch_contacts__query */ t0.customer_id, t0.id, t0.first_name, t0.last_name, t0.email from be_contact t0 where");
   }
 
   @Test
-  public void fetchCache() {
+  void fetchCache() {
 
     new QOrder()
       .status.eq(Order.Status.NEW)
@@ -108,7 +108,7 @@ public class QOrderTest {
   }
 
   @Test
-  public void viaFetchGraph() {
+  void viaFetchGraph() {
 
     DB.getDefault();
     LoggedSql.start();
@@ -121,11 +121,11 @@ public class QOrderTest {
 
     final List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
-    assertThat(sql.get(0)).contains("select t0.id, t0.status, t0.ship_date, t0.customer_id from o_order t0 where");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.viaFetchGraph */ t0.id, t0.status, t0.ship_date, t0.customer_id from o_order t0 where");
   }
 
   @Test
-  public void viaFetchGraph_withJoin() {
+  void viaFetchGraph_withJoin() {
 
     DB.getDefault();
     LoggedSql.start();
@@ -138,11 +138,11 @@ public class QOrderTest {
 
     final List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
-    assertThat(sql.get(0)).contains("select t0.id, t0.status, t1.id, t1.name from o_order t0 join be_customer t1 on t1.id = t0.customer_id where");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.viaFetchGraph_withJoin */ t0.id, t0.status, t1.id, t1.name from o_order t0 join be_customer t1 on t1.id = t0.customer_id where");
   }
 
   @Test
-  public void viaFetchGraph_withNested() {
+  void viaFetchGraph_withNested() {
 
     DB.getDefault();
     LoggedSql.start();
@@ -154,11 +154,11 @@ public class QOrderTest {
 
     final List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
-    assertThat(sql.get(0)).contains("select t0.id, t0.status, t0.ship_date, t1.id, t1.name, t1.phone_number from o_order t0 join be_customer t1 on t1.id = t0.customer_id where");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.viaFetchGraph_withNested */ t0.id, t0.status, t0.ship_date, t1.id, t1.name, t1.phone_number from o_order t0 join be_customer t1 on t1.id = t0.customer_id where");
   }
 
   @Test
-  public void viaFetchGraph_withNested_fetchQuery() {
+  void viaFetchGraph_withNested_fetchQuery() {
 
     DB.getDefault();
     LoggedSql.start();
@@ -172,15 +172,15 @@ public class QOrderTest {
 
     // assert fetching customer via fetchQuery
     assertThat(sql).hasSize(2);
-    assertThat(sql.get(0)).contains("select t0.id, t0.status, t0.customer_id from o_order t0 where t0.id = ?");
-    assertThat(sql.get(1)).contains("select t0.id, t0.name, t0.phone_number from be_customer t0 where t0.id = ?");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.viaFetchGraph_withNested_fetchQuery */ t0.id, t0.status, t0.customer_id from o_order t0 where t0.id = ?");
+    assertThat(sql.get(1)).contains("select /* QOrderTest.viaFetchGraph_withNested_fetchQuery_customer__query */ t0.id, t0.name, t0.phone_number from be_customer t0 where t0.id = ?");
 
     assertThat(found.getCustomer().getPhoneNumber().getMsisdn()).isEqualTo("Ph1");
   }
 
 
   @Test
-  public void viaFetchGraph_withNested_fetchCache() {
+  void viaFetchGraph_withNested_fetchCache() {
 
     DB.getDefault();
 
@@ -201,11 +201,11 @@ public class QOrderTest {
 
     // assert we only hit DB for order
     assertThat(sql).hasSize(1);
-    assertThat(sql.get(0)).contains("select t0.id, t0.status, t0.customer_id from o_order t0 where t0.id = ?");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.viaFetchGraph_withNested_fetchQuery */ t0.id, t0.status, t0.customer_id from o_order t0 where t0.id = ?");
   }
 
   @Test
-  public void select_partial() {
+  void select_partial() {
 
     DB.getDefault();
     LoggedSql.start();
@@ -218,11 +218,11 @@ public class QOrderTest {
 
     final List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
-    assertThat(sql.get(0)).contains("select t0.id, t0.status, t0.order_date from o_order t0");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.select_partial */ t0.id, t0.status, t0.order_date from o_order t0");
   }
 
   @Test
-  public void fetch_partial() {
+  void fetch_partial() {
 
     DB.getDefault();
     LoggedSql.start();
@@ -237,12 +237,12 @@ public class QOrderTest {
 
     final List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
-    assertThat(sql.get(0)).contains("select t0.id, t0.status, t1.id, t1.email, t1.name from o_order t0 join be_customer t1 on t1.id = t0.customer_id");
+    assertThat(sql.get(0)).contains("select /* QOrderTest.fetch_partial */ t0.id, t0.status, t1.id, t1.email, t1.name from o_order t0 join be_customer t1 on t1.id = t0.customer_id");
 
   }
 
   @Test
-  public void updateQuery() {
+  void updateQuery() {
     LoggedSql.start();
     new QOrder()
       .status.eq(Order.Status.COMPLETE)
@@ -258,7 +258,7 @@ public class QOrderTest {
   }
 
   @Test
-  public void stdExpression_iLikeConcatCoalesce() {
+  void stdExpression_iLikeConcatCoalesce() {
     QOrder o = QOrder.alias();
 
     // LOWER(CONCAT(COALESCE(a.name, ""), ":", a.description)) LIKE LOWER(:param)
@@ -273,7 +273,7 @@ public class QOrderTest {
   }
 
   @Test
-  public void stdExpression_gtCoalesce() {
+  void stdExpression_gtCoalesce() {
     QOrder o = QOrder.alias();
 
     Query<Order> query = new QOrder()
@@ -288,7 +288,7 @@ public class QOrderTest {
 
     String sql = query.getGeneratedSql();
     assertThat(sql).contains(" where (coalesce(t1.version,0) > ? or t0.id < ?)");
-    assertThat(sql).isEqualTo("select t0.id, t0.status from o_order t0 join be_customer t1 on t1.id = t0.customer_id where (coalesce(t1.version,0) > ? or t0.id < ?)");
+    assertThat(sql).isEqualTo("select /* QOrderTest.stdExpression_gtCoalesce */ t0.id, t0.status from o_order t0 join be_customer t1 on t1.id = t0.customer_id where (coalesce(t1.version,0) > ? or t0.id < ?)");
   }
 
   @Test
@@ -301,7 +301,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered >= (select max(o.order_date) as foo from o_order o)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.geSqlSubQuery */ t0.id from be_customer t0 where t0.registered >= (select max(o.order_date) as foo from o_order o)");
   }
 
   @Test
@@ -314,7 +314,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered > (select max(o.order_date) as foo from o_order o)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.gtSqlSubQuery */ t0.id from be_customer t0 where t0.registered > (select max(o.order_date) as foo from o_order o)");
   }
 
   @Test
@@ -327,7 +327,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered <= (select max(o.order_date) as foo from o_order o)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.leSqlSubQuery */ t0.id from be_customer t0 where t0.registered <= (select max(o.order_date) as foo from o_order o)");
   }
 
   @Test
@@ -340,7 +340,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered < (select max(o.order_date) as foo from o_order o)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.ltSqlSubQuery */ t0.id from be_customer t0 where t0.registered < (select max(o.order_date) as foo from o_order o)");
   }
 
   @Test
@@ -353,7 +353,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered = (select max(o.order_date) as foo from o_order o)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.eqSqlSubQuery */ t0.id from be_customer t0 where t0.registered = (select max(o.order_date) as foo from o_order o)");
   }
 
   @Test
@@ -366,7 +366,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered <> (select max(o.order_date) as foo from o_order o)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.neSqlSubQuery */ t0.id from be_customer t0 where t0.registered <> (select max(o.order_date) as foo from o_order o)");
   }
 
   @Test
@@ -384,7 +384,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered >= (select max(t0.order_date) from o_order t0)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.geSubQuery */ t0.id from be_customer t0 where t0.registered >= (select max(t0.order_date) from o_order t0)");
   }
 
   @Test
@@ -399,7 +399,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.version > (select sum(t0.version) from o_order t0)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.gtSubQuery */ t0.id from be_customer t0 where t0.version > (select sum(t0.version) from o_order t0)");
   }
 
   @Test
@@ -414,7 +414,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered <= (select max(t0.order_date) from o_order t0)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.leSubQuery */ t0.id from be_customer t0 where t0.registered <= (select max(t0.order_date) from o_order t0)");
   }
 
   @Test
@@ -429,7 +429,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered < (select max(t0.order_date) from o_order t0)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.ltSubQuery */ t0.id from be_customer t0 where t0.registered < (select max(t0.order_date) from o_order t0)");
   }
 
   @Test
@@ -444,7 +444,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered = (select max(t0.order_date) from o_order t0)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.eqSubQuery */ t0.id from be_customer t0 where t0.registered = (select max(t0.order_date) from o_order t0)");
   }
 
   @Test
@@ -459,7 +459,7 @@ public class QOrderTest {
       .query();
     query.findList();
 
-    assertThat(query.getGeneratedSql()).contains("select t0.id from be_customer t0 where t0.registered <> (select max(t0.order_date) from o_order t0)");
+    assertThat(query.getGeneratedSql()).contains("select /* QOrderTest.neSubQuery */ t0.id from be_customer t0 where t0.registered <> (select max(t0.order_date) from o_order t0)");
   }
 
   @Test

--- a/ebean-querybean/src/test/java/org/querytest/QueryAlsoIfTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QueryAlsoIfTest.java
@@ -20,7 +20,7 @@ class QueryAlsoIfTest {
       .query();
 
     q.findList();
-    assertThat(q.getGeneratedSql()).isEqualTo("select t0.id, t0.name from be_customer t0 where t0.name is not null and t0.status = ?");
+    assertThat(q.getGeneratedSql()).isEqualTo("select /* QueryAlsoIfTest.apply */ t0.id, t0.name from be_customer t0 where t0.name is not null and t0.status = ?");
   }
 
   @Test
@@ -32,6 +32,6 @@ class QueryAlsoIfTest {
       .query();
 
     q.findList();
-    assertThat(q.getGeneratedSql()).isEqualTo("select t0.id, t0.name from be_customer t0 where t0.name is not null");
+    assertThat(q.getGeneratedSql()).isEqualTo("select /* QueryAlsoIfTest.notApply */ t0.id, t0.name from be_customer t0 where t0.name is not null");
   }
 }

--- a/ebean-querybean/src/test/resources/application-test.properties
+++ b/ebean-querybean/src/test/resources/application-test.properties
@@ -3,6 +3,7 @@ ebean.ddl.run=true
 ebean.ddl.initSql=init-db.sql
 ebean.dumpMetricsOnShutdown=true
 ebean.dumpMetricsOptions=sql,hash,loc
+ebean.includeLabelInSql=true
 
 datasource.default=h2
 

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
@@ -164,8 +164,13 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
 
     DtoQuery<ContactDto> query = DB.find(Contact.class)
       // we must explicitly add the id property for DTO query (if we want it)
-      .select("id, email, " + concat("lastName", ", ", "firstName") + " as fullName").where().isNotNull("email")
-      .isNotNull("lastName").order().asc("lastName").asDto(ContactDto.class).setLabel("explicitId")
+      .select("id, email, " + concat("lastName", ", ", "firstName") + " as fullName")
+      .where()
+      .isNotNull("email")
+      .isNotNull("lastName")
+      .orderBy().asc("lastName")
+      .asDto(ContactDto.class)
+      .setLabel("explicitId")
       .setRelaxedMode();
 
     List<ContactDto> dtos = query.findList();
@@ -178,7 +183,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.stop();
-    assertSql(sql.get(0)).contains("select t0.id, t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
+    assertSql(sql.get(0)).contains("select /* explicitId */ t0.id, t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
       + " fullName from contact t0 where t0.email is not null and t0.last_name is not null order by t0.last_name");
   }
 

--- a/ebean-test/src/test/java/io/ebean/xtest/base/FetchGroupTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/FetchGroupTest.java
@@ -26,11 +26,12 @@ public class FetchGroupTest extends BaseTestCase {
       .query()
       .where()
       .ilike("name", "rob")
+      .setLabel("hello")
       .select(fetch);
 
     query.findList();
 
-    assertThat(sqlOf(query)).contains("select t0.id, t0.name, t0.status from");
+    assertThat(sqlOf(query)).contains("select /* hello */ t0.id, t0.name, t0.status from");
   }
 
 

--- a/ebean-test/src/test/resources/ebean.properties
+++ b/ebean-test/src/test/resources/ebean.properties
@@ -17,6 +17,7 @@ ebean.encryptKeyManager=org.tests.basic.encrypt.BasicEncyptKeyManager
 #ebean.autoTune.mode=DEFAULT_ON
 #ebean.autoTune.profiling=true
 #ebean.autoTune.profilingUpdateFrequency=5
+ebean.includeLabelInSql=true
 
 ebean.ddl.generate=true
 ebean.ddl.run=true


### PR DESCRIPTION
The generated select queries can look like:

```sql
select /* MyService.myMethod */ t0.id, ...
```

Using either query.setLabel() or profile location (which all query beans get by default). This means that tooling looking at sql in the database can more easily relate that sql back to application code.