### PR TITLE
FIX: export io.ebeaninternal.api to support `@Transactional` on the module path 

### DIFF
--- a/ebean-core/src/main/java/module-info.java
+++ b/ebean-core/src/main/java/module-info.java
@@ -47,7 +47,7 @@ module io.ebean.core {
   exports io.ebeanservice.docstore.api.support to io.ebean.elastic, io.ebean.test;
   exports io.ebeanservice.docstore.api.mapping to io.ebean.elastic;
 
-  exports io.ebeaninternal.api to io.ebean.ddl.generator, io.ebean.querybean, io.ebean.autotune, io.ebean.postgis, io.ebean.test, io.ebean.elastic, io.ebean.spring.txn, io.ebean.postgis.types;
+  exports io.ebeaninternal.api;
   exports io.ebeaninternal.api.json to io.ebean.test;
   exports io.ebeaninternal.json to io.ebean.test;
   exports io.ebeaninternal.server.autotune to io.ebean.autotune;


### PR DESCRIPTION
resolves #3533 by exporting the inaccessible module