### PR TITLE
Deprecate Query bean constructor that takes transaction - migrate to query.usingTransaction() instead

### DIFF
--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/KotlinLangAdapter.java
@@ -61,8 +61,9 @@ class KotlinLangAdapter implements LangAdapter {
     }
 
     writer.append("  /**").eol();
-    writer.append("   * Construct with a given Transaction.", name).eol();
+    writer.append("   * @deprecated migrate to query.usingTransaction()", name).eol();
     writer.append("   */").eol();
+    writer.append("   @Deprecated").eol();
     if (dbName == null) {
       writer.append("  constructor(transaction: io.ebean.Transaction) : super(%s::class.java, transaction)", fullName).eol().eol();
     } else {

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -160,7 +160,8 @@ class SimpleQueryBeanWriter {
     writer.append("  }").eol();
     writer.eol();
 
-    writer.append("  /** Construct with a given transaction */").eol();
+    writer.append("  /** @deprecated migrate to query.usingTransaction() */").eol();
+    writer.append("  @Deprecated(forRemoval = true)").eol();
     writer.append("  public Q%s(io.ebean.Transaction transaction) {", shortName).eol();
     if (dbName == null) {
       writer.append("    super(%s.class, transaction);", beanFullName).eol();


### PR DESCRIPTION
Migrate to query.usingTransaction() instead of the constructor that takes a transaction.