### PR TITLE
No productive code change: cleanup basic test data

### DIFF
--- a/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
+++ b/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
@@ -55,6 +55,9 @@ public class TestBatchInsertFlush extends BaseTestCase {
       DB.saveAll(customers);
 
       txn.commit();
+    } finally {
+      DB.find(Customer.class).where().startsWith("name", "BatchFlush").delete();
+      DB.find(Contact.class).where().startsWith("firstName", "Fred").startsWith("lastName", "Blue").delete();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
+++ b/ebean-test/src/test/java/org/tests/batchinsert/TestBatchInsertFlush.java
@@ -42,13 +42,13 @@ public class TestBatchInsertFlush extends BaseTestCase {
 
       for (int i = 0; i < 3; i++) {
         Customer customer = ResetBasicData.createCustomer("BatchFlushPreInsert " + i, null, null, 3);
-        customer.addContact(new Contact("Fred" + i, "Blue"));
+        customer.addContact(new Contact("BatchFlush" + i, "Blue"));
         customers.add(customer);
       }
 
       for (int i = 3; i < 6; i++) {
         Customer customer = ResetBasicData.createCustomer("BatchFlushPostInsert " + i, null, null, 3);
-        customer.addContact(new Contact("Fred" + i, "Blue"));
+        customer.addContact(new Contact("BatchFlush" + i, "Blue"));
         customers.add(customer);
       }
 
@@ -57,7 +57,7 @@ public class TestBatchInsertFlush extends BaseTestCase {
       txn.commit();
     } finally {
       DB.find(Customer.class).where().startsWith("name", "BatchFlush").delete();
-      DB.find(Contact.class).where().startsWith("firstName", "Fred").startsWith("lastName", "Blue").delete();
+      DB.find(Contact.class).where().startsWith("firstName", "BatchFlush").startsWith("lastName", "Blue").delete();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/cache/TestBeanCacheContactLazyLoad.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestBeanCacheContactLazyLoad.java
@@ -52,24 +52,30 @@ public class TestBeanCacheContactLazyLoad extends BaseTestCase {
 
     DB.save(contact);
 
-    // Only get two properties, so we have to lazy-load later
-    final Contact contactDb = DB.find(Contact.class).where().eq("email", "tim@button.com").select("email,lastName").findOne();
-    assertThat(contactDb).isNotNull();
-    LoggedSql.start();
-    contactDb.setLastName("Buttonnnn");
-    List<String> sql = LoggedSql.collect();
-    assertThat(sql).isEmpty(); // setter did not trigger lazy load
+    try {
 
-    // trigger lazy load
-    assertThat(contactDb.getPhone()).isEqualTo("1234567890");
-    sql = LoggedSql.collect();
-    assertThat(sql).isNotEmpty(); // Lazy-load took place
+      // Only get two properties, so we have to lazy-load later
+      final Contact contactDb = DB.find(Contact.class).where().eq("email", "tim@button.com").select("email,lastName").findOne();
+      assertThat(contactDb).isNotNull();
+      LoggedSql.start();
+      contactDb.setLastName("Buttonnnn");
+      List<String> sql = LoggedSql.collect();
+      assertThat(sql).isEmpty(); // setter did not trigger lazy load
 
-    final Contact contactDb2 = DB.find(Contact.class).where().eq("email", "tim@button.com").select("email,lastName").findOne();
-    sql = LoggedSql.stop();
-    assertThat(sql).isEmpty(); // We expect that the bean was loaded from cache
-    assertThat(contactDb2).isNotNull();
-    assertThat(contactDb2.getLastName()).isEqualTo("Button");
+      // trigger lazy load
+      assertThat(contactDb.getPhone()).isEqualTo("1234567890");
+      sql = LoggedSql.collect();
+      assertThat(sql).isNotEmpty(); // Lazy-load took place
+
+      final Contact contactDb2 = DB.find(Contact.class).where().eq("email", "tim@button.com").select("email,lastName").findOne();
+      sql = LoggedSql.stop();
+      assertThat(sql).isEmpty(); // We expect that the bean was loaded from cache
+      assertThat(contactDb2).isNotNull();
+      assertThat(contactDb2.getLastName()).isEqualTo("Button");
+    } finally {
+      DB.delete(customer);
+      DB.find(Contact.class).where().eq("email", "tim@button.com").delete();
+    }
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/model/basic/ResetBasicData.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/ResetBasicData.java
@@ -26,7 +26,7 @@ public class ResetBasicData {
         // OK, test data not modified
         outputCustomerIds();
       } else {
-        outputState();
+        outputState(true);
       }
       return;
     }
@@ -45,11 +45,11 @@ public class ResetBasicData {
       me.insertProducts();
       me.insertTestCustAndOrders();
     });
-    outputState();
+    outputState(false);
     runOnce = true;
   }
 
-  private static void outputState() {
+  private static void outputState(boolean warning) {
     StringBuilder sb = new StringBuilder();
     sb.append("CustomerIds:");
     server.find(Customer.class).findEach(c -> sb.append(' ').append(c.getId()));
@@ -59,8 +59,13 @@ public class ResetBasicData {
     server.find(Country.class).findEach(c -> sb.append(' ').append(c.getCode()));
     sb.append(", Products:");
     server.find(Product.class).findEach(c -> sb.append(' ').append(c.getId()));
-    System.err.println("WARNING: basic test data was modified. Current content:");
-    System.err.println(sb);
+    if (warning) {
+      System.err.println("WARNING: basic test data was modified. Current content:");
+      System.err.println(sb);
+    } else {
+      System.out.println("ResetBasicData. basic test data was initialized Current content:");
+      System.out.println(sb);
+    }
   }
 
   private static void outputCustomerIds() {

--- a/ebean-test/src/test/java/org/tests/transaction/TestExecuteComplete.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestExecuteComplete.java
@@ -141,7 +141,11 @@ public class TestExecuteComplete extends BaseTestCase {
     cust.setName("Roland");
     DB.save(cust);
 
-    assertThat(getInScopeTransaction()).isNull();
+    try {
+      assertThat(getInScopeTransaction()).isNull();
+    } finally {
+      DB.delete(cust);
+    }
   }
 
   @ForPlatform(Platform.H2)


### PR DESCRIPTION
Hello @rbygrave,

our ebean fork has a green build in github and local, but not on our Bamboo server. 

Reason: one test is based on the 4 basic customers in the DB and other tests create customers that are never cleaned up. The execution order is different on different servers, so it is a matter of luck whether the build goes through.

I have adjusted the affected tests to clean up their test data, so there is no longer a warning in the build log with "WARNING: basic test data was modified. Current content:"

Can you take a look at it?

Cheers
Noemi