### PR TITLE
Fix orderBy for cached many requests

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -105,6 +105,9 @@ final class DefaultBeanLoader {
     if (ebi.isReadOnly()) {
       query.setReadOnly(true);
     }
+    if (many.hasOrderColumn()) {
+      query.orderBy(many.path() + "." +  many.fetchOrderBy());
+    }
 
     server.findOne(query);
     if (beanCollection != null) {

--- a/ebean-test/src/test/java/org/tests/cascade/TestOrderedList.java
+++ b/ebean-test/src/test/java/org/tests/cascade/TestOrderedList.java
@@ -188,4 +188,51 @@ public class TestOrderedList extends BaseTestCase {
     assertThat(masterDb.getDetails()).containsExactlyInAnyOrder(detail3, detail1);
 
   }
+
+  @Test
+  public void testModifyListWithCache2() {
+    final OmCacheOrderedMaster master = new OmCacheOrderedMaster("Master");
+    final OmCacheOrderedDetail detail1 = new OmCacheOrderedDetail("Detail1");
+    final OmCacheOrderedDetail detail2 = new OmCacheOrderedDetail("Detail2");
+    final OmCacheOrderedDetail detail3 = new OmCacheOrderedDetail("Detail3");
+    DB.save(detail1);
+    DB.save(detail2);
+    DB.save(detail3);
+    master.getDetails().add(detail1);
+    master.getDetails().add(detail2);
+    master.getDetails().add(detail3);
+
+    DB.save(master);
+
+    OmCacheOrderedMaster masterDb = DB.find(OmCacheOrderedMaster.class, master.getId()); // load cache
+    assertThat(masterDb.getDetails()).containsExactly(detail1, detail2, detail3);
+
+    masterDb = DB.find(OmCacheOrderedMaster.class, master.getId());
+    assertThat(masterDb.getDetails()).containsExactly(detail1, detail2, detail3); // hit cache
+
+    // 1 und 2 tauschen
+    masterDb.getDetails().add(0, masterDb.getDetails().remove(1));
+    DB.save(masterDb);
+
+    masterDb.getDetails().remove(2);
+    DB.save(masterDb);
+
+    LoggedSql.start();
+    OmCacheOrderedMaster masterDbNew = DB.find(OmCacheOrderedMaster.class, master.getId());
+    masterDbNew.getDetails().size();
+    assertThat(masterDbNew.getDetails()).containsExactly(detail2, detail1);
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1).first().asString()
+      .startsWith("select t0.id, t1.id, t1.name, t1.version, t1.sort_order, t1.master_id from om_cache_ordered_master t0 left join om_cache_ordered_detail t1 on t1.master_id = t0.id where t0.id = ? order by t1.sort_order;");
+
+    DB.cacheManager().clearAll();
+    masterDbNew = DB.find(OmCacheOrderedMaster.class, master.getId());
+    LoggedSql.start();
+    masterDbNew.getDetails().size();
+    sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1).first().asString()
+      .startsWith("select t0.master_id, t0.id, t0.name, t0.version, t0.sort_order, t0.master_id from om_cache_ordered_detail t0 where (t0.master_id) in (?) order by t0.master_id, t0.sort_order;");
+
+    assertThat(masterDbNew.getDetails()).containsExactly(detail2, detail1);
+  }
 }


### PR DESCRIPTION
Hello @rbygrave,

@rPraml and I have a test case in which we change the order of the ordered many properties. 
We then load the parent with a find() and the details with getDetails().

The master bean is loaded from the cache, but the details are loaded directly from the database because they are not in the cache. However, @OrderColumn is not taken into account and the details are delivered in the wrong order. We have an easy fix for this in this PR.

We have observed that the queries are different when you get the parent bean from cache or from the database. We tried to refactor so that the same query is produced in both cases, see our next PR.

Can you please take a look and give us feedback?

Best regards
Noemi