### PR TITLE
fix: #3142 Cascading a OneToMany, set the relationship when the child isn't new or dirty

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocMany.java
@@ -588,10 +588,9 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
   }
 
   /**
-   * Set the join properties from the parent bean to the child bean.
-   * This is only valid for OneToMany and NOT valid for ManyToMany.
+   * Set the parent bean to the child (update the relationship).
    */
-  public void setJoinValuesToChild(EntityBean parent, EntityBean child, Object mapKeyValue) {
+  public void setParentToChild(EntityBean parent, EntityBean child, Object mapKeyValue) {
     if (mapKeyProperty != null) {
       mapKeyProperty.setValue(child, mapKeyValue);
     }
@@ -600,6 +599,31 @@ public class BeanPropertyAssocMany<T> extends BeanPropertyAssoc<T> implements ST
       // exists on the 'detail' bean
       childMasterProperty.setValueIntercept(child, parent);
     }
+  }
+
+  /**
+   * Return true if the parent bean has been set to the child (updated the relationship).
+   */
+  public boolean setParentToChild(EntityBean parent, EntityBean child, Object mapKeyValue, BeanDescriptor<?> parentDesc) {
+    if (manyToMany
+      || childMasterProperty == null
+      || !child._ebean_getIntercept().isLoadedProperty(childMasterProperty.propertyIndex())) {
+      return false;
+    }
+
+    Object currentParent = childMasterProperty.getValue(child);
+    if (currentParent != null) {
+      Object newId = parentDesc.getId(parent);
+      Object oldId = parentDesc.id(currentParent);
+      if (Objects.equals(newId, oldId)) {
+        return false;
+      }
+    }
+    childMasterProperty.setValueIntercept(child, parent);
+    if (mapKeyProperty != null) {
+      mapKeyProperty.setValue(child, mapKeyValue);
+    }
+    return true;
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -172,7 +172,9 @@ final class SaveManyBeans extends SaveManyBase {
           } else if (ebi.isNewOrDirty()) {
             skipSavingThisBean = false;
             // set the parent bean to detailBean
-            many.setJoinValuesToChild(parentBean, detail, mapKeyValue);
+            many.setParentToChild(parentBean, detail, mapKeyValue);
+          } else if (many.setParentToChild(parentBean, detail, mapKeyValue, request.descriptor())) {
+            skipSavingThisBean = false;
           } else {
             skipSavingThisBean = saveRecurseSkippable;
           }


### PR DESCRIPTION
That is, previously the relationship back from the child to the parent was being updated when the child bean was new or dirty BUT NOT in the case when the child bean was loaded and unchanged.

This fix includes that case updating the ManyToOne side of the relationship on the child when the save is cascaded.