### PR TITLE
FIX: IllegalAccessError on modular DTO queries

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaConstructor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaConstructor.java
@@ -14,7 +14,7 @@ final class DtoMetaConstructor {
 
   private final Class<?>[] types;
   private final MethodHandle handle;
-  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
   private final ScalarType<?>[] scalarTypes;
 
   DtoMetaConstructor(TypeManager typeManager, Constructor<?> constructor, Class<?> someClass) throws NoSuchMethodException, IllegalAccessException {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
@@ -13,7 +13,7 @@ import java.sql.SQLException;
 
 final class DtoMetaProperty implements DtoReadSet {
 
-  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
 
   private final Class<?> dtoType;
   private final String name;


### PR DESCRIPTION
When using a dto query on a JPMS application, I get an IllegalAccessError even though I export and open my package.

This change allows for the lookup of public method/constructor method handles in JPMS