### PR TITLE
Potentially breaking change: Throw PersistenceException for unknown property in select clause

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -11,6 +11,7 @@ import io.ebeaninternal.server.deploy.InheritInfo;
 import io.ebeaninternal.server.deploy.TableJoin;
 import io.ebeaninternal.server.querydefn.OrmQueryDetail;
 import io.ebeaninternal.server.querydefn.OrmQueryProperties;
+import jakarta.persistence.PersistenceException;
 
 import java.util.*;
 
@@ -440,12 +441,9 @@ public final class SqlTreeBuilder {
 
     } else {
       // find the property including searching the
-      // sub class hierarchy if required
       STreeProperty p = desc.findPropertyWithDynamic(propName, queryProps.getPath());
       if (p == null) {
-        log.log(ERROR, "property [{0}] not found on {1} for query - excluding it.", propName, desc);
-        p = desc.findProperty("id");
-        selectProps.add(p);
+        throw new PersistenceException("Property not found - " + SplitName.add(queryProps.getPath(), propName));
 
       } else if (p.isId() && excludeIdProperty()) {
         // do not bother to include id for normal queries as the

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/WriteJsonTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/WriteJsonTest.java
@@ -12,14 +12,14 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class WriteJsonTest {
+class WriteJsonTest {
 
   @Test
-  public void test_push() {
+  void test_push() {
 
     ResetBasicData.reset();
 
-    FetchPath fetchPath = PathProperties.parse("id,status,name,customer(id,name,billingAddress(street,city)),details(qty,product(sku,prodName))");
+    FetchPath fetchPath = PathProperties.parse("id,status,customer(id,name,billingAddress(line1,city)),details(orderQty,product(sku,name))");
 
     Query<Order> query = DB.find(Order.class);
 

--- a/ebean-test/src/test/java/org/tests/basic/TestMappedSuper.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestMappedSuper.java
@@ -20,7 +20,7 @@ public class TestMappedSuper extends BaseTestCase {
     // select includes a transient property
     TMapSuperEntity e2 = DB.find(TMapSuperEntity.class)
       .where().idEq(e.getId())
-      .select("id, name, myint, someObject, bananan")
+      .select("id, name, myint, someObject")
       .findOne();
 
     assertNotNull(e2);

--- a/ebean-test/src/test/java/org/tests/model/noid/TestInsertNoIdBean.java
+++ b/ebean-test/src/test/java/org/tests/model/noid/TestInsertNoIdBean.java
@@ -2,9 +2,11 @@ package org.tests.model.noid;
 
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
+import jakarta.persistence.PersistenceException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TestInsertNoIdBean extends BaseTestCase {
 
@@ -18,5 +20,16 @@ class TestInsertNoIdBean extends BaseTestCase {
 
     int rowCount = DB.find(NoIdBean.class).findCount();
     assertThat(rowCount).isGreaterThan(0);
+  }
+
+  @Test
+  void testInvalidSelectColumn_expect_PersistenceException() {
+    assertThatThrownBy(() ->
+      DB.find(NoIdBean.class)
+        .select("does_not_exist_user_id, name")
+        .where().eq("name", "foo")
+        .findList()
+    ).isInstanceOf(PersistenceException.class)
+    .hasMessageContaining("Property not found - does_not_exist_user_id");
   }
 }

--- a/ebean-test/src/test/java/org/tests/query/TestInvalidFetchPath.java
+++ b/ebean-test/src/test/java/org/tests/query/TestInvalidFetchPath.java
@@ -9,10 +9,10 @@ import jakarta.persistence.PersistenceException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class TestInvalidFetchPath extends BaseTestCase {
+class TestInvalidFetchPath extends BaseTestCase {
 
   @Test
-  public void invalidFetchPathAndProperties_expect_error() {
+  void invalidFetchPathAndProperties_expect_error() {
     assertThrows(PersistenceException.class, () ->
       DB.find(Customer.class)
         .fetch("notValidPath", "notHaveProps")
@@ -20,7 +20,7 @@ public class TestInvalidFetchPath extends BaseTestCase {
   }
 
   @Test
-  public void invalidFetchPath_expect_error() {
+  void invalidFetchPath_expect_error() {
     assertThrows(PersistenceException.class, () ->
       DB.find(Customer.class)
         .fetch("notValidPath")
@@ -28,9 +28,10 @@ public class TestInvalidFetchPath extends BaseTestCase {
   }
 
   @Test
-  public void fetchWithInvalidPropertyName_expect_allowed() {
-    DB.find(Customer.class)
-      .fetch("billingAddress", "invalidPropertyName")
-      .findList();
+  void fetchWithInvalidPropertyName_expect_error() {
+    assertThrows(PersistenceException.class, () ->
+      DB.find(Customer.class)
+        .fetch("billingAddress", "invalidPropertyName")
+        .findList());
   }
 }

--- a/ebean-test/src/test/java/org/tests/types/TestFileType.java
+++ b/ebean-test/src/test/java/org/tests/types/TestFileType.java
@@ -14,10 +14,10 @@ import java.net.URL;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestFileType extends BaseTestCase {
+class TestFileType extends BaseTestCase {
 
-  private File file = getFile("/profile-image.jpg");
-  private File file2 = getFile("/java-64.png");
+  private final File file = getFile("/profile-image.jpg");
+  private final File file2 = getFile("/java-64.png");
 
   private File newTempFile() throws IOException {
     File tempFile = File.createTempFile("testfile", "txt");
@@ -113,7 +113,7 @@ public class TestFileType extends BaseTestCase {
     DB.save(bean0);
 
     SomeFileBean bean1 = DB.find(SomeFileBean.class)
-      .select("name, file")
+      .select("name, content")
       .setId(bean0.getId())
       .findOne();
 
@@ -124,7 +124,7 @@ public class TestFileType extends BaseTestCase {
     DB.save(bean1);
 
     SomeFileBean bean2 = DB.find(SomeFileBean.class)
-      .select("name, file")
+      .select("name, content")
       .setId(bean0.getId())
       .findOne();
 
@@ -146,7 +146,7 @@ public class TestFileType extends BaseTestCase {
     DB.save(bean0);
 
     SomeFileBean bean1 = DB.find(SomeFileBean.class)
-      .select("name, file")
+      .select("name, content")
       .setId(bean0.getId())
       .findOne();
 
@@ -161,7 +161,7 @@ public class TestFileType extends BaseTestCase {
 
 
     SomeFileBean bean2 = DB.find(SomeFileBean.class)
-      .select("name, file")
+      .select("name, content")
       .setId(bean0.getId())
       .findOne();
 
@@ -173,7 +173,7 @@ public class TestFileType extends BaseTestCase {
     DB.save(bean2);
 
     SomeFileBean bean3 = DB.find(SomeFileBean.class)
-      .select("name, file")
+      .select("name, content")
       .setId(bean0.getId())
       .findOne();
 
@@ -194,7 +194,7 @@ public class TestFileType extends BaseTestCase {
     DB.save(bean0);
 
     SomeFileBean bean1 = DB.find(SomeFileBean.class)
-        .select("name, file")
+        .select("name, content")
         .setId(bean0.getId())
         .findOne();
 

--- a/ebean-test/src/test/java/org/tests/types/TestFileTypeFetching.java
+++ b/ebean-test/src/test/java/org/tests/types/TestFileTypeFetching.java
@@ -48,7 +48,7 @@ public class TestFileTypeFetching extends BaseTestCase {
     DB.update(statelessUpdateBean);
 
     SomeFileBean bean2 = DB.find(SomeFileBean.class)
-      .select("file")
+      .select("content")
       .setId(bean0.getId())
       .findOne();
 


### PR DESCRIPTION
The prior behaviour was "relaxed" / "loose" in that it allowed unknown properties in the select clause to be ignored. 

At this stage, I think this was likely to be bad behaviour in that it might not be expected and people might be thinking that the select clause is successfully including a property that in fact was getting ignored.

If you have an application that hits this `PersistenceException("Property not found - ___")` exception and you don't like this change in behaviour, please get in touch and lets see. In theory this change should make the behaviour better but there might be code out there that is based on the assumption that the select clause is "relaxed" wrt unknown properties.