### PR TITLE
Rollback/Commit raw connections before close

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/SequenceIdGenerator.java
@@ -157,7 +157,7 @@ public abstract class SequenceIdGenerator implements PlatformIdGenerator {
       if (newIds.isEmpty()) {
         throw new PersistenceException("Always expecting more than 1 row from " + sql);
       }
-
+      connection.commit();
       return newIds;
 
     } catch (SQLException e) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DatabasePlatformFactory.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DatabasePlatformFactory.java
@@ -77,7 +77,12 @@ public class DatabasePlatformFactory {
    */
   private DatabasePlatform byDataSource(DataSource dataSource) {
     try (Connection connection = dataSource.getConnection()) {
-      return byDatabaseMeta(connection.getMetaData(), connection);
+      DatabasePlatform platform = byDatabaseMeta(connection.getMetaData(), connection);
+      if (!connection.getAutoCommit()) {
+        // we must roll back before close.
+        connection.rollback();
+      }
+      return platform;
     } catch (SQLException ex) {
       throw new PersistenceException(ex);
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultContainer.java
@@ -262,6 +262,8 @@ public final class DefaultContainer implements SpiContainer {
     try (Connection connection = config.getDataSource().getConnection()) {
       if (connection.getAutoCommit()) {
         log.log(WARNING, "DataSource [{0}] has autoCommit defaulting to true!", config.getName());
+      } else {
+        connection.rollback();
       }
       return true;
     } catch (SQLException ex) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlanManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlanManager.java
@@ -63,6 +63,13 @@ public final class CQueryPlanManager implements QueryPlanManager {
       while (req.hasNext()) {
         req.nextCapture();
       }
+      if (!connection.getAutoCommit()) {
+        // CHECKME: commit or rollback here?
+        // arguments for rollback: the collecting should never modify data.
+        // if there are collectors that may copy the plan into tables, it's up to the collector to
+        // commit the transaction.
+        connection.rollback();
+      }
       return req.plans();
     } catch (SQLException e) {
       CoreLog.log.log(ERROR, "Error during query plan collection", e);

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -442,6 +442,7 @@ public class QCustomerTest {
         .usingConnection(connection)
         .findList();
 
+      connection.rollback();
       assertThat(foo).hasSize(1);
     }
 

--- a/ebean-querybean/src/test/resources/application-test.properties
+++ b/ebean-querybean/src/test/resources/application-test.properties
@@ -11,6 +11,7 @@ datasource.default=h2
 datasource.h2.username=sa
 datasource.h2.password=
 datasource.h2.url=jdbc:h2:mem:tests;NON_KEYWORDS=KEY,VALUE
+datasource.h2.closeWithinTxn=fail
 
 datasource.pg.username=sa
 datasource.pg.password=

--- a/ebean-test/src/test/java/io/ebean/xtest/dbmigration/DbMigrationTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/dbmigration/DbMigrationTest.java
@@ -220,7 +220,7 @@ public class DbMigrationTest extends BaseTestCase {
     config.setName(server().name());
     config.loadFromProperties(server().pluginApi().config().getProperties());
     config.setDataSource(server().dataSource());
-    config.setReadOnlyDataSource(server().dataSource());
+    config.setReadOnlyDataSource(server().readOnlyDataSource());
     config.setDdlGenerate(false);
     config.setDdlRun(false);
     config.setRegister(false);
@@ -292,7 +292,7 @@ public class DbMigrationTest extends BaseTestCase {
     config.setName(server().name());
     config.loadFromProperties(server().pluginApi().config().getProperties());
     config.setDataSource(server().dataSource());
-    config.setReadOnlyDataSource(server().dataSource());
+    config.setReadOnlyDataSource(server().readOnlyDataSource());
     config.setDdlGenerate(false);
     config.setDdlRun(false);
     config.setRegister(false);

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/rawsql/TestRawSqlBuilder.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/rawsql/TestRawSqlBuilder.java
@@ -266,6 +266,7 @@ public class TestRawSqlBuilder extends BaseTestCase {
           }
         }
       }
+      connection.rollback();
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/basic/TestQueryUsingConnection.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestQueryUsingConnection.java
@@ -32,6 +32,7 @@ public class TestQueryUsingConnection extends BaseTestCase {
         .findCount();
 
       assertThat(count).isGreaterThan(0);
+      connection.rollback();
     }
   }
 

--- a/ebean-test/src/test/resources/ebean.properties
+++ b/ebean-test/src/test/resources/ebean.properties
@@ -76,6 +76,7 @@ datasource.db.databaseDriver=org.h2.Driver
 datasource.h2.username=sa
 datasource.h2.password=
 datasource.h2.url=jdbc:h2:mem:testsMem;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=KEY,VALUE
+datasource.h2.closeWithinTxn=fail
 datasource.h2.poolListener=org.tests.basic.MyTestDataSourcePoolListener
 #datasource.h2.minConnections=1
 #datasource.h2.maxConnections=25


### PR DESCRIPTION
Summary of changes:
- Add commit() obtaining Sequence values
- Add rollback() when detecting database platform via jdbc meta data
- Add rollback() when detecting AutoCommit mode
- Add rollback() when obtaining query plan


---------------------------

This PR makse ebean ready to follow the JDBC spec for close.
See https://github.com/ebean-orm/ebean-datasource/pull/107 for details.
Here we introduce `closeWithinTxn=fail` so that the ebean datasource enforces commit/rollback as some drivers will do. We see missing rollbacks in tests.

Note: by default the ebean-datasource should and would handle this situation automatically in production, if there was a missing commit/rollback
(Other datasources like hikariCP put a lot of effort to find out, if there is an open txn: https://github.com/brettwooldridge/HikariCP/commit/22389819d579fbea13b7cab0b6de6ea8141a783f and do similar things- i'm unsure, if it is worth, as there are only a few places, where commit/rollback is missing)

Q: You may ask, why do we need the commits and rollbacks now and not rely on ebean-datasource directly to handle this situation
A1: It is strongly recommended by the JDBC spec.
A2: You may use a different datasource or even the DB2-driver without a DS at all (not recommended), then you will need the commits
