### PR TITLE
Change includeLabelInSql to default to true

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -129,7 +129,7 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
    * When true then include a sql comment in generated SELECT queries with the query
    * label or profile location label.
    */
-  private boolean includeLabelInSql;
+  private boolean includeLabelInSql = true;
 
   /**
    * Interesting classes such as entities, embedded, ScalarTypes,

--- a/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
+++ b/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
@@ -76,7 +76,7 @@ class DatabaseConfigTest {
     props.setProperty("skipDataSourceCheck", "true");
     props.setProperty("readOnlyDatabase", "true");
     props.setProperty("lengthCheck", "ON");
-    props.setProperty("includeLabelInSql", "true");
+    props.setProperty("includeLabelInSql", "false");
 
     props.setProperty("queryPlan.enable", "true");
     props.setProperty("queryPlan.thresholdMicros", "10000");
@@ -97,7 +97,7 @@ class DatabaseConfigTest {
     assertTrue(settings.isLoadModuleInfo());
     assertTrue(settings.skipDataSourceCheck());
     assertTrue(settings.readOnlyDatabase());
-    assertTrue(settings.isIncludeLabelInSql());
+    assertFalse(settings.isIncludeLabelInSql());
     assertThat(settings.getLengthCheck()).isEqualTo(LengthCheck.ON);
 
     assertTrue(settings.isIdGeneratorAutomatic());
@@ -183,7 +183,7 @@ class DatabaseConfigTest {
     assertEquals(10000L, config.getQueryPlanCaptureMaxTimeMillis());
     assertEquals(10, config.getQueryPlanCaptureMaxCount());
     assertThat(config.getLengthCheck()).isEqualTo(LengthCheck.OFF);
-    assertFalse(config.isIncludeLabelInSql());
+    assertTrue(config.isIncludeLabelInSql());
 
     config.setLoadModuleInfo(false);
     assertFalse(config.isAutoLoadModuleInfo());


### PR DESCRIPTION
To disable this use ebean.includeLabelInSql=false or set this via `DatabaseBuilder.includeLabelInSql(false)``