### PR TITLE
#3466 - Duplicated entities in findMany when a ManyToOne relation is fetched

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiQuery.java
@@ -580,7 +580,12 @@ public interface SpiQuery<T> extends Query<T>, SpiQueryFetch, TxnProfileEventCod
   /**
    * Convert joins as necessary to query joins etc.
    */
-  SpiQuerySecondary convertJoins();
+  SpiQueryManyJoin convertJoins();
+
+  /**
+   * Return secondary queries if required.
+   */
+  SpiQuerySecondary secondaryQuery();
 
   /**
    * Return the TransactionContext.

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiQueryManyJoin.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiQueryManyJoin.java
@@ -1,0 +1,17 @@
+package io.ebeaninternal.api;
+
+/**
+ * A SQL Join for a ToMany property included in the query.
+ */
+public interface SpiQueryManyJoin {
+
+  /**
+   * The full path of the many property to include in the query via join.
+   */
+  String path();
+
+  /**
+   * Order by clause defined via mapping on the ToMany property.
+   */
+  String fetchOrderBy();
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -41,9 +41,9 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   private CQueryPlanKey queryPlanKey;
   private SpiQuerySecondary secondaryQueries;
   private List<T> cacheBeans;
-  private BeanPropertyAssocMany<?> manyProperty;
   private boolean inlineCountDistinct;
   private Set<String> dependentTables;
+  private SpiQueryManyJoin manyJoin;
 
   public OrmQueryRequest(SpiEbeanServer server, OrmQueryEngine queryEngine, SpiQuery<T> query, SpiTransaction t) {
     super(server, t);
@@ -168,7 +168,8 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
    */
   @Override
   public void prepareQuery() {
-    secondaryQueries = query.convertJoins();
+    manyJoin = query.convertJoins();
+    secondaryQueries = query.secondaryQuery();
     beanDescriptor.prepareQuery(query);
     adapterPreQuery();
     queryPlanKey = query.prepare(this);
@@ -446,19 +447,19 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
     return query;
   }
 
-  /**
-   * Determine and return the ToMany property that is included in the query.
-   */
-  public BeanPropertyAssocMany<?> determineMany() {
-    manyProperty = beanDescriptor.manyProperty(query);
-    return manyProperty;
+  public SpiQueryManyJoin manyJoin() {
+    return manyJoin;
   }
 
   /**
-   * Return the many property that is fetched in the query or null if there is not one.
+   * Return true if there is a manyJoin that should be included with this query.
    */
-  public BeanPropertyAssocMany<?> manyPropertyForOrderBy() {
-    return query.isSingleAttribute() ? null : manyProperty;
+  public boolean includeManyJoin() {
+    if (manyJoin == null || query.isSingleAttribute()) {
+      return false;
+    }
+    final Type type = query.type();
+    return type != Type.SQ_EX && type != Type.COUNT;
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1602,19 +1602,6 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   }
 
   /**
-   * Return the many property included in the query or null if one is not.
-   */
-  public BeanPropertyAssocMany<?> manyProperty(SpiQuery<?> query) {
-    OrmQueryDetail detail = query.detail();
-    for (BeanPropertyAssocMany<?> many : propertiesMany) {
-      if (detail.includesPath(many.name())) {
-        return many;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Return a raw expression for 'where parent id in ...' clause.
    */
   String parentIdInExpr(int parentIdSize, String rawWhere) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyDeploy.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyDeploy.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.el;
 
+import io.ebeaninternal.api.SpiQueryManyJoin;
 import io.ebeaninternal.server.deploy.BeanProperty;
 
 /**
@@ -10,7 +11,7 @@ import io.ebeaninternal.server.deploy.BeanProperty;
  * joins and set place holders for table alias'.
  * </p>
  */
-public interface ElPropertyDeploy {
+public interface ElPropertyDeploy extends SpiQueryManyJoin {
 
   /**
    * This is the elPrefix for all root level properties.
@@ -80,4 +81,14 @@ public interface ElPropertyDeploy {
    * is left as a 'join' and which get converted to query join.
    */
   int fetchPreference();
+
+  @Override
+  default String path() {
+    return elName();
+  }
+
+  @Override
+  default String fetchOrderBy() {
+    return beanProperty().fetchOrderBy();
+  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -504,22 +504,26 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
   }
 
   @Override
-  public final SpiQuerySecondary convertJoins() {
+  public final SpiQueryManyJoin convertJoins() {
     if (!useDocStore) {
       createExtraJoinsToSupportManyWhereClause();
     }
-    markQueryJoins();
+    return markQueryJoins();
+  }
+
+  @Override
+  public SpiQuerySecondary secondaryQuery() {
     return new OrmQuerySecondary(removeQueryJoins(), removeLazyJoins());
   }
 
   /**
    * Limit the number of fetch joins to Many properties, mark as query joins as needed.
+   *
+   * @return The query join many property or null.
    */
-  private void markQueryJoins() {
-    if (distinctOn == null) {
-      // no automatic join to query join conversion when distinctOn is used
-      detail.markQueryJoins(beanDescriptor, lazyLoadManyPath, isAllowOneManyFetch(), type.defaultSelect());
-    }
+  private SpiQueryManyJoin markQueryJoins() {
+    // no automatic join to query join conversion when distinctOn is used
+    return distinctOn != null ? null : detail.markQueryJoins(beanDescriptor, lazyLoadManyPath, isAllowOneManyFetch(), type.defaultSelect());
   }
 
   private boolean isAllowOneManyFetch() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryDetail.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryDetail.java
@@ -3,6 +3,7 @@ package io.ebeaninternal.server.querydefn;
 import io.ebean.FetchConfig;
 import io.ebean.event.BeanQueryRequest;
 import io.ebean.util.SplitName;
+import io.ebeaninternal.api.SpiQueryManyJoin;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanPropertyAssoc;
 import io.ebeaninternal.server.el.ElPropertyDeploy;
@@ -327,12 +328,15 @@ public final class OrmQueryDetail implements Serializable {
 
   /**
    * Mark 'fetch joins' to 'many' properties over to 'query joins' where needed.
+   *
+   * @return The fetch join many property or null
    */
-  void markQueryJoins(BeanDescriptor<?> beanDescriptor, String lazyLoadManyPath, boolean allowOne, boolean addIds) {
+  SpiQueryManyJoin markQueryJoins(BeanDescriptor<?> beanDescriptor, String lazyLoadManyPath, boolean allowOne, boolean addIds) {
     if (fetchPaths.isEmpty()) {
-      return;
+      return null;
     }
 
+    ElPropertyDeploy many = null;
     // the name of the many fetch property if there is one
     String manyFetchProperty = null;
     // flag that is set once the many fetch property is chosen
@@ -353,6 +357,7 @@ public final class OrmQueryDetail implements Serializable {
             fetchJoinFirstMany = false;
             manyFetchProperty = pair.getPath();
             chunk.filterManyInline();
+            many = elProp;
           } else {
             // convert this one over to a 'query join'
             chunk.markForQueryJoin();
@@ -360,6 +365,7 @@ public final class OrmQueryDetail implements Serializable {
         }
       }
     }
+    return many;
   }
 
   /**

--- a/ebean-querybean/src/test/java/org/querytest/QOrderTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QOrderTest.java
@@ -5,6 +5,7 @@ import io.ebean.FetchConfig;
 import io.ebean.FetchGroup;
 import io.ebean.Query;
 import io.ebean.test.LoggedSql;
+import org.example.domain.Contact;
 import org.example.domain.Customer;
 import org.example.domain.Order;
 import org.example.domain.OrderDetail;
@@ -88,7 +89,7 @@ class QOrderTest {
     query.findList();
 
     String sql = query.getGeneratedSql();
-    assertThat(sql).contains("select /* QOrderTest.orderById:88 */ t0.id, t0.status from o_order t0 order by t0.id");
+    assertThat(sql).contains("select /* QOrderTest.orderById:89 */ t0.id, t0.status from o_order t0 order by t0.id");
 
     Query<Order> query2 = new QOrder()
       .select(QOrder.Alias.status)
@@ -98,7 +99,7 @@ class QOrderTest {
     query2.findList();
 
     String sql2 = query2.getGeneratedSql();
-    assertThat(sql2).contains("select /* QOrderTest.orderById:98 */ t0.id, t0.status from o_order t0 order by t0.status, t0.id");
+    assertThat(sql2).contains("select /* QOrderTest.orderById:99 */ t0.id, t0.status from o_order t0 order by t0.status, t0.id");
   }
 
   @Test
@@ -112,6 +113,70 @@ class QOrderTest {
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
     assertThat(sql.get(0)).contains("select /*+ FirstRows */ /* QOrderTest.hint */ t0.id, t0.name from be_customer t0");
+  }
+
+  @Test
+  void fetchGroup_nestedMany_expect_orderByClauseAdded() {
+    var o = QOrder.alias();
+    var c = QCustomer.alias();
+    var ct = QContact.alias();
+
+    var fg = QOrder.forFetchGroup()
+      .select(o.status, o.orderDate)
+      .customer.fetch(c.email)
+      .customer.contacts.fetch(ct.firstName, ct.lastName)
+      .buildFetchGroup();
+
+    LoggedSql.start();
+
+    new QOrder()
+      .select(fg)
+      .status.eq(Order.Status.NEW)
+      .findList();
+
+    final List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("order by t0.id");
+  }
+
+  @Test
+  void fetchGroup_nestedMany2_expect_orderByClauseAdded() {
+    var fg1 = FetchGroup.of(Order.class)
+      .fetch("customer")
+      .fetch("customer.contacts")
+      .build();
+
+    LoggedSql.start();
+
+    new QOrder()
+      .select(fg1)
+      .status.eq(Order.Status.NEW)
+      .findList();
+
+    final List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("order by t0.id");
+  }
+
+  @Test
+  void fetchGroup_nestedMany3_expect_orderByClauseAdded() {
+    var fg = FetchGroup.of(Order.class)
+      .fetch("customer", FetchGroup.of(Customer.class)
+        .fetch("contacts", FetchGroup.of(Contact.class)
+          .build())
+        .build())
+      .build();
+
+    LoggedSql.start();
+
+    new QOrder()
+      .select(fg)
+      .status.eq(Order.Status.NEW)
+      .findList();
+
+    final List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("order by t0.id");
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/basic/TestFetchId.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestFetchId.java
@@ -1,5 +1,6 @@
 package org.tests.basic;
 
+import io.ebean.test.LoggedSql;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.FutureIds;
@@ -28,8 +29,13 @@ public class TestFetchId extends BaseTestCase {
       .gt("details.id", 0)
       .query();
 
+    LoggedSql.start();
     List<Object> ids = query.findIds();
     assertThat(ids).isNotEmpty();
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).doesNotContain("order by");
+    assertThat(sql.get(0)).doesNotContain("join o_order_detail t1");
 
     FutureIds<Order> futureIds = query.findFutureIds();
 

--- a/ebean-test/src/test/java/org/tests/batchload/TestQueryJoinToAssocOne.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestQueryJoinToAssocOne.java
@@ -230,5 +230,6 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
     String originQuery = trimSql(loggedSql.get(0), 5);
     assertThat(originQuery).contains("select t0.id, t0.status, t0.ship_date, t1.id, t1.order_qty, t1.unit_price");
     assertThat(originQuery).contains(" from o_order t0 left join o_order_detail t1 ");
+    assertThat(originQuery).contains(" order by t0.id, t1.id asc, t1.order_qty asc, t1.cretime desc;");
   }
 }

--- a/ebean-test/src/test/java/org/tests/cascade/TestOrderedList.java
+++ b/ebean-test/src/test/java/org/tests/cascade/TestOrderedList.java
@@ -185,7 +185,7 @@ public class TestOrderedList extends BaseTestCase {
     DB.save(masterDb);
 
     masterDb = DB.find(OmCacheOrderedMaster.class, master.getId());
-    assertThat(masterDb.getDetails()).containsExactly(detail3, detail1);
+    assertThat(masterDb.getDetails()).containsExactlyInAnyOrder(detail3, detail1);
 
   }
 }

--- a/ebean-test/src/test/java/org/tests/query/TestManyWhereJoin.java
+++ b/ebean-test/src/test/java/org/tests/query/TestManyWhereJoin.java
@@ -181,5 +181,6 @@ public class TestManyWhereJoin extends BaseTestCase {
 
     // additional join for fetching the many details
     assertThat(sql).contains(" left join o_order_detail t1 on t1.order_id = t0.id");
+    assertThat(sql).contains("order by t0.cretime, t0.id, t1.id asc, t1.order_qty asc, t1.cretime desc");
   }
 }

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFilterMany.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFilterMany.java
@@ -213,6 +213,7 @@ public class TestQueryFilterMany extends BaseTestCase {
     assertThat(sql).hasSize(1);
     assertThat(sql.get(0)).contains("from o_customer t0 left join o_order t1");
     assertThat(sql.get(0)).contains("where t1.order_date is not null");
+    assertThat(sql.get(0)).contains("order by t0.id");
   }
 
   @Test
@@ -269,6 +270,7 @@ public class TestQueryFilterMany extends BaseTestCase {
     List<String> sqlList = LoggedSql.stop();
     assertEquals(1, sqlList.size());
     assertThat(sqlList.get(0)).contains("select count(*) from o_customer");
+    assertThat(sqlList.get(0)).doesNotContain("order by");
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFilterManyOnM2M.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFilterManyOnM2M.java
@@ -1,17 +1,27 @@
 package org.tests.query;
 
+import io.ebean.test.LoggedSql;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.MUser;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class TestQueryFilterManyOnM2M extends BaseTestCase {
 
   @Test
   public void test() {
+    LoggedSql.start();
 
     DB.find(MUser.class).fetch("roles").filterMany("roles").ilike("roleName", "Jim%").findList();
 
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("select t0.userid, t0.user_name, t0.user_type_id, t1.roleid, t1.role_name from muser t0 left join mrole_muser t1z_ on t1z_.muser_userid = t0.userid left join mrole t1 on t1.roleid = t1z_.mrole_roleid where lower(t1.role_name) like");
+    assertThat(sql.get(0)).contains("order by t0.userid;");
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/query/TestRowCount.java
+++ b/ebean-test/src/test/java/org/tests/query/TestRowCount.java
@@ -1,5 +1,6 @@
 package org.tests.query;
 
+import io.ebean.test.LoggedSql;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Query;
@@ -17,9 +18,9 @@ public class TestRowCount extends BaseTestCase {
 
   @Test
   public void test() {
-
     ResetBasicData.reset();
 
+    LoggedSql.start();
     Query<Order> query = DB.find(Order.class)
       .fetch("details")
       .where()
@@ -28,11 +29,14 @@ public class TestRowCount extends BaseTestCase {
       .order("id desc").query();
 
     int rc = query.findCount();
-
     List<Object> ids = query.findIds();
-
     List<Order> list = query.findList();
-    System.out.println(list);
+
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(3);
+    assertThat(sql.get(0)).doesNotContain("order by");
+    assertThat(sql.get(1)).contains("order by");
+    assertThat(sql.get(2)).contains("order by t0.id desc");
     for (Order order : list) {
       order.getStatus();
     }


### PR DESCRIPTION
#3466 - Duplicated entities in findMany when a ManyToOne relation is fetched

Internally in OrmQueryDetail.markQueryJoins() the SpiQueryManyJoin is determined and returned. This change uses this and effectively removes the code from OrmQueryRequest.determineMany() and BeanDescriptor.manyProperty() which was the source of this issue (performing a similar task but not correctly taking the full path into account and hence the source of this bug).