### PR TITLE
Work around `mysqldump` bug by moving comment one line up

### DIFF
--- a/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl.xml
+++ b/ebean-ddl-generator/src/main/resources/io/ebeaninternal/dbmigration/builtin-extra-ddl.xml
@@ -155,8 +155,8 @@ EXECUTE stmt;
 END LOOP;
 
 CLOSE curs;
-END
 -- play-ebean-end
+END
 $$
 
 DROP PROCEDURE IF EXISTS usp_ebean_drop_column;
@@ -173,8 +173,8 @@ CALL usp_ebean_drop_foreign_keys(p_table_name, p_column_name);
 SET @sql = CONCAT('ALTER TABLE `', p_table_name, '` DROP COLUMN `', p_column_name, '`');
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
-END
 -- play-ebean-end
+END
 $$
 </ddl-script>
 


### PR DESCRIPTION
It seems like `mysqldump` just adds `;;` to the last line but unfortunately does not check if that line is a comment. To work around that it's good enough to move the comment one line up - as long as the END does not end with ; (which here it does not so that is ok)

- Fixes #3577