### PR TITLE
#3511 bump ebean-test-containers dependency

### DIFF
--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
@@ -138,9 +138,9 @@ public class TestQueryFindIterate extends BaseTestCase {
     List<String> loggedSql = LoggedSql.stop();
 
     assertEquals(3, loggedSql.size());
-    assertTrue(trimSql(loggedSql.get(0), 7).contains("select t0.id, t0.status, t0.order_date, t1.id, t1.name from o_order t0 join o_customer t1"));
-    assertTrue(trimSql(loggedSql.get(1), 7).contains("select t0.order_id, t0.id, t0.order_qty, t0.ship_qty, t0.unit_price"));
-    assertTrue(trimSql(loggedSql.get(2), 7).contains("select t0.order_id, t0.id, t0.ship_time, t0.cretime, t0.updtime, t0.version, t0.order_id from or_order_ship"));
+    assertThat(trimSql(loggedSql.get(0), 7)).contains("select t0.id, t0.status, t0.order_date, t1.id, t1.name from o_order t0 join o_customer t1");
+    assertThat(trimSql(loggedSql.get(1), 7)).contains("select t0.order_id, t0.id, t0.order_qty, t0.ship_qty, t0.unit_price");
+    assertThat(trimSql(loggedSql.get(2), 7)).contains("select t0.order_id, t0.id, t0.ship_time, t0.cretime, t0.updtime, t0.version, t0.order_id from or_order_ship");
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindIterate.java
@@ -138,9 +138,9 @@ public class TestQueryFindIterate extends BaseTestCase {
     List<String> loggedSql = LoggedSql.stop();
 
     assertEquals(3, loggedSql.size());
-    assertThat(trimSql(loggedSql.get(0), 7)).contains("select t0.id, t0.status, t0.order_date, t1.id, t1.name from o_order t0 join o_customer t1");
-    assertThat(trimSql(loggedSql.get(1), 7)).contains("select t0.order_id, t0.id, t0.order_qty, t0.ship_qty, t0.unit_price");
-    assertThat(trimSql(loggedSql.get(2), 7)).contains("select t0.order_id, t0.id, t0.ship_time, t0.cretime, t0.updtime, t0.version, t0.order_id from or_order_ship");
+    assertThat(trimSql(loggedSql.get(0), 7)).contains(" t0.id, t0.status, t0.order_date, t1.id, t1.name from o_order t0 join o_customer t1");
+    assertThat(trimSql(loggedSql.get(1), 7)).contains(" t0.order_id, t0.id, t0.order_qty, t0.ship_qty, t0.unit_price");
+    assertThat(trimSql(loggedSql.get(2), 7)).contains(" t0.order_id, t0.id, t0.ship_time, t0.cretime, t0.updtime, t0.version, t0.order_id from or_order_ship");
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithMany.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithMany.java
@@ -53,7 +53,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
     String lazyLoadSql = loggedSql.get(1);
     // contains the foreign key back to the parent bean (t0.order_id)
-    assertThat(trimSql(lazyLoadSql, 2)).contains("select t0.order_id, t0.id");
+    assertThat(trimSql(lazyLoadSql, 2)).contains(" t0.order_id, t0.id");
     assertThat(lazyLoadSql).contains("order by t0.order_id, t0.id, t0.order_qty, t0.cretime desc");
 
   }

--- a/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithMany.java
+++ b/ebean-test/src/test/java/org/tests/query/orderby/TestOrderByWithMany.java
@@ -49,12 +49,12 @@ public class TestOrderByWithMany extends BaseTestCase {
 
     // first one is the main query and others are lazy loading queries
     List<String> loggedSql = LoggedSql.stop();
-    assertTrue(loggedSql.size() > 1);
+    assertThat(loggedSql.size()).isGreaterThan(1);
 
     String lazyLoadSql = loggedSql.get(1);
     // contains the foreign key back to the parent bean (t0.order_id)
-    assertTrue(trimSql(lazyLoadSql, 2).contains("select t0.order_id, t0.id"));
-    assertTrue(lazyLoadSql.contains("order by t0.order_id, t0.id, t0.order_qty, t0.cretime desc"));
+    assertThat(trimSql(lazyLoadSql, 2)).contains("select t0.order_id, t0.id");
+    assertThat(lazyLoadSql).contains("order by t0.order_id, t0.id, t0.order_qty, t0.cretime desc");
 
   }
 
@@ -77,8 +77,8 @@ public class TestOrderByWithMany extends BaseTestCase {
     String sql = query.getGeneratedSql();
 
     // t0.id inserted into the middle of the order by
-    assertTrue(sql.contains("order by t1.name desc, t0.id, t2.id asc"));
-    assertTrue(sql.contains("t2.id asc, t2.order_qty asc, t2.cretime desc"));
+    assertThat(sql).contains("order by t1.name desc, t0.id, t2.id asc");
+    assertThat(sql).contains("t2.id asc, t2.order_qty asc, t2.cretime desc");
   }
 
   private void checkAppendId() {
@@ -90,7 +90,7 @@ public class TestOrderByWithMany extends BaseTestCase {
     String sql = query.getGeneratedSql();
 
     // append the id to ensure ordering of root level objects
-    assertTrue(sql.contains("order by t1.name desc, t0.id"));
+    assertThat(sql).contains("order by t1.name desc, t0.id");
   }
 
   private void checkNone() {
@@ -103,8 +103,8 @@ public class TestOrderByWithMany extends BaseTestCase {
 
     // no need to append id to order by as there is no 'many' included in the
     // query
-    assertTrue(sql.contains("order by t1.name desc"));
-    assertTrue(!sql.contains("order by t1.name desc,"));
+    assertThat(sql).contains("order by t1.name desc");
+    assertThat(sql).doesNotContain("order by t1.name desc,");
   }
 
   private void checkBoth() {
@@ -116,7 +116,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
     String sql = query.getGeneratedSql();
     // insert id into the middle of the order by
-    assertTrue(sql.contains("order by t1.name, t0.id, t2.ship_time desc"));
+    assertThat(sql).contains("order by t1.name, t0.id, t2.ship_time desc");
   }
 
   private void checkPrepend() {
@@ -128,7 +128,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
     String sql = query.getGeneratedSql();
     // prepend id in order by
-    assertTrue(sql.contains("order by t0.id, t1.ship_time desc"));
+    assertThat(sql).contains("order by t0.id, t1.ship_time desc");
   }
 
   private void checkAlreadyIncluded() {
@@ -140,7 +140,7 @@ public class TestOrderByWithMany extends BaseTestCase {
 
     String sql = query.getGeneratedSql();
     // prepend id in order by
-    assertTrue(sql.contains("order by t0.id, t1.ship_time desc"));
+    assertThat(sql).contains("order by t0.id, t1.ship_time desc");
   }
 
   private void checkAlreadyIncluded2() {

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <ebean-ddl-runner.version>2.3</ebean-ddl-runner.version>
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>14.2.0</ebean-migration.version>
-    <ebean-test-containers.version>7.5</ebean-test-containers.version>
+    <ebean-test-containers.version>7.6</ebean-test-containers.version>
     <ebean-datasource.version>9.0</ebean-datasource.version>
     <ebean-agent.version>14.9.0</ebean-agent.version>
     <ebean-maven-plugin.version>14.9.0</ebean-maven-plugin.version>


### PR DESCRIPTION
ebean-test-containers version 7.6 supports extraDb for MySql and MariaDb, resolving #3511 with extraDb configuration for each extra schema/database required with MySql or MariaDb.