### PR TITLE
#3412 Use existing/parent transaction with fetch query on ToMany paths

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadBeanRequest.java
@@ -84,10 +84,17 @@ public final class LoadBeanRequest extends LoadRequest {
     return idList;
   }
 
+  public SpiQuery<?> createQuery(SpiEbeanServer server) {
+    final SpiQuery<?> query = server.createQuery(beanType());
+    query.usingTransaction(transaction);
+    configureQuery(query);
+    return query;
+  }
+
   /**
    * Configure the query for lazy loading execution.
    */
-  public void configureQuery(SpiQuery<?> query) {
+  private void configureQuery(SpiQuery<?> query) {
     query.setMode(Mode.LAZYLOAD_BEAN);
     query.setPersistenceContext(loadBuffer.persistenceContext());
     query.setLoadDescription(mode(), description());

--- a/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/LoadManyRequest.java
@@ -94,6 +94,7 @@ public final class LoadManyRequest extends LoadRequest {
   public SpiQuery<?> createQuery(SpiEbeanServer server) {
     BeanPropertyAssocMany<?> many = many();
     SpiQuery<?> query = many.newQuery(server);
+    query.usingTransaction(transaction);
     String orderBy = many.lazyFetchOrderBy();
     if (orderBy != null) {
       query.orderBy(orderBy);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -126,9 +126,7 @@ final class DefaultBeanLoader {
     if (loadRequest.checkEmpty()) {
       throw new RuntimeException("Nothing in batch?");
     }
-    final SpiQuery<?> query = server.createQuery(loadRequest.beanType());
-    query.usingTransaction(loadRequest.transaction());
-    loadRequest.configureQuery(query);
+    final SpiQuery<?> query = loadRequest.createQuery(server);
     loadRequest.postLoad(executeQuery(loadRequest, query));
   }
 


### PR DESCRIPTION
Fix such that LoadManyRequest uses the parent requests transaction rather than obtain a new read only transaction to perform the fetch query.