### PR TITLE
Add metadata to stored procedures for 3rd party libs

### DIFF
--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresHistoryDdl.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/ddlgeneration/platform/PostgresHistoryDdl.java
@@ -71,6 +71,8 @@ public class PostgresHistoryDdl extends DbTriggerBasedHistoryDdl {
     apply
       .append("create or replace function ").append(procedureName).append("() returns trigger as $$").newLine();
 
+    apply.append("-- play-ebean-start").newLine();
+
     apply.append("declare").newLine()
       .append("  lowerTs timestamptz;").newLine()
       .append("  upperTs timestamptz;").newLine();
@@ -93,6 +95,7 @@ public class PostgresHistoryDdl extends DbTriggerBasedHistoryDdl {
     apply
       .append("  end if;").newLine()
       .append("end;").newLine()
+      .append("-- play-ebean-end").newLine()
       .append("$$ LANGUAGE plpgsql;").newLine();
 
     apply.end();

--- a/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl-partitioning.xml
+++ b/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl-partitioning.xml
@@ -10,6 +10,7 @@
 -- Type used to hold common partitioning parameters such as period start and end etc
 ------------------------------------------------------------------------------------
 do $$
+-- play-ebean-start
 begin
   if not exists (select 1 from pg_type where typname = 'partition_meta') THEN
     create type partition_meta as
@@ -22,7 +23,9 @@ begin
       part_name      text
     );
   end if;
-end$$;
+end;
+-- play-ebean-end
+$$;
 
 ------------------------------------------------------------------------------------
 -- Function: _partition_create
@@ -34,6 +37,7 @@ create or replace function _partition_create(meta partition_meta)
 language plpgsql
 set timezone to 'UTC'
 as $$
+-- play-ebean-start
 begin
   if (meta.schema_name = '') then
     execute format('create table if not exists %I partition of %I for values from (''%s'') TO (''%s'')', meta.part_name, meta.base_name, meta.period_start, meta.period_end);
@@ -42,6 +46,7 @@ begin
   end if;
   return meta.part_name;
 end;
+-- play-ebean-end
 $$;
 
 
@@ -60,6 +65,7 @@ create or replace function _partition_meta(
 language plpgsql
 set timezone to 'UTC'
 as $$
+-- play-ebean-start
 declare
   partName  text;
   meta      partition_meta;
@@ -92,6 +98,7 @@ begin
 
   return meta;
 end;
+-- play-ebean-end
 $$;
 
 ------------------------------------------------------------------------------------
@@ -108,6 +115,7 @@ create or replace function _partition_over(
   returns TABLE(of_date date)
 language plpgsql
 as $$
+-- play-ebean-start
 declare
   endDate date;
 begin
@@ -132,6 +140,7 @@ begin
     return query select s::date from generate_series(fromDate, endDate, '1 month') s;
   end if;
 end;
+-- play-ebean-end
 $$;
 
 
@@ -158,11 +167,13 @@ create or replace function partition(
 language plpgsql
 set timezone to 'UTC'
 as $$
+-- play-ebean-start
 begin
   perform _partition_create(_partition_meta(mode, poDate, baseName, schemaName))
   from _partition_over(mode, fromDate, partitionCount) poDate;
   return 'done';
 end;
+-- play-ebean-end
 $$;
 </ddl-script>
 

--- a/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl.xml
+++ b/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl.xml
@@ -24,7 +24,9 @@ GO
 -- deletes all indices referring to TABLE.COLUMN
 --
 CREATE OR ALTER PROCEDURE usp_ebean_drop_indices @tableName nvarchar(255), @columnName nvarchar(255)
-AS SET NOCOUNT ON
+AS
+-- play-ebean-start
+SET NOCOUNT ON
 declare @sql nvarchar(1000)
 declare @indexName nvarchar(255)
 BEGIN
@@ -44,6 +46,7 @@ BEGIN
   CLOSE index_cursor;
   DEALLOCATE index_cursor;
 END
+-- play-ebean-end
 GO
 
 --
@@ -51,7 +54,9 @@ GO
 -- deletes the default constraint, which has a random name
 --
 CREATE OR ALTER PROCEDURE usp_ebean_drop_default_constraint @tableName nvarchar(255), @columnName nvarchar(255)
-AS SET NOCOUNT ON
+AS
+-- play-ebean-start
+SET NOCOUNT ON
 declare @tmp nvarchar(1000)
 BEGIN
   select @tmp = t1.name from sys.default_constraints t1
@@ -60,6 +65,7 @@ BEGIN
 
   if @tmp is not null EXEC('alter table [' + @tableName +'] drop constraint ' + @tmp);
 END
+-- play-ebean-end
 GO
 
 --
@@ -67,7 +73,9 @@ GO
 -- deletes constraints and foreign keys refering to TABLE.COLUMN
 --
 CREATE OR ALTER PROCEDURE usp_ebean_drop_constraints @tableName nvarchar(255), @columnName nvarchar(255)
-AS SET NOCOUNT ON
+AS
+-- play-ebean-start
+SET NOCOUNT ON
 declare @sql nvarchar(1000)
 declare @constraintName nvarchar(255)
 BEGIN
@@ -93,6 +101,7 @@ BEGIN
   CLOSE name_cursor;
   DEALLOCATE name_cursor;
 END
+-- play-ebean-end
 GO
 
 --
@@ -100,7 +109,9 @@ GO
 -- deletes the column annd ensures that all indices and constraints are dropped first
 --
 CREATE OR ALTER PROCEDURE usp_ebean_drop_column @tableName nvarchar(255), @columnName nvarchar(255)
-AS SET NOCOUNT ON
+AS
+-- play-ebean-start
+SET NOCOUNT ON
 declare @sql nvarchar(1000)
 BEGIN
   EXEC usp_ebean_drop_indices @tableName, @columnName;
@@ -110,6 +121,7 @@ BEGIN
   set @sql = 'alter table [' + @tableName + '] drop column [' + @columnName + ']';
   EXECUTE(@sql);
 END
+-- play-ebean-end
 GO
 </ddl-script>
 <ddl-script name="create procs" platforms="mysql mariadb" init="true">-- Inital script to create stored procedures etc for mysql platform
@@ -121,6 +133,7 @@ delimiter $$
 -- deletes all constraints and foreign keys referring to TABLE.COLUMN
 --
 CREATE PROCEDURE usp_ebean_drop_foreign_keys(IN p_table_name VARCHAR(255), IN p_column_name VARCHAR(255))
+-- play-ebean-start
 BEGIN
 DECLARE done INT DEFAULT FALSE;
 DECLARE c_fk_name CHAR(255);
@@ -143,6 +156,7 @@ END LOOP;
 
 CLOSE curs;
 END
+-- play-ebean-end
 $$
 
 DROP PROCEDURE IF EXISTS usp_ebean_drop_column;
@@ -153,12 +167,14 @@ delimiter $$
 -- deletes the column and ensures that all indices and constraints are dropped first
 --
 CREATE PROCEDURE usp_ebean_drop_column(IN p_table_name VARCHAR(255), IN p_column_name VARCHAR(255))
+-- play-ebean-start
 BEGIN
 CALL usp_ebean_drop_foreign_keys(p_table_name, p_column_name);
 SET @sql = CONCAT('ALTER TABLE `', p_table_name, '` DROP COLUMN `', p_column_name, '`');
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
 END
+-- play-ebean-end
 $$
 </ddl-script>
 
@@ -170,6 +186,7 @@ delimiter $$
 --
 CREATE OR REPLACE PROCEDURE usp_ebean_drop_foreign_keys(IN table_name NVARCHAR(256), IN column_name NVARCHAR(256))
 AS
+-- play-ebean-start
 BEGIN
 DECLARE foreign_key_names TABLE(CONSTRAINT_NAME NVARCHAR(256), TABLE_NAME NVARCHAR(256));
 DECLARE i INT;
@@ -181,6 +198,7 @@ EXEC 'ALTER TABLE "' || ESCAPE_DOUBLE_QUOTES(:foreign_key_names.TABLE_NAME[i]) |
 END FOR;
 
 END;
+-- play-ebean-end
 $$
 
 delimiter $$
@@ -190,10 +208,12 @@ delimiter $$
 --
 CREATE OR REPLACE PROCEDURE usp_ebean_drop_column(IN table_name NVARCHAR(256), IN column_name NVARCHAR(256))
 AS
+-- play-ebean-start
 BEGIN
 CALL usp_ebean_drop_foreign_keys(table_name, column_name);
 EXEC 'ALTER TABLE "' || UPPER(ESCAPE_DOUBLE_QUOTES(table_name)) || '" DROP ("' || UPPER(ESCAPE_DOUBLE_QUOTES(column_name)) || '")';
 END;
+-- play-ebean-end
 $$
 </ddl-script>
 </extra-ddl>


### PR DESCRIPTION
Hi @rbygrave!

You may remember the problem we, from the Play Framework, had in
- https://github.com/playframework/play-ebean/issues/166

The problem is that Play splits sql scripts by `;` meaning that any stored procedures that usually contains `;` in their body will be split into weird statements, making the sql script fail. We do have an escape mechanism by using two `;;`, which avoids the string getting split and the double `;;` will end up as a single `;` in the final statement.

The problem is that when ebean (re)generates its ddl scripts it will override existing once, so each time people would have to replace `;`  with `;;` which is annoying. Even worse, lots of people don't even know what's going on and just see an exception without having a clue why ebean generated ddl scripts don't apply with Play evolutions and just open issues like "ebean doesn't work", "play-ebean doesn' work", etc.

Now I think the solution to this problem is actually quite easy:
If you could add meta data to your ddl scripts, like shown in this pull request, we could easily parse that meta data and make Play evolution ignore the semicolon within such a "meta data block".
The naming of the meta data comments I came up with is currently:
```
-- !Play-Evolutions: KEEP SEMICOLONS START
-- !Play-Evolutions: KEEP SEMICOLONS END
```

but I am totally open for other naming.

What do you think about that? IMHO this shouldn't hurt ebean but 3rd party libraries would benefit from finally being able to correctly handle your ddl scripts.

Thanks!