### PR TITLE
#3533 Support @Transactional on module path

### DIFF
--- a/ebean-api/src/main/java/io/ebean/plugin/AOPTransactionScope.java
+++ b/ebean-api/src/main/java/io/ebean/plugin/AOPTransactionScope.java
@@ -1,25 +1,34 @@
-package io.ebeaninternal.api;
+package io.ebean.plugin;
 
+import io.ebean.DB;
 import io.ebean.TxScope;
-import io.ebean.plugin.AOPTransactionScope;
 
 /**
  * Helper object to make AOP generated code simpler.
  */
-public final class HelpScopeTrans {
+public final class AOPTransactionScope {
+  private static boolean enabled = true;
 
   /**
    * Entering an enhanced transactional method.
    */
   public static void enter(TxScope txScope) {
-    AOPTransactionScope.enter(txScope);
+    if (enabled) {
+      server().scopedTransactionEnter(txScope);
+    }
   }
 
   /**
    * Exiting an enhanced transactional method.
    */
   public static void exit(Object returnOrThrowable, int opCode) {
-    AOPTransactionScope.exit(returnOrThrowable, opCode);
+    if (enabled) {
+      server().scopedTransactionExit(returnOrThrowable, opCode);
+    }
+  }
+
+  private static SpiServer server() {
+    return (SpiServer) DB.getDefault();
   }
 
   /**
@@ -29,6 +38,6 @@ public final class HelpScopeTrans {
    * @param enabled if set to false, @Transactional will not create a transaction
    */
   public static void setEnabled(boolean enabled) {
-    AOPTransactionScope.setEnabled(enabled);
+    AOPTransactionScope.enabled = enabled;
   }
 }

--- a/ebean-api/src/main/java/io/ebean/plugin/SpiServer.java
+++ b/ebean-api/src/main/java/io/ebean/plugin/SpiServer.java
@@ -1,6 +1,7 @@
 package io.ebean.plugin;
 
 import io.ebean.Database;
+import io.ebean.TxScope;
 import io.ebean.bean.BeanLoader;
 import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.DatabaseBuilder;
@@ -63,4 +64,15 @@ public interface SpiServer extends Database {
    * Typically due to serialisation or multiple stateless updates.
    */
   void loadBean(EntityBeanIntercept ebi);
+
+  /**
+   * Start an enhanced transactional method.
+   */
+  void scopedTransactionEnter(TxScope txScope);
+
+  /**
+   * Handle the end of an enhanced Transactional method.
+   */
+  void scopedTransactionExit(Object returnOrThrowable, int opCode);
+
 }

--- a/ebean-api/src/main/resources/META-INF/ebean-version.mf
+++ b/ebean-api/src/main/resources/META-INF/ebean-version.mf
@@ -1,1 +1,1 @@
-ebean-version: 148
+ebean-version: 149

--- a/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/SpiEbeanServer.java
@@ -217,16 +217,6 @@ public interface SpiEbeanServer extends SpiServer, ExtendedServer, BeanCollectio
   void slowQueryCheck(long executionTimeMicros, int rowCount, SpiQuery<?> query);
 
   /**
-   * Start an enhanced transactional method.
-   */
-  void scopedTransactionEnter(TxScope txScope);
-
-  /**
-   * Handle the end of an enhanced Transactional method.
-   */
-  void scopedTransactionExit(Object returnOrThrowable, int opCode);
-
-  /**
    * SqlQuery find single attribute.
    */
   <T> T findSingleAttribute(SpiSqlQuery query, Class<T> cls);

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -309,7 +309,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.8.0</tile>
+            <tile>io.ebean.tile:enhancement:14.8.1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -309,7 +309,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.8.1</tile>
+            <tile>io.ebean.tile:enhancement:14.9.0-RC1</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiServer.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/api/TDSpiServer.java
@@ -188,6 +188,16 @@ public class TDSpiServer implements SpiServer {
   }
 
   @Override
+  public void scopedTransactionEnter(TxScope txScope) {
+
+  }
+
+  @Override
+  public void scopedTransactionExit(Object returnOrThrowable, int opCode) {
+
+  }
+
+  @Override
   public Transaction createTransaction() {
     return null;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <ebean-migration.version>14.2.0</ebean-migration.version>
     <ebean-test-containers.version>7.5</ebean-test-containers.version>
     <ebean-datasource.version>9.0</ebean-datasource.version>
-    <ebean-agent.version>14.8.1</ebean-agent.version>
-    <ebean-maven-plugin.version>14.8.1</ebean-maven-plugin.version>
+    <ebean-agent.version>14.9.0-RC1</ebean-agent.version>
+    <ebean-maven-plugin.version>14.9.0-RC1</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>
     <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
   </properties>


### PR DESCRIPTION
As HelpScopeTrans isn't in an exported package it's use fails with an error in module path. This adds AOPTransactionScope in the exported package io.ebean.plugin and moves the required methods from SpiEbeanServer to SpiServer to support this move.

This also requires an associate change in ebean-agent to support this feature which will be in ebean-agent 14.9.0.