### PR TITLE
#3129 Fix to verify DBJson dirtiness using same field ordering on both sides (due to PostgreSQL reordering fields for JsonB types)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -744,9 +744,9 @@ public class BeanProperty implements ElPropertyValue, Property, STreeProperty {
   }
 
   /**
-   * creates a mutableHash for the given JSON value.
+   * creates a mutableHash for the given Object value.
    */
-  public MutableValueInfo createMutableInfo(String json) {
+  public MutableValueInfo createMutableInfo(Object value) {
     throw new UnsupportedOperationException();
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindablePropertyJsonInsert.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindablePropertyJsonInsert.java
@@ -29,7 +29,7 @@ final class BindablePropertyJsonInsert extends BindableProperty {
       } else {
         // on insert store hash and push json
         final String json = prop.format(value);
-        final MutableValueInfo hash = prop.createMutableInfo(json);
+        final MutableValueInfo hash = prop.createMutableInfo(value);
         bean._ebean_getIntercept().mutableInfo(propertyIndex, hash);
         request.pushJson(json);
         request.bind(value, prop);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
@@ -190,6 +190,9 @@ final class ScalarTypeJsonSet {
 
     @SuppressWarnings("unchecked")
     private Set convertList(List list) {
+      if (list == null) {
+        return null;
+      }
       return new LinkedHashSet(list);
     }
   }


### PR DESCRIPTION
**Same as PR #3402 but starting / targeting `master` branch.**

This pull request aim to fix a problem (https://github.com/ebean-orm/ebean/issues/3129) where @DbJsonB fields are always considered dirty on load if the order of their properties do not match fields ordering from data stored in Postgres.

This is due to the fact that Postgres is re-ordering the fields if column type is a JsonB in order to optimize storage / index / etc...

To solve this problem, we parse/format the value coming from readSet method in order to be sure that comparison will be done using Java Jackson encoded JSON on both side.