### PR TITLE
Rename QueryBean interface to IQueryBean (because we want to rename TQRootBean)

### DIFF
--- a/ebean-querybean/src/main/java/io/ebean/typequery/IQueryBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/IQueryBean.java
@@ -1,21 +1,12 @@
 package io.ebean.typequery;
 
-import io.avaje.lang.Nullable;
 import io.ebean.*;
 import io.ebean.search.MultiMatch;
 import io.ebean.search.TextCommonTerms;
 import io.ebean.search.TextQueryString;
 import io.ebean.search.TextSimple;
-import io.ebean.text.PathProperties;
 
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.Timestamp;
-import java.util.*;
-import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.util.Collection;
 
 /**
  * Query bean for strongly typed query construction and execution.
@@ -53,7 +44,7 @@ import java.util.stream.Stream;
  * @param <T> the entity bean type (normal entity bean type e.g. Customer)
  * @param <R> the specific query bean type (e.g. QCustomer)
  */
-public interface QueryBean<T, R> extends QueryBuilder<R, T> {
+public interface IQueryBean<T, R> extends QueryBuilder<R, T> {
 
   /**
    * Return the underlying query.

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQRootBean.java
@@ -57,7 +57,7 @@ import java.util.stream.Stream;
  * @param <R> the specific root query bean type (e.g. QCustomer)
  */
 @NonNullApi
-public abstract class TQRootBean<T, R> implements QueryBean<T, R> {
+public abstract class TQRootBean<T, R> implements IQueryBean<T, R> {
 
   /**
    * The underlying query.

--- a/ebean-test/src/test/resources/logback-test.xml
+++ b/ebean-test/src/test/resources/logback-test.xml
@@ -82,9 +82,9 @@
 
 <!--  <logger name="io.ebean.DDL" level="DEBUG"/>-->
 
-  <logger name="io.ebean.SQL" level="TRACE"/>
-  <logger name="io.ebean.TXN" level="TRACE"/>
-  <logger name="io.ebean.SUM" level="TRACE"/>
+<!--  <logger name="io.ebean.SQL" level="TRACE"/>-->
+<!--  <logger name="io.ebean.TXN" level="TRACE"/>-->
+<!--  <logger name="io.ebean.SUM" level="TRACE"/>-->
 
 <!--  <logger name="io.ebean.cache" level="TRACE"/>-->
 <!--  <logger name="io.ebean.cache.REGION" level="TRACE"/>-->


### PR DESCRIPTION
We want to rename TQRootBean to QueryBean. I can't do that right now because we need to make ebean-agent aware of that first. So yes, perhaps not ideal with IQueryBean but I think it will make sense once TQRootBean is renamed to QueryBean.