### PR TITLE
[querybean-generator] FilerException trying to write EntityClassRegister with Quarkus dev mode / hot reload #3541

### DIFF
--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -415,9 +415,10 @@ class ProcessingContext implements Constants {
     messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
   }
 
-  /**
-   * Log a info message.
-   */
+  void logWarn(String msg, Object... args) {
+    messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args));
+  }
+
   void logNote(String msg, Object... args) {
     messager.printMessage(Diagnostic.Kind.NOTE, String.format(msg, args));
   }
@@ -559,7 +560,6 @@ class ProcessingContext implements Constants {
     } catch (FilerException e) {
       logNote(null, "FilerException reading services file: " + e.getMessage());
     } catch (Exception e) {
-      e.printStackTrace();
       logError(null, "Error reading services file: " + e.getMessage());
     }
     return null;

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -1,6 +1,7 @@
 package io.ebean.querybean.generator;
 
 import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.FilerException;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
@@ -99,7 +100,7 @@ public class Processor extends AbstractProcessor implements Constants {
     try {
       new SimpleModuleInfoWriter(processingContext).write();
     } catch (FilerException e) {
-      processingContext.logWarn(null, "FilerException trying to write EntityClassRegister error: " + e);
+      processingContext.logWarn(null, "FilerException trying to write EntityClassRegister: " + e);
     } catch (Throwable e) {
       processingContext.logError(null, "Failed to write EntityClassRegister error:" + e + " stack:" + Arrays.toString(e.getStackTrace()));
     }

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -19,14 +19,12 @@ public class Processor extends AbstractProcessor implements Constants {
   private static final String KAPT_KOTLIN_GENERATED_OPTION = "kapt.kotlin.generated";
 
   private ProcessingContext processingContext;
-  private SimpleModuleInfoWriter moduleWriter;
 
   public Processor() {
   }
 
   @Override
   public Set<String> getSupportedOptions() {
-
     Set<String> options =  new LinkedHashSet<>();
     options.add(KAPT_KOTLIN_GENERATED_OPTION);
     options.add(GENERATE_KOTLIN_CODE_OPTION);
@@ -61,7 +59,6 @@ public class Processor extends AbstractProcessor implements Constants {
     int count = processEntities(roundEnv);
     processOthers(roundEnv);
     final int loaded = processingContext.complete();
-    initModuleInfoBean();
     if (roundEnv.processingOver()) {
       writeModuleInfoBean();
     }
@@ -98,26 +95,12 @@ public class Processor extends AbstractProcessor implements Constants {
     }
   }
 
-  private void initModuleInfoBean() {
-    try {
-      if (moduleWriter == null) {
-        moduleWriter = new SimpleModuleInfoWriter(processingContext);
-      }
-    } catch (Throwable e) {
-      e.printStackTrace();
-      processingContext.logError(null, "Failed to initialise EntityClassRegister error:" + e + " stack:" + Arrays.toString(e.getStackTrace()));
-    }
-  }
-
   private void writeModuleInfoBean() {
     try {
-      if (moduleWriter == null) {
-        processingContext.logError(null, "EntityClassRegister was not initialised and not written");
-      } else {
-        moduleWriter.write();
-      }
+      new SimpleModuleInfoWriter(processingContext).write();
+    } catch (FilerException e) {
+      processingContext.logWarn(null, "FilerException trying to write EntityClassRegister error: " + e);
     } catch (Throwable e) {
-      e.printStackTrace();
       processingContext.logError(null, "Failed to write EntityClassRegister error:" + e + " stack:" + Arrays.toString(e.getStackTrace()));
     }
   }

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
@@ -50,7 +50,6 @@ class SimpleModuleInfoWriter {
       }
 
     } catch (IOException e) {
-      e.printStackTrace();
       processingContext.logError(null, "Failed to write services file " + e.getMessage());
     }
   }
@@ -70,7 +69,6 @@ class SimpleModuleInfoWriter {
       }
 
     } catch (IOException e) {
-      e.printStackTrace();
       processingContext.logError(null, "Failed to write services file " + e.getMessage());
     }
   }

--- a/querybean-generator/pom.xml
+++ b/querybean-generator/pom.xml
@@ -7,9 +7,10 @@
     <version>14.8.1</version>
   </parent>
 
+  <version>14.8.2-RC2</version>
   <name>querybean generator</name>
-  <description>Querybean generator</description>
   <artifactId>querybean-generator</artifactId>
+  <description>Querybean generator</description>
 
   <build>
     <plugins>

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -403,6 +403,10 @@ class ProcessingContext implements Constants {
     messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
   }
 
+  void logWarn(String msg, Object... args) {
+    messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args));
+  }
+
   void logNote(String msg, Object... args) {
     messager.printMessage(Diagnostic.Kind.NOTE, String.format(msg, args));
   }
@@ -549,7 +553,6 @@ class ProcessingContext implements Constants {
     } catch (FilerException e) {
       logNote(null, "FilerException reading services file: " + e.getMessage());
     } catch (Exception e) {
-      e.printStackTrace();
       logError(null, "Error reading services file: " + e.getMessage());
     }
     return null;

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -89,7 +89,7 @@ public class Processor extends AbstractProcessor implements Constants {
     try {
       new SimpleModuleInfoWriter(processingContext).write();
     } catch (FilerException e) {
-      processingContext.logWarn(null, "FilerException trying to write EntityClassRegister error: " + e);
+      processingContext.logWarn(null, "FilerException trying to write EntityClassRegister: " + e);
     } catch (Throwable e) {
       processingContext.logError(null, "Failed to write EntityClassRegister error:" + e + " stack:" + Arrays.toString(e.getStackTrace()));
     }


### PR DESCRIPTION
Drop to log at WARN level when we catch FilerException such that Quarkus dev mode / hot reload works

The effective change here is to catch FilerException and log at WARN rather than ERROR:
```java
} catch (FilerException e) {
  processingContext.logWarn(null, "FilerException trying to write EntityClassRegister: " + e);
}
```