### PR TITLE
Fix: dynamic property group by with alias

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/DynamicPropertyAggregationFormula.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/DynamicPropertyAggregationFormula.java
@@ -63,6 +63,11 @@ class DynamicPropertyAggregationFormula extends DynamicPropertyBase {
   }
 
   @Override
+  public void appendGroupBy(DbSqlContext ctx, boolean subQuery) {
+    ctx.appendParseSelect(parsedFormula, null);
+  }
+
+  @Override
   public boolean isLobForPlatform() {
     return false;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/STreeProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/STreeProperty.java
@@ -93,6 +93,13 @@ public interface STreeProperty extends ScalarDataReader<Object> {
   void appendSelect(DbSqlContext ctx, boolean subQuery);
 
   /**
+   * Append to group by.
+   */
+  default void appendGroupBy(DbSqlContext ctx, boolean subQuery) {
+    appendSelect(ctx, subQuery);
+  }
+
+  /**
    * Append to the from clause.
    */
   void appendFrom(DbSqlContext ctx, SqlJoinType joinType, String manyWhere);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeBean.java
@@ -163,7 +163,7 @@ class SqlTreeNodeBean implements SqlTreeNode {
     }
     for (STreeProperty property : properties) {
       if (!property.isAggregation()) {
-        property.appendSelect(ctx, subQuery);
+        property.appendGroupBy(ctx, subQuery);
       }
     }
     for (SqlTreeNode child : children) {

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQuery2Test.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQuery2Test.java
@@ -1,5 +1,7 @@
 package io.ebean.xtest.base;
 
+import io.ebean.DB;
+import io.ebean.Query;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DtoQuery;
 import io.ebean.QueryIterator;
@@ -9,6 +11,7 @@ import io.ebean.test.LoggedSql;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.tests.model.basic.Contact;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
 
@@ -406,6 +409,22 @@ public class DtoQuery2Test extends BaseTestCase {
     assertThat(robs).isNotEmpty();
   }
 
+  @Test
+  void dto_test_formula_with_group_by() {
+    ResetBasicData.reset();
+
+    Query<Contact> query = server().find(Contact.class)
+      .select("concat(first_name, last_name) as custname, count(*) as cnt")
+      .orderBy("custname desc");
+
+    List<DCustFormula> ret = query.asDto(DCustFormula.class).findList();
+
+    log.info(query.getGeneratedSql());
+    log.info(ret.toString());
+    assertThat(ret.get(0).getCustname()).isEqualTo("TracyRed");
+    assertThat(ret.get(0).getCnt()).isEqualTo(1L);
+  }
+
   public static class DCust {
 
     final Integer id;
@@ -612,6 +631,35 @@ public class DtoQuery2Test extends BaseTestCase {
     public DCustCamelCols2 setNameFORMe(String nameFORMe) {
       this.nameFORMe = nameFORMe;
       return this;
+    }
+  }
+
+  public static class DCustFormula {
+
+    String custname;
+    Long cnt;
+
+    public DCustFormula() {}
+
+    public void setCustname(String custname) {
+      this.custname = custname;
+    }
+
+    public String getCustname() {
+      return custname;
+    }
+
+    public void setCnt(Long cnt) {
+      this.cnt = cnt;
+    }
+
+    public Long getCnt() {
+      return cnt;
+    }
+
+    @Override
+    public String toString() {
+      return getCustname() + ": " + getCnt();
     }
   }
 }


### PR DESCRIPTION
If I use formula in dto queries e.g. concat(...) and i want count them,
I have to specify an alias to map it to the dto.
Then this alias will be put into the group by clause additionally to the formula, this leads to an incorrect query.
see the test


I have implemented an easy fix for this.