### PR TITLE
Transaction setReadOnly

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequest.java
@@ -149,6 +149,13 @@ public abstract class PersistRequest extends BeanRequest implements BatchPostExe
   }
 
   /**
+   * Mark the underlying transaction as not being query only.
+   */
+  public void markNotQueryOnly() {
+    transaction.markNotQueryOnly();
+  }
+
+  /**
    * Return the type of this request. One of INSERT, UPDATE, DELETE, UPDATESQL or CALLABLESQL.
    */
   public Type type() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -87,6 +87,7 @@ public final class DefaultPersister implements Persister {
   private int executeOrQueue(PersistRequest request) {
     try {
       request.initTransIfRequired();
+      request.transaction().markNotQueryOnly();
       int rc = request.executeOrQueue();
       request.commitTransIfRequired();
       return rc;
@@ -383,6 +384,7 @@ public final class DefaultPersister implements Persister {
     req.checkDraft();
     try {
       req.initTransIfRequiredWithBatchCascade();
+      req.transaction().markNotQueryOnly();
       if (req.isReference()) {
         // its a reference so see if there are manys to save...
         if (req.isPersistCascade()) {
@@ -430,6 +432,7 @@ public final class DefaultPersister implements Persister {
     }
     try {
       req.initTransIfRequiredWithBatchCascade();
+      req.transaction().markNotQueryOnly();
       insert(req);
       req.resetDepth();
       req.commitTransIfRequired();
@@ -562,6 +565,7 @@ public final class DefaultPersister implements Persister {
     }
     try {
       req.initTransIfRequiredWithBatchCascade();
+      req.transaction().markNotQueryOnly();
       int rows = delete(req);
       if (draftReq != null) {
         // delete the 'draft' bean ('live' bean deleted first)

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -87,7 +87,7 @@ public final class DefaultPersister implements Persister {
   private int executeOrQueue(PersistRequest request) {
     try {
       request.initTransIfRequired();
-      request.transaction().markNotQueryOnly();
+      request.markNotQueryOnly();
       int rc = request.executeOrQueue();
       request.commitTransIfRequired();
       return rc;
@@ -384,7 +384,7 @@ public final class DefaultPersister implements Persister {
     req.checkDraft();
     try {
       req.initTransIfRequiredWithBatchCascade();
-      req.transaction().markNotQueryOnly();
+      req.markNotQueryOnly();
       if (req.isReference()) {
         // its a reference so see if there are manys to save...
         if (req.isPersistCascade()) {
@@ -432,7 +432,7 @@ public final class DefaultPersister implements Persister {
     }
     try {
       req.initTransIfRequiredWithBatchCascade();
-      req.transaction().markNotQueryOnly();
+      req.markNotQueryOnly();
       insert(req);
       req.resetDepth();
       req.commitTransIfRequired();
@@ -565,7 +565,7 @@ public final class DefaultPersister implements Persister {
     }
     try {
       req.initTransIfRequiredWithBatchCascade();
-      req.transaction().markNotQueryOnly();
+      req.markNotQueryOnly();
       int rows = delete(req);
       if (draftReq != null) {
         // delete the 'draft' bean ('live' bean deleted first)

--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/JdbcTransaction.java
@@ -417,6 +417,10 @@ class JdbcTransaction implements SpiTransaction, TxnProfileEventCodes {
   @Override
   public final void markNotQueryOnly() {
     this.queryOnly = false;
+    // if the transaction is readonly, it should not allow updates/deletes
+    if (localReadOnly){
+      throw new IllegalStateException("This transaction is read-only");
+    }
   }
 
   @Override

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionReadOnly.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionReadOnly.java
@@ -1,0 +1,31 @@
+package org.tests.transaction;
+
+import io.ebean.DB;
+import io.ebean.Transaction;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Customer;
+import org.tests.model.basic.ResetBasicData;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestTransactionReadOnly extends BaseTestCase {
+
+  @Test
+  public void testReadOnlyTransactionWithUpdateQuery() {
+
+    ResetBasicData.reset();
+
+    try (Transaction txn = DB.beginTransaction()) {
+      txn.setReadOnly(true);
+
+      assertThatThrownBy(() -> DB.update(Customer.class).set("name", "Rob2").where().eq("name", "Rob").update())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      txn.commit();
+    }
+
+  }
+
+}

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionReadOnly.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionReadOnly.java
@@ -4,8 +4,12 @@ import io.ebean.DB;
 import io.ebean.Transaction;
 import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Country;
 import org.tests.model.basic.Customer;
+import org.tests.model.basic.OrderDetail;
 import org.tests.model.basic.ResetBasicData;
+
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -20,6 +24,93 @@ public class TestTransactionReadOnly extends BaseTestCase {
       txn.setReadOnly(true);
 
       assertThatThrownBy(() -> DB.update(Customer.class).set("name", "Rob2").where().eq("name", "Rob").update())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.sqlUpdate("update o_customer set name = ? where name = ?")
+        .setParameter(1, "Rob2")
+        .setParameter(2, "Rob").execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.createUpdate(Customer.class, "update customer set name = ? where name = ?")
+        .setParameter(1, "Rob2")
+        .setParameter(2, "Rob").execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      Customer customer = DB.find(Customer.class).where().eq("name", "Rob").findOne();
+      customer.setName("Rob2");
+      assertThatThrownBy(() ->  DB.save(customer))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      txn.commit();
+    }
+
+  }
+
+  @Test
+  public void testReadOnlyTransactionWithDeleteQuery() {
+
+    ResetBasicData.reset();
+
+    try (Transaction txn = DB.beginTransaction()) {
+      txn.setReadOnly(true);
+
+      assertThatThrownBy(() -> DB.find(OrderDetail.class).where().eq("id", 1).delete())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.sqlUpdate("delete o_order_detail where id = ?")
+        .setParameter(1, 1).execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.createUpdate(OrderDetail.class, "delete o_order_detail where id = ?")
+        .setParameter(1, 1).execute())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      OrderDetail orderDetail = DB.find(OrderDetail.class).where().eq("id", 1).findOne();
+      assertThatThrownBy(() ->  DB.delete(orderDetail))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.deleteAll(Arrays.asList(orderDetail)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      txn.commit();
+    }
+
+  }
+
+  @Test
+  public void testReadOnlyTransactionWithInsertQuery() {
+
+    ResetBasicData.reset();
+
+    try (Transaction txn = DB.beginTransaction()) {
+      txn.setReadOnly(true);
+
+      Country country = new Country();
+      country.setName("Germany");
+      country.setCode("DE");
+
+      assertThatThrownBy(() ->  DB.save(country))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.saveAll(country))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.insert(country))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("This transaction is read-only");
+
+      assertThatThrownBy(() ->  DB.insertAll(Arrays.asList(country)))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("This transaction is read-only");
 


### PR DESCRIPTION
Hello @rbygrave ,

we have the following use case: in some cases we would like to allow the user to start a so-called test run, e.g. updating the user data using external LDAP. The test run does not perform any writing operations in the database, but returns a CSV file of what the updated data would look like. The user can then look at this CSV to see whether the update would be correct and whether they still need to tweak a few parameters of the LDAP import.

The use case runs in a transaction that could potentially be quite large. For this reason, we don't want to rely on a transaction rollback operation. We don't want to put unnecessary load on the database (our experience shows that this is particularly bad with too big DB2 transaction logs).

We tried `transaction.setReadOnly(true)` which did not reflect our expected results. We thought that if the transaction is in read-only mode and a write operation is called (update/delete), an exception will be thrown and the further process will be aborted.

I have developed a unit test and a possible solution proposal for this. Can you please take a look if it would go in the right direction?

We have chosen a central location that is called for updates/deletes: `markNotQueryOnly`. Here I queried the local variable because most connections (e.g. H2) don't notice this and `connection.isReadOnly` returns the wrong result.

Of course, as I receive feedback, I can create more tests and consider other implementations of the `markNotQueryOnly`.

What else we tried: we create the transaction with readonly scope as `try (Transaction txn = DB.beginTransaction(TxScope.required().setReadOnly(true))) { ...`. It works for a single tenant mode (such as the unittests) but it does not work in a multi tenant mode.

Cheers,
Noemi