### PR TITLE
Possible critical bug: cache invalidation in QueryCache

### DIFF
--- a/ebean-test/src/test/java/org/tests/cache/TestQueryCacheConcurrent.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestQueryCacheConcurrent.java
@@ -1,0 +1,96 @@
+package org.tests.cache;
+
+import io.ebean.DB;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+import org.tests.model.cache.EColAB;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestQueryCacheConcurrent extends BaseTestCase {
+
+  private volatile boolean running;
+  private volatile boolean failed;
+  private volatile int  step;
+
+  @Test
+  public void testConcurrent() throws InterruptedException {
+
+    Thread t1 = new Thread(() -> {
+      while (running) {
+        while (step <1) {
+          if (!running) return;
+        }
+        System.out.println("T1 BEFORE Insert");
+        new EColAB("01", "20").save();
+        System.out.println("T1 AFTER Insert");
+        step = 2;
+        while (step < 3) {
+          if (!running) return;
+        }
+        System.out.println("-------------------------");
+        step = 1;
+      }
+    });
+
+    Thread t2 = new Thread(() -> {
+      while (running) {
+        while (step < 1) {
+          if (!running) return;
+        }
+        System.out.println("T2 before FIND1");
+        List<EColAB> list = DB.find(EColAB.class)
+          .setUseQueryCache(true)
+          .where()
+          .eq("columnA", "01")
+          .eq("columnB", "20")
+          .findList();
+        System.out.println("T2 FIND1: " + list.size());
+        while (step < 2) {
+          if (!running) return;
+        }
+        System.out.println("T2 before FIND2");
+        list = DB.find(EColAB.class)
+          .setUseQueryCache(true)
+          .where()
+          .eq("columnA", "01")
+          .eq("columnB", "20")
+          .findList();
+        System.out.println("T2 FIND2: " + list.size());
+        if (list.isEmpty()) {
+          try {
+            Thread.sleep(1000);
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+          list = DB.find(EColAB.class)
+            .setUseQueryCache(true)
+            .where()
+            .eq("columnA", "01")
+            .eq("columnB", "20")
+            .findList();
+          System.out.println("After 1s: in cache" + list);
+          System.out.println("...          in DB" + DB.find(EColAB.class).findOne());
+        }
+        if (list.isEmpty()) {
+          failed = true;
+        }
+        DB.find(EColAB.class).delete();
+        step = 3;
+      }
+    });
+
+    running = true;
+    t1.start();
+    t2.start();
+    step = 1;
+    Thread.sleep(1000);
+    running = false;
+    t1.join();
+    t2.join();
+    assertThat(failed).isFalse();
+  }
+
+}


### PR DESCRIPTION
Hello @rbygrave,

In our application we found an interesting situation when the caches are not working correctly.
We have two threads, T2 is a worker thread that periodically checks a table to see whether there are new records.
T1 creates such data sets.

Use case: T1 inserts a record into the database and after that notifies T2 that the data now exists and he should start working now.
T2 has a query with `.setUseQueryCache(true)`. Normally T2 should now find the inserted record from T1 (that's how the where conditions are defined).
If the timing happens that T1 inserts the record while T2 happens to be executing a `DB.find.setUseQueryCache(true)`, incorrect data is stored in the cache. From then on, the data record will not be found, even though it is in the DB. Not even if you wait a few seconds.

We wrote a test case that reproduces the behavior and tries to explain what happens in the table below:

```
    Thread 1        |  Thread 2
---------------------------------------------------------
                    |  T2 before FIND1
                    |    find (with .setUseQueryCache(true))
T1 BEFORE Insert    |
  insert into       |  
  clear CACHE       |
T1 AFTER Insert     |
                    |    put CACHE <-- The error is here
                    |  T2 FIND1: 0 <-- ok, not yet synchronized
                synchronize
                    |  T2 before FIND2
                    |    find (with .setUseQueryCache(true))
                    |    hit CACHE
                    |  T2 FIND2: 0 <-- wrong
```

in my opinion put cache overwrites the current state of what T1 has written. A possible fix could be that we remember the cache.clear count before the find and take this into account when putting cache.
Or implement another type of locking.

Cheers
Noemi