### PR TITLE
Allow OneToOne to map to ManyToOne

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -1002,11 +1002,8 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
     if (!(mappedProp instanceof DeployBeanPropertyAssocOne<?>)) {
       throw new PersistenceException("Error on " + prop + ". mappedBy property " + targetDesc + "." + mappedBy + " is not a OneToOne?");
     }
-    DeployBeanPropertyAssocOne<?> mappedAssocOne = (DeployBeanPropertyAssocOne<?>) mappedProp;
-    if (!mappedAssocOne.isOneToOne()) {
-      throw new PersistenceException("Error on " + prop + ". mappedBy property " + targetDesc + "." + mappedBy + " is not a OneToOne?");
-    }
-    return mappedAssocOne;
+    // this is allowed to be a OneToOne or ManyToOne
+    return (DeployBeanPropertyAssocOne<?>) mappedProp;
   }
 
   private void checkUniDirectionalPrimaryKeyJoin(DeployBeanPropertyAssocOne<?> prop) {

--- a/ebean-test/src/test/java/org/tests/model/basic/OEngine.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/OEngine.java
@@ -1,9 +1,7 @@
 package org.tests.model.basic;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Version;
+import jakarta.persistence.*;
+
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -20,7 +18,7 @@ public class OEngine implements Serializable {
   @Version
   private Integer version;
 
-  @OneToOne
+  @ManyToOne
   private OCar car;
 
   public OEngine() {


### PR DESCRIPTION
This change allows a `@OneToOne(mappedBy=...)` to map to a `@ManyToOne`
```
Caused by: jakarta.persistence.PersistenceException: Error on ___. mappedBy property ___ is not a OneToOne?
	at io.ebeaninternal.server.deploy.BeanDescriptorManager.mappedOneToOne(BeanDescriptorManager.java:869)
	at io.ebeaninternal.server.deploy.BeanDescriptorManager.checkMappedByOneToOne(BeanDescriptorManager.java:843)
	at io.ebeaninternal.server.deploy.BeanDescriptorManager.checkMappedBy(BeanDescriptorManager.java:675)
	at io.ebeaninternal.server.deploy.BeanDescriptorManager.readEntityRelationships(BeanDescriptorManager.java:631)
	at io.ebeaninternal.server.deploy.BeanDescriptorManager.deploy(BeanDescriptorManager.java:277)
```