### PR TITLE
mysql: Support "NoTimeZone" to bypass MySQL JDBC use of Timezone Calendar

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
@@ -449,6 +449,9 @@ public final class InternalConfiguration {
    */
   private DataTimeZone initDataTimeZone() {
     String tz = config.getDataTimeZone();
+    if ("NoTimeZone".equals(tz)) {
+      return new NoDataTimeZone();
+    }
     if (tz == null) {
       if (isMySql(getPlatform())) {
         return new MySqlDataTimeZone();


### PR DESCRIPTION
Refer #3393 #3394

Logic added into InternalConfiguration.initDataTimeZone()

```java
if ("NoTimeZone".equals(tz)) {
  return new NoDataTimeZone();
}
```

Refer to: https://groups.google.com/g/ebean/c/rEjbcYE6K84/m/IpOxG2GQAwAJ?utm_medium=email&utm_source=footer