### PR TITLE
Bump ebean-migration dependency to 14.1.0 with fastMode enabled by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <ebean-annotation.version>8.4</ebean-annotation.version>
     <ebean-ddl-runner.version>2.3</ebean-ddl-runner.version>
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
-    <ebean-migration.version>14.0.0</ebean-migration.version>
+    <ebean-migration.version>14.1.0</ebean-migration.version>
     <ebean-test-containers.version>7.4</ebean-test-containers.version>
     <ebean-datasource.version>8.14</ebean-datasource.version>
     <ebean-agent.version>14.3.1</ebean-agent.version>


### PR DESCRIPTION
ebean-migration 14.1.0 defaults fastMode to true. This means that it first runs a fast check that all migrations have been run. If that does not succeed for any reason it runs the normal migration process.