### PR TITLE
Nested transactions: settings won't be resetted after inner Trx is done

### DIFF
--- a/ebean-test/src/test/java/org/tests/transaction/TestNestedTransaction.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestNestedTransaction.java
@@ -1,5 +1,6 @@
 package org.tests.transaction;
 
+import io.ebean.TxScope;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.Transaction;
@@ -235,4 +236,19 @@ public class TestNestedTransaction extends BaseTestCase {
     }
     assertModified();
   }
+
+  @Test
+  public void test_txn_with_BatchMode() {
+
+    try (Transaction txn1 = DB.beginTransaction(TxScope.requiresNew())) {
+
+      try (Transaction txn2 = DB.beginTransaction()) {
+        txn2.setBatchMode(true);
+        txn2.commit();
+      }
+      // resume txn1
+      assertThat(txn1.isBatchMode()).isFalse();
+    }
+  }
+
 }


### PR DESCRIPTION
Hello @rbygrave,

in our application we have a constellation that we use nested transactions (as in the testcase).
We switch on batchMode in the inner transaction, but unfortunately this also remains switched on for the outer transaction.
mariaDb cannot handle some prepared queries in the outer transaction and throws an exception in our use case.

We assumed that the settings in the nested transaction have no effect on the outer one. Do we assume this correctly?

Cheers
Noemi