### PR TITLE
Adjust LookupWriter to log at WARN rather than ERROR due to Quarkus dev mode

### DIFF
--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/LookupWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/LookupWriter.java
@@ -7,13 +7,14 @@ import java.io.Writer;
 import java.util.Collection;
 import java.util.Set;
 
+import javax.annotation.processing.FilerException;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.tools.FileObject;
 
 /** Write the source code for the factory. */
-class LookupWriter {
+final class LookupWriter {
   private LookupWriter() {}
 
   private static final String METAINF_SERVICES_LOOKUP =
@@ -58,21 +59,20 @@ class LookupWriter {
       String fqn = pkg + ".EbeanMethodLookup";
       try {
         var javaFileObject = processingContext.createWriter(fqn);
-
         var writer = new Append(javaFileObject.openWriter());
 
         writer.append(FILE_STRING, pkg);
         writer.close();
         writeServicesFile(processingContext, fqn);
+      } catch (FilerException e) {
+        processingContext.logWarn(null, "FilerException writing Lookup " + e.getMessage());
       } catch (IOException e) {
         processingContext.logError(null, "Failed to write lookup class " + e.getMessage());
       }
     }
   }
 
-  private static void writeServicesFile(ProcessingContext processingContext, String fqn)
-      throws IOException {
-
+  private static void writeServicesFile(ProcessingContext processingContext, String fqn) throws IOException {
     FileObject jfo = processingContext.createMetaInfWriter(METAINF_SERVICES_LOOKUP);
     if (jfo != null) {
       Writer writer = jfo.openWriter();


### PR DESCRIPTION
Due to Quarkus dev mode (#3541 #3582) we want to log FilerException at WARN level rather than ERROR. This is because Quarkus dev mode will invoke the annotation processor more than usual, so we expect to fail with the FilerException.