### PR TITLE
Bump parent to 4.1 with Byte-Buddy net.bytebuddy.experimental=true

### DIFF
--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>ebean-test</artifactId>
 
   <properties>
-    <bytebuddy.version>1.14.12</bytebuddy.version>
+    <bytebuddy.version>1.14.13</bytebuddy.version>
     <assertj.version>3.25.3</assertj.version>
   </properties>
 
@@ -293,7 +293,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>3.12</version>
+    <version>4.1</version>
   </parent>
 
   <groupId>io.ebean</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
       <scope>test</scope>
     </dependency>
 

--- a/tests/test-kotlin/pom.xml
+++ b/tests/test-kotlin/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Uses maven-surefire-plugin with:
<argLine>-XX:+EnableDynamicAgentLoading -Dnet.bytebuddy.experimental=true</argLine>