### PR TITLE
fixed flaky test in ToStringBuilderTest.java

### DIFF
--- a/ebean-api/src/test/java/io/ebean/bean/ToStringBuilderTest.java
+++ b/ebean-api/src/test/java/io/ebean/bean/ToStringBuilderTest.java
@@ -213,7 +213,7 @@ class ToStringBuilderTest {
 
     final int id;
 
-    final Map<String, ParamValue> map = new HashMap<>();
+    final Map<String, ParamValue> map = new LinkedHashMap<>();
 
 
     ParamStore(final int id) {


### PR DESCRIPTION
The order of items in the `map` variable for the `ParamStore` class is indeterministic, causing the `map_recurse()` test case to sometimes fail. Since `map` is a HashMap and the items inside are unordered, the conversion to string doesn't always guarantee the same string.

This PR proposes to change the `map` variable from a HashMap to a LinkedHashMap, preserving the ordering of insertion and removing the flakiness of the test. 

This change was confirmed by running the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which explores and reports errors in different behaviors of under-determined Java APIs.

To reproduce this problem, you can run the test with NonDex using this command:

```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl ebean-api -Dtest=io.ebean.bean.ToStringBuilderTest#map_recurse
``` 
Here are screenshots of the outputs produced by NonDex before and after the fix: 

![image](https://github.com/user-attachments/assets/9a53b70e-b77a-4ace-9e90-29d3d14e1de2)

![image](https://github.com/user-attachments/assets/666152c9-ab01-494e-9abc-ce5ba2a02244)

Please let me know if you'd like to discuss the fix. 
