### PR TITLE
Pass create/configOptions to DB2 test container

### DIFF
--- a/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/Config.java
@@ -19,7 +19,7 @@ class Config {
   /**
    * Common optional docker parameters that we just transfer to docker properties.
    */
-  private static final String[] DOCKER_TEST_PARAMS = {"fastStartMode", "inMemory", "initSqlFile", "seedSqlFile", "adminUser", "adminPassword", "extraDb", "extraDb.dbName", "extraDb.username", "extraDb.password", "extraDb.extensions", "extraDb.initSqlFile", "extraDb.seedSqlFile"};
+  private static final String[] DOCKER_TEST_PARAMS = {"fastStartMode", "inMemory", "initSqlFile", "seedSqlFile", "adminUser", "adminPassword", "extraDb", "extraDb.dbName", "extraDb.username", "extraDb.password", "extraDb.extensions", "extraDb.initSqlFile", "extraDb.seedSqlFile", "createOptions", "configOptions"};
   private static final String[] DOCKER_PLATFORM_PARAMS = {"containerName", "image", "internalPort", "startMode", "shutdownMode", "maxReadyAttempts", "tmpfs", "collation", "characterSet"};
 
   private static final String DDL_MODE_OPTIONS = "dropCreate, create, none, migration, createOnly or migrationDropCreate";


### PR DESCRIPTION
This allows to pass collation/pagesize settings via the `ebean.test.createOptions=` property to the container

This is a quick workaround, so that I can set up DB2 containers with certain pagesize.
Please see also https://github.com/ebean-orm/ebean-test-containers/issues/116, if this is right way for long term?