### PR TITLE
Modify disableLazyLoad to throw LazyInitialisationException instead o…

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
+++ b/ebean-api/src/main/java/io/ebean/bean/EntityBeanIntercept.java
@@ -382,11 +382,6 @@ public interface EntityBeanIntercept extends Serializable {
   void loadBean(int loadProperty);
 
   /**
-   * Invoke the lazy loading. This method is synchronised externally.
-   */
-  void loadBeanInternal(int loadProperty, BeanLoader loader);
-
-  /**
    * Called when a BeanCollection is initialised automatically.
    */
   void initialisedMany(int propertyIndex);

--- a/ebean-api/src/main/java/io/ebean/bean/InterceptReadOnly.java
+++ b/ebean-api/src/main/java/io/ebean/bean/InterceptReadOnly.java
@@ -394,11 +394,6 @@ public final class InterceptReadOnly extends InterceptBase {
   }
 
   @Override
-  public void loadBeanInternal(int loadProperty, BeanLoader loader) {
-
-  }
-
-  @Override
   public void initialisedMany(int propertyIndex) {
     loaded[propertyIndex] = true;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadContext.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/loadcontext/DLoadContext.java
@@ -97,7 +97,7 @@ public final class DLoadContext implements LoadContext {
     this.profilingListener = query.profilingListener();
     this.planLabel = query.planLabel();
     this.profileLocation = query.profileLocation();
-    this.secondaryProperties = query.isUnmodifiable() ? new HashSet<>() : null;
+    this.secondaryProperties = query.isUnmodifiable() || query.isDisableLazyLoading() ? new HashSet<>() : null;
 
     ObjectGraphNode parentNode = query.parentNode();
     if (parentNode != null) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeLoadBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeLoadBean.java
@@ -32,6 +32,7 @@ class SqlTreeLoadBean implements SqlTreeLoad {
   private final boolean readIdNormal;
   private final boolean disableLazyLoad;
   private final boolean unmodifiable;
+  private final boolean loadListReferences;
   private final InheritInfo inheritInfo;
   final String prefix;
   private final Map<String, String> pathMap;
@@ -55,6 +56,7 @@ class SqlTreeLoadBean implements SqlTreeLoad {
     this.readIdNormal = readId && !temporalVersions;
     this.disableLazyLoad = node.disableLazyLoad;
     this.unmodifiable = node.unmodifiable;
+    this.loadListReferences = !unmodifiable && !disableLazyLoad;
     this.partialObject = node.partialObject;
     this.properties = node.properties;
     this.pathMap = node.pathMap;
@@ -301,7 +303,7 @@ class SqlTreeLoadBean implements SqlTreeLoad {
       boolean forceNewReference = queryMode == Mode.REFRESH_BEAN;
       for (STreePropertyAssocMany many : localDesc.propsMany()) {
         if (many != loadingChildProperty) {
-          if (!unmodifiable || ctx.includeSecondary(many.asMany())) {
+          if (loadListReferences || ctx.includeSecondary(many.asMany())) {
             // create a proxy for the many (deferred fetching)
             BeanCollection<?> ref = many.createReference(localBean, forceNewReference);
             if (ref != null) {

--- a/ebean-test/src/test/java/io/ebean/xtest/config/PlatformNoGeneratedKeysTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/config/PlatformNoGeneratedKeysTest.java
@@ -1,10 +1,7 @@
 package io.ebean.xtest.config;
 
-import io.ebean.Database;
-import io.ebean.DatabaseFactory;
-import io.ebean.Transaction;
+import io.ebean.*;
 import io.ebean.annotation.Platform;
-import io.ebean.DatabaseBuilder;
 import io.ebean.config.DatabaseConfig;
 import io.ebean.config.dbplatform.DbIdentity;
 import io.ebean.config.dbplatform.IdType;
@@ -15,6 +12,7 @@ import org.tests.model.basic.EBasicVer;
 import org.tests.model.draftable.BasicDraftableBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PlatformNoGeneratedKeysTest {
 
@@ -39,7 +37,7 @@ public class PlatformNoGeneratedKeysTest {
       .findOne();
 
     assertThat(found.getName()).isEqualTo("basic");
-    assertThat(found.getDescription()).isNull();
+    assertThrows(LazyInitialisationException.class, found::getDescription);
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/batchload/TestBeanState.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestBeanState.java
@@ -2,7 +2,7 @@ package org.tests.batchload;
 
 import io.ebean.BeanState;
 import io.ebean.DB;
-import io.ebean.UnmodifiableEntityException;
+import io.ebean.LazyInitialisationException;
 import io.ebean.bean.EntityBean;
 import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.xtest.BaseTestCase;
@@ -83,7 +83,7 @@ class TestBeanState extends BaseTestCase {
 
     BeanState beanState = DB.beanState(customer);
     beanState.setDisableLazyLoad(true);
-    assertNull(customer.getName());
+    assertThrows(LazyInitialisationException.class, customer::getName);
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/batchload/TestQueryJoinToAssocOne.java
+++ b/ebean-test/src/test/java/org/tests/batchload/TestQueryJoinToAssocOne.java
@@ -1,5 +1,6 @@
 package org.tests.batchload;
 
+import io.ebean.LazyInitialisationException;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.test.LoggedSql;
@@ -16,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestQueryJoinToAssocOne extends BaseTestCase {
 
@@ -91,15 +93,15 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
 
     Order order = l0.get(0);
     // normally invokes lazy loading
-    order.getOrderDate();
+    assertThrows(LazyInitialisationException.class, order::getOrderDate);
 
     List<OrderDetail> details = order.getDetails();
     OrderDetail orderDetail = details.get(0);
     // normally invokes lazy loading
-    orderDetail.getShipQty();
+    assertThrows(LazyInitialisationException.class, orderDetail::getShipQty);
 
     // normally invokes lazy loading
-    order.getShipments().size();
+    assertThrows(LazyInitialisationException.class, order::getShipments);
 
     List<String> loggedSql = LoggedSql.stop();
     assertThat(loggedSql).hasSize(2);
@@ -129,13 +131,11 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
 
     Order order = l0.get(0);
     // try to invoke lazy loading on the bean
-    assertThat(order.getCustomer()).isNull();
-    assertThat(order.getCretime()).isNull();
+    assertThrows(LazyInitialisationException.class, order::getCustomer);
+    assertThrows(LazyInitialisationException.class, order::getCretime);
 
     // try to invoke lazy loading on the OneToMany ...
-    List<OrderDetail> details = order.getDetails();
-    assertThat(details).isEmpty();
-    assertThat(details.size()).isEqualTo(0);
+    assertThrows(LazyInitialisationException.class, order::getDetails);
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
@@ -163,7 +163,7 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
       .setId(tenant.getId())
       .findOne();
 
-    assertThat(found.getRoles().size()).isEqualTo(0);
+    assertThrows(LazyInitialisationException.class, found::getRoles);
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(1);
@@ -189,7 +189,7 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
       .findOne();
 
     // normally invokes lazy loading
-    assertThat(found.getRoles().size()).isEqualTo(0);
+    assertThrows(LazyInitialisationException.class, found::getRoles);
 
     // only 1 query ... no lazy loading query
     List<String> sql = LoggedSql.stop();
@@ -217,12 +217,12 @@ public class TestQueryJoinToAssocOne extends BaseTestCase {
 
     Order order = l0.get(0);
     // normally invokes lazy loading
-    order.getOrderDate();
+    assertThrows(LazyInitialisationException.class, order::getOrderDate);
 
     List<OrderDetail> details = order.getDetails();
     OrderDetail orderDetail = details.get(0);
     // normally invokes lazy loading
-    orderDetail.getShipQty();
+    assertThrows(LazyInitialisationException.class, orderDetail::getShipQty);
 
     List<String> loggedSql = LoggedSql.stop();
     assertThat(loggedSql).hasSize(1);

--- a/ebean-test/src/test/java/org/tests/model/aggregation/TestAggregationMany.java
+++ b/ebean-test/src/test/java/org/tests/model/aggregation/TestAggregationMany.java
@@ -1,5 +1,6 @@
 package org.tests.model.aggregation;
 
+import io.ebean.LazyInitialisationException;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.test.LoggedSql;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestAggregationMany extends BaseTestCase {
 
@@ -26,7 +28,7 @@ public class TestAggregationMany extends BaseTestCase {
 
     for (DMachine machine : machines) {
       assertThat(machine.getAuxUseAggs()).isNotEmpty();
-      assertThat(machine.getMachineStats()).isEmpty();
+      assertThrows(LazyInitialisationException.class, machine::getMachineStats);
     }
 
     List<String> sql = LoggedSql.stop();
@@ -57,7 +59,7 @@ public class TestAggregationMany extends BaseTestCase {
 
     for (DMachine machine : machines) {
       assertThat(machine.getAuxUseAggs()).isNotEmpty();
-      assertThat(machine.getMachineStats()).isEmpty();
+      assertThrows(LazyInitialisationException.class, machine::getMachineStats);
     }
 
     List<String> sql = LoggedSql.stop();
@@ -83,7 +85,7 @@ public class TestAggregationMany extends BaseTestCase {
     for (DMachine machine : machines) {
       assertThat(machine.getAuxUseAggs()).isNotEmpty();
       System.out.println(machine);
-      assertThat(machine.getMachineStats()).isEmpty();
+      assertThrows(LazyInitialisationException.class, machine::getMachineStats);
     }
 
     List<String> sql = LoggedSql.stop();

--- a/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
+++ b/ebean-test/src/test/java/org/tests/text/json/TestTextJsonReferenceBean.java
@@ -1,5 +1,6 @@
 package org.tests.text.json;
 
+import io.ebean.LazyInitialisationException;
 import io.ebean.text.json.JsonReadOptions;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.BeanState;
@@ -19,8 +20,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTextJsonReferenceBean extends BaseTestCase {
 
@@ -33,7 +33,7 @@ public class TestTextJsonReferenceBean extends BaseTestCase {
 
     assertThat(DB.beanState(productRefBean).isReference()).isTrue();
     // does not lazy load by default
-    assertThat(productRefBean.getName()).isNull();
+    assertThrows(LazyInitialisationException.class, productRefBean::getName);
   }
 
   @Test


### PR DESCRIPTION
…f returning null

Modify such that accessing an unloaded property throws a LazyInitialisationException. This includes ToMany collections that where previously initialised as empty collections (that didn't lazy load).

This change brings the disableLazyLoad behaviour in line with the unmodifiable behaviour.

It does mean that the use case of bulk mapping from entities to DTOs via something like MapStruct will no longer work nicely (mapping nulls and empty lists versus LazyInitialisationException).