### PR TITLE
Bug: Batch ordering - Regression introduced in version 13.26.1, insertAll() leaves batchMode=true enabled ... when it should not

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1689,6 +1689,7 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
       for (Object bean : beans) {
         persister.insert(checkEntityBean(bean), options, txn);
       }
+      txn.flushBatchOnCollection();
       return 0;
     }, transaction);
   }

--- a/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
+++ b/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
@@ -15,6 +15,7 @@ import io.ebean.xtest.base.DtoQuery2Test;
 import io.ebeaninternal.api.SpiTransaction;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.*;
+import org.tests.query.cache.Acl;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -357,6 +358,24 @@ public class TestBatchInsertFlush extends BaseTestCase {
 
     } finally {
       txn.end();
+    }
+  }
+
+  @Test
+  public void testBatchEscalationInsert() {
+    try (Transaction txn = DB.beginTransaction()) {
+      assertThat(txn.isBatchMode()).isFalse();
+      DB.insertAll(List.of(new Acl("test")));
+      assertThat(txn.isBatchMode()).isFalse();
+    }
+  }
+
+  @Test
+  public void testBatchEscalationSave() {
+    try (Transaction txn = DB.beginTransaction()) {
+      assertThat(txn.isBatchMode()).isFalse();
+      DB.saveAll(List.of(new Acl("test")));
+      assertThat(txn.isBatchMode()).isFalse();
     }
   }
 }


### PR DESCRIPTION
Hello @rbygrave,

we are currently in the process of updating from ebean 13 to 14 and we encountered a bug, see the test case.

The entity `Contact` has a `@ManyToOne` property (without cascadeType) `ContactGroup`.

In a transaction we store some elements using `DB.insertAll()`. Then we save a contact (without a group), we create a group with a certain id, we save it and then we put the group in the contact.

With transaction flush, however, the order in the queue is not correct: contact (with group) is saved first, but group does not yet exist in the DB.

What we discovered during debugging: after `DB.insertAll()`, txn.batchMode = true is set (this was not the case with ebean 13) and during flush the objects contact and group are in the wrong order in the queue.

With ebean 13 you have to explicitly call `txn.setBatchMode(true)` for the test to fail.

Could you please take a look and help us fix this?

Cheers,
Noemi

@rPraml FYI