### PR TITLE
New Postgis types / Java modules

### DIFF
--- a/composites/ebean-net-postgis/pom.xml
+++ b/composites/ebean-net-postgis/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>ebean-parent</artifactId>
+    <groupId>io.ebean</groupId>
+    <version>14.4.0</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <name>ebean-net-postgis</name>
+  <description>ebean-net-postgis composite</description>
+  <artifactId>ebean-net-postgis</artifactId>
+
+  <properties>
+    <postgis.jdbc.version>2023.1.0</postgis.jdbc.version>
+    <postgres.jdbc.version>42.7.2</postgres.jdbc.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-api</artifactId>
+      <version>14.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-core</artifactId>
+      <version>14.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-datasource</artifactId>
+      <version>${ebean-datasource.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-migration</artifactId>
+      <version>${ebean-migration.version}</version>
+    </dependency>
+
+    <!-- Technically optional but most expected to use query beans -->
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-querybean</artifactId>
+      <version>14.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-platform-postgres</artifactId>
+      <version>14.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-net-postgis-types</artifactId>
+      <version>14.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgres.jdbc.version}</version>
+      <exclusions>
+        <!-- exclude unnecessary checker framework -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>net.postgis</groupId>
+      <artifactId>postgis-jdbc</artifactId>
+      <version>${postgis.jdbc.version}</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/composites/ebean-net-postgis/src/main/java/io/ebean/postgis/assembly/Assembly.java
+++ b/composites/ebean-net-postgis/src/main/java/io/ebean/postgis/assembly/Assembly.java
@@ -1,0 +1,7 @@
+package io.ebean.postgis.assembly;
+
+/**
+ * Nothing interesting here - required placeholder for javadoc.
+ */
+public class Assembly {
+}

--- a/composites/ebean-net-postgis/src/main/java/module-info.java
+++ b/composites/ebean-net-postgis/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module io.ebean.postgis {
+
+  requires transitive io.ebean.api;
+  requires transitive io.ebean.core;
+  requires transitive io.ebean.datasource;
+  requires transitive io.ebean.querybean;
+  requires transitive io.ebean.platform.postgres;
+  // requires transitive io.ebean.postgis.types;
+
+}

--- a/composites/pom.xml
+++ b/composites/pom.xml
@@ -24,6 +24,7 @@
     <module>ebean-oracle</module>
     <module>ebean-postgres</module>
     <module>ebean-postgis</module>
+    <module>ebean-net-postgis</module>
 <!--    <module>sqlanywhere</module>-->
     <module>ebean-sqlite</module>
     <module>ebean-sqlserver</module>

--- a/ebean-api/src/main/java/module-info.java
+++ b/ebean-api/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module io.ebean.api {
   uses io.ebean.service.SpiRawSqlService;
   uses io.ebean.service.SpiProfileLocationFactory;
   uses io.ebean.service.SpiFetchGroupService;
+  uses io.ebean.service.SpiJsonService;
 
   requires transitive java.sql;
   requires transitive io.avaje.config;

--- a/ebean-core/src/main/java/module-info.java
+++ b/ebean-core/src/main/java/module-info.java
@@ -47,7 +47,7 @@ module io.ebean.core {
   exports io.ebeanservice.docstore.api.support to io.ebean.elastic, io.ebean.test;
   exports io.ebeanservice.docstore.api.mapping to io.ebean.elastic;
 
-  exports io.ebeaninternal.api to io.ebean.ddl.generator, io.ebean.querybean, io.ebean.autotune, io.ebean.postgis, io.ebean.test, io.ebean.elastic, io.ebean.spring.txn;
+  exports io.ebeaninternal.api to io.ebean.ddl.generator, io.ebean.querybean, io.ebean.autotune, io.ebean.postgis, io.ebean.test, io.ebean.elastic, io.ebean.spring.txn, io.ebean.postgis.types;
   exports io.ebeaninternal.api.json to io.ebean.test;
   exports io.ebeaninternal.json to io.ebean.test;
   exports io.ebeaninternal.server.autotune to io.ebean.autotune;
@@ -69,7 +69,7 @@ module io.ebean.core {
   exports io.ebeaninternal.server.querydefn to io.ebean.autotune, io.ebean.querybean, io.ebean.test, io.ebean.elastic;
   exports io.ebeaninternal.server.rawsql to io.ebean.test;
   exports io.ebeaninternal.server.json to io.ebean.test, io.ebean.elastic;
-  exports io.ebeaninternal.server.type to io.ebean.postgis, io.ebean.test;
+  exports io.ebeaninternal.server.type to io.ebean.postgis, io.ebean.test, io.ebean.postgis.types;
   exports io.ebeaninternal.server.transaction to io.ebean.test, io.ebean.elastic, io.ebean.spring.txn, io.ebean.k8scache;
   exports io.ebeaninternal.server.util to io.ebean.querybean;
 

--- a/ebean-ddl-generator/src/main/java/module-info.java
+++ b/ebean-ddl-generator/src/main/java/module-info.java
@@ -15,4 +15,6 @@ module io.ebean.ddl.generator {
 
   // support existing tests
   exports io.ebeaninternal.extraddl.model to io.ebean.test;
+
+  opens io.ebeaninternal.extraddl.model to jakarta.xml.bind;
 }

--- a/ebean-net-postgis-types/.editorconfig
+++ b/ebean-net-postgis-types/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+spaces_around_operators = true
+max_line_length = 130
+
+[pom.xml]
+# Because of <project... line
+max_line_length = 999

--- a/ebean-net-postgis-types/LICENSE
+++ b/ebean-net-postgis-types/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ebean-net-postgis-types/README.md
+++ b/ebean-net-postgis-types/README.md
@@ -1,0 +1,3 @@
+# ebean.postgis.types
+
+Ebean support for Postgres Geometry types

--- a/ebean-net-postgis-types/pom.xml
+++ b/ebean-net-postgis-types/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>ebean-parent</artifactId>
+    <groupId>io.ebean</groupId>
+    <version>14.4.0</version>
+  </parent>
+
+  <name>ebean net postgis types</name>
+  <artifactId>ebean-net-postgis-types</artifactId>
+
+  <properties>
+    <postgis.jdbc.version>2023.1.0</postgis.jdbc.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-platform-postgres</artifactId>
+      <version>14.4.0</version>
+    </dependency>
+
+    <!-- provided scope -->
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-core</artifactId>
+      <version>14.4.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>net.postgis</groupId>
+      <artifactId>postgis-jdbc</artifactId>
+      <version>${postgis.jdbc.version}</version>
+    </dependency>
+
+    <!-- expected to be provided -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.7.2</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-test</artifactId>
+      <version>14.4.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.avaje.composite</groupId>
+      <artifactId>logback</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <!-- for testing -->
+      <plugin>
+        <groupId>io.repaint.maven</groupId>
+        <artifactId>tiles-maven-plugin</artifactId>
+        <version>2.40</version>
+        <extensions>true</extensions>
+        <configuration>
+          <tiles>
+            <tile>io.ebean.tile:enhancement:14.3.0</tile>
+          </tiles>
+        </configuration>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/PostgisExtraTypeFactory.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/PostgisExtraTypeFactory.java
@@ -1,0 +1,23 @@
+package io.ebean.postgis;
+
+import io.ebean.DatabaseBuilder;
+import io.ebean.core.type.ExtraTypeFactory;
+import io.ebean.core.type.ScalarType;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PostgisExtraTypeFactory implements ExtraTypeFactory {
+
+  @Override
+  public List<ScalarType<?>> createTypes(DatabaseBuilder.Settings config, Object objectMapper) {
+    return Arrays.asList(
+      new ScalarTypePgisPoint(),
+      new ScalarTypePgisPolygon(),
+      new ScalarTypePgisLineString(),
+      new ScalarTypePgisMultiPolygon(),
+      new ScalarTypePgisMultiPoint(),
+      new ScalarTypePgisMultiLineString()
+    );
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/PostgisGeoTypeBindProvider.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/PostgisGeoTypeBindProvider.java
@@ -1,0 +1,13 @@
+package io.ebean.postgis;
+
+import io.ebean.DatabaseBuilder;
+import io.ebeaninternal.api.GeoTypeProvider;
+import io.ebeaninternal.server.type.GeoTypeBinder;
+
+public class PostgisGeoTypeBindProvider implements GeoTypeProvider {
+
+  @Override
+  public GeoTypeBinder createBinder(DatabaseBuilder.Settings config) {
+    return new PostgisGeoTypeBinder();
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/PostgisGeoTypeBinder.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/PostgisGeoTypeBinder.java
@@ -1,0 +1,21 @@
+package io.ebean.postgis;
+
+import io.ebean.core.type.DataBinder;
+import io.ebeaninternal.server.type.GeoTypeBinder;
+import net.postgis.jdbc.PGgeometryLW;
+import net.postgis.jdbc.geometry.Geometry;
+
+import java.sql.SQLException;
+
+class PostgisGeoTypeBinder implements GeoTypeBinder {
+
+  PostgisGeoTypeBinder() {
+  }
+
+  @Override
+  public void bind(DataBinder binder, int dataType, Object data) throws SQLException {
+      if (data instanceof Geometry) {
+        binder.setObject(new PGgeometryLW((Geometry) data));
+      }
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisBase.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisBase.java
@@ -1,0 +1,118 @@
+package io.ebean.postgis;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import io.ebean.core.type.DataBinder;
+import io.ebean.core.type.DataReader;
+import io.ebean.core.type.DocPropertyType;
+import io.ebean.core.type.ScalarType;
+import net.postgis.jdbc.PGgeometry;
+import net.postgis.jdbc.PGgeometryLW;
+import net.postgis.jdbc.geometry.Geometry;
+import net.postgis.jdbc.geometry.GeometryBuilder;
+import net.postgis.jdbc.geometry.binary.BinaryParser;
+import org.postgresql.util.PGobject;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.sql.SQLException;
+import java.sql.Types;
+
+abstract class ScalarTypePgisBase<T extends Geometry> implements ScalarType<T> {
+
+  private final int jdbcType;
+
+  private final Class<T> cls;
+
+  ScalarTypePgisBase(int jdbcType, Class<T> cls) {
+    this.jdbcType = jdbcType;
+    this.cls = cls;
+  }
+
+  @Override
+  public void bind(DataBinder binder, T value) throws SQLException {
+    if (value == null) {
+      binder.setNull(Types.NULL);
+    } else {
+      binder.setObject(new PGgeometryLW(value));
+    }
+  }
+
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public T read(DataReader reader) throws SQLException {
+    Object object = reader.getObject();
+    if (object == null) {
+      return null;
+    }
+    if (object instanceof PGgeometryLW) {
+      return (T) ((PGgeometryLW) object).getGeometry();
+
+    } else if (object instanceof PGgeometry) {
+      return (T) ((PGgeometry) object).getGeometry();
+
+    } else if (object instanceof PGobject) {
+      return (T) GeometryBuilder.geomFromString(((PGobject) object).getValue(), new BinaryParser(), false);
+
+    } else {
+      throw new IllegalStateException("Could not convert from " + object.getClass() + " to " + cls);
+    }
+  }
+
+
+  @Override
+  public boolean jdbcNative() {
+    return true;
+  }
+
+  @Override
+  public int jdbcType() {
+    return jdbcType;
+  }
+
+  @Override
+  public Class<T> type() {
+    return cls;
+  }
+
+  @Override
+  public T readData(DataInput dataInput) {
+    return null;
+  }
+
+  @Override
+  public void writeData(DataOutput dataOutput, T v) {
+
+  }
+
+  @Override
+  public Object toJdbcType(Object value) {
+    return null;
+  }
+
+  @Override
+  public T toBeanType(Object value) {
+    return null;
+  }
+
+  @Override
+  public String formatValue(T value) {
+    return value.toString();
+  }
+
+  @Override
+  public DocPropertyType docType() {
+    return null;
+  }
+
+  @Override
+  public T jsonRead(JsonParser parser) {
+    return null;
+  }
+
+  @Override
+  public void jsonWrite(JsonGenerator writer, T value) {
+
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisLineString.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisLineString.java
@@ -1,0 +1,22 @@
+package io.ebean.postgis;
+
+import io.ebean.config.dbplatform.ExtraDbTypes;
+import net.postgis.jdbc.geometry.LineString;
+
+import java.sql.SQLException;
+
+public class ScalarTypePgisLineString extends ScalarTypePgisBase<LineString> {
+
+  public ScalarTypePgisLineString() {
+    super(ExtraDbTypes.LINESTRING, LineString.class);
+  }
+
+  @Override
+  public LineString parse(String value) {
+    try {
+      return new LineString(value);
+    } catch (SQLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisMultiLineString.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisMultiLineString.java
@@ -1,0 +1,22 @@
+package io.ebean.postgis;
+
+import io.ebean.config.dbplatform.ExtraDbTypes;
+import net.postgis.jdbc.geometry.MultiLineString;
+
+import java.sql.SQLException;
+
+public class ScalarTypePgisMultiLineString extends ScalarTypePgisBase<MultiLineString> {
+
+  public ScalarTypePgisMultiLineString() {
+    super(ExtraDbTypes.MULTILINESTRING, MultiLineString.class);
+  }
+
+  @Override
+  public MultiLineString parse(String value) {
+    try {
+      return new MultiLineString(value);
+    } catch (SQLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisMultiPoint.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisMultiPoint.java
@@ -1,0 +1,22 @@
+package io.ebean.postgis;
+
+import io.ebean.config.dbplatform.ExtraDbTypes;
+import net.postgis.jdbc.geometry.MultiPoint;
+
+import java.sql.SQLException;
+
+public class ScalarTypePgisMultiPoint extends ScalarTypePgisBase<MultiPoint> {
+
+  public ScalarTypePgisMultiPoint() {
+    super(ExtraDbTypes.MULTIPOINT, MultiPoint.class);
+  }
+
+  @Override
+  public MultiPoint parse(String value) {
+    try {
+      return new MultiPoint(value);
+    } catch (SQLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisMultiPolygon.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisMultiPolygon.java
@@ -1,0 +1,22 @@
+package io.ebean.postgis;
+
+import io.ebean.config.dbplatform.ExtraDbTypes;
+import net.postgis.jdbc.geometry.MultiPolygon;
+
+import java.sql.SQLException;
+
+public class ScalarTypePgisMultiPolygon extends ScalarTypePgisBase<MultiPolygon> {
+
+  public ScalarTypePgisMultiPolygon() {
+    super(ExtraDbTypes.MULTIPOLYGON, MultiPolygon.class);
+  }
+
+  @Override
+  public MultiPolygon parse(String value) {
+    try {
+      return new MultiPolygon(value);
+    } catch (SQLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisPoint.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisPoint.java
@@ -1,0 +1,22 @@
+package io.ebean.postgis;
+
+import io.ebean.config.dbplatform.ExtraDbTypes;
+import net.postgis.jdbc.geometry.Point;
+
+import java.sql.SQLException;
+
+public class ScalarTypePgisPoint extends ScalarTypePgisBase<Point> {
+
+  public ScalarTypePgisPoint() {
+    super(ExtraDbTypes.POINT, Point.class);
+  }
+
+  @Override
+  public Point parse(String value) {
+    try {
+      return new Point(value);
+    } catch (SQLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisPolygon.java
+++ b/ebean-net-postgis-types/src/main/java/io/ebean/postgis/ScalarTypePgisPolygon.java
@@ -1,0 +1,22 @@
+package io.ebean.postgis;
+
+import io.ebean.config.dbplatform.ExtraDbTypes;
+import net.postgis.jdbc.geometry.Polygon;
+
+import java.sql.SQLException;
+
+public class ScalarTypePgisPolygon extends ScalarTypePgisBase<Polygon> {
+
+  public ScalarTypePgisPolygon() {
+    super(ExtraDbTypes.POLYGON, Polygon.class);
+  }
+
+  @Override
+  public Polygon parse(String value) {
+    try {
+      return new Polygon(value);
+    } catch (SQLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/ebean-net-postgis-types/src/main/java/module-info.java
+++ b/ebean-net-postgis-types/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+import io.ebean.core.type.ExtraTypeFactory;
+import io.ebeaninternal.api.GeoTypeProvider;
+
+/**
+ * Provides GeoTypeProvider and ExtraTypeFactory.
+ */
+module io.ebean.postgis.types {
+
+  provides ExtraTypeFactory with io.ebean.postgis.PostgisExtraTypeFactory;
+  provides GeoTypeProvider with io.ebean.postgis.PostgisGeoTypeBindProvider;
+
+  requires io.ebean.core;
+  requires org.postgresql.jdbc;
+  requires net.postgis.jdbc;
+  requires net.postgis.jdbc.geometry;
+  requires com.fasterxml.jackson.core;
+}

--- a/ebean-net-postgis-types/src/main/resources/META-INF/services/io.ebean.core.type.ExtraTypeFactory
+++ b/ebean-net-postgis-types/src/main/resources/META-INF/services/io.ebean.core.type.ExtraTypeFactory
@@ -1,0 +1,1 @@
+io.ebean.postgis.PostgisExtraTypeFactory

--- a/ebean-net-postgis-types/src/main/resources/META-INF/services/io.ebeaninternal.api.GeoTypeProvider
+++ b/ebean-net-postgis-types/src/main/resources/META-INF/services/io.ebeaninternal.api.GeoTypeProvider
@@ -1,0 +1,1 @@
+io.ebean.postgis.PostgisGeoTypeBindProvider

--- a/ebean-net-postgis-types/src/test/java/org/example/domain/BaseEntity.java
+++ b/ebean-net-postgis-types/src/test/java/org/example/domain/BaseEntity.java
@@ -1,0 +1,20 @@
+package org.example.domain;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+abstract class BaseEntity {
+
+  @Id
+  Long id;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+}

--- a/ebean-net-postgis-types/src/test/java/org/example/domain/CachedBean.java
+++ b/ebean-net-postgis-types/src/test/java/org/example/domain/CachedBean.java
@@ -1,0 +1,43 @@
+package org.example.domain;
+
+import io.ebean.annotation.Cache;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import net.postgis.jdbc.geometry.Point;
+import net.postgis.jdbc.geometry.Polygon;
+
+@Entity
+@Table(name="mybean_cached")
+@Cache
+public class CachedBean extends BaseEntity {
+  String name;
+
+  Point point;
+
+  Polygon polygon;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Point getPoint() {
+    return point;
+  }
+
+  public void setPoint(Point point) {
+    this.point = point;
+  }
+
+  public Polygon getPolygon() {
+    return polygon;
+  }
+
+  public void setPolygon(Polygon polygon) {
+    this.polygon = polygon;
+  }
+}

--- a/ebean-net-postgis-types/src/test/java/org/example/domain/MyBean.java
+++ b/ebean-net-postgis-types/src/test/java/org/example/domain/MyBean.java
@@ -1,0 +1,92 @@
+package org.example.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import net.postgis.jdbc.geometry.*;
+
+@Entity
+@Table(name="mybean")
+public class MyBean extends BaseEntity {
+
+  String name;
+
+  Point point;
+
+  Polygon poly;
+
+  LineString lineString;
+
+  MultiLineString multiLineString;
+
+  MultiPoint multiPoint;
+
+  MultiPolygon mpoly;
+
+  @Column(columnDefinition = "geometry(Point, 4326)", unique = true)
+  Point wgs84Point;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Point getPoint() {
+    return point;
+  }
+
+  public void setPoint(Point point) {
+    this.point = point;
+  }
+
+  public Polygon getPoly() {
+    return poly;
+  }
+
+  public void setPoly(Polygon poly) {
+    this.poly = poly;
+  }
+
+  public LineString getLineString() {
+    return lineString;
+  }
+
+  public void setLineString(LineString lineString) {
+    this.lineString = lineString;
+  }
+
+  public MultiLineString getMultiLineString() {
+    return multiLineString;
+  }
+
+  public void setMultiLineString(MultiLineString multiLineString) {
+    this.multiLineString = multiLineString;
+  }
+
+  public MultiPoint getMultiPoint() {
+    return multiPoint;
+  }
+
+  public void setMultiPoint(MultiPoint multiPoint) {
+    this.multiPoint = multiPoint;
+  }
+
+  public MultiPolygon getMpoly() {
+    return mpoly;
+  }
+
+  public void setMpoly(MultiPolygon mpoly) {
+    this.mpoly = mpoly;
+  }
+
+  public Point getWgs84Point() {
+    return wgs84Point;
+  }
+
+  public void setWgs84Point(final Point wgs84Point) {
+    this.wgs84Point = wgs84Point;
+  }
+}

--- a/ebean-net-postgis-types/src/test/java/org/example/domain/TestCacheSerialization.java
+++ b/ebean-net-postgis-types/src/test/java/org/example/domain/TestCacheSerialization.java
@@ -1,0 +1,84 @@
+package org.example.domain;
+
+import io.ebean.DB;
+import net.postgis.jdbc.geometry.Point;
+import net.postgis.jdbc.geometry.Polygon;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestCacheSerialization {
+  @Test
+  public void testCache() throws SQLException {
+    Point p1=new Point(1.0, 2.0);
+    p1.setSrid(4674);
+
+    Polygon pol=new Polygon("SRID=4674;POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),(1 1, 1 2, 2 2, 2 1, 1 1))");
+
+    CachedBean tb=new CachedBean();
+    tb.setId(2080L);
+    tb.setName("Serialize Test");
+    tb.setPoint(p1);
+    tb.setPolygon(pol);
+
+    DB.insert(tb);
+
+    CachedBean r1=DB.find(CachedBean.class, tb.getId());
+    assertNotNull(r1);
+    assertEquals(p1, r1.getPoint());
+    assertEquals(pol, r1.getPolygon());
+
+    CachedBean r2=DB.find(CachedBean.class, tb.getId());  // this is returned from cache
+    assertNotNull(r2);
+    assertEquals(p1, r2.getPoint());  // and did fail https://github.com/ebean-orm/ebean/issues/3026
+    assertEquals(pol, r2.getPolygon());
+
+    DB.delete(tb);
+
+  }
+
+  @Test
+  public void testNullCache() throws SQLException {
+    Point p1=new Point(1.0, 2.0);
+    p1.setSrid(4674);
+    Polygon pol=new Polygon("SRID=4674;POLYGON((0 0, 10 0, 10 10, 0 10, 0 0),(1 1, 1 2, 2 2, 2 1, 1 1))");
+
+    CachedBean tb=new CachedBean();
+    tb.setId(2081L);
+    tb.setName("Serialize Test");
+    tb.setPoint(p1);
+    tb.setPolygon(null);
+
+    DB.insert(tb);
+
+    CachedBean r1=DB.find(CachedBean.class, tb.getId());
+    assertNotNull(r1);
+    assertEquals(p1, r1.getPoint());
+    assertNull(r1.getPolygon());
+
+    CachedBean r2=DB.find(CachedBean.class, tb.getId());  // this is returned from cache
+    assertNotNull(r2);
+    assertEquals(p1, r2.getPoint());  // and did fail https://github.com/ebean-orm/ebean/issues/3026
+    assertNull(r1.getPolygon());
+
+    tb.setPoint(null);
+    tb.setPolygon(pol);
+
+    DB.save(tb);
+
+    r1=DB.find(CachedBean.class, tb.getId());
+    assertNotNull(r1);
+    assertEquals(pol, r1.getPolygon());
+    assertNull(r1.getPoint());
+
+    r2=DB.find(CachedBean.class, tb.getId());  // this is returned from cache
+    assertNotNull(r2);
+    assertEquals(pol, r2.getPolygon());  // and did fail https://github.com/ebean-orm/ebean/issues/3026
+    assertNull(r1.getPoint());
+
+    DB.delete(tb);
+
+  }
+}

--- a/ebean-net-postgis-types/src/test/java/org/example/domain/TestInsertQuery.java
+++ b/ebean-net-postgis-types/src/test/java/org/example/domain/TestInsertQuery.java
@@ -1,0 +1,57 @@
+package org.example.domain;
+
+import io.ebean.DB;
+import net.postgis.jdbc.geometry.*;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class TestInsertQuery {
+
+  /**
+   * Not automated this test yet.
+   */
+  @Test
+  public void insert() throws SQLException {
+
+
+    List<MyBean> list = DB.find(MyBean.class).findList();
+    for (MyBean MyBean : list) {
+      System.out.println(MyBean.getPoint());
+    }
+
+    List<MyBean> list1 = DB.find(MyBean.class)
+        .where()
+        .raw("st_within(st_pointfromwkb(st_point(?, ?), 4674), poly)", 1.9, 1.9)
+        .findList();
+
+    System.out.println(list1);
+
+
+    Point point = new Point("SRID=4674;POINT(2.8 1.7)");
+    Polygon poly =  new Polygon("SRID=4674;POLYGON((2 2, 2 -2, -2 -2, -2 2, 2 2))");
+    LineString lineString = new LineString("SRID=4674;LINESTRING(0 0, 1 2)");
+    MultiLineString multiLineString = new MultiLineString("SRID=4674;MULTILINESTRING((0 0, 1 2), (1 2, 3 -1))");
+    MultiPoint multiPoint = new MultiPoint("SRID=4674;MULTIPOINT((2 3), (7 8))");
+    MultiPolygon mpoly =  new MultiPolygon("SRID=4674;MULTIPOLYGON(((1 1, 1 -1, -1 -1, -1 1, 1 1)),((1 1, 3 1, 3 3, 1 3, 1 1)))");
+
+    MyBean p = new MyBean();
+    p.setName("me at "+System.currentTimeMillis());
+    p.setPoint(point);
+    p.setPoly(poly);
+    p.setLineString(lineString);
+    p.setMultiLineString(multiLineString);
+    p.setMultiPoint(multiPoint);
+    p.setMpoly(mpoly);
+
+    DB.save(p);
+
+    List<String> content =
+      DB.find(MyBean.class)
+      .select("ST_AsText(lineString)::String")
+      .findSingleAttributeList();
+
+    System.out.println(content);
+  }
+}

--- a/ebean-net-postgis-types/src/test/resources/application-test.yml
+++ b/ebean-net-postgis-types/src/test/resources/application-test.yml
@@ -1,0 +1,18 @@
+ebean:
+  dbSchema: mygisapp
+  geometrySRID: 4674
+
+  test:
+#    useDocker: false
+#    shutdown: stop # stop | remove
+    platform: netpostgis
+    ddlMode: dropCreate # none | dropCreate | create | migration | createOnly | migrationDropCreate
+    dbName: mygisapp
+
+    postgis:
+      containerName: ebeanbuild_postgis
+      port: 9432
+      image: ghcr.io/baosystems/postgis:15
+#      extensions: postgis
+#      url: jdbc:postgresql_lwgis://localhost:6432/mygisapp
+#      driver: org.postgis.DriverWrapperLW

--- a/ebean-net-postgis-types/src/test/resources/logback-test.xml
+++ b/ebean-net-postgis-types/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<configuration scan="true" scanPeriod="3 seconds">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <!-- Logging for SQL etc -->
+
+    <logger name="io.ebean.docker" level="TRACE"/>
+
+    <logger name="io.ebean.SQL" level="TRACE"/>
+    <logger name="io.ebean.TXN" level="TRACE"/>
+    <logger name="io.ebean.SUM" level="TRACE"/>
+    <logger name="io.ebean.DDL" level="TRACE"/>
+
+</configuration>

--- a/ebean-net-postgis-types/src/test/resources/notused-test-ebean.properties
+++ b/ebean-net-postgis-types/src/test/resources/notused-test-ebean.properties
@@ -1,0 +1,18 @@
+
+## when running tests
+
+ebean.ddl.generate=true
+#ebean.ddl.run=true
+#ebean.ddl.createOnly=true
+
+ebean.geometrySRID=4674
+
+datasource.default=db
+
+datasource.db.username=pgis
+datasource.db.password=pgis
+datasource.db.databaseUrl=jdbc:postgresql_lwgis://127.0.0.1:5432/pgis
+datasource.db.databaseDriver=net.postgis.jdbc.DriverWrapperLW
+
+
+

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/NetPostgisSetup.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/NetPostgisSetup.java
@@ -1,0 +1,56 @@
+package io.ebean.test.config.platform;
+
+import java.util.Properties;
+
+/**
+ * A variation of Postgres that expected Postgis extension support.
+ *
+ * Uses postgis/postgis image by default.
+ */
+class NetPostgisSetup implements PlatformSetup {
+
+  @Override
+  public Properties setup(Config config) {
+    int defaultPort = config.isUseDocker() ? 7432 : 5432;
+    config.setDockerPlatform("postgis");
+    config.ddlMode("dropCreate");
+    config.setDefaultPort(defaultPort);
+    config.setUsernameDefault();
+    config.setPasswordDefault();
+    config.setDriver("net.postgis.jdbc.DriverWrapperLW");
+    config.setUrl("jdbc:postgresql_lwgis://${host}:${port}/${databaseName}");
+
+    String schema = config.getSchema();
+    if (schema != null && !schema.equals(config.getUsername())) {
+      config.urlAppend("?currentSchema=" + schema);
+    }
+    config.datasourceDefaults();
+    return dockerProperties(config);
+  }
+
+  private Properties dockerProperties(Config config) {
+    if (!config.isUseDocker()) {
+      return new Properties();
+    }
+    config.setExtensions("hstore,pgcrypto,postgis");
+    config.setDockerContainerName("ut_postgis");
+    config.setDockerVersion("14-3.2");
+    return config.getDockerProperties();
+  }
+
+  @Override
+  public void setupExtraDbDataSource(Config config) {
+    int defaultPort = config.isUseDocker() ? 7432 : 5432;
+    config.setDefaultPort(defaultPort);
+    config.setExtraUsernameDefault();
+    config.setExtraDbPasswordDefault();
+    config.setExtraUrl("jdbc:postgresql_lwgis://${host}:${port}/${databaseName}");
+    config.extraDatasourceDefaults();
+  }
+
+  @Override
+  public boolean isLocal() {
+    return false;
+  }
+
+}

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/PlatformAutoConfig.java
@@ -26,6 +26,7 @@ public class PlatformAutoConfig {
     KNOWN_PLATFORMS.put("sqlite", new SqliteSetup());
     KNOWN_PLATFORMS.put("postgres", new PostgresSetup());
     KNOWN_PLATFORMS.put("postgis", new PostgisSetup());
+    KNOWN_PLATFORMS.put("netpostgis", new NetPostgisSetup());
     KNOWN_PLATFORMS.put("nuodb", new NuoDBSetup());
     KNOWN_PLATFORMS.put("mysql", new MySqlSetup());
     KNOWN_PLATFORMS.put("mariadb", new MariaDBSetup());

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
     <module>kotlin-querybean-generator</module>
     <module>ebean-querybean</module>
     <module>ebean-postgis-types</module>
+    <module>ebean-net-postgis-types</module>
     <module>ebean-redis</module>
     <module>platforms</module>
     <module>composites</module>


### PR DESCRIPTION
Added 2 modules (`ebean-net-postgis`, `ebean-net-postgis-types`) with support of new `net.postgis` libraries (`2023.1.0`) which are compatible with Java modules.

Changed 2 `module-info.java` files to make it work correcty with Java modules.

More in Google Group thread: https://groups.google.com/g/ebean/c/F9beU1uixWY