### PR TITLE
Replaced .order() with .orderBy()

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DB.java
+++ b/ebean-api/src/main/java/io/ebean/DB.java
@@ -605,7 +605,7 @@ public final class DB {
    *   // find orders and their customers
    *   List<Order> list = DB.find(Order.class)
    *     .fetch("customer")
-   *     .order("id")
+   *     .orderBy("id")
    *     .findList();
    *
    *   // sort by customer name ascending, then by order shipDate

--- a/ebean-api/src/main/java/io/ebean/Database.java
+++ b/ebean-api/src/main/java/io/ebean/Database.java
@@ -400,7 +400,7 @@ public interface Database {
    *   // find orders and their customers
    *   List<Order> list = database.find(Order.class)
    *     .fetch("customer")
-   *     .order("id")
+   *     .orderBy("id")
    *     .findList();
    *
    *   // sort by customer name ascending, then by order shipDate

--- a/ebean-api/src/main/java/io/ebean/ExpressionList.java
+++ b/ebean-api/src/main/java/io/ebean/ExpressionList.java
@@ -355,7 +355,7 @@ public interface ExpressionList<T> {
    *  List<String> names =
    *    DB.find(Customer.class)
    *      .select("name")
-   *      .order().asc("name")
+   *      .orderBy().asc("name")
    *      .findSingleAttributeList();
    *
    * }</pre>
@@ -368,7 +368,7 @@ public interface ExpressionList<T> {
    *      .setDistinct(true)
    *      .select("name")
    *      .where().eq("status", Customer.Status.NEW)
-   *      .order().asc("name")
+   *      .orderBy().asc("name")
    *      .setMaxRows(100)
    *      .findSingleAttributeList();
    *
@@ -1713,7 +1713,7 @@ public interface ExpressionList<T> {
    *        .eq("status", Customer.Status.ACTIVE)
    *        .gt("id", 0)
    *        .endAnd()
-   *      .order().asc("name")
+   *      .orderBy().asc("name")
    *      .findList();
    * }</pre>
    */
@@ -1734,7 +1734,7 @@ public interface ExpressionList<T> {
    *    .or()
    *      .eq("status", Customer.Status.ACTIVE)
    *      .isNull("anniversary")
-   *    .order().asc("name")
+   *    .orderBy().asc("name")
    *    .findList();
    *
    * }</pre>
@@ -1754,7 +1754,7 @@ public interface ExpressionList<T> {
    *        .eq("status", Customer.Status.ACTIVE)
    *        .gt("id", 0)
    *        .endAnd()
-   *      .order().asc("name")
+   *      .orderBy().asc("name")
    *      .findList();
    *
    * }</pre>
@@ -1788,7 +1788,7 @@ public interface ExpressionList<T> {
    *       .gt("id", 1)
    *       .eq("anniversary", onAfter)
    *       .endNot()
-   *     .order()
+   *     .orderBy()
    *       .asc("name")
    *     .findList();
    *

--- a/ebean-api/src/main/java/io/ebean/Finder.java
+++ b/ebean-api/src/main/java/io/ebean/Finder.java
@@ -35,7 +35,7 @@ import java.util.List;
  *   public List<Customer> findNew() {
  *     return query().where()
  *       .eq("status", Customer.Status.NEW)
- *       .order("name")
+ *       .orderBy("name")
  *       .findList()
  *   }
  * }

--- a/ebean-api/src/main/java/io/ebean/Junction.java
+++ b/ebean-api/src/main/java/io/ebean/Junction.java
@@ -61,7 +61,7 @@ package io.ebean;
  *            .eq("status", Customer.Status.ACTIVE)
  *            .gt("id", 0)
  *            .endAnd()
- *      .order().asc("name");
+ *      .orderBy().asc("name");
  *
  * q.findList();
  * String s = q.getGeneratedSql();

--- a/ebean-api/src/main/java/io/ebean/PagedList.java
+++ b/ebean-api/src/main/java/io/ebean/PagedList.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
  *
  *     PagedList<Order> pagedList = DB.find(Order.class)
  *       .where().eq("status", Order.Status.NEW)
- *       .order().asc("id")
+ *       .orderBy().asc("id")
  *       .setFirstRow(0)
  *       .setMaxRows(50)
  *       .findPagedList();

--- a/ebean-api/src/main/java/io/ebean/Pairs.java
+++ b/ebean-api/src/main/java/io/ebean/Pairs.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  *   .where()
  *   .eq("store", "def")
  *   .inPairs(pairs)       // IN clause with 'pairs' of values
- *   .order("sku desc")
+ *   .orderBy("sku desc")
  *
  *   // query expressions cover the natural key properties
  *   // so we can choose to hit the L2 bean cache if we want

--- a/ebean-api/src/main/java/io/ebean/Query.java
+++ b/ebean-api/src/main/java/io/ebean/Query.java
@@ -13,7 +13,7 @@ import org.jspecify.annotations.NullMarked;
  *     .where()
  *       .like("customer.name","rob%")
  *       .gt("orderDate",lastWeek)
- *     .order("customer.id, id desc")
+ *     .orderBy("customer.id, id desc")
  *     .setMaxRows(50)
  *     .findList();
  *

--- a/ebean-api/src/main/java/io/ebean/QueryIterator.java
+++ b/ebean-api/src/main/java/io/ebean/QueryIterator.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
  *
  *  Query<Customer> query = database.find(Customer.class)
  *     .where().gt("id", 0)
- *     .order("id")
+ *     .orderBy("id")
  *     .setMaxRows(2);
  *
  *  QueryIterator<Customer> it = query.findIterate();

--- a/ebean-api/src/main/java/io/ebean/RawSql.java
+++ b/ebean-api/src/main/java/io/ebean/RawSql.java
@@ -111,7 +111,7 @@ package io.ebean;
  *     .fetch("order.customer", "name")
  *     .where().gt("order.id", 0)
  *     .having().gt("totalAmount", 20)
- *     .order().desc("totalAmount")
+ *     .orderBy().desc("totalAmount")
  *     .setMaxRows(10)
  *     .findList();
  *

--- a/ebean-api/src/main/java/io/ebean/text/json/package-info.java
+++ b/ebean-api/src/main/java/io/ebean/text/json/package-info.java
@@ -15,7 +15,7 @@
  *     .fetch("billingAddress","line1, city")
  *     .fetch("billingAddress.country", "*")
  *     .fetch("contacts", "firstName,email")
- *     .order().desc("id")
+ *     .orderBy().desc("id")
  *     .findList();
  *
  * JsonContext json = DB.json();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -3186,8 +3186,8 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
    * provides unique ordering of the rows (so that the paging is predicable).
    */
   public void appendOrderById(SpiQuery<T> query) {
-    if (idProperty != null && !idProperty.isEmbedded() && !query.order().containsProperty(idProperty.name())) {
-      query.order().asc(idProperty.name());
+    if (idProperty != null && !idProperty.isEmbedded() && !query.orderBy().containsProperty(idProperty.name())) {
+      query.orderBy().asc(idProperty.name());
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/expression/FilterExpressionList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/expression/FilterExpressionList.java
@@ -172,7 +172,7 @@ public final class FilterExpressionList<T> extends DefaultExpressionList<T> {
       query.setMaxRows(maxRows);
     }
     if (orderByClause != null) {
-      query.order(orderByClause);
+      query.orderBy(orderByClause);
     }
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/grammer/EqlAdapter.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/grammer/EqlAdapter.java
@@ -152,7 +152,7 @@ class EqlAdapter<T> extends EqlWhereListener<T> {
       }
     }
 
-    query.order().add(new OrderBy.Property(path, asc, nulls, nullsFirstLast));
+    query.orderBy().add(new OrderBy.Property(path, asc, nulls, nullsFirstLast));
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -240,7 +240,7 @@ public final class CQueryEngine {
     }
 
     // order by lower sys period desc
-    query.order().desc(sysPeriodLower);
+    query.orderBy().desc(sysPeriodLower);
     CQuery<T> cquery = queryBuilder.buildQuery(request);
     request.setCancelableQuery(cquery);
     try {

--- a/ebean-core/src/test/java/io/ebeaninternal/server/querydefn/OrmQueryPlanKeyTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/querydefn/OrmQueryPlanKeyTest.java
@@ -151,11 +151,11 @@ public class OrmQueryPlanKeyTest extends BaseTest {
   @Test
   public void equals_when_diffOrderByNull() {
 
-    CQueryPlanKey key1 = planKey(query().order("id"));
+    CQueryPlanKey key1 = planKey(query().orderBy("id"));
     CQueryPlanKey key2 = planKey(query());
     assertDifferent(key1, key2);
 
-    key1 = planKey(query().order().asc("id"));
+    key1 = planKey(query().orderBy().asc("id"));
     key2 = planKey(query());
     assertDifferent(key1, key2);
   }
@@ -163,8 +163,8 @@ public class OrmQueryPlanKeyTest extends BaseTest {
   @Test
   public void equals_when_orderBySame() {
 
-    CQueryPlanKey key1 = planKey(query().order("id, name"));
-    CQueryPlanKey key2 = planKey(query().order("id, name"));
+    CQueryPlanKey key1 = planKey(query().orderBy("id, name"));
+    CQueryPlanKey key2 = planKey(query().orderBy("id, name"));
     assertSame(key1, key2);
   }
 

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQPropertyBase.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQPropertyBase.java
@@ -29,7 +29,7 @@ public abstract class TQPropertyBase<R, T> extends TQProperty<R, T> {
    * Order by ascending on this property.
    */
   public final R asc() {
-    expr().order().asc(_name);
+    expr().orderBy().asc(_name);
     return _root;
   }
 
@@ -37,7 +37,7 @@ public abstract class TQPropertyBase<R, T> extends TQProperty<R, T> {
    * Order by descending on this property.
    */
   public final R desc() {
-    expr().order().desc(_name);
+    expr().orderBy().desc(_name);
     return _root;
   }
 

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
@@ -57,7 +57,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
       DB.find(Contact.class)
         .setProfileLocation(loc0)
         .select("email, " + concat("lastName", ", ", "firstName") + " as fullName").where()
-        .istartsWith(concat("lastName", ", ", "firstName"), val).order().asc("lastName").setMaxRows(10)
+        .istartsWith(concat("lastName", ", ", "firstName"), val).orderBy().asc("lastName").setMaxRows(10)
         .asDto(ContactDto.class).setLabel("prefixLoop").findList();
     }
 
@@ -196,7 +196,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
     LoggedSql.start();
 
     DtoQuery<ContactDto2> query = DB.find(Contact.class)
-      .where().isNotNull("email").order().asc("lastName")
+      .where().isNotNull("email").orderBy().asc("lastName")
       .asDto(ContactDto2.class)
       .setRelaxedMode();
 
@@ -226,7 +226,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
       .where()
       .isNotNull("email")
       .isNotNull("lastName")
-      .order().asc("lastName")
+      .orderBy().asc("lastName")
       .asDto(ContactDto.class);
 
     List<ContactDto> dtos = query.findList();
@@ -288,7 +288,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
 
     List<ContactDto> contactDtos = DB.find(Contact.class)
       .select("id, email, " + concat("lastName", ", ", "firstName") + " as fullName").where().isNotNull("email")
-      .isNotNull("lastName").order().asc("lastName").setMaxRows(10).asDto(ContactDto.class).findList();
+      .isNotNull("lastName").orderBy().asc("lastName").setMaxRows(10).asDto(ContactDto.class).findList();
 
     assertThat(contactDtos).isNotEmpty();
 
@@ -317,7 +317,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
     LoggedSql.start();
 
     List<ContactDto> contactDtos = DB.find(Contact.class)
-      .select(concat("lastName", ", ", "firstName") + " as fullName").where().isNotNull("lastName").order()
+      .select(concat("lastName", ", ", "firstName") + " as fullName").where().isNotNull("lastName").orderBy()
       .asc("lastName").asDto(ContactDto.class).setFirstRow(2).setMaxRows(5).findList();
 
     assertThat(contactDtos).isNotEmpty();
@@ -340,7 +340,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
     LoggedSql.start();
 
     List<ContactTotals> contactDtos = DB.find(Contact.class).select("lastName, count(*) as totalCount").where()
-      .isNotNull("lastName").having().gt("count(*)", 1).order().desc("count(*)").asDto(ContactTotals.class)
+      .isNotNull("lastName").having().gt("count(*)", 1).orderBy().desc("count(*)").asDto(ContactTotals.class)
       .findList();
 
     assertThat(contactDtos).isNotEmpty();

--- a/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServer_eqlTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServer_eqlTest.java
@@ -133,7 +133,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
     query.setMaxRows(10);
     query.setFirstRow(3);
     if (isSqlServer()) {
-      query.order("id");
+      query.orderBy("id");
     }
     query.findList();
 
@@ -213,7 +213,7 @@ public class EbeanServer_eqlTest extends BaseTestCase {
     ResetBasicData.reset();
 
     Query<Customer> name = server().createNamedQuery(Customer.class, "withStatus");
-    name.order().clear().asc("status");
+    name.orderBy().clear().asc("status");
     name.findList();
 
     assertThat(sqlOf(name, 2)).contains("select t0.id, t0.name, t0.status from o_customer t0 order by t0.status");

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/TestJsonWriteVisitor.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/TestJsonWriteVisitor.java
@@ -26,7 +26,7 @@ public class TestJsonWriteVisitor extends BaseTestCase {
       .fetch("billingAddress", "line1, city")
       .fetch("billingAddress.country", "*")
       .fetch("contacts", "firstName,email")
-      .order().desc("id")
+      .orderBy().desc("id")
       .findList();
 
     JsonContext json = DB.json();

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/TestTextJsonBeanReadVisitor.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/text/json/TestTextJsonBeanReadVisitor.java
@@ -30,7 +30,7 @@ public class TestTextJsonBeanReadVisitor extends BaseTestCase {
       .fetch("billingAddress", "line1, city")
       .fetch("billingAddress.country", "*")
       .fetch("contacts", "firstName,email")
-      .order().desc("id")
+      .orderBy().desc("id")
       .findList();
 
     JsonContext json = DB.json();

--- a/ebean-test/src/test/java/org/tests/aggregateformula/TestAggregateFormula.java
+++ b/ebean-test/src/test/java/org/tests/aggregateformula/TestAggregateFormula.java
@@ -26,7 +26,7 @@ public class TestAggregateFormula extends BaseTestCase {
     List<Contact> contacts = DB.find(Contact.class)
       .setDistinct(true)
       .select("lastName, min(customer)")
-      .order("min(customer) asc nulls last")
+      .orderBy("min(customer) asc nulls last")
       .findList();
 
     List<String> sql = LoggedSql.stop();

--- a/ebean-test/src/test/java/org/tests/basic/MainDbBoolean.java
+++ b/ebean-test/src/test/java/org/tests/basic/MainDbBoolean.java
@@ -118,7 +118,7 @@ public class MainDbBoolean {
 
     List<TOne> list = server.find(TOne.class)
       .setAutoTune(false)
-      .order("id")
+      .orderBy("id")
       .findList();
 
     assertThat(list).hasSize(2);
@@ -135,7 +135,7 @@ public class MainDbBoolean {
 
     Query<TOne> query = server.find(TOne.class)
       .setAutoTune(false)
-      .order("id");
+      .orderBy("id");
 
     int rc = query.findCount();
     assertThat(rc).isGreaterThan(0);

--- a/ebean-test/src/test/java/org/tests/basic/TestLazyLoadInCache.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLazyLoadInCache.java
@@ -25,7 +25,7 @@ public class TestLazyLoadInCache extends BaseTestCase {
       .select("id, name")
       .setBeanCacheMode(CacheMode.PUT)
       .setReadOnly(true)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findMap();
 
     assertFalse(map.isEmpty());

--- a/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLimitQuery.java
@@ -36,7 +36,7 @@ public class TestLimitQuery extends BaseTestCase {
       .where().gt("details.id", 0)
       .setMaxRows(0)
       .setFirstRow(3)
-      .order().asc("orderDate");
+      .orderBy().asc("orderDate");
 
     query.findList();
 

--- a/ebean-test/src/test/java/org/tests/basic/TestLoadBeanCache.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestLoadBeanCache.java
@@ -36,7 +36,7 @@ class TestLoadBeanCache extends BaseTestCase {
       .setBeanCacheMode(CacheMode.PUT)
       .setUseQueryCache(true)
       .setReadOnly(true)
-      .order("name")
+      .orderBy("name")
       .findMap();
 
     Country loadedNz = map.get("NZ");

--- a/ebean-test/src/test/java/org/tests/basic/TestManyLazyLoad.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestManyLazyLoad.java
@@ -21,7 +21,7 @@ public class TestManyLazyLoad extends BaseTestCase {
 
     awaitL2Cache();
 
-    List<Order> list = DB.find(Order.class).order().asc("id").findList();
+    List<Order> list = DB.find(Order.class).orderBy().asc("id").findList();
     assertFalse(list.isEmpty());
 
     // just use the first one

--- a/ebean-test/src/test/java/org/tests/basic/TestQueryWhereBetween.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestQueryWhereBetween.java
@@ -25,7 +25,7 @@ public class TestQueryWhereBetween extends BaseTestCase {
     Timestamp t = new Timestamp(System.currentTimeMillis());
 
     Query<Order> query = DB.find(Order.class).setAutoTune(false).where()
-      .betweenProperties("cretime", "updtime", t).order().asc("orderDate").order().desc("id");
+      .betweenProperties("cretime", "updtime", t).orderBy().asc("orderDate").orderBy().desc("id");
 
     query.findList();
 
@@ -91,8 +91,8 @@ public class TestQueryWhereBetween extends BaseTestCase {
     Query<Order> query = DB.find(Order.class).setAutoTune(false)
       .where()
       .le("cretime", t)
-      .order().asc("orderDate")
-      .order().desc("id");
+      .orderBy().asc("orderDate")
+      .orderBy().desc("id");
 
     query.findList();
 

--- a/ebean-test/src/test/java/org/tests/batchload/TestBasicLazy.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestBasicLazy.java
@@ -22,7 +22,7 @@ public class TestBasicLazy extends BaseTestCase {
 
     ResetBasicData.reset();
 
-    Order order = DB.find(Order.class).select("totalAmount").setMaxRows(1).order("id")
+    Order order = DB.find(Order.class).select("totalAmount").setMaxRows(1).orderBy("id")
       .findOne();
 
     assertNotNull(order);
@@ -70,7 +70,7 @@ public class TestBasicLazy extends BaseTestCase {
   public void testRaceCondition_Simple() throws Throwable {
     ResetBasicData.reset();
 
-    Order order = DB.find(Order.class).select("totalAmount").setMaxRows(1).order("id")
+    Order order = DB.find(Order.class).select("totalAmount").setMaxRows(1).orderBy("id")
       .findOne();
 
     assertNotNull(order);

--- a/ebean-test/src/test/java/org/tests/batchload/TestBatchLazyWithCacheHits.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestBatchLazyWithCacheHits.java
@@ -46,7 +46,7 @@ public class TestBatchLazyWithCacheHits extends BaseTestCase {
     List<UUOne> list = DB.find(UUOne.class)
       .select("id")
       .where().startsWith("name", "testBLWCH")
-      .order("name")
+      .orderBy("name")
       .findList();
 
     // invoke lazy loading

--- a/ebean-test/src/test/java/org/tests/batchload/TestBatchLazyWithDeleted.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestBatchLazyWithDeleted.java
@@ -47,7 +47,7 @@ public class TestBatchLazyWithDeleted extends BaseTestCase {
     List<UUTwo> list = DB.find(UUTwo.class)
       .fetchLazy("master")
       .where().startsWith("name", "two-bld-")
-      .order("name")
+      .orderBy("name")
       .findList();
 
     // delete a bean that will be batch lazy loaded but

--- a/ebean-test/src/test/java/org/tests/batchload/TestBeanState.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestBeanState.java
@@ -72,7 +72,7 @@ class TestBeanState extends BaseTestCase {
 
   @Test
   void setDisableLazyLoad_expect_lazyLoadingDisabled() {
-    List<Customer> custs = DB.find(Customer.class).order("id").findList();
+    List<Customer> custs = DB.find(Customer.class).orderBy("id").findList();
 
     Customer customer = DB.find(Customer.class)
       .setId(custs.get(0).getId())
@@ -88,7 +88,7 @@ class TestBeanState extends BaseTestCase {
   @Test
   void changedProps_when_setManyProperty() {
 
-    Customer customer = DB.find(Customer.class).order("id").setMaxRows(1).findOne();
+    Customer customer = DB.find(Customer.class).orderBy("id").setMaxRows(1).findOne();
 
     BeanState beanState = DB.beanState(customer);
     assertThat(beanState.changedProps()).isEmpty();

--- a/ebean-test/src/test/java/org/tests/batchload/TestLazyJoin.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestLazyJoin.java
@@ -24,7 +24,7 @@ public class TestLazyJoin extends BaseTestCase {
       .select("status")
       .fetchLazy("customer", "name, status")
       .fetch("customer.contacts")
-      .order().asc("id");
+      .orderBy().asc("id");
 
     List<Order> list = query.findList();
 

--- a/ebean-test/src/test/java/org/tests/batchload/TestLazyJoin2.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestLazyJoin2.java
@@ -25,7 +25,7 @@ public class TestLazyJoin2 extends BaseTestCase {
 
       .fetchQuery("customer", "name")
       .fetch("customer.contacts", "firstName, lastName, mobile")
-      .fetch("customer.shippingAddress", "line1, city").order().asc("id").findList();
+      .fetch("customer.shippingAddress", "line1, city").orderBy().asc("id").findList();
 
     Order o0 = l0.get(0);
     Customer c0 = o0.getCustomer();
@@ -40,7 +40,7 @@ public class TestLazyJoin2 extends BaseTestCase {
 
     List<Order> orders = DB.find(Order.class)
       // .select("status")
-      .fetchQuery("customer").order().asc("id").findList();
+      .fetchQuery("customer").orderBy().asc("id").findList();
     // .join("customer.contacts");
 
     // List<Order> list = query.findList();
@@ -58,7 +58,7 @@ public class TestLazyJoin2 extends BaseTestCase {
 
     List<Order> list = DB.find(Order.class).fetchLazy("customer", "name")
       .fetch("customer.contacts", "contactName, phone, email").fetch("customer.shippingAddress")
-      .where().eq("status", Order.Status.NEW).order().asc("id").findList();
+      .where().eq("status", Order.Status.NEW).orderBy().asc("id").findList();
 
     Order order2 = list.get(0);
     Customer customer2 = order2.getCustomer();

--- a/ebean-test/src/test/java/org/tests/batchload/TestQueryDisableLazyLoad.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestQueryDisableLazyLoad.java
@@ -25,7 +25,7 @@ public class TestQueryDisableLazyLoad extends BaseTestCase {
 
     List<Order> l0 = DB.find(Order.class)
       .setDisableLazyLoading(true)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(l0).isNotEmpty();
@@ -51,7 +51,7 @@ public class TestQueryDisableLazyLoad extends BaseTestCase {
 
     List<Order> l0 = DB.find(Order.class)
       .setDisableLazyLoading(true)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(l0).isNotEmpty();
@@ -75,7 +75,7 @@ public class TestQueryDisableLazyLoad extends BaseTestCase {
     List<Order> l0 = DB.find(Order.class)
       .setDisableLazyLoading(true)
       .fetch("customer", "smallnote")
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(l0).isNotEmpty();

--- a/ebean-test/src/test/java/org/tests/batchload/TestQueryJoin.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestQueryJoin.java
@@ -30,7 +30,7 @@ public class TestQueryJoin extends BaseTestCase {
 
     Query<Order> query = DB.find(Order.class).select("status")
       .fetchLazy("customer", "name, status")
-      .fetch("customer.contacts").order().asc("id");
+      .fetch("customer.contacts").orderBy().asc("id");
 
     List<Order> list = query.findList();
 

--- a/ebean-test/src/test/java/org/tests/batchload/TestQueryJoinToAssocOne.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestQueryJoinToAssocOne.java
@@ -84,7 +84,7 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
       .select("status, shipDate")
       .fetchQuery("details", "orderQty, unitPrice")
       .fetch("details.product", "sku, name")
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(l0).isNotEmpty();
@@ -122,7 +122,7 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
     List<Order> l0 = DB.find(Order.class)
       .setDisableLazyLoading(true)
       .select("status, shipDate")
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(l0).isNotEmpty();

--- a/ebean-test/src/test/java/org/tests/cache/TestCacheCollectionIds.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestCacheCollectionIds.java
@@ -33,7 +33,7 @@ class TestCacheCollectionIds extends BaseTestCase {
     custManyIdsCache.clear();
 
     List<Customer> list = DB.find(Customer.class).setAutoTune(false).setBeanCacheMode(CacheMode.PUT)
-      .order().asc("id").findList();
+      .orderBy().asc("id").findList();
 
     assertTrue(list.size() > 1);
     // Assert.assertEquals(list.size(),

--- a/ebean-test/src/test/java/org/tests/cache/TestQueryCacheCountry.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestQueryCacheCountry.java
@@ -35,7 +35,7 @@ public class TestQueryCacheCountry extends BaseTestCase {
     List<Country> countryList0 = DB.find(Country.class)
       .setUseQueryCache(true)
       .where().startsWith("name", "XLKMG")
-      .order().asc("name")
+      .orderBy().asc("name")
       .findList();
 
     assertThat(countryList0).isEmpty();
@@ -47,7 +47,7 @@ public class TestQueryCacheCountry extends BaseTestCase {
     List<Country> countryList1 = DB.find(Country.class)
       .setUseQueryCache(true)
       .where().startsWith("name", "XLKMG")
-      .order().asc("name")
+      .orderBy().asc("name")
       .findList();
 
     assertThat(countryList1).isEmpty();
@@ -124,7 +124,7 @@ public class TestQueryCacheCountry extends BaseTestCase {
 
     List<Country> countryList0 = DB.find(Country.class)
       .setUseQueryCache(true)
-      .order().asc("name")
+      .orderBy().asc("name")
       .findList();
 
     assertEquals(1, queryCache.statistics(false).getSize());
@@ -132,7 +132,7 @@ public class TestQueryCacheCountry extends BaseTestCase {
 
     List<Country> countryList1 = DB.find(Country.class)
       .setUseQueryCache(true)
-      .order().asc("name")
+      .orderBy().asc("name")
       .findList();
 
     ServerCacheStatistics statistics = queryCache.statistics(false);
@@ -150,7 +150,7 @@ public class TestQueryCacheCountry extends BaseTestCase {
 
     List<Country> countryList2 = DB.find(Country.class)
       .setUseQueryCache(true)
-      .order().asc("name")
+      .orderBy().asc("name")
       .findList();
 
     assertNotSame(countryList2, countryList0);

--- a/ebean-test/src/test/java/org/tests/compositekeys/TestCKeyLazyLoad.java
+++ b/ebean-test/src/test/java/org/tests/compositekeys/TestCKeyLazyLoad.java
@@ -93,7 +93,7 @@ public class TestCKeyLazyLoad extends BaseTestCase {
   private void exerciseMaxRowsQuery_with_embeddedId() {
 
     PagedList<CKeyParent> siteUserPage = DB.find(CKeyParent.class).where()
-      .order("name asc")
+      .orderBy("name asc")
       .setMaxRows(10)
       .findPagedList();
     siteUserPage.getList();

--- a/ebean-test/src/test/java/org/tests/compositekeys/TestCore.java
+++ b/ebean-test/src/test/java/org/tests/compositekeys/TestCore.java
@@ -142,7 +142,7 @@ public class TestCore extends BaseTestCase {
   @Test
   public void testEmbeddedWithOrder() {
 
-    List<Item> items = server().find(Item.class).order("auditInfo.created asc, type asc").findList();
+    List<Item> items = server().find(Item.class).orderBy("auditInfo.created asc, type asc").findList();
 
     assertNotNull(items);
     assertEquals(2, items.size());
@@ -151,7 +151,7 @@ public class TestCore extends BaseTestCase {
   @Test
   public void testFindAndOrderByEType() {
 
-    List<Item> items = server().find(Item.class).order("eType").findList();
+    List<Item> items = server().find(Item.class).orderBy("eType").findList();
 
     assertNotNull(items);
     assertEquals(2, items.size());

--- a/ebean-test/src/test/java/org/tests/draftable/LinkQueryPublishTest.java
+++ b/ebean-test/src/test/java/org/tests/draftable/LinkQueryPublishTest.java
@@ -45,7 +45,7 @@ public class LinkQueryPublishTest {
 
     Query<Link> pubQuery = server.find(Link.class)
       .where().idIn(ids)
-      .order().asc("id");
+      .orderBy().asc("id");
 
 
     List<Link> pubList = server.publish(pubQuery);

--- a/ebean-test/src/test/java/org/tests/expression/bitwise/TestBitwiseExpressions.java
+++ b/ebean-test/src/test/java/org/tests/expression/bitwise/TestBitwiseExpressions.java
@@ -55,7 +55,7 @@ class TestBitwiseExpressions extends BaseTestCase {
   void bitwiseAny() {
     List<BwBean> list = DB.find(BwBean.class)
       .where().bitwiseAny("flags", BwFlags.HAS_BULK + BwFlags.HAS_SIZE)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(3);
@@ -65,21 +65,21 @@ class TestBitwiseExpressions extends BaseTestCase {
 
     list = DB.find(BwBean.class)
       .where().bitwiseAny("flags", BwFlags.HAS_BULK + BwFlags.HAS_SIZE + BwFlags.HAS_COLOUR)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(4);
 
     list = DB.find(BwBean.class)
       .where().bitwiseAny("flags", BwFlags.HAS_SIZE + BwFlags.HAS_COLOUR)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(4);
 
     list = DB.find(BwBean.class)
       .where().bitwiseAny("flags", BwFlags.HAS_SIZE)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(2);
@@ -88,7 +88,7 @@ class TestBitwiseExpressions extends BaseTestCase {
 
     list = DB.find(BwBean.class)
       .where().bitwiseAny("flags", BwFlags.HAS_COLOUR)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(3);
@@ -108,7 +108,7 @@ class TestBitwiseExpressions extends BaseTestCase {
 
     list = DB.find(BwBean.class)
       .where().bitwiseAll("flags", BwFlags.HAS_BULK + BwFlags.HAS_COLOUR)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(2);
@@ -117,7 +117,7 @@ class TestBitwiseExpressions extends BaseTestCase {
 
     list = DB.find(BwBean.class)
       .where().bitwiseAll("flags", BwFlags.HAS_SIZE)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(2);
@@ -126,7 +126,7 @@ class TestBitwiseExpressions extends BaseTestCase {
 
     list = DB.find(BwBean.class)
       .where().bitwiseAll("flags", BwFlags.HAS_COLOUR)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertThat(list).hasSize(3);

--- a/ebean-test/src/test/java/org/tests/inheritance/TestInheritanceBatchLazyLoad.java
+++ b/ebean-test/src/test/java/org/tests/inheritance/TestInheritanceBatchLazyLoad.java
@@ -30,7 +30,7 @@ public class TestInheritanceBatchLazyLoad {
     List<Vehicle> list = DB.find(Vehicle.class)
       .select("licenseNumber")
       .where().startsWith("licenseNumber", "VZVZ")
-      .order().asc("licenseNumber")
+      .orderBy().asc("licenseNumber")
       .findList();
 
     assertThat(list).hasSize(2);

--- a/ebean-test/src/test/java/org/tests/inheritance/bothsides/TestInheritanceBothSides.java
+++ b/ebean-test/src/test/java/org/tests/inheritance/bothsides/TestInheritanceBothSides.java
@@ -18,7 +18,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
   @Test
   public void selectSourceBaseSql() {
 
-    final Query<SourceBase> query = DB.find(SourceBase.class).order("pos");
+    final Query<SourceBase> query = DB.find(SourceBase.class).orderBy("pos");
     query.findList();
 
     assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id order by t0.pos");
@@ -27,7 +27,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
   @Test
   public void selectSourceASql() {
 
-    final Query<SourceA> query = DB.find(SourceA.class).order("pos");
+    final Query<SourceA> query = DB.find(SourceA.class).orderBy("pos");
     query.findList();
 
     assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t0.target_id from source_base t0 left join target_base t1 on t1.id = t0.target_id where t0.dtype = 'SourceA' order by t0.pos");
@@ -36,7 +36,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
   @Test
   public void selectSourceAWithJoin() {
 
-    final Query<SourceA> query = DB.find(SourceA.class).fetch("target", "name").order("pos");
+    final Query<SourceA> query = DB.find(SourceA.class).fetch("target", "name").orderBy("pos");
     query.findList();
 
     assertThat(sqlOf(query)).contains("select t0.dtype, t0.id, t0.name, t0.pos, t1.dtype, t1.id, t1.name from source_base t0 left join target_base t1 on t1.id = t0.target_id and t1.dtype = 'Target1' where t0.dtype = 'SourceA' order by t0.pos");
@@ -78,7 +78,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
 
     final List<SourceA> sourceAList = DB.find(SourceA.class)
       .fetch("target", "name")
-      .order("pos")
+      .orderBy("pos")
       .findList();
 
     final String joinedNames = sourceAList.stream()
@@ -99,7 +99,7 @@ public class TestInheritanceBothSides extends BaseTestCase {
 
     LoggedSql.start();
 
-    final List<SourceBase> sources = DB.find(SourceBase.class).order("pos").findList();
+    final List<SourceBase> sources = DB.find(SourceBase.class).orderBy("pos").findList();
     for (SourceBase source : sources) {
       if (source instanceof SourceA) {
         SourceA a = (SourceA) source;

--- a/ebean-test/src/test/java/org/tests/level/test/ManyToManyTest.java
+++ b/ebean-test/src/test/java/org/tests/level/test/ManyToManyTest.java
@@ -69,7 +69,7 @@ public class ManyToManyTest extends BaseTestCase {
         .fetch("level4s")
         .fetch("level2s")
         .fetch("level2s.level3s")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
       validateObjectGraph(i, ii, iii, one, two, x1, x2, x3, x4, x5, things);
@@ -79,7 +79,7 @@ public class ManyToManyTest extends BaseTestCase {
         .fetch("level2s")
         .fetch("level2s.level3s")
         .fetch("level4s")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
       validateObjectGraph(i, ii, iii, one, two, x1, x2, x3, x4, x5, things);
@@ -88,7 +88,7 @@ public class ManyToManyTest extends BaseTestCase {
       things = DB.find(Level1.class)
         .fetch("level2s")
         .fetch("level4s")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
       validateObjectGraph(i, ii, iii, one, two, x1, x2, x3, x4, x5, things);

--- a/ebean-test/src/test/java/org/tests/m2m/TestM2MDistinct_sqlServer.java
+++ b/ebean-test/src/test/java/org/tests/m2m/TestM2MDistinct_sqlServer.java
@@ -24,7 +24,7 @@ public class TestM2MDistinct_sqlServer extends BaseTestCase {
     LoggedSql.start();
 
     List<Role> roles = DB.find(Role.class).where().eq("permissions", perm)
-      .order().asc("name", "Latin1_General_CI_AS")
+      .orderBy().asc("name", "Latin1_General_CI_AS")
       .findList();
 
     List<String> sqls = LoggedSql.stop();

--- a/ebean-test/src/test/java/org/tests/m2m/softdelete/TestM2MSoftDeleteExists.java
+++ b/ebean-test/src/test/java/org/tests/m2m/softdelete/TestM2MSoftDeleteExists.java
@@ -23,7 +23,7 @@ public class TestM2MSoftDeleteExists extends BaseTestCase {
 
     Query<MsManyA> query = DB.find(MsManyA.class)
       .where().isNotEmpty("manybs")
-      .order("aid").query();
+      .orderBy("aid").query();
 
     List<MsManyA> list = query.findList();
 
@@ -45,7 +45,7 @@ public class TestM2MSoftDeleteExists extends BaseTestCase {
 
     List<MsManyA> list = DB.find(MsManyA.class)
       .where().isNotEmpty("manybs")
-      .order("aid")
+      .orderBy("aid")
       .findList();
 
     assertThat(list).hasSize(2);
@@ -61,7 +61,7 @@ public class TestM2MSoftDeleteExists extends BaseTestCase {
 
     List<MsManyA> list = DB.find(MsManyA.class)
       .where().isNotEmpty("manybs")
-      .order("aid")
+      .orderBy("aid")
       .findList();
 
     assertThat(list).hasSize(1);

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey.java
@@ -103,7 +103,7 @@ public class TestCacheViaComplexNaturalKey extends BaseTestCase {
       .eq("store", storeId)
       .in("sku", skus)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     List<String> sql = LoggedSql.collect();
@@ -122,7 +122,7 @@ public class TestCacheViaComplexNaturalKey extends BaseTestCase {
       .eq("store", storeId)
       .in("sku", skus)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     sql = LoggedSql.collect();
@@ -141,7 +141,7 @@ public class TestCacheViaComplexNaturalKey extends BaseTestCase {
       .eq("store", storeId)
       .in("sku", skus)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     sql = LoggedSql.stop();
@@ -171,7 +171,7 @@ public class TestCacheViaComplexNaturalKey extends BaseTestCase {
       .eq("store", storeId)
       .in("sku", skus)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     List<String> sql = LoggedSql.stop();
@@ -200,7 +200,7 @@ public class TestCacheViaComplexNaturalKey extends BaseTestCase {
       .eq("store", storeId)
       .in("sku", skus)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     List<String> sql = LoggedSql.stop();

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/TestCacheViaComplexNaturalKey3.java
@@ -113,7 +113,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
       .eq("sku", "2")
       .in("code", codes)
       .setUseCache(true)
-      .order().asc("code")
+      .orderBy().asc("code")
       .setMapKey("sku")
       .findMap();
 
@@ -142,7 +142,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
       .eq("sku", "2")
       .in("code", codes)
       .setUseCache(true)
-      .order().asc("code")
+      .orderBy().asc("code")
       .setMapKey("sku")
       .findMap();
 
@@ -203,8 +203,8 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
       .in("code", codes)
       .eq("sku", "2")
       .setUseCache(true)
-      .order().desc("sku")
-      .order().asc("code")
+      .orderBy().desc("sku")
+      .orderBy().asc("code")
       .findList();
 
     List<String> sql = LoggedSql.stop();
@@ -236,7 +236,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
       .in("sku", skus)
       .eq("code", 1001)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     List<String> sql = LoggedSql.stop();
@@ -266,7 +266,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
       .in("sku", skus)
       .eq("code", 1001)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     List<String> sql = LoggedSql.stop();
@@ -361,7 +361,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
       .eq("store", "def")
       .inPairs(pairs)
       .setUseCache(true)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     List<String> sql = LoggedSql.stop();
@@ -404,7 +404,7 @@ public class TestCacheViaComplexNaturalKey3 extends BaseTestCase {
       .eq("store", "def")
       .inPairs(pairs)
       .setBeanCacheMode(CacheMode.ON)
-      .order("sku desc")
+      .orderBy("sku desc")
       .findList();
 
     List<String> sql = LoggedSql.stop();

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasic.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasic.java
@@ -90,7 +90,7 @@ class TestElementCollectionBasic extends BaseTestCase {
     List<EcPerson> found =
       DB.find(EcPerson.class).where()
         .startsWith("name", "Fiona0")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     List<String> phoneNumbers0 = found.get(0).getPhoneNumbers();
@@ -110,7 +110,7 @@ class TestElementCollectionBasic extends BaseTestCase {
         .fetch("phoneNumbers")
         .where()
         .startsWith("name", "Fiona0")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     assertThat(found2).hasSize(2);

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMap.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicMap.java
@@ -48,7 +48,7 @@ public class TestElementCollectionBasicMap extends BaseTestCase {
     List<EcmPerson> found =
       DB.find(EcmPerson.class).where()
         .startsWith("name", "MFiona0")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     assertThat(found).hasSize(2);
@@ -72,7 +72,7 @@ public class TestElementCollectionBasicMap extends BaseTestCase {
         .fetch("phoneNumbers")
         .where()
         .startsWith("name", "MFiona0")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     assertThat(found2).hasSize(2);

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicSet.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionBasicSet.java
@@ -45,7 +45,7 @@ class TestElementCollectionBasicSet extends BaseTestCase {
     List<EcsPerson> found =
       DB.find(EcsPerson.class).where()
         .startsWith("name", "Fiona0")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     Set<String> phoneNumbers0 = found.get(0).getPhoneNumbers();
@@ -67,7 +67,7 @@ class TestElementCollectionBasicSet extends BaseTestCase {
         .fetch("phoneNumbers")
         .where()
         .startsWith("name", "Fiona0")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     assertThat(found2).hasSize(2);

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedList.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedList.java
@@ -44,7 +44,7 @@ public class TestElementCollectionEmbeddedList extends BaseTestCase {
     List<EcblPerson> found =
       DB.find(EcblPerson.class).where()
         .startsWith("name", "Fiona640")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     List<EcPhone> phoneNumbers0 = found.get(0).getPhoneNumbers();
@@ -64,7 +64,7 @@ public class TestElementCollectionEmbeddedList extends BaseTestCase {
         .fetch("phoneNumbers")
         .where()
         .startsWith("name", "Fiona640")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     assertThat(found2).hasSize(2);

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedMap.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionEmbeddedMap.java
@@ -47,7 +47,7 @@ public class TestElementCollectionEmbeddedMap extends BaseTestCase {
     List<EcbmPerson> found =
       DB.find(EcbmPerson.class).where()
         .startsWith("name", "Fiona640")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     Map<String,EcPhone> phoneNumbers0 = found.get(0).getPhoneNumbers();
@@ -62,7 +62,7 @@ public class TestElementCollectionEmbeddedMap extends BaseTestCase {
         .fetch("phoneNumbers")
         .where()
         .startsWith("name", "Fiona640")
-        .order().asc("id")
+        .orderBy().asc("id")
         .findList();
 
     assertThat(found2).hasSize(2);

--- a/ebean-test/src/test/java/org/tests/model/pview/TestPview.java
+++ b/ebean-test/src/test/java/org/tests/model/pview/TestPview.java
@@ -19,7 +19,7 @@ public class TestPview extends BaseTestCase {
     Query<Paggview> query = DB.find(Paggview.class);
     query.select("amount");
     query.where().eq("pview.wviews", wview);
-    query.order("pview.value");
+    query.orderBy("pview.value");
     query.findList();
     String generatedSql = sqlOf(query, 1);
 

--- a/ebean-test/src/test/java/org/tests/model/selfref/TestSelfRefExample.java
+++ b/ebean-test/src/test/java/org/tests/model/selfref/TestSelfRefExample.java
@@ -42,7 +42,7 @@ public class TestSelfRefExample extends BaseTestCase {
     DB.save(e8);
 
     Query<SelfRefExample> examples = DB.find(SelfRefExample.class).setLazyLoadBatchSize(1);
-    List<SelfRefExample> list = examples.where().eq("name", "test1").order().asc("id").findList();
+    List<SelfRefExample> list = examples.where().eq("name", "test1").orderBy().asc("id").findList();
 
     assertThat(list).hasSize(2);
 
@@ -66,7 +66,7 @@ public class TestSelfRefExample extends BaseTestCase {
     assertThat(e3Searched.getChildren()).extracting("id").contains(e7.getId());
 
     // If we get all the items, you can see the structure goes down a fair bit further.
-    Query<SelfRefExample> examples2 = DB.createQuery(SelfRefExample.class).order("id asc");
+    Query<SelfRefExample> examples2 = DB.createQuery(SelfRefExample.class).orderBy("id asc");
     List<SelfRefExample> list2 = examples2.findList();
 
     assertEquals(e1.getId(), list2.get(0).getId());

--- a/ebean-test/src/test/java/org/tests/model/selfref/TestTextJsonSelfRef.java
+++ b/ebean-test/src/test/java/org/tests/model/selfref/TestTextJsonSelfRef.java
@@ -35,7 +35,7 @@ public class TestTextJsonSelfRef extends BaseTestCase {
       }
     });
 
-    List<SelfRefCustomer> customers = DB.find(SelfRefCustomer.class).order("id desc").findList();
+    List<SelfRefCustomer> customers = DB.find(SelfRefCustomer.class).orderBy("id desc").findList();
 
     // Check that there are no 'reference' beans here
     for (SelfRefCustomer cust : customers) {

--- a/ebean-test/src/test/java/org/tests/persistencecontext/TestPersistenceContextScopeUsingOrders.java
+++ b/ebean-test/src/test/java/org/tests/persistencecontext/TestPersistenceContextScopeUsingOrders.java
@@ -28,7 +28,7 @@ public class TestPersistenceContextScopeUsingOrders extends BaseTestCase {
       .setPersistenceContextScope(QUERY)
       .fetch("customer", "id, name")
       .where().istartsWith("customer.name", "rob").eq("customer.id", 1)
-      .order().asc("customer.name")
+      .orderBy().asc("customer.name")
       .findList();
 
     assertTrue(!orders.isEmpty());

--- a/ebean-test/src/test/java/org/tests/query/TestAddOrderByWithFirstRowsMaxRows.java
+++ b/ebean-test/src/test/java/org/tests/query/TestAddOrderByWithFirstRowsMaxRows.java
@@ -29,7 +29,7 @@ public class TestAddOrderByWithFirstRowsMaxRows extends BaseTestCase {
 
     DB.find(Order.class)
       .setFirstRow(3)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     List<String> loggedSql = LoggedSql.stop();
@@ -69,7 +69,7 @@ public class TestAddOrderByWithFirstRowsMaxRows extends BaseTestCase {
     DB.find(Order.class)
       .setFirstRow(3)
       .setMaxRows(10)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     List<String> loggedSql = LoggedSql.stop();
@@ -129,7 +129,7 @@ public class TestAddOrderByWithFirstRowsMaxRows extends BaseTestCase {
     DB.find(Order.class)
       .setFirstRow(10)
       .setMaxRows(10)
-      .order("id")
+      .orderBy("id")
       .findPagedList()
       .getList();
 
@@ -150,7 +150,7 @@ public class TestAddOrderByWithFirstRowsMaxRows extends BaseTestCase {
     LoggedSql.start();
 
     DB.find(Order.class)
-      .order().asc("orderDate")
+      .orderBy().asc("orderDate")
       .setMaxRows(10)
       .findPagedList()
       .getList();
@@ -169,8 +169,8 @@ public class TestAddOrderByWithFirstRowsMaxRows extends BaseTestCase {
     LoggedSql.start();
 
     DB.find(Order.class)
-      .order().asc("orderDate")
-      .order().desc("id")
+      .orderBy().asc("orderDate")
+      .orderBy().desc("id")
       .setMaxRows(10)
       .findPagedList()
       .getList();

--- a/ebean-test/src/test/java/org/tests/query/TestExprNestedDisjunction.java
+++ b/ebean-test/src/test/java/org/tests/query/TestExprNestedDisjunction.java
@@ -22,7 +22,7 @@ public class TestExprNestedDisjunction extends BaseTestCase {
       .disjunction()
       .conjunction().startsWith("name", "r").eq("anniversary", onAfter).endJunction()
       .conjunction().eq("status", Customer.Status.ACTIVE).gt("id", 0).endJunction()
-      .order().asc("name");
+      .orderBy().asc("name");
 
     q.findList();
     String s = q.getGeneratedSql();
@@ -46,7 +46,7 @@ public class TestExprNestedDisjunction extends BaseTestCase {
       .startsWith("name", "r").eq("anniversary", onAfter).endAnd()
       .and()
       .eq("status", Customer.Status.ACTIVE).gt("id", 0).endAnd()
-      .order().asc("name");
+      .orderBy().asc("name");
 
     q.findList();
     String s = q.getGeneratedSql();
@@ -68,7 +68,7 @@ public class TestExprNestedDisjunction extends BaseTestCase {
       .gt("id", 1)
       .eq("anniversary", onAfter)
       .endNot()
-      .order().asc("name");
+      .orderBy().asc("name");
 
     q.findList();
     String s = q.getGeneratedSql();
@@ -90,7 +90,7 @@ public class TestExprNestedDisjunction extends BaseTestCase {
       .not()
       .gt("id", 1)
       .eq("anniversary", onAfter)
-      .order().asc("name");
+      .orderBy().asc("name");
 
     q.findList();
     String s = q.getGeneratedSql();
@@ -114,7 +114,7 @@ public class TestExprNestedDisjunction extends BaseTestCase {
       .eq("anniversary", onAfter)
       .endNot()
       .endOr()
-      .order().asc("name");
+      .orderBy().asc("name");
 
     q.findList();
     String s = q.getGeneratedSql();

--- a/ebean-test/src/test/java/org/tests/query/TestLimitAlterFetchMany.java
+++ b/ebean-test/src/test/java/org/tests/query/TestLimitAlterFetchMany.java
@@ -24,7 +24,7 @@ public class TestLimitAlterFetchMany extends BaseTestCase {
     Query<Customer> query = DB.find(Customer.class)
       // this will automatically get converted to a
       // query join ... due to the maxRows
-      .fetch("contacts").setMaxRows(5).order("id");
+      .fetch("contacts").setMaxRows(5).orderBy("id");
 
     List<Customer> list = query.findList();
 

--- a/ebean-test/src/test/java/org/tests/query/TestManyWhereJoin.java
+++ b/ebean-test/src/test/java/org/tests/query/TestManyWhereJoin.java
@@ -89,7 +89,7 @@ public class TestManyWhereJoin extends BaseTestCase {
 
     Query<Order> query = DB.find(Order.class)
       .where().eq("details.product.id", productId)
-      .order("cretime asc").query();
+      .orderBy("cretime asc").query();
 
     query.findList();
     String sql = sqlOf(query, 3);
@@ -123,7 +123,7 @@ public class TestManyWhereJoin extends BaseTestCase {
     Query<Order> query = DB.find(Order.class)
       //.fetch("details")
       .where().eq("details.product", product)
-      .order("cretime asc").query();
+      .orderBy("cretime asc").query();
 
     query.findList();
     String sql = sqlOf(query, 3);
@@ -157,7 +157,7 @@ public class TestManyWhereJoin extends BaseTestCase {
     Query<Order> query = DB.find(Order.class)
       .fetch("details")
       .where().eq("details.product", product)
-      .order("cretime asc").query();
+      .orderBy("cretime asc").query();
 
     query.findList();
     String sql = sqlOf(query, 3);

--- a/ebean-test/src/test/java/org/tests/query/TestOuterJoin.java
+++ b/ebean-test/src/test/java/org/tests/query/TestOuterJoin.java
@@ -154,7 +154,7 @@ public class TestOuterJoin extends BaseTestCase {
 
     LoggedSql.start();
 
-    List<Order> orders1 =  DB.find(Order.class).order("id").findList();
+    List<Order> orders1 =  DB.find(Order.class).orderBy("id").findList();
 
     assertThat(LoggedSql.collect().get(0))
       .contains(" join o_customer") // ensure that we do not left join the customer
@@ -165,7 +165,7 @@ public class TestOuterJoin extends BaseTestCase {
     LoggedSql.start();
 
     List<Order> orders2 =  DB.find(Order.class)
-        .fetch("details", "id").order("id").findList();
+        .fetch("details", "id").orderBy("id").findList();
 
     assertThat(LoggedSql.collect().get(0))
       .contains(" left join o_order_detail ");

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFetchJoinWithOrder.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFetchJoinWithOrder.java
@@ -20,16 +20,16 @@ public class TestQueryFetchJoinWithOrder extends BaseTestCase {
 
     List<Order> list = DB.find(Order.class)
       .fetchQuery("details")
-      .order().asc("id")
-      .order().desc("details.id").findList();
+      .orderBy().asc("id")
+      .orderBy().desc("details.id").findList();
 
     assertNotNull(list);
 
     List<Order> list2 = DB.find(Order.class)
       .fetchQuery("customer")
       .fetch("customer.contacts")
-      .order().asc("id")
-      .order().asc("customer.contacts.lastName")
+      .orderBy().asc("id")
+      .orderBy().asc("customer.contacts.lastName")
       .findList();
 
     assertNotNull(list2);
@@ -37,7 +37,7 @@ public class TestQueryFetchJoinWithOrder extends BaseTestCase {
     List<Customer> list3 = DB.find(Customer.class)
       .fetch("orders")
       .filterMany("orders").eq("status", Order.Status.NEW)
-      .order().desc("orders.id")
+      .orderBy().desc("orders.id")
       .findList();
 
     assertNotNull(list3);

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFilterMany.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFilterMany.java
@@ -30,7 +30,7 @@ public class TestQueryFilterMany extends BaseTestCase {
       .fetchLazy("orders")
       .filterMany("orders").eq("status", Order.Status.NEW)
       .where().ieq("name", "Rob")
-      .order().asc("id").setMaxRows(1)
+      .orderBy().asc("id").setMaxRows(1)
       .findList().get(0);
 
     final int size = customer.getOrders().size();
@@ -55,8 +55,8 @@ public class TestQueryFilterMany extends BaseTestCase {
     final Query<Customer> query = DB.find(Customer.class)
       .where().ieq("name", "Rob")
       // fluid style adding maxRows/firstRow to filterMany
-      .filterMany("orders").eq("status", Order.Status.NEW).order("id desc").setMaxRows(100).setFirstRow(3)
-      .order().asc("id").setMaxRows(5);
+      .filterMany("orders").eq("status", Order.Status.NEW).orderBy("id desc").setMaxRows(100).setFirstRow(3)
+      .orderBy().asc("id").setMaxRows(5);
 
     final List<Customer> customers = query.findList();
     assertThat(customers).isNotEmpty();
@@ -82,10 +82,10 @@ public class TestQueryFilterMany extends BaseTestCase {
 
     final Query<Customer> query = DB.find(Customer.class)
       .where().ieq("name", "Rob")
-      .order().asc("id").setMaxRows(5);
+      .orderBy().asc("id").setMaxRows(5);
 
     // non-fluid style adding maxRows/firstRow
-    final ExpressionList<Customer> filterMany = query.filterMany("orders").order("id desc").eq("status", Order.Status.NEW);
+    final ExpressionList<Customer> filterMany = query.filterMany("orders").orderBy("id desc").eq("status", Order.Status.NEW);
     filterMany.setMaxRows(100);
     filterMany.setFirstRow(3);
 
@@ -116,8 +116,8 @@ public class TestQueryFilterMany extends BaseTestCase {
       .where().ieq("name", "Rob")
       // use expression + fluid style adding maxRows/firstRow to filterMany
       .filterMany("orders", "status = ?", Order.Status.NEW)
-        .setMaxRows(100).setFirstRow(3).order("orderDate desc, id")
-      .order().asc("id").setMaxRows(5);
+        .setMaxRows(100).setFirstRow(3).orderBy("orderDate desc, id")
+      .orderBy().asc("id").setMaxRows(5);
 
     final List<Customer> customers = query.findList();
     assertThat(customers).isNotEmpty();
@@ -143,8 +143,8 @@ public class TestQueryFilterMany extends BaseTestCase {
       .where().ieq("name", "Rob")
       // use expression + fluid style adding maxRows/firstRow to filterMany
       .filterManyRaw("orders", "status = ?", Order.Status.NEW)
-      .setMaxRows(100).setFirstRow(3).order("orderDate desc, id")
-      .order().asc("id").setMaxRows(5);
+      .setMaxRows(100).setFirstRow(3).orderBy("orderDate desc, id")
+      .orderBy().asc("id").setMaxRows(5);
 
     final List<Customer> customers = query.findList();
     assertThat(customers).isNotEmpty();
@@ -169,7 +169,7 @@ public class TestQueryFilterMany extends BaseTestCase {
     final Query<Customer> query = DB.find(Customer.class)
       .where().ieq("name", "Rob")
       .filterManyRaw("orders", "status = ?", Order.Status.NEW)
-      .order().asc("id");
+      .orderBy().asc("id");
 
     final List<Customer> customers = query.findList();
     assertThat(customers).isNotEmpty();
@@ -185,7 +185,7 @@ public class TestQueryFilterMany extends BaseTestCase {
     LoggedSql.start();
     Customer customer = DB.find(Customer.class)
       .setMaxRows(1)
-      .order().asc("id")
+      .orderBy().asc("id")
       .fetch("orders")
       .filterMany("orders").raw("orderDate is not null")
       .findOne();
@@ -203,7 +203,7 @@ public class TestQueryFilterMany extends BaseTestCase {
 
     LoggedSql.start();
     var result = DB.find(Customer.class)
-      .order().asc("id")
+      .orderBy().asc("id")
       .fetch("orders")
       .filterMany("orders").raw("orderDate is not null")
       .findList();
@@ -222,7 +222,7 @@ public class TestQueryFilterMany extends BaseTestCase {
 
     Optional<Customer> customer = DB.find(Customer.class)
       .setMaxRows(1)
-      .order().asc("id")
+      .orderBy().asc("id")
       .fetch("orders")
       .filterMany("orders").raw("1 = 0")
       .findOneOrEmpty();
@@ -262,7 +262,7 @@ public class TestQueryFilterMany extends BaseTestCase {
     Query<Customer> query = DB.find(Customer.class)
       .fetch("orders")
       .filterMany("orders").in("status", Order.Status.NEW)
-      .order().asc("id");
+      .orderBy().asc("id");
 
     query.findCount();
 
@@ -281,7 +281,7 @@ public class TestQueryFilterMany extends BaseTestCase {
     Query<Customer> query = DB.find(Customer.class)
       .fetch("orders")
       .filterMany("orders").in("status", Order.Status.NEW)
-      .order().asc("id");
+      .orderBy().asc("id");
 
     query.copy().findList();
 
@@ -304,7 +304,7 @@ public class TestQueryFilterMany extends BaseTestCase {
     Query<Customer> query = DB.find(Customer.class)
       .fetchQuery("orders") // explicitly fetch orders separately
       .filterMany("orders").in("status", Order.Status.NEW)
-      .order().asc("id");
+      .orderBy().asc("id");
 
     query.findList();
 

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindEach.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindEach.java
@@ -39,7 +39,7 @@ public class TestQueryFindEach extends BaseTestCase {
 
     Query<Customer> query = DB.find(Customer.class)
       .fetchQuery("contacts")
-      .where().gt("id", 0).order("id")
+      .where().gt("id", 0).orderBy("id")
       .setMaxRows(2).query();
 
     final AtomicInteger counter = new AtomicInteger(0);
@@ -146,7 +146,7 @@ public class TestQueryFindEach extends BaseTestCase {
 
     Query<Customer> query = DB.find(Customer.class)
       .fetchQuery("contacts")
-      .where().gt("id", 0).order("id")
+      .where().gt("id", 0).orderBy("id")
       .setMaxRows(2).query();
 
     final AtomicInteger counter = new AtomicInteger(0);

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindEachWhile.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindEachWhile.java
@@ -21,7 +21,7 @@ public class TestQueryFindEachWhile extends BaseTestCase {
     Query<Customer> query
       = DB.find(Customer.class)
       .setAutoTune(false)
-      .fetchQuery("contacts").where().gt("id", 0).order("id")
+      .fetchQuery("contacts").where().gt("id", 0).orderBy("id")
       .setMaxRows(2).query();
 
     final AtomicInteger counter = new AtomicInteger(0);
@@ -43,7 +43,7 @@ public class TestQueryFindEachWhile extends BaseTestCase {
     ResetBasicData.reset();
 
     Query<Customer> query = DB.find(Customer.class).setAutoTune(false)
-      .fetchQuery("contacts").where().gt("id", 0).order("id")
+      .fetchQuery("contacts").where().gt("id", 0).orderBy("id")
       .setMaxRows(2).query();
 
     final AtomicInteger counter = new AtomicInteger(0);

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
@@ -54,7 +54,7 @@ public class TestQueryFindIterate extends BaseTestCase {
       .where()
       .isNotNull("name")
       .setMaxRows(3)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findIterate();
 
     try {
@@ -161,7 +161,7 @@ public class TestQueryFindIterate extends BaseTestCase {
       .fetch("customer", "name")
       .fetch("details")
       .where().gt("id", 0).le("id", 10)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findEach(order -> {
         Customer customer = order.getCustomer();
         order.getId();
@@ -233,7 +233,7 @@ public class TestQueryFindIterate extends BaseTestCase {
       .where()
       .isNotNull("name")
       .setMaxRows(3)
-      .order().asc("id");
+      .orderBy().asc("id");
 
     if (withLoadBatch) {
       query.setLazyLoadBatchSize(1);

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindPagedList.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindPagedList.java
@@ -108,7 +108,7 @@ public class TestQueryFindPagedList extends BaseTestCase {
     PagedList<Order> pagedList2 = DB.find(Order.class)
       .setFirstRow(1)
       .setMaxRows(3)
-      .order("id")
+      .orderBy("id")
       .findPagedList();
 
     pagedList2.loadCount();
@@ -124,7 +124,7 @@ public class TestQueryFindPagedList extends BaseTestCase {
     PagedList<Order> pagedList3 = DB.find(Order.class)
       .setFirstRow(2)
       .setMaxRows(150)
-      .order("id")
+      .orderBy("id")
       .findPagedList();
 
     assertFalse(pagedList3.hasNext());

--- a/ebean-test/src/test/java/org/tests/query/TestQueryOrderById.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryOrderById.java
@@ -23,7 +23,7 @@ public class TestQueryOrderById extends BaseTestCase {
 
     Query<Customer> query = DB.find(Customer.class)
       .select("id,name")
-      .order("id")
+      .orderBy("id")
       .setFirstRow(1)
       .setMaxRows(5);
 

--- a/ebean-test/src/test/java/org/tests/query/TestQueryPathJoinAndOrder.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryPathJoinAndOrder.java
@@ -18,7 +18,7 @@ public class TestQueryPathJoinAndOrder extends BaseTestCase {
     ResetBasicData.reset();
 
     List<Customer> list = DB.find(Customer.class).select("id,name, status").fetch("contacts")
-      .order().asc("id").order().desc("contacts.firstName").setMaxRows(3).findList();
+      .orderBy().asc("id").orderBy().desc("contacts.firstName").setMaxRows(3).findList();
 
     assertNotNull(list);
 

--- a/ebean-test/src/test/java/org/tests/query/TestQueryPlanCacheRowCount.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryPlanCacheRowCount.java
@@ -20,7 +20,7 @@ public class TestQueryPlanCacheRowCount extends BaseTestCase {
     ResetBasicData.reset();
 
     Query<Order> query = DB.find(Order.class).where().eq("status", Order.Status.NEW).ge("id", 1)
-      .order().desc("id");
+      .orderBy().desc("id");
 
     int rc0 = query.findCount();
 
@@ -47,7 +47,7 @@ public class TestQueryPlanCacheRowCount extends BaseTestCase {
 
     // should still hit query plan cache
     Query<Order> query2 = DB.find(Order.class).where().eq("status", Order.Status.NEW)
-      .ge("id", idGt).order().desc("id");
+      .ge("id", idGt).orderBy().desc("id");
 
     int rc2 = query2.findCount();
 

--- a/ebean-test/src/test/java/org/tests/query/TestRowCount.java
+++ b/ebean-test/src/test/java/org/tests/query/TestRowCount.java
@@ -26,7 +26,7 @@ public class TestRowCount extends BaseTestCase {
       .where()
       .gt("id", 1)
       .gt("details.id", 1)
-      .order("id desc").query();
+      .orderBy("id desc").query();
 
     int rc = query.findCount();
     List<Object> ids = query.findIds();

--- a/ebean-test/src/test/java/org/tests/query/aggregation/TestAggregationCount.java
+++ b/ebean-test/src/test/java/org/tests/query/aggregation/TestAggregationCount.java
@@ -117,7 +117,7 @@ public class TestAggregationCount extends BaseTestCase {
       .startsWith("logs.description", "a")
       .having()
       .ge("count", 1)
-      .order().asc("name");
+      .orderBy().asc("name");
 
     List<TEventOne> list = query2.findList();
     for (TEventOne eventOne : list) {
@@ -142,7 +142,7 @@ public class TestAggregationCount extends BaseTestCase {
 
     Query<TEventOne> query = DB.find(TEventOne.class)
       .select("name, count, totalUnits, totalAmount")
-      .order().asc("totalUnits").order().asc("name");
+      .orderBy().asc("totalUnits").orderBy().asc("name");
 
     List<TEventOne> list = query.findList();
     assertThat(list).isNotEmpty();
@@ -201,7 +201,7 @@ public class TestAggregationCount extends BaseTestCase {
     Query<TEventOne> query1 = DB.find(TEventOne.class)
       .select("name, count, totalUnits, totalAmount")
       .having().ge("count", 1)
-      .order().asc("name");
+      .orderBy().asc("name");
 
     query1.findList();
     assertThat(query1.getGeneratedSql()).contains("having count(u1.id) >= ? order by t0.name");
@@ -420,7 +420,7 @@ public class TestAggregationCount extends BaseTestCase {
       DB.find(Contact.class)
         .select(concat("lastName",", ","firstName"))
         .where().isNull("phone")
-        .order().asc("lastName")
+        .orderBy().asc("lastName")
         .findSingleAttributeList();
 
     assertThat(names).isNotEmpty();
@@ -441,7 +441,7 @@ public class TestAggregationCount extends BaseTestCase {
       DB.find(Contact.class)
         .select(concat("updtime",", ","firstName")+"::String")
         .where().isNull("phone")
-        .order().asc("lastName")
+        .orderBy().asc("lastName")
         .findSingleAttributeList();
 
     assertThat(names).isNotEmpty();
@@ -483,7 +483,7 @@ public class TestAggregationCount extends BaseTestCase {
       DB.find(Contact.class)
         .select("email, " + concat("lastName",", ","firstName") + " as lastName")
         .where().isNull("phone")
-        .order().asc("lastName")
+        .orderBy().asc("lastName")
         .findList();
 
     assertThat(contacts).isNotEmpty();

--- a/ebean-test/src/test/java/org/tests/query/joins/TestQueryJoinOnFormula.java
+++ b/ebean-test/src/test/java/org/tests/query/joins/TestQueryJoinOnFormula.java
@@ -79,7 +79,7 @@ public class TestQueryJoinOnFormula extends BaseTestCase {
     // Tests if SqlTreeBuilder.IncludesDistiller.createExtraJoin appends formulaJoinProperties
     Query<OrderShipment> shipQuery = DB.find(OrderShipment.class)
       .select("id")
-      .order().asc("order.totalAmount");
+      .orderBy().asc("order.totalAmount");
 
     shipQuery.findList();
     assertSql(shipQuery.getGeneratedSql()).isEqualTo("select t0.id "
@@ -137,7 +137,7 @@ public class TestQueryJoinOnFormula extends BaseTestCase {
     Query<OrderShipment> shipQuery = DB.find(OrderShipment.class)
       .select("id")
       .fetch("order", "totalAmount")
-      .order().asc("order.totalAmount");
+      .orderBy().asc("order.totalAmount");
 
     shipQuery.findList();
     assertSql(shipQuery.getGeneratedSql()).isEqualTo("select t0.id, t1.id, z_bt1.total_amount "

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByClear.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByClear.java
@@ -20,10 +20,10 @@ public class TestOrderByClear extends BaseTestCase {
     ResetBasicData.reset();
 
     Query<Order> query = DB.find(Order.class)
-      .order().asc("orderDate");
+      .orderBy().asc("orderDate");
 
 
-    OrderBy<Order> orderBy = query.order();
+    OrderBy<Order> orderBy = query.orderBy();
     assertTrue(orderBy.containsProperty("orderDate"));
 
     orderBy.clear();
@@ -38,7 +38,7 @@ public class TestOrderByClear extends BaseTestCase {
     assertTrue(sql.contains("order by t0.ship_date"));
 
   }
-  
+
   @Test
   public void testWithCache() {
     ResetBasicData.reset();
@@ -46,10 +46,10 @@ public class TestOrderByClear extends BaseTestCase {
     Query<OrderDetail> query = DB.find(OrderDetail.class).where().idIn(1,2,3).query();
     query.setUseCache(true);
     query.findList();
-    query.order().asc("cretime").findList(); // hit cache
-    query.order().clear();
+    query.orderBy().asc("cretime").findList(); // hit cache
+    query.orderBy().clear();
     query.findList(); // hit cache again
-    
+
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByOnComplex.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByOnComplex.java
@@ -19,7 +19,7 @@ public class TestOrderByOnComplex extends BaseTestCase {
 
     ResetBasicData.reset();
 
-    Query<Order> query = DB.find(Order.class).order().desc("customer");
+    Query<Order> query = DB.find(Order.class).orderBy().desc("customer");
 
     query.findList();
 
@@ -33,7 +33,7 @@ public class TestOrderByOnComplex extends BaseTestCase {
     ResetBasicData.reset();
 
     Query<Order> query = DB.find(Order.class)
-      .order("case when status=3 then 10 when status=2 then 11 else 99 end");
+      .orderBy("case when status=3 then 10 when status=2 then 11 else 99 end");
 
     List<Order> list = query.findList();
 

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithDistinct.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithDistinct.java
@@ -32,7 +32,7 @@ public class TestOrderByWithDistinct extends BaseTestCase {
       .where()
       .eq("junk", "blah")
       .eq("name", "jim")
-      .order("id desc,path.that.does.not.exist,contacts.group.name asc").query();
+      .orderBy("id desc,path.that.does.not.exist,contacts.group.name asc").query();
 
     Set<String> unknownProperties = query.validate();
     assertThat(unknownProperties).isNotEmpty();
@@ -50,7 +50,7 @@ public class TestOrderByWithDistinct extends BaseTestCase {
     Query<MUser> query = DB.find(MUser.class)
       .where()
       .eq("roles", role)
-      .order("userName asc nulls first").query();
+      .orderBy("userName asc nulls first").query();
 
     query.findList();
 
@@ -149,7 +149,7 @@ public class TestOrderByWithDistinct extends BaseTestCase {
       .fetch("userType", "name")
       .where()
       .eq("roles.roleName", "A")
-      .order("userType.name, userName").query();
+      .orderBy("userType.name, userName").query();
     List<MUser> list = query.findList();
 
     // select distinct t0.userid c0, t0.user_name c1, t1.id c2, t1.name c3
@@ -183,7 +183,7 @@ public class TestOrderByWithDistinct extends BaseTestCase {
       .fetch("userType", "name")
       .where()
       .eq("roles.roleName", "A")
-      .order("userType.name").query();
+      .orderBy("userType.name").query();
     list = query.findList();
 
     assertEquals(1, list.size());

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithDistinctTake2.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithDistinctTake2.java
@@ -25,7 +25,7 @@ public class TestOrderByWithDistinctTake2 extends BaseTestCase {
     Query<Customer> query = DB.find(Customer.class)
       .select("id, name")
       .where().ilike("contacts.firstName", "R%")
-      .order("name desc").query();
+      .orderBy("name desc").query();
 
     query.findList();
 
@@ -53,7 +53,7 @@ public class TestOrderByWithDistinctTake2 extends BaseTestCase {
     Query<Customer> query = DB.find(Customer.class)
       .select("id")
       .where().ilike("contacts.firstName", "R%")
-      .order("name asc,id desc").query();
+      .orderBy("name asc,id desc").query();
 
     query.findList();
 

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithFunction.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithFunction.java
@@ -20,7 +20,7 @@ public class TestOrderByWithFunction extends BaseTestCase {
       length = "len";
     }
 
-    Query<Customer> query = DB.find(Customer.class).order(length + "(name),name");
+    Query<Customer> query = DB.find(Customer.class).orderBy(length + "(name),name");
 
     query.findList();
     String sql = query.getGeneratedSql();

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithMany.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithMany.java
@@ -70,7 +70,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
   private void checkWithBuiltInMany() {
 
-    Query<Order> query = DB.find(Order.class).fetch("details").order().desc("customer.name");
+    Query<Order> query = DB.find(Order.class).fetch("details").orderBy().desc("customer.name");
 
     query.findList();
 
@@ -83,7 +83,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
   private void checkAppendId() {
 
-    Query<Order> query = DB.find(Order.class).fetch("shipments").order().desc("customer.name");
+    Query<Order> query = DB.find(Order.class).fetch("shipments").orderBy().desc("customer.name");
 
     query.findList();
 
@@ -95,7 +95,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
   private void checkNone() {
 
-    Query<Order> query = DB.find(Order.class).order().desc("customer.name");
+    Query<Order> query = DB.find(Order.class).orderBy().desc("customer.name");
 
     query.findList();
 
@@ -109,7 +109,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
   private void checkBoth() {
 
-    Query<Order> query = DB.find(Order.class).fetch("shipments").order()
+    Query<Order> query = DB.find(Order.class).fetch("shipments").orderBy()
       .desc("customer.name, shipments.shipTime");
 
     query.findList();
@@ -121,7 +121,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
   private void checkPrepend() {
 
-    Query<Order> query = DB.find(Order.class).fetch("shipments").order()
+    Query<Order> query = DB.find(Order.class).fetch("shipments").orderBy()
       .desc("shipments.shipTime");
 
     query.findList();
@@ -133,7 +133,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
   private void checkAlreadyIncluded() {
 
-    Query<Order> query = DB.find(Order.class).fetch("shipments").order()
+    Query<Order> query = DB.find(Order.class).fetch("shipments").orderBy()
       .desc("id, shipments.shipTime");
 
     query.findList();
@@ -145,7 +145,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
   private void checkAlreadyIncluded2() {
 
-    Query<Order> query = DB.find(Order.class).fetch("shipments").order()
+    Query<Order> query = DB.find(Order.class).fetch("shipments").orderBy()
       .desc("orderDate, id, shipments.shipTime");
 
     query.findList();

--- a/ebean-test/src/test/java/org/tests/query/other/TestQueryConversationRowCount.java
+++ b/ebean-test/src/test/java/org/tests/query/other/TestQueryConversationRowCount.java
@@ -31,7 +31,7 @@ public class TestQueryConversationRowCount extends BaseTestCase {
       .endJunction()
       .eq("open", true)
       .endJunction()
-      .order("whenCreated desc").query();
+      .orderBy("whenCreated desc").query();
 
     query.findList();
     String generatedSql = sqlOf(query, 1);

--- a/ebean-test/src/test/java/org/tests/query/other/TestQueryRowCountWithMany.java
+++ b/ebean-test/src/test/java/org/tests/query/other/TestQueryRowCountWithMany.java
@@ -27,7 +27,7 @@ public class TestQueryRowCountWithMany extends BaseTestCase {
     Query<Order> query = DB.find(Order.class)
       .fetch("details")
       .where().eq("details.product.id", productId)
-      .order("cretime asc").query();
+      .orderBy("cretime asc").query();
 
     List<Order> list = query.findList();
 

--- a/ebean-test/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
+++ b/ebean-test/src/test/java/org/tests/query/other/TestQuerySingleAttribute.java
@@ -76,7 +76,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
         .setDistinct(true)
         .select("name")
         .where().eq("status", Customer.Status.NEW).startsWith("name", "R")
-        .order().asc("name")
+        .orderBy().asc("name")
         .setMaxRows(100)
         .findSingleAttributeList();
 
@@ -95,7 +95,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
         .setDistinct(true)
         .select("anniversary")
         .where().isNotNull("anniversary")
-        .order().asc("anniversary")
+        .orderBy().asc("anniversary")
         .findSingleAttributeList();
 
     assertThat(dates).isNotNull();
@@ -502,7 +502,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
     Query<Contact> query = DB.find(Contact.class)
       .setDistinct(true)
       .select("customer")
-      .order().desc("customer");
+      .orderBy().desc("customer");
 
     query.findSingleAttributeList();
 
@@ -516,7 +516,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
     Query<Contact> query = DB.find(Contact.class)
       .setDistinct(true)
       .select("customer.id")
-      .order().desc("customer.id");
+      .orderBy().desc("customer.id");
 
     query.findSingleAttributeList();
 
@@ -530,7 +530,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
     Query<Contact> query = DB.find(Contact.class)
       .setDistinct(true)
       .fetch("customer", "billingAddress")
-      .order().desc("customer.billingAddress");
+      .orderBy().desc("customer.billingAddress");
 
     query.findSingleAttributeList();
 
@@ -545,7 +545,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
       .setDistinct(true)
       .fetch("customer", "billingAddress")
       .where().eq("customer.billingAddress.city", "Auckland")
-      .order().desc("customer.billingAddress.id");
+      .orderBy().desc("customer.billingAddress.id");
 
     List<Integer> ids = query.findSingleAttributeList();
     assertThat(ids).isNotEmpty();
@@ -565,7 +565,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
       .setDistinct(true)
       .fetch("customer", "billingAddress")
       .where().eq("customer.billingAddress.city", "Auckland")
-      .order().desc("customer.billingAddress.id");
+      .orderBy().desc("customer.billingAddress.id");
 
     List<Short> ids = query.findSingleAttributeList();
     assertThat(ids).isNotEmpty();
@@ -585,7 +585,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
       .setDistinct(true)
       .fetch("customer", "billingAddress")
       .where().eq("customer.billingAddress.city", "Auckland")
-      .order().desc("customer.billingAddress.id");
+      .orderBy().desc("customer.billingAddress.id");
 
     List<Integer> ids = query.findSingleAttributeList();
     assertThat(ids).isNotEmpty();
@@ -605,7 +605,7 @@ class TestQuerySingleAttribute extends BaseTestCase {
       .setDistinct(true)
       .fetch("customer", "billingAddress")
       .where().eq("customer.shippingAddress.city", "Auckland") // query on shippingAddress
-      .order().desc("customer.billingAddress.id");
+      .orderBy().desc("customer.billingAddress.id");
 
     List<Short> ids = query.findSingleAttributeList();
     assertThat(ids).isNotEmpty();

--- a/ebean-test/src/test/java/org/tests/query/other/TestWhereAnnotation.java
+++ b/ebean-test/src/test/java/org/tests/query/other/TestWhereAnnotation.java
@@ -45,7 +45,7 @@ public class TestWhereAnnotation extends BaseTestCase {
     LoggedSql.start();
 
     List<Customer> customers = DB.find(Customer.class)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     List<Order> orders = customers.get(0).getOrders();

--- a/ebean-test/src/test/java/org/tests/rawsql/TestRawSqlOrmQuery.java
+++ b/ebean-test/src/test/java/org/tests/rawsql/TestRawSqlOrmQuery.java
@@ -133,7 +133,7 @@ class TestRawSqlOrmQuery extends BaseTestCase {
 
     query.setFirstRow(1);
     query.setMaxRows(2);
-    query.order("id");
+    query.orderBy("id");
 
     List<Customer> list = query.findList();
 
@@ -263,14 +263,14 @@ class TestRawSqlOrmQuery extends BaseTestCase {
     query.setMaxRows(100);
 
     if (isSqlServer()) {
-      query.order("coalesce(shipDate, getdate()) desc");
+      query.orderBy("coalesce(shipDate, getdate()) desc");
       query.findList();
 
       assertThat(sqlOf(query)).contains("order by coalesce(o.ship_date, getdate()) desc");
       assertThat(sqlOf(query)).contains("select top 100");
 
     } else {
-      query.order("coalesce(shipDate, now()) desc");
+      query.orderBy("coalesce(shipDate, now()) desc");
       query.findList();
 
       if (isDb2()) {
@@ -299,14 +299,14 @@ class TestRawSqlOrmQuery extends BaseTestCase {
     query.orderById(true);
 
     if (isSqlServer()) {
-      query.order("coalesce(shipDate, getdate()) desc");
+      query.orderBy("coalesce(shipDate, getdate()) desc");
       query.findList();
 
       assertThat(sqlOf(query)).contains("order by coalesce(o.ship_date, getdate()) desc, o.id");
       assertThat(sqlOf(query)).contains("select top 100");
 
     } else {
-      query.order("coalesce(shipDate, now()) desc");
+      query.orderBy("coalesce(shipDate, now()) desc");
       query.findList();
 
       if (isDb2()) {
@@ -331,7 +331,7 @@ class TestRawSqlOrmQuery extends BaseTestCase {
     query.setRawSql(rawSql);
 
     query.setMaxRows(100);
-    query.order("id desc");
+    query.orderBy("id desc");
     PagedList<Order> pagedList = query.findPagedList();
     pagedList.getList();
     pagedList.getTotalCount();

--- a/ebean-test/src/test/java/org/tests/rawsql/TestRawSqlOrmWrapper2.java
+++ b/ebean-test/src/test/java/org/tests/rawsql/TestRawSqlOrmWrapper2.java
@@ -30,7 +30,7 @@ public class TestRawSqlOrmWrapper2 extends BaseTestCase {
     Query<OrderAggregate> query = DB.find(OrderAggregate.class);
     query.setRawSql(rawSql).fetchQuery("order", "status,orderDate")
       .fetch("order.customer", "name").where().gt("order.id", 0).having().gt("totalAmount", 20)
-      .order().desc("totalAmount").setMaxRows(10);
+      .orderBy().desc("totalAmount").setMaxRows(10);
 
     List<OrderAggregate> list = query.findList();
     assertNotNull(list);

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonBeanReadVisitor.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonBeanReadVisitor.java
@@ -25,7 +25,7 @@ public class TestTextJsonBeanReadVisitor extends BaseTestCase {
       .fetch("billingAddress", "line1, city")
       .fetch("billingAddress.country", "*")
       .fetch("contacts", "firstName,email")
-      .order().desc("id").findList();
+      .orderBy().desc("id").findList();
 
     JsonContext json = DB.json();
 

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReadManyLazyLoad.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReadManyLazyLoad.java
@@ -21,7 +21,7 @@ public class TestTextJsonReadManyLazyLoad extends BaseTestCase {
 
     ResetBasicData.reset();
 
-    List<Customer> list = DB.find(Customer.class).select("id, status, shippingAddress").order()
+    List<Customer> list = DB.find(Customer.class).select("id, status, shippingAddress").orderBy()
       .desc("id").findList();
 
     JsonContext json = DB.json();
@@ -42,7 +42,7 @@ public class TestTextJsonReadManyLazyLoad extends BaseTestCase {
     ResetBasicData.reset();
 
     List<Customer> list = DB.find(Customer.class).select("id, status, shippingAddress")
-      .fetch("contacts").order().desc("id").findList();
+      .fetch("contacts").orderBy().desc("id").findList();
 
     JsonContext json = DB.json();
 
@@ -63,7 +63,7 @@ public class TestTextJsonReadManyLazyLoad extends BaseTestCase {
 
     List<Customer> list = DB.find(Customer.class).select("id, name, status, shippingAddress")
       // .fetch("contacts")
-      .order().desc("id").findList();
+      .orderBy().desc("id").findList();
 
     JsonContext json = DB.json();
 

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
@@ -72,7 +72,7 @@ public class TestTextJsonReferenceBean extends BaseTestCase {
       // .setUseCache(false)
       .select("status, orderDate, shipDate, customer").fetch("details", "*")
       // .fetch("details.product","id")
-      .order().asc("id").findList();
+      .orderBy().asc("id").findList();
 
     Order order = orders.get(0);
 

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonSimple.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonSimple.java
@@ -66,7 +66,7 @@ public class TestTextJsonSimple extends BaseTestCase {
       .select("id, name, status, shippingAddress")
       .fetch("billingAddress", "line1, city").fetch("billingAddress.country", "*")
       .fetch("contacts", "firstName,email")
-      .order().desc("id").findList();
+      .orderBy().desc("id").findList();
 
     Database server = DB.getDefault();
 
@@ -102,7 +102,7 @@ public class TestTextJsonSimple extends BaseTestCase {
 
     List<Customer> list = DB.find(Customer.class)
       .select("id, name")
-      .order().desc("id").findList();
+      .orderBy().desc("id").findList();
 
     Database server = DB.getDefault();
 
@@ -125,7 +125,7 @@ public class TestTextJsonSimple extends BaseTestCase {
 
     List<Customer> list = DB.find(Customer.class)
       .select("id, name")
-      .order().desc("id").findList();
+      .orderBy().desc("id").findList();
 
     Database server = DB.getDefault();
 

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonSuperSimple.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonSuperSimple.java
@@ -20,7 +20,7 @@ public class TestTextJsonSuperSimple extends BaseTestCase {
 
     ResetBasicData.reset();
 
-    List<Customer> list = DB.find(Customer.class).select("id, name").order().desc("id")
+    List<Customer> list = DB.find(Customer.class).select("id, name").orderBy().desc("id")
       .findList();
 
     Database server = DB.getDefault();

--- a/ebean-test/src/test/java/org/tests/update/TestUpdateAllLoadedProperties.java
+++ b/ebean-test/src/test/java/org/tests/update/TestUpdateAllLoadedProperties.java
@@ -65,7 +65,7 @@ public class TestUpdateAllLoadedProperties extends BaseTestCase {
     List<EBasicVer> beans = DB.find(EBasicVer.class)
       .select("name, other")
       .where().idIn(ids)
-      .order().asc("id")
+      .orderBy().asc("id")
       .findList();
 
     assertEquals(2, beans.size());


### PR DESCRIPTION
No effective code change, just replaced the deprecated .order() with the .orderBy()

This was mostly done with search and replace, so this PR corrects also javadoc.

Sidenote: We may loose code coverage on `order()` and `order(String)` now, which effectively calls `orderBy