### PR TITLE
Add setArrayParameter to SqlQuery

### DIFF
--- a/ebean-api/src/main/java/io/ebean/SqlQuery.java
+++ b/ebean-api/src/main/java/io/ebean/SqlQuery.java
@@ -6,6 +6,7 @@ import io.avaje.lang.Nullable;
 import javax.sql.DataSource;
 import java.io.Serializable;
 import java.sql.Connection;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -171,7 +172,7 @@ public interface SqlQuery extends Serializable, CancelableQuery {
    *   List<SqlRow> list =
    *     DB.sqlQuery(sql)
    *       .setParameter("Rob")
-   *       .setParameter("Status.NEW)
+   *       .setParameter(Status.NEW)
    *       .findList();
    *
    *   // the same as ...
@@ -242,9 +243,30 @@ public interface SqlQuery extends Serializable, CancelableQuery {
   SqlQuery setParameter(int position, Object value);
 
   /**
+   * Bind the array parameter by its index position (1 based like JDBC).
+   *
+   * <pre>{@code
+   *
+   *    String sql = "select name from customer where id in (:1)";
+   *
+   *    List<SqlRow> list =
+   *      DB.sqlQuery(sql)
+   *        .setArrayParameter(List.of(1, 2, 3))
+   *        .findList();
+   *
+   * }</pre>
+   */
+  SqlQuery setArrayParameter(int position, Collection<?> value);
+
+  /**
    * Bind the named parameter value.
    */
   SqlQuery setParameter(String name, Object value);
+
+  /**
+   * Bind the named array parameter value.
+   */
+  SqlQuery setArrayParameter(String name, Collection<?> value);
 
   /**
    * Set the index of the first row of the results to return.

--- a/ebean-core/src/main/java/io/ebeaninternal/api/BindParams.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/BindParams.java
@@ -234,6 +234,14 @@ public final class BindParams implements Serializable {
   /**
    * Set a named In parameter that is multi-valued.
    */
+  public void setArrayParameter(int position, Collection<?> value) {
+    Param p = parameter(position);
+    p.setInValue(new MultiValueWrapper(value));
+  }
+
+  /**
+   * Set a named In parameter that is multi-valued.
+   */
   public void setArrayParameter(String name, Collection<?> value) {
     Param p = parameter(name);
     p.setInValue(new MultiValueWrapper(value));

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
@@ -10,6 +10,7 @@ import io.ebeaninternal.api.SpiTransaction;
 import io.ebeaninternal.server.transaction.ExternalJdbcTransaction;
 
 import java.sql.Connection;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -134,8 +135,20 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   }
 
   @Override
+  public DefaultRelationalQuery setArrayParameter(int position, Collection<?> value) {
+    bindParams.setArrayParameter(position, value);
+    return this;
+  }
+
+  @Override
   public DefaultRelationalQuery setParameter(String paramName, Object value) {
     bindParams.setParameter(paramName, value);
+    return this;
+  }
+
+  @Override
+  public DefaultRelationalQuery setArrayParameter(String paramName, Collection<?> value) {
+    bindParams.setArrayParameter(paramName, value);
     return this;
   }
 


### PR DESCRIPTION

The `DB.sqlQuery` was the only API that did not support array parameters.

This PR adds the feature.

```
DB.sqlQuery("select * from table where id in (?)")
  .setArrayParameter("ids", List.of(1, 2, 3, 4))
  ...
```