### PR TITLE
#3564 Fix for nested transaction with batch-mode does not flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,6 @@ Work at the highest level of abstraction and drop down levels as needed.
         </a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://www.payintech.com/" target="_blank">
-          <img width="222px" src="https://ebean.io/images/sponsor_PayinTech-logo-noir.png">
-        </a>
-      </td>
-      <td align="center" valign="middle">
         <a href="https://www.premium-minds.com" target="_blank">
           <img width="222px" src="https://ebean.io/images/logo-med-principal.png">
         </a>

--- a/ebean-core/src/main/java/io/ebeaninternal/api/ScopeTrans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/ScopeTrans.java
@@ -142,6 +142,8 @@ public final class ScopeTrans {
       transaction.commit();
     } else {
       nestedCommit = true;
+      transaction.flush();
+      // restore the batch settings
       transaction.setFlushOnQuery(restoreBatchFlushOnQuery);
       transaction.setBatchMode(restoreBatch);
       transaction.setBatchOnCascade(restoreBatchOnCascade);

--- a/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/api/ScopedTransaction.java
@@ -168,7 +168,7 @@ public final class ScopedTransaction extends SpiTransactionProxy {
   /**
    * Maybe rollback based on TxScope rollback on settings.
    */
-  public Exception caughtThrowable(Exception e) {
+  public <T extends Exception> T caughtThrowable(T e) {
     return current.caughtThrowable(e);
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -680,6 +680,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
       return callable.call();
     } catch (Error e) {
       throw scopeTrans.caughtError(e);
+    } catch (PersistenceException e) {
+      throw scopeTrans.caughtThrowable(e);
     } catch (Exception e) {
       throw new PersistenceException(scopeTrans.caughtThrowable(e));
     } finally {
@@ -699,6 +701,8 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
       runnable.run();
     } catch (Error e) {
       throw t.caughtError(e);
+    } catch (PersistenceException e) {
+      throw t.caughtThrowable(e);
     } catch (Exception e) {
       throw new PersistenceException(t.caughtThrowable(e));
     } finally {

--- a/ebean-test/src/test/java/org/tests/transaction/TestExecuteComplete.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestExecuteComplete.java
@@ -67,7 +67,7 @@ public class TestExecuteComplete extends BaseTestCase {
 
   @ForPlatform(Platform.H2)
   @Test
-  public void transactional_errorOnCommit_expect_threadScopeCleanup() {
+  void transactional_errorOnCommit_expect_threadScopeCleanup() {
     try {
       errorOnCommit();
       fail();

--- a/ebean-test/src/test/java/org/tests/transaction/TestNested.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestNested.java
@@ -9,11 +9,10 @@ import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestNested extends BaseTestCase {
+class TestNested extends BaseTestCase {
 
   @Test
-  public void testRunnableFail() {
-
+  void testRunnableFail() {
     try {
       DB.execute(this::willFail);
     } catch (PersistenceException e) {
@@ -22,8 +21,7 @@ public class TestNested extends BaseTestCase {
   }
 
   @Test
-  public void testCallableFail() {
-
+  void testCallableFail() {
     try {
       DB.execute(this::willFailCallable);
     } catch (PersistenceException e) {


### PR DESCRIPTION
- Adds flush() into ScopeTrans.commitTransaction()
- Related fixes in DefaultServer execute() and executeCall() where it was performing extra unnecessary nesting on PersistenceException