### PR TITLE
Fixed non-idempotent tests in `TestCacheSerialization`

### DIFF
--- a/ebean-postgis-types/src/test/java/org/example/domain/TestCacheSerialization.java
+++ b/ebean-postgis-types/src/test/java/org/example/domain/TestCacheSerialization.java
@@ -35,6 +35,8 @@ public class TestCacheSerialization {
     assertEquals(p1, r2.getPoint());  // and did fail https://github.com/ebean-orm/ebean/issues/3026
     assertEquals(pol, r2.getPolygon());
 
+    DB.delete(tb);
+
   }
 
   @Test
@@ -75,6 +77,8 @@ public class TestCacheSerialization {
     assertNotNull(r2);
     assertEquals(pol, r2.getPolygon());  // and did fail https://github.com/ebean-orm/ebean/issues/3026
     assertNull(r1.getPoint());
+
+    DB.delete(tb);
 
   }
 }


### PR DESCRIPTION
## The Problem

In `TestCacheSerialization`, `testNullCache()` and `testCache()` are non-idempotent, as they pass in the first run but fail in the second run. A fix is necessary since unit tests shall be self-contained, ensuring that the state of the system under test is consistent at the beginning of each test. In practice, fixing non-idempotent tests can help proactively avoid state pollution that results in test order dependency (which could cause problems under test selection , prioritization or parallelization).

## Source of Error
Each of the tests creates a cached bean `tb` in the database, but did not delete it after test execution. Therefore, repeated test runs would fail when trying to create `tb` since a bean with the same ID already exists in the database. 

## Reproduce
Use the `NIOInspector` plugin that supports rerunning JUnit tests in the same environment. Use `TestCacheSerialization#testNullCache` as an example:
```
cd ebean-postgis-types
mvn edu.illinois:NIOInspector:rerun -Dtest=org.example.domain.TestCacheSerialization#testNullCache

```

## Error Message in the 2nd test execution
```
io.ebean.DuplicateKeyException: Error: ERROR: duplicate key value violates unique constraint "pk_mybean_cached"   Detail: Key (id)=(2081) already exists.
	at io.ebean.config.dbplatform.SqlCodeTranslator.translate(SqlCodeTranslator.java:77)
	at io.ebean.config.dbplatform.DatabasePlatform.translate(DatabasePlatform.java:212)
	at io.ebeaninternal.server.persist.dml.DmlBeanPersister.execute(DmlBeanPersister.java:77)
	at io.ebeaninternal.server.persist.dml.DmlBeanPersister.insert(DmlBeanPersister.java:46)
	at io.ebeaninternal.server.core.PersistRequestBean.executeInsert(PersistRequestBean.java:1216)
	at io.ebeaninternal.server.core.PersistRequestBean.executeNow(PersistRequestBean.java:736)
	at io.ebeaninternal.server.core.PersistRequestBean.executeNoBatch(PersistRequestBean.java:780)
	at io.ebeaninternal.server.core.PersistRequestBean.executeOrQueue(PersistRequestBean.java:771)
	at io.ebeaninternal.server.persist.DefaultPersister.insert(DefaultPersister.java:483)
	at io.ebeaninternal.server.persist.DefaultPersister.insert(DefaultPersister.java:433)
	at io.ebeaninternal.server.core.DefaultServer.insert(DefaultServer.java:1649)
	at io.ebean.DB.insert(DB.java:310)
	at org.example.domain.TestCacheSerialization.testNullCache(TestCacheSerialization.java:52)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "pk_mybean_cached"
  Detail: Key (id)=(2081) already exists.
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2725)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2412)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:371)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:502)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:419)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:194)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:155)
	at io.ebean.datasource.pool.ExtendedPreparedStatement.executeUpdate(ExtendedPreparedStatement.java:123)
	at io.ebeaninternal.server.bind.DataBind.executeUpdate(DataBind.java:102)
	at io.ebeaninternal.server.persist.dml.InsertHandler.execute(InsertHandler.java:105)
	at io.ebeaninternal.server.persist.dml.DmlHandler.executeNoBatch(DmlHandler.java:88)
	at io.ebeaninternal.server.persist.dml.DmlBeanPersister.execute(DmlBeanPersister.java:69)
	... 13 common frames omitted
```

## Fix
Delete `tb` at the end of each test.