### PR TITLE
#3379 Followup, Move orderById() to common QueryBuilder interface

### DIFF
--- a/ebean-api/src/main/java/io/ebean/Query.java
+++ b/ebean-api/src/main/java/io/ebean/Query.java
@@ -511,14 +511,6 @@ public interface Query<T> extends CancelableQuery, QueryBuilder<Query<T>, T> {
   QueryType getQueryType();
 
   /**
-   * Controls, if paginated queries should always append an 'order by id' statement at the end to
-   * guarantee a deterministic sort result. This may affect performance.
-   * If this is not enabled, and an orderBy is set on the query, it's up to the programmer that
-   * this query provides a deterministic result.
-   */
-  Query<T> orderById(boolean orderById);
-
-  /**
    * Set the profile location of this query. This is used to relate query execution metrics
    * back to a location like a specific line of code.
    */

--- a/ebean-api/src/main/java/io/ebean/QueryBuilder.java
+++ b/ebean-api/src/main/java/io/ebean/QueryBuilder.java
@@ -467,6 +467,14 @@ public interface QueryBuilder<SELF, T> extends QueryBuilderProjection<SELF, T> {
   SELF setOrderBy(OrderBy<T> orderBy);
 
   /**
+   * Controls, if paginated queries should always append an 'order by id' statement at the end to
+   * guarantee a deterministic sort result. This may affect performance.
+   * If this is not enabled, and an orderBy is set on the query, it's up to the programmer that
+   * this query provides a deterministic result.
+   */
+  SELF orderById(boolean orderById);
+
+  /**
    * Execute the query with the given lock type and WAIT.
    * <p>
    * Note that <code>forUpdate()</code> is the same as

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
@@ -583,6 +583,12 @@ public abstract class TQRootBean<T, R> implements QueryBean<T, R> {
   }
 
   @Override
+  public R orderById(boolean orderById) {
+    query.orderById(orderById);
+    return root;
+  }
+
+  @Override
   @Deprecated(since = "13.19", forRemoval = true)
   public final R order(String orderByClause) {
     return orderBy(orderByClause);

--- a/ebean-querybean/src/test/java/org/querytest/QOrderTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QOrderTest.java
@@ -80,6 +80,28 @@ class QOrderTest {
   }
 
   @Test
+  void orderById() {
+    Query<Order> query = new QOrder()
+      .select(QOrder.Alias.status)
+      .orderById(true).query();
+
+    query.findList();
+
+    String sql = query.getGeneratedSql();
+    assertThat(sql).contains("select /* QOrderTest.orderById:88 */ t0.id, t0.status from o_order t0 order by t0.id");
+
+    Query<Order> query2 = new QOrder()
+      .select(QOrder.Alias.status)
+      .orderById(true).orderBy().status.asc()
+      .query();
+
+    query2.findList();
+
+    String sql2 = query2.getGeneratedSql();
+    assertThat(sql2).contains("select /* QOrderTest.orderById:98 */ t0.id, t0.status from o_order t0 order by t0.status, t0.id");
+  }
+
+  @Test
   void hint() {
     LoggedSql.start();
     new QCustomer()


### PR DESCRIPTION
Effectively this adds it to QueryBeans (where it was missing)