### PR TITLE
Invalid SQL for exist queries with many to many relation.

### DIFF
--- a/ebean-test/src/test/java/org/tests/m2m/TestM2MQueryAndIds.java
+++ b/ebean-test/src/test/java/org/tests/m2m/TestM2MQueryAndIds.java
@@ -56,7 +56,8 @@ public class TestM2MQueryAndIds extends BaseTestCase {
     Query<Role> query = DB.find(Role.class).select("id").where().exists(sq1).query();
     List<Role> models = query.findList();
     assertThat(models).hasSize(1);
-    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id left join mt_permission t1 on t1.id = t1z_.mt_permission_id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1.id))");
+    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1z_.mt_permission_id))");
+//    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id left join mt_permission t1 on t1.id = t1z_.mt_permission_id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1.id))");
   }
 
   @ForPlatform(Platform.H2)

--- a/ebean-test/src/test/java/org/tests/m2m/TestM2MQueryAndIds.java
+++ b/ebean-test/src/test/java/org/tests/m2m/TestM2MQueryAndIds.java
@@ -6,7 +6,11 @@ import io.ebean.Query;
 import io.ebean.annotation.Platform;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.xtest.ForPlatform;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.tests.model.m2m.Permission;
 import org.tests.model.m2m.Role;
@@ -16,17 +20,10 @@ import java.util.List;
 import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Foconis Analytics GmbH
- */
 public class TestM2MQueryAndIds extends BaseTestCase {
 
-  @BeforeEach
-  public void beforeEach() {
-    DB.find(Role.class).delete();
-    DB.find(Permission.class).delete();
-    DB.find(Tenant.class).delete();
-
+  @BeforeAll
+  public static void beforeAll() throws Exception {
     Tenant tenant = new Tenant("TestTenant");
     DB.save(tenant);
 
@@ -39,6 +36,13 @@ public class TestM2MQueryAndIds extends BaseTestCase {
     DB.save(role);
   }
 
+  @AfterAll
+  public static void afterAll() {
+    DB.find(Role.class).delete();
+    DB.find(Permission.class).delete();
+    DB.find(Tenant.class).delete();
+  }
+
   @ForPlatform(Platform.H2)
   @Test
   public void testM2MWithId() {
@@ -49,10 +53,10 @@ public class TestM2MQueryAndIds extends BaseTestCase {
       .raw("(sq1.id = permissions.id)")
       .query();
 
-    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    Query<Role> query = DB.find(Role.class).select("id").where().exists(sq1).query();
     List<Role> models = query.findList();
     assertThat(models).hasSize(1);
-    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id left join mt_permission t1 on t1.id = t1z_.mt_permission_id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1.id))");
+    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id left join mt_permission t1 on t1.id = t1z_.mt_permission_id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1.id))");
   }
 
   @ForPlatform(Platform.H2)
@@ -65,11 +69,11 @@ public class TestM2MQueryAndIds extends BaseTestCase {
       .raw("(sq1.id = permissions)")
       .query();
 
-    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    Query<Role> query = DB.find(Role.class).select("id").where().exists(sq1).query();
     List<Role> models = query.findList();
     assertThat(models).hasSize(1);
-    //                                                      select          t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0                                                              where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t0.[*]null))
-    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1z_.mt_permission_id))");
+    // query from testO2MWith...Id():                       select          t0.id from mt_role t0                                                              where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t0.tenant_id))
+    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1z_.mt_permission_id))");
   }
 
   @ForPlatform(Platform.H2)
@@ -82,10 +86,10 @@ public class TestM2MQueryAndIds extends BaseTestCase {
       .raw("(sq1.id = tenant.id)")
       .query();
 
-    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    Query<Role> query = DB.find(Role.class).select("id").where().exists(sq1).query();
     List<Role> models = query.findList();
     assertThat(models).hasSize(1);
-    assertThat(query.getGeneratedSql()).isEqualTo("select t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 where exists (select 1 from mt_tenant sq1 where sq1.name = ? and (sq1.id = t0.tenant_id))");
+    assertThat(query.getGeneratedSql()).isEqualTo("select t0.id from mt_role t0 where exists (select 1 from mt_tenant sq1 where sq1.name = ? and (sq1.id = t0.tenant_id))");
   }
 
   @ForPlatform(Platform.H2)
@@ -98,9 +102,9 @@ public class TestM2MQueryAndIds extends BaseTestCase {
       .raw("(sq1.id = tenant)")
       .query();
 
-    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    Query<Role> query = DB.find(Role.class).select("id").where().exists(sq1).query();
     List<Role> models = query.findList();
     assertThat(models).hasSize(1);
-    assertThat(query.getGeneratedSql()).isEqualTo("select t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 where exists (select 1 from mt_tenant sq1 where sq1.name = ? and (sq1.id = t0.tenant_id))");
+    assertThat(query.getGeneratedSql()).isEqualTo("select t0.id from mt_role t0 where exists (select 1 from mt_tenant sq1 where sq1.name = ? and (sq1.id = t0.tenant_id))");
   }
 }

--- a/ebean-test/src/test/java/org/tests/m2m/TestM2MQueryAndIds.java
+++ b/ebean-test/src/test/java/org/tests/m2m/TestM2MQueryAndIds.java
@@ -1,0 +1,106 @@
+package org.tests.m2m;
+
+
+import io.ebean.DB;
+import io.ebean.Query;
+import io.ebean.annotation.Platform;
+import io.ebean.xtest.BaseTestCase;
+import io.ebean.xtest.ForPlatform;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.tests.model.m2m.Permission;
+import org.tests.model.m2m.Role;
+import org.tests.model.m2m.Tenant;
+
+import java.util.List;
+import java.util.Set;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Foconis Analytics GmbH
+ */
+public class TestM2MQueryAndIds extends BaseTestCase {
+
+  @BeforeEach
+  public void beforeEach() {
+    DB.find(Role.class).delete();
+    DB.find(Permission.class).delete();
+    DB.find(Tenant.class).delete();
+
+    Tenant tenant = new Tenant("TestTenant");
+    DB.save(tenant);
+
+    Permission perm = new Permission("TestPerm");
+    DB.save(perm);
+
+    Role role = new Role("TestRole");
+    role.getPermissions().add(perm);
+    role.setTenant(tenant);
+    DB.save(role);
+  }
+
+  @ForPlatform(Platform.H2)
+  @Test
+  public void testM2MWithId() {
+    Query<Permission> sq1 = DB.find(Permission.class)
+      .alias("sq1")
+      .where()
+      .eq("name", "TestPerm")
+      .raw("(sq1.id = permissions.id)")
+      .query();
+
+    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    List<Role> models = query.findList();
+    assertThat(models).hasSize(1);
+    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id left join mt_permission t1 on t1.id = t1z_.mt_permission_id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1.id))");
+  }
+
+  @ForPlatform(Platform.H2)
+  @Test
+  public void testM2MWithoutId() {
+    Query<Permission> sq1 = DB.find(Permission.class)
+      .alias("sq1")
+      .where()
+      .eq("name", "TestPerm")
+      .raw("(sq1.id = permissions)")
+      .query();
+
+    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    List<Role> models = query.findList();
+    assertThat(models).hasSize(1);
+    //                                                      select          t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0                                                              where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t0.[*]null))
+    assertThat(query.getGeneratedSql()).isEqualTo("select distinct t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 left join mt_role_permission t1z_ on t1z_.mt_role_id = t0.id where exists (select 1 from mt_permission sq1 where sq1.name = ? and (sq1.id = t1z_.mt_permission_id))");
+  }
+
+  @ForPlatform(Platform.H2)
+  @Test
+  public void testO2MWithId() {
+    Query<Tenant> sq1 = DB.find(Tenant.class)
+      .alias("sq1")
+      .where()
+      .eq("name", "TestTenant")
+      .raw("(sq1.id = tenant.id)")
+      .query();
+
+    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    List<Role> models = query.findList();
+    assertThat(models).hasSize(1);
+    assertThat(query.getGeneratedSql()).isEqualTo("select t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 where exists (select 1 from mt_tenant sq1 where sq1.name = ? and (sq1.id = t0.tenant_id))");
+  }
+
+  @ForPlatform(Platform.H2)
+  @Test
+  public void testO2MWithoutId() {
+    Query<Tenant> sq1 = DB.find(Tenant.class)
+      .alias("sq1")
+      .where()
+      .eq("name", "TestTenant")
+      .raw("(sq1.id = tenant)")
+      .query();
+
+    Query<Role> query = DB.find(Role.class).where().exists(sq1).query();
+    List<Role> models = query.findList();
+    assertThat(models).hasSize(1);
+    assertThat(query.getGeneratedSql()).isEqualTo("select t0.id, t0.name, t0.version, t0.tenant_id from mt_role t0 where exists (select 1 from mt_tenant sq1 where sq1.name = ? and (sq1.id = t0.tenant_id))");
+  }
+}


### PR DESCRIPTION
Hello @rbygrave ,
We have identified the following issue: when performing an exists query with a One-To-Many relationship, correct SQL is generated regardless of whether an id is present or not. (The generated SQL does not include unnecessary joins).
However, when executing the same type of query with a Many-To-Many relationship, different SQL is being generated:
- without id: the SQL is incorrect. It contains `sq1.id = t0.null`.
- with id: the SQL works, but includes an unnecessary join: `left join mt_permission t1 on t1.id = t1z_.mt_permission_id`.

Perhaps you could take a look at this. We have 2 tests with asserts where we are expecting different results.

Juri