### PR TITLE
Fix SELF of QueryBuilder, QueryBean, IQueryBean for fluid use

### DIFF
--- a/ebean-api/src/main/java/io/ebean/QueryBuilder.java
+++ b/ebean-api/src/main/java/io/ebean/QueryBuilder.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
  * @param <SELF> The type of the builder
  * @param <T>    The entity bean type
  */
-public interface QueryBuilder<SELF, T> extends QueryBuilderProjection<SELF, T> {
+public interface QueryBuilder<SELF extends QueryBuilder<SELF, T>, T> extends QueryBuilderProjection<SELF, T> {
 
   /**
    * Set root table alias.

--- a/ebean-api/src/main/java/io/ebean/QueryBuilderProjection.java
+++ b/ebean-api/src/main/java/io/ebean/QueryBuilderProjection.java
@@ -6,7 +6,7 @@ package io.ebean;
  * @param <SELF> The builder type
  * @param <T>    The entity bean type
  */
-public interface QueryBuilderProjection<SELF, T> {
+public interface QueryBuilderProjection<SELF extends QueryBuilderProjection<SELF, T>, T> {
 
   /**
    * Apply the path properties replacing the select and fetch clauses.

--- a/ebean-api/src/main/resources/META-INF/ebean-version.mf
+++ b/ebean-api/src/main/resources/META-INF/ebean-version.mf
@@ -1,1 +1,1 @@
-ebean-version: 145
+ebean-version: 148

--- a/ebean-net-postgis-types/pom.xml
+++ b/ebean-net-postgis-types/pom.xml
@@ -78,7 +78,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.6.0</tile>
+            <tile>io.ebean.tile:enhancement:14.7.1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-postgis-types/pom.xml
+++ b/ebean-postgis-types/pom.xml
@@ -86,7 +86,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.6.0</tile>
+            <tile>io.ebean.tile:enhancement:14.7.1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-querybean/pom.xml
+++ b/ebean-querybean/pom.xml
@@ -100,7 +100,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.6.0</tile>
+            <tile>io.ebean.tile:enhancement:14.7.1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-querybean/src/main/java/io/ebean/typequery/IQueryBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/IQueryBean.java
@@ -44,7 +44,7 @@ import java.util.Collection;
  * @param <T> the entity bean type (normal entity bean type e.g. Customer)
  * @param <R> the specific query bean type (e.g. QCustomer)
  */
-public interface IQueryBean<T, R> extends QueryBuilder<R, T> {
+public interface IQueryBean<T, R extends IQueryBean<T, R>> extends QueryBuilder<R, T> {
 
   /**
    * Return the underlying query.
@@ -64,6 +64,7 @@ public interface IQueryBean<T, R> extends QueryBuilder<R, T> {
    *
    * @param properties The properties to include in the DISTINCT ON clause.
    */
+  @SuppressWarnings("unchecked")
   R distinctOn(TQProperty<R, ?>... properties);
 
   /**

--- a/ebean-querybean/src/main/java/io/ebean/typequery/QueryBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/QueryBean.java
@@ -57,7 +57,7 @@ import java.util.stream.Stream;
  * @param <R> the specific root query bean type (e.g. QCustomer)
  */
 @NonNullApi
-public abstract class QueryBean<T, R> implements IQueryBean<T, R> {
+public abstract class QueryBean<T, R extends QueryBean<T, R>> implements IQueryBean<T, R> {
 
   /**
    * The underlying query.

--- a/ebean-querybean/src/test/java/org/querytest/QueryAlsoIfTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QueryAlsoIfTest.java
@@ -1,5 +1,9 @@
 package org.querytest;
 
+import io.ebean.QueryBuilder;
+import io.ebean.QueryBuilderProjection;
+import io.ebean.typequery.IQueryBean;
+import io.ebean.typequery.QueryBean;
 import org.example.domain.Customer;
 import org.example.domain.query.QCustomer;
 import org.junit.jupiter.api.Test;
@@ -45,5 +49,30 @@ class QueryAlsoIfTest {
 
     q.findList();
     assertThat(q.getGeneratedSql()).isEqualTo("select /* QueryAlsoIfTest.notApply */ t0.id, t0.name from be_customer t0 where t0.name is not null");
+  }
+
+  @Test
+  void queryBuilders_expect_fluidUseOfSELF() {
+    var q = new QCustomer();
+    checkQueryBean(q);
+    checkIQueryBean(q);
+    checkQueryBuilder(q);
+    checkQueryBuilderProjection(q);
+  }
+
+  private void checkQueryBean(QueryBean<?, ?> queryBean) {
+    queryBean.setFirstRow(10).setMaxRows(10);
+  }
+
+  private void checkIQueryBean(IQueryBean<?, ?> iQueryBean) {
+    iQueryBean.setFirstRow(10).setMaxRows(20);
+  }
+
+  private void checkQueryBuilderProjection(QueryBuilderProjection<?, ?> queryBuilder) {
+    queryBuilder.fetch("a").fetch("b");
+  }
+
+  private void checkQueryBuilder(QueryBuilder<?,?> queryBuilder) {
+    queryBuilder.setFirstRow(10).setMaxRows(10);
   }
 }

--- a/ebean-redis/pom.xml
+++ b/ebean-redis/pom.xml
@@ -72,7 +72,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.6.0</tile>
+            <tile>io.ebean.tile:enhancement:14.7.1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-spring-txn/pom.xml
+++ b/ebean-spring-txn/pom.xml
@@ -99,7 +99,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.6.0</tile>
+            <tile>io.ebean.tile:enhancement:14.7.1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -309,7 +309,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.6.0</tile>
+            <tile>io.ebean.tile:enhancement:14.7.1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <ebean-migration.version>14.2.0</ebean-migration.version>
     <ebean-test-containers.version>7.4</ebean-test-containers.version>
     <ebean-datasource.version>9.0</ebean-datasource.version>
-    <ebean-agent.version>14.7.0</ebean-agent.version>
-    <ebean-maven-plugin.version>14.7.0</ebean-maven-plugin.version>
+    <ebean-agent.version>14.7.1</ebean-agent.version>
+    <ebean-maven-plugin.version>14.7.1</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>
   </properties>
 

--- a/tests/test-java16/pom.xml
+++ b/tests/test-java16/pom.xml
@@ -52,7 +52,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.6.0</tile>
+            <tile>io.ebean.tile:enhancement:14.7.1</tile>
           </tiles>
         </configuration>
       </plugin>


### PR DESCRIPTION
Currently, the SELF response type of QueryBuilder returns as Object when really we want it to return the SELF generic type of QueryBuilder, QueryBean, IQueryBean etc

Note that this change requires an updated ebean-agent