### PR TITLE
#3557 [Query beans] Remove deprecated filterMany(String expressions, Object... params) from generated query beans

### DIFF
--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocBean.java
@@ -196,12 +196,6 @@ public abstract class TQAssocBean<T, R, QB> extends TQAssoc<T, R> {
     return _root;
   }
 
-  /** Deprecated(forRemoval = true) */
-  protected final R _filterMany(String expressions, Object... params) {
-    expr().filterMany(_name, expressions, params);
-    return _root;
-  }
-
   protected final R _filterManyRaw(String rawExpressions, Object... params) {
     expr().filterManyRaw(_name, rawExpressions, params);
     return _root;

--- a/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocMany.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/TQAssocMany.java
@@ -23,38 +23,6 @@ public interface TQAssocMany<T, R, QB> {
   R filterMany(ExpressionList<T> filter);
 
   /**
-   * @param expressions The expressions including and, or, not etc with ? and ?1 bind params.
-   * @param params      The bind parameter values
-   * @deprecated for removal - migrate to {@link #filterManyRaw(String, Object...)}.
-   * <p>
-   * Apply a filter when fetching these beans.
-   * <p>
-   * The expressions can use any valid Ebean expression and contain
-   * placeholders for bind values using <code>?</code> or <code>?1</code> style.
-   * </p>
-   *
-   * <pre>{@code
-   *
-   *     new QCustomer()
-   *       .name.startsWith("Postgres")
-   *       .contacts.filterMany("firstName istartsWith ?", "Rob")
-   *       .findList();
-   *
-   * }</pre>
-   *
-   * <pre>{@code
-   *
-   *     new QCustomer()
-   *       .name.startsWith("Postgres")
-   *       .contacts.filterMany("whenCreated inRange ? to ?", startDate, endDate)
-   *       .findList();
-   *
-   * }</pre>
-   */
-  @Deprecated(forRemoval = true)
-  R filterMany(String expressions, Object... params);
-
-  /**
    * Add filter expressions for the many path. The expressions can include SQL functions if
    * desired and the property names are translated to column names.
    * <p>

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -667,7 +667,7 @@ public class QCustomerTest {
 
     new QCustomer()
       .name.startsWith("Postgres")
-      .contacts.filterMany("firstName istartsWith ?", "Rob")
+      .contacts.filterManyRaw("firstName like ?", "Rob%")
       .findList();
 
     final LocalDate startDate = LocalDate.now().minusDays(7);
@@ -675,7 +675,7 @@ public class QCustomerTest {
 
     new QCustomer()
       .name.startsWith("Postgres")
-      .contacts.filterMany("whenCreated inRange ? to ?", startDate, endDate)
+      .contacts.filterManyRaw("whenCreated >= ? and whenCreated < ?", startDate, endDate)
       .findList();
   }
 

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -328,12 +328,6 @@ class SimpleQueryBeanWriter {
     writer.append("      return _filterManyRaw(rawExpressions, *params)").eol();
     writer.append("    }").eol().eol();
 
-    // Ebean 14.x only
-    writer.append("    @Deprecated(\"for removal, migrate to filterManyRaw()\")").eol();
-    writer.append("    override fun filterMany(rawExpressions: String, vararg params: Any): R {").eol();
-    writer.append("      return _filterMany(rawExpressions, *params)").eol();
-    writer.append("    }").eol().eol();
-
     writer.append("    override fun isEmpty(): R {").eol();
     writer.append("      return _isEmpty() ").eol();
     writer.append("    }").eol().eol();

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleQueryBeanWriter.java
@@ -322,10 +322,6 @@ class SimpleQueryBeanWriter {
     writer.append("    public R filterManyRaw(String rawExpressions, Object... params) { return _filterManyRaw(rawExpressions, params); }").eol();
     writer.eol();
     writer.append("    @Override").eol();
-    writer.append("    @Deprecated(forRemoval = true)").eol();
-    writer.append("    public R filterMany(String expressions, Object... params) { return _filterMany(expressions, params); }").eol();
-    writer.eol();
-    writer.append("    @Override").eol();
     writer.append("    public R isEmpty() { return _isEmpty(); }").eol();
     writer.eol();
     writer.append("    @Override").eol();


### PR DESCRIPTION
Migrate to filterManyRaw()