### PR TITLE
OneToMany initialisation via List.of() - was Tests only - new test on multiple many joins

### DIFF
--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -309,7 +309,7 @@
         <extensions>true</extensions>
         <configuration>
           <tiles>
-            <tile>io.ebean.tile:enhancement:14.9.0</tile>
+            <tile>io.ebean.tile:enhancement:14.10.0</tile>
           </tiles>
         </configuration>
       </plugin>

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/Order.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/Order.java
@@ -1,0 +1,25 @@
+package org.tests.model.join.initfields;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "join_initfields_order")
+public class Order {
+  @Id
+  int id;
+
+  @OneToMany
+  public List<OrderItem> orderItems = new ArrayList<>();
+
+  @OneToMany
+  public List<OrderDetail> orderDetails = new ArrayList<>();
+
+  @OneToMany
+  public List<OrderInvoice> orderInvoices = List.of(); // Change this to new ArrayList<>() to make the test pass.
+}

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/Order.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/Order.java
@@ -15,11 +15,27 @@ public class Order {
   int id;
 
   @OneToMany
-  public List<OrderItem> orderItems = new ArrayList<>();
+  List<OrderItem> orderItems = new ArrayList<>();
 
   @OneToMany
-  public List<OrderDetail> orderDetails = new ArrayList<>();
+  List<OrderDetail> orderDetails = new ArrayList<>();
 
   @OneToMany
   public List<OrderInvoice> orderInvoices = List.of(); // Change this to new ArrayList<>() to make the test pass.
+
+  public int id() {
+    return id;
+  }
+
+  public List<OrderItem> orderItems() {
+    return orderItems;
+  }
+
+  public List<OrderDetail> orderDetails() {
+    return orderDetails;
+  }
+
+  public List<OrderInvoice> orderInvoices() {
+    return orderInvoices;
+  }
 }

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/OrderDetail.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/OrderDetail.java
@@ -1,0 +1,16 @@
+package org.tests.model.join.initfields;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="join_initfields_order_detail")
+public class OrderDetail {
+  @Id
+  int id;
+
+  @ManyToOne
+  public Order order;
+}

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/OrderDetail.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/OrderDetail.java
@@ -12,5 +12,10 @@ public class OrderDetail {
   int id;
 
   @ManyToOne
-  public Order order;
+  Order order;
+
+  public OrderDetail(Order order) {
+    this.order = order;
+  }
+
 }

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/OrderInvoice.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/OrderInvoice.java
@@ -12,5 +12,9 @@ public class OrderInvoice {
   int id;
 
   @ManyToOne
-  public Order order;
+  Order order;
+
+  public OrderInvoice(Order order) {
+    this.order = order;
+  }
 }

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/OrderInvoice.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/OrderInvoice.java
@@ -1,0 +1,16 @@
+package org.tests.model.join.initfields;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="join_initfields_order_invoice")
+public class OrderInvoice {
+  @Id
+  int id;
+
+  @ManyToOne
+  public Order order;
+}

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/OrderItem.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/OrderItem.java
@@ -12,5 +12,9 @@ public class OrderItem {
   int id;
 
   @ManyToOne
-  public Order order;
+  Order order;
+
+  public OrderItem(Order order) {
+    this.order = order;
+  }
 }

--- a/ebean-test/src/test/java/org/tests/model/join/initfields/OrderItem.java
+++ b/ebean-test/src/test/java/org/tests/model/join/initfields/OrderItem.java
@@ -1,0 +1,16 @@
+package org.tests.model.join.initfields;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="join_initfields_order_item")
+public class OrderItem {
+  @Id
+  int id;
+
+  @ManyToOne
+  public Order order;
+}

--- a/ebean-test/src/test/java/org/tests/model/lazywithid/Tune.java
+++ b/ebean-test/src/test/java/org/tests/model/lazywithid/Tune.java
@@ -1,7 +1,5 @@
 package org.tests.model.lazywithid;
 
-import io.ebean.common.BeanList;
-
 import jakarta.persistence.*;
 import java.util.List;
 
@@ -15,7 +13,7 @@ public class Tune {
   String name;
 
   @OneToMany(cascade = CascadeType.ALL)
-  private List<Looney> loonies = new BeanList<>();
+  private List<Looney> loonies;
 
   public String getName() {
     return name;

--- a/ebean-test/src/test/java/org/tests/query/TestQueryMultiJoinFetchPath.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryMultiJoinFetchPath.java
@@ -75,29 +75,14 @@ class TestQueryMultiJoinFetchPath extends BaseTestCase {
     Order o = new Order();
     DB.save(o);
 
-    OrderItem p1 = new OrderItem();
-    p1.order = o;
-    DB.save(p1);
+    OrderItem p1 = new OrderItem(o);
+    OrderItem p2 = new OrderItem(o);
+    OrderDetail d1 = new OrderDetail(o);
+    OrderDetail d2 = new OrderDetail(o);
+    OrderInvoice i1 = new OrderInvoice(o);
+    OrderInvoice i2 = new OrderInvoice(o);
 
-    OrderItem p2 = new OrderItem();
-    p2.order = o;
-    DB.save(p2);
-
-    OrderDetail d1 = new OrderDetail();
-    d1.order = o;
-    DB.save(d1);
-
-    OrderDetail d2 = new OrderDetail();
-    d2.order = o;
-    DB.save(d2);
-
-    OrderInvoice i1 = new OrderInvoice();
-    i1.order = o;
-    DB.save(i1);
-
-    OrderInvoice i2 = new OrderInvoice();
-    i2.order = o;
-    DB.save(i2);
+    DB.saveAll(p1, p2, d1, d2, i1, i2);
 
     // This first query behaves as expected: a main query and its secondary query.
     LoggedSql.start();
@@ -107,8 +92,8 @@ class TestQueryMultiJoinFetchPath extends BaseTestCase {
       .where().gt("id", 0)
       .findList();
 
-    assertThat(list1.get(0).orderItems).hasSize(2);
-    assertThat(list1.get(0).orderDetails).hasSize(2);
+    assertThat(list1.get(0).orderItems()).hasSize(2);
+    assertThat(list1.get(0).orderDetails()).hasSize(2);
 
     List<String> sql1 = LoggedSql.collect();
     assertThat(sql1).hasSize(2);
@@ -121,7 +106,7 @@ class TestQueryMultiJoinFetchPath extends BaseTestCase {
       .where().gt("id", 0)
       .findList();
 
-    assertThat(list2.get(0).orderItems).hasSize(2);
+    assertThat(list2.get(0).orderItems()).hasSize(2);
     assertThat(list2.get(0).orderInvoices).hasSize(2);
 
     List<String> sql2 = LoggedSql.stop();

--- a/ebean-test/src/test/java/org/tests/query/TestQueryMultiJoinFetchPath.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryMultiJoinFetchPath.java
@@ -14,7 +14,6 @@ import org.tests.model.join.initfields.OrderItem;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestQueryMultiJoinFetchPath extends BaseTestCase {
 
@@ -108,24 +107,24 @@ class TestQueryMultiJoinFetchPath extends BaseTestCase {
       .where().gt("id", 0)
       .findList();
 
-    assertEquals(2, list1.get(0).orderItems.size());
-    assertEquals(2, list1.get(0).orderDetails.size());
+    assertThat(list1.get(0).orderItems).hasSize(2);
+    assertThat(list1.get(0).orderDetails).hasSize(2);
 
-    List<String> sql1 = LoggedSql.stop();
-    assertEquals(2, sql1.size());
+    List<String> sql1 = LoggedSql.collect();
+    assertThat(sql1).hasSize(2);
 
     // This query does not eager fetch invoices. We get an NPE on orderInvoices. Only the main query is executed.
-    LoggedSql.start();
+    LoggedSql.collect();
     List<Order> list2 = DB.find(Order.class)
       .fetch("orderItems")
       .fetch("orderInvoices")
       .where().gt("id", 0)
       .findList();
 
-    assertEquals(2, list2.get(0).orderItems.size());
-    assertEquals(2, list2.get(0).orderInvoices.size());
+    assertThat(list2.get(0).orderItems).hasSize(2);
+    assertThat(list2.get(0).orderInvoices).hasSize(2);
 
     List<String> sql2 = LoggedSql.stop();
-    assertEquals(2, sql2.size());
+    assertThat(sql2).hasSize(2);
   }
 }


### PR DESCRIPTION
This test reproduce the problem of #3573
The field initialization `= List.of();` prevents eager secondary query.