### PR TITLE
Db2 forupdate fix

### DIFF
--- a/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
+++ b/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
@@ -57,6 +57,6 @@ public abstract class BaseDB2Platform extends DatabasePlatform {
   @Override
   protected String withForUpdate(String sql, Query.LockWait lockWait, Query.LockType lockType) {
     // NOWAIT and SKIP LOCKED not supported with Db2
-    return sql + " for update";
+    return sql + " with rs use and keep update locks";
   }
 }


### PR DESCRIPTION
Hello Rob,

In our application we assume that the forUpdate() query locks the selected rows (that read access from another thread is no longer possible). It works on MariaDb and SqlServer, but not on Db2.

The DB2 documentation states that the rows are locked but are not protected against write access: https://www.ibm.com/docs/en/db2/11.5?topic=statement-update-clause 

We found out that if you add an orderBy("id") to the query, the locking also works under DB2. In our opinion it is just a workaround and not the solution. (And we do not understand why)

We found another way for DB2 forUpdate() to lock the rows: with `rs use and keep update locks`

Can you please look at the PullRequest and give us feedback?

Best regards
Noemi