### PR TITLE
#3423 JtaTransactionManager keeps reference to already closed scope (…

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransaction.java
@@ -357,4 +357,8 @@ public interface SpiTransaction extends Transaction {
    */
   void postRollback(Throwable cause);
 
+  /**
+   * Set the transaction to be inactive via external transaction manager.
+   */
+  void deactivateExternal();
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiTransactionProxy.java
@@ -447,4 +447,9 @@ public abstract class SpiTransactionProxy implements SpiTransaction {
   public void postRollback(Throwable cause) {
     transaction.postRollback(cause);
   }
+
+  @Override
+  public void deactivateExternal() {
+    transaction.deactivateExternal();
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/ImplicitReadOnlyTransaction.java
@@ -609,6 +609,11 @@ final class ImplicitReadOnlyTransaction implements SpiTransaction, TxnProfileEve
     // do nothing
   }
 
+  @Override
+  public void deactivateExternal() {
+    this.active = false;
+  }
+
   /**
    * Return true if the transaction is active.
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -1083,6 +1083,11 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   }
 
   @Override
+  public void deactivateExternal() {
+    this.active = false;
+  }
+
+  @Override
   public final boolean isPersistCascade() {
     return persistCascade;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JtaTransactionManager.java
@@ -94,9 +94,14 @@ public final class JtaTransactionManager implements ExternalTransactionManager {
     // check current Ebean transaction
     SpiTransaction currentEbeanTransaction = scope.inScope();
     if (currentEbeanTransaction != null) {
-      // NOT expecting this so log WARNING
-      log.log(WARNING, "JTA Transaction - no current txn BUT using current Ebean one {0}", currentEbeanTransaction.id());
-      return currentEbeanTransaction;
+      if (currentEbeanTransaction.isActive()) {
+        // NOT expecting this so log WARNING
+        log.log(WARNING, "JTA Transaction - no current txn BUT using current Ebean one {0}", currentEbeanTransaction.id());
+        return currentEbeanTransaction;
+      } else {
+        log.log(DEBUG, "JTA Transaction - clearing inActive Ebean transaction {0}", currentEbeanTransaction.id());
+        scope.clearExternal();
+      }
     }
 
     UserTransaction ut = userTransaction();
@@ -186,27 +191,27 @@ public final class JtaTransactionManager implements ExternalTransactionManager {
 
     @Override
     public void afterCompletion(int status) {
-      switch (status) {
-        case Status.STATUS_COMMITTED:
-          log.log(DEBUG, "Jta Txn [{0}] committed", transaction.id());
-          transaction.postCommit();
-          // Remove this transaction object as it is completed
-          transactionManager.scope().clearExternal();
-          break;
+      try {
+        switch (status) {
+          case Status.STATUS_COMMITTED:
+            log.log(DEBUG, "Jta Txn [{0}] committed", transaction.id());
+            transaction.postCommit();
+            break;
 
-        case Status.STATUS_ROLLEDBACK:
-          log.log(DEBUG, "Jta Txn [{0}] rollback", transaction.id());
-          transaction.postRollback(null);
-          // Remove this transaction object as it is completed
-          transactionManager.scope().clearExternal();
-          break;
+          case Status.STATUS_ROLLEDBACK:
+            log.log(DEBUG, "Jta Txn [{0}] rollback", transaction.id());
+            transaction.postRollback(null);
+            break;
 
-        default:
-          log.log(DEBUG, "Jta Txn [{0}] status:{1}", transaction.id(), status);
+          default:
+            log.log(DEBUG, "Jta Txn [{0}] status:{1}", transaction.id(), status);
+        }
+      } finally {
+        transaction.deactivateExternal();
+        transactionManager.scope().clearExternal();
+        // No matter the completion status of the transaction, we release the connection we got from the pool.
+        JdbcClose.close(transaction.internalConnection());
       }
-
-      // No matter the completion status of the transaction, we release the connection we got from the pool.
-      JdbcClose.close(transaction.internalConnection());
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/NoTransaction.java
@@ -117,6 +117,10 @@ final class NoTransaction implements SpiTransaction {
     // do nothing
   }
 
+  @Override
+  public void deactivateExternal() {
+    // do nothing
+  }
 
   @Override
   public boolean isLogSql() {


### PR DESCRIPTION
…and Transaction/connection ThreadLocal) when JtaTxnListener#afterCompletion is called by a different thread

Bugfix for "Long/slow transaction reaper" in Wildfire that can close/rollback a transaction in a different thread. Fix is to use active flag to inactivate the transaction and detect that case in JtaTransactionManager.getCurrentTransaction()