### PR TITLE
Bump ebean-datasource dependency to 9.0 with automatic Lambda mode detection

### DIFF
--- a/ebean-core/src/test/java/io/ebeaninternal/server/core/InitDataSourceTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/core/InitDataSourceTest.java
@@ -196,10 +196,6 @@ public class InitDataSourceTest {
     public void dataSourceDown(DataSource dataSource, SQLException reason) {
     }
 
-    @Override
-    public void dataSourceWarning(DataSource dataSource, String msg) {
-    }
-
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
@@ -228,7 +228,7 @@ public class TestQueryFindIterate extends BaseTestCase {
       dsPool = (DataSourcePool) server().dataSource();
     }
 
-    int startConns = dsPool.getStatus(false).getBusy();
+    int startConns = dsPool.status(false).busy();
     final Query<Customer> query = server().find(Customer.class)
       .where()
       .isNotNull("name")
@@ -241,22 +241,22 @@ public class TestQueryFindIterate extends BaseTestCase {
 
     QueryIterator<Customer> queryIterator = query.findIterate();
 
-    assertThat(dsPool.getStatus(false).getBusy()).isEqualTo(startConns + 1);
+    assertThat(dsPool.status(false).busy()).isEqualTo(startConns + 1);
 
     assertTrue(queryIterator.hasNext());
     assertThat(queryIterator.next()).isNotNull();
-    assertThat(dsPool.getStatus(false).getBusy()).isEqualTo(startConns + 1);
+    assertThat(dsPool.status(false).busy()).isEqualTo(startConns + 1);
 
     assertTrue(queryIterator.hasNext());
     assertThat(queryIterator.next()).isNotNull();
-    assertThat(dsPool.getStatus(false).getBusy()).isEqualTo(startConns + 1);
+    assertThat(dsPool.status(false).busy()).isEqualTo(startConns + 1);
 
     assertTrue(queryIterator.hasNext());
     assertThat(queryIterator.next()).isNotNull();
-    assertThat(dsPool.getStatus(false).getBusy()).isEqualTo(startConns + 1);
+    assertThat(dsPool.status(false).busy()).isEqualTo(startConns + 1);
 
     assertFalse(queryIterator.hasNext());
-    assertThat(dsPool.getStatus(false).getBusy()).isEqualTo(startConns);
+    assertThat(dsPool.status(false).busy()).isEqualTo(startConns);
     try {
       queryIterator.next();
       fail("noSuchElementException expected");

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>14.0.0</ebean-migration.version>
     <ebean-test-containers.version>7.4</ebean-test-containers.version>
-    <ebean-datasource.version>8.14</ebean-datasource.version>
+    <ebean-datasource.version>9.0</ebean-datasource.version>
     <ebean-agent.version>14.3.1</ebean-agent.version>
     <ebean-maven-plugin.version>14.3.1</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>


### PR DESCRIPTION
ebean-datasource 9.0 automatically detects when it is running in AWS Lambda and will set validateOnHeartbeat to false. In Lambda we don't want to validate connections in background threads that can suspend in Lambda.