### PR TITLE
Change findFuture queries such that they can use the read only DataSource

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1254,96 +1254,58 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
     }
   }
 
+  private <T> SpiQuery<T> configureForFuture(SpiQuery<T> query) {
+    query.usingFuture();
+    if (query.transaction() == null) {
+      // use a current transaction if active
+      query.usingTransaction(currentServerTransaction());
+    }
+    return query;
+  }
+
   @Override
   public <T> FutureRowCount<T> findFutureCount(SpiQuery<T> query) {
-    SpiQuery<T> copy = query.copy();
-    copy.usingFuture();
-    boolean createdTransaction = false;
-    SpiTransaction transaction = query.transaction();
-    if (transaction == null) {
-      transaction = currentServerTransaction();
-      if (transaction == null) {
-        transaction = (SpiTransaction) createTransaction();
-        createdTransaction = true;
-      }
-      copy.usingTransaction(transaction);
-    }
-    var queryFuture = new QueryFutureRowCount<>(new CallableQueryCount<>(this, copy, createdTransaction));
+    SpiQuery<T> copy = configureForFuture(query.copy());
+    var queryFuture = new QueryFutureRowCount<>(new CallableQueryCount<>(this, copy));
     backgroundExecutor.execute(queryFuture.futureTask());
     return queryFuture;
   }
 
   @Override
   public <T> FutureIds<T> findFutureIds(SpiQuery<T> query) {
-    SpiQuery<T> copy = query.copy();
-    copy.usingFuture();
-    boolean createdTransaction = false;
-    SpiTransaction transaction = query.transaction();
-    if (transaction == null) {
-      transaction = currentServerTransaction();
-      if (transaction == null) {
-        transaction = (SpiTransaction) createTransaction();
-        createdTransaction = true;
-      }
-      copy.usingTransaction(transaction);
-    }
-    QueryFutureIds<T> queryFuture = new QueryFutureIds<>(new CallableQueryIds<>(this, copy, createdTransaction));
+    SpiQuery<T> copy = configureForFuture(query.copy());
+    final var queryFuture = new QueryFutureIds<T>(new CallableQueryIds<>(this, copy));
     backgroundExecutor.execute(queryFuture.futureTask());
     return queryFuture;
   }
 
   @Override
   public <T> FutureList<T> findFutureList(SpiQuery<T> query) {
-    SpiQuery<T> spiQuery = query.copy();
-    spiQuery.usingFuture();
-    // FutureList query always run in it's own persistence content
+    SpiQuery<T> spiQuery = configureForFuture(query.copy());
+    // FutureList query always run in its own persistence content
     spiQuery.setPersistenceContext(new DefaultPersistenceContext());
     if (!spiQuery.isDisableReadAudit()) {
       BeanDescriptor<T> desc = descriptorManager.descriptor(spiQuery.getBeanType());
       desc.readAuditFutureList(spiQuery);
     }
-    // Create a new transaction solely to execute the findList() at some future time
-    boolean createdTransaction = false;
-    SpiTransaction transaction = query.transaction();
-    if (transaction == null) {
-      transaction = currentServerTransaction();
-      if (transaction == null) {
-        transaction = (SpiTransaction) createTransaction();
-        createdTransaction = true;
-      }
-      spiQuery.usingTransaction(transaction);
-    }
-    QueryFutureList<T> queryFuture = new QueryFutureList<>(new CallableQueryList<>(this, spiQuery, createdTransaction));
+    final var queryFuture = new QueryFutureList<T>(new CallableQueryList<>(this, spiQuery));
     backgroundExecutor.execute(queryFuture.futureTask());
     return queryFuture;
   }
 
   @Override
   public <K, T> FutureMap<K, T> findFutureMap(SpiQuery<T> query) {
-    SpiQuery<T> spiQuery = query.copy();
-    spiQuery.usingFuture();
+    SpiQuery<T> spiQuery = configureForFuture(query.copy());
     // FutureMap query always run in it's own persistence content
     spiQuery.setPersistenceContext(new DefaultPersistenceContext());
     if (!spiQuery.isDisableReadAudit()) {
       BeanDescriptor<T> desc = descriptorManager.descriptor(spiQuery.getBeanType());
       desc.readAuditFutureList(spiQuery);
     }
-    // Create a new transaction solely to execute the findMap() at some future time
-    boolean createdTransaction = false;
-    SpiTransaction transaction = query.transaction();
-    if (transaction == null) {
-      transaction = currentServerTransaction();
-      if (transaction == null) {
-        transaction = (SpiTransaction) createTransaction();
-        createdTransaction = true;
-      }
-      spiQuery.usingTransaction(transaction);
-    }
-    QueryFutureMap<K, T> queryFuture = new QueryFutureMap<>(new CallableQueryMap<>(this, spiQuery, createdTransaction));
+    final var queryFuture = new QueryFutureMap<K, T>(new CallableQueryMap<>(this, spiQuery));
     backgroundExecutor.execute(queryFuture.futureTask());
     return queryFuture;
   }
-
 
   @Override
   public <T> PagedList<T> findPagedList(SpiQuery<T> query) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQuery.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.query;
 
-import io.ebean.Transaction;
 import io.ebeaninternal.api.SpiEbeanServer;
 import io.ebeaninternal.api.SpiQuery;
 
@@ -11,11 +10,9 @@ abstract class CallableQuery<T> {
 
   final SpiQuery<T> query;
   final SpiEbeanServer server;
-  final Transaction transaction;
 
   CallableQuery(SpiEbeanServer server, SpiQuery<T> query) {
     this.server = server;
     this.query = query;
-    this.transaction = query.transaction();
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryCount.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryCount.java
@@ -10,15 +10,8 @@ import java.util.concurrent.Callable;
  */
 public final class CallableQueryCount<T> extends CallableQuery<T> implements Callable<Integer> {
 
-  private final boolean createdTransaction;
-
-  /**
-   * Note that the transaction passed in is always a new transaction solely to
-   * find the row count so it must be cleaned up by this CallableQueryRowCount.
-   */
-  public CallableQueryCount(SpiEbeanServer server, SpiQuery<T> query, boolean createdTransaction) {
+  public CallableQueryCount(SpiEbeanServer server, SpiQuery<T> query) {
     super(server, query);
-    this.createdTransaction = createdTransaction;
   }
 
   /**
@@ -26,13 +19,7 @@ public final class CallableQueryCount<T> extends CallableQuery<T> implements Cal
    */
   @Override
   public Integer call() {
-    try {
-      return server.findCountWithCopy(query);
-    } finally {
-      if (createdTransaction) {
-        transaction.end();
-      }
-    }
+    return server.findCountWithCopy(query);
   }
 
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryIds.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryIds.java
@@ -11,28 +11,16 @@ import java.util.concurrent.Callable;
  */
 public final class CallableQueryIds<T> extends CallableQuery<T> implements Callable<List<Object>> {
 
-  private final boolean createdTransaction;
-
-  public CallableQueryIds(SpiEbeanServer server, SpiQuery<T> query, boolean createdTransaction) {
+  public CallableQueryIds(SpiEbeanServer server, SpiQuery<T> query) {
     super(server, query);
-    this.createdTransaction = createdTransaction;
   }
 
-  /**
-   * Execute the find Id's query returning the list of Id's.
-   */
   @Override
   public List<Object> call() {
     // we have already made a copy of the query
     // this way the same query instance is available to the
     // QueryFutureIds (as so has access to the List before it is done)
-    try {
-      return server.findIdsWithCopy(query);
-    } finally {
-      if (createdTransaction) {
-        transaction.end();
-      }
-    }
+    return server.findIdsWithCopy(query);
   }
 
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryList.java
@@ -11,25 +11,13 @@ import java.util.concurrent.Callable;
  */
 public final class CallableQueryList<T> extends CallableQuery<T> implements Callable<List<T>> {
 
-  private final boolean createdTransaction;
-
-  public CallableQueryList(SpiEbeanServer server, SpiQuery<T> query, boolean createdTransaction) {
+  public CallableQueryList(SpiEbeanServer server, SpiQuery<T> query) {
     super(server, query);
-    this.createdTransaction = createdTransaction;
   }
 
-  /**
-   * Execute the query returning the resulting List.
-   */
   @Override
   public List<T> call() {
-    try {
-      return server.findList(query);
-    } finally {
-      if (createdTransaction) {
-        transaction.end();
-      }
-    }
+    return server.findList(query);
   }
 
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryMap.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CallableQueryMap.java
@@ -11,25 +11,13 @@ import java.util.concurrent.Callable;
  */
 public final class CallableQueryMap<K, T> extends CallableQuery<T> implements Callable<Map<K, T>> {
 
-  private final boolean createdTransaction;
-
-  public CallableQueryMap(SpiEbeanServer server, SpiQuery<T> query, boolean createdTransaction) {
+  public CallableQueryMap(SpiEbeanServer server, SpiQuery<T> query) {
     super(server, query);
-    this.createdTransaction = createdTransaction;
   }
 
-  /**
-   * Execute the query returning the resulting map.
-   */
   @Override
   public Map<K, T> call() {
-    try {
-      return server.findMap(query);
-    } finally {
-      if (createdTransaction) {
-        transaction.end();
-      }
-    }
+    return server.findMap(query);
   }
 
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureIds.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureIds.java
@@ -23,10 +23,6 @@ public final class QueryFutureIds<T> extends BaseFuture<List<Object>> implements
     return futureTask;
   }
 
-  public Transaction transaction() {
-    return call.transaction;
-  }
-
   @Override
   public Query<T> getQuery() {
     return call.query;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureList.java
@@ -27,10 +27,6 @@ public final class QueryFutureList<T> extends BaseFuture<List<T>> implements Fut
     return futureTask;
   }
 
-  public Transaction transaction() {
-    return call.transaction;
-  }
-
   @Override
   public Query<T> getQuery() {
     return call.query;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureMap.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureMap.java
@@ -27,10 +27,6 @@ public final class QueryFutureMap<K, T> extends BaseFuture<Map<K, T>> implements
     return futureTask;
   }
 
-  public Transaction transaction() {
-    return call.transaction;
-  }
-
   @Override
   public Query<T> getQuery() {
     return call.query;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureRowCount.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/QueryFutureRowCount.java
@@ -21,10 +21,6 @@ public final class QueryFutureRowCount<T> extends BaseFuture<Integer> implements
     return futureTask;
   }
 
-  public Transaction transaction() {
-    return call.transaction;
-  }
-
   @Override
   public boolean cancel(boolean mayInterruptIfRunning) {
     call.query.cancel();

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/query/TestFutureRowCountErrorHandling.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/query/TestFutureRowCountErrorHandling.java
@@ -2,99 +2,50 @@ package io.ebean.xtest.internal.server.query;
 
 import io.ebean.*;
 import io.ebean.xtest.BaseTestCase;
-import io.ebeaninternal.server.query.QueryFutureIds;
-import io.ebeaninternal.server.query.QueryFutureList;
-import io.ebeaninternal.server.query.QueryFutureRowCount;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Customer;
 import org.tests.model.basic.ResetBasicData;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class TestFutureRowCountErrorHandling extends BaseTestCase {
+class TestFutureRowCountErrorHandling extends BaseTestCase {
 
   @Test
-  public void testFutureRowCount() throws InterruptedException {
-
+  void testFutureRowCount() {
     ResetBasicData.reset();
 
-    Database server = DB.getDefault();
-
-    Query<Customer> query = server.createQuery(Customer.class)
+    Query<Customer> query = DB.find(Customer.class)
       .where().eq("doesNotExist", "this will fail")
       .query();
 
     FutureRowCount<Customer> futureRowCount = query.findFutureCount();
 
-    QueryFutureRowCount<Customer> internalRowCount = (QueryFutureRowCount<Customer>) futureRowCount;
-    Transaction t = internalRowCount.transaction();
-
-    try {
-      futureRowCount.get();
-      fail("never get here as the SQL is invalid");
-
-    } catch (ExecutionException e) {
-      // Confirm the Transaction has been rolled back
-      assertFalse(t.isActive());
-    }
-
+    assertThrows(ExecutionException.class, futureRowCount::get);
   }
 
   @Test
-  public void testFutureIds() throws InterruptedException {
-
+  void testFutureIds() {
     ResetBasicData.reset();
 
-    Database server = DB.getDefault();
-
-    Query<Customer> query = server.createQuery(Customer.class)
+    Query<Customer> query = DB.find(Customer.class)
       .where().eq("doesNotExist", "this will fail")
       .query();
 
     FutureIds<Customer> futureIds = query.findFutureIds();
-
-    QueryFutureIds<Customer> internalFuture = (QueryFutureIds<Customer>) futureIds;
-    Transaction t = internalFuture.transaction();
-
-    try {
-      internalFuture.get();
-      fail("never get here as the SQL is invalid");
-
-    } catch (ExecutionException e) {
-      // Confirm the Transaction has been rolled back
-      assertFalse(t.isActive());
-    }
-
+    assertThrows(ExecutionException.class, futureIds::get);
   }
 
-
   @Test
-  public void testFutureList() throws InterruptedException {
-
+  void testFutureList() {
     ResetBasicData.reset();
 
-    Database server = DB.getDefault();
-
-    Query<Customer> query = server.createQuery(Customer.class)
+    Query<Customer> query = DB.createQuery(Customer.class)
       .where().eq("doesNotExist", "this will fail")
       .query();
 
     FutureList<Customer> futureList = query.findFutureList();
-
-    QueryFutureList<Customer> internalFuture = (QueryFutureList<Customer>) futureList;
-    Transaction t = internalFuture.transaction();
-
-    try {
-      internalFuture.get();
-      fail("never get here as the SQL is invalid");
-
-    } catch (ExecutionException e) {
-      // Confirm the Transaction has been rolled back
-      assertFalse(t.isActive());
-    }
-
+    assertThrows(ExecutionException.class, futureList::get);
   }
 }

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindFutureList.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindFutureList.java
@@ -1,24 +1,28 @@
 package org.tests.query;
 
+import io.ebean.FutureMap;
 import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
 import io.ebean.FutureList;
 import io.ebean.Transaction;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Order;
+import org.tests.model.basic.Product;
 import org.tests.model.basic.ResetBasicData;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestQueryFindFutureList extends BaseTestCase {
+class TestQueryFindFutureList extends BaseTestCase {
 
   @Test
-  public void test_cancel() throws InterruptedException {
-
+  @SuppressWarnings("resource")
+  void test_cancel() throws InterruptedException {
     ResetBasicData.reset();
 
     // warm the connection pool
@@ -41,8 +45,7 @@ public class TestQueryFindFutureList extends BaseTestCase {
   }
 
   @Test
-  public void test_findFutureList() throws InterruptedException {
-
+  void test_findFutureList() {
     ResetBasicData.reset();
 
     FutureList<Order> futureList = DB.find(Order.class).findFutureList();
@@ -54,16 +57,47 @@ public class TestQueryFindFutureList extends BaseTestCase {
   }
 
   @Test
-  public void test_findFutureListWithTimeout() throws InterruptedException, TimeoutException {
-
+  void test_findFutureListWithTimeout() throws TimeoutException {
     ResetBasicData.reset();
 
     FutureList<Order> futureList = DB.find(Order.class).findFutureList();
+    FutureList<Product> futureList2 = DB.find(Product.class).findFutureList();
 
     // wait for it to complete
     List<Order> orders = futureList.getUnchecked(1, TimeUnit.SECONDS);
+    List<Product> products2 = futureList2.getUnchecked(1, TimeUnit.SECONDS);
 
     assertEquals(DB.find(Order.class).findCount(), orders.size());
+    assertThat(products2).isNotEmpty();
+  }
+
+  @Test
+  void test_findFutureMap_defaultIdAsKey() {
+    ResetBasicData.reset();
+
+    FutureMap<Integer, Order> futureMap = DB.find(Order.class)
+      .findFutureMap();
+
+    // wait for it to complete
+    Map<Integer, Order> orders = futureMap.getUnchecked();
+
+    assertEquals(DB.find(Order.class).findCount(), orders.size());
+  }
+
+  @Test
+  void test_findFutureMap() {
+    ResetBasicData.reset();
+
+    FutureMap<String, Product> futureMap = DB.find(Product.class)
+      .setMapKey("sku")
+      .findFutureMap();
+
+    // wait for it to complete
+    Map<String, Product> products = futureMap.getUnchecked();
+    Product desk = products.get("DSK1");
+    assertThat(desk).isNotNull();
+    assertThat(desk.getName()).isEqualTo("Desk");
+    assertEquals(DB.find(Product.class).findCount(), products.size());
   }
 
 }


### PR DESCRIPTION
Prior to this change they made an explicit transaction if one was needed, and this would always use the Main DataSource.

With this change, when there is no transaction assigned to the query and no active transaction, then the find future query will use the ReadOnly DataSource if it has been configured (e.g. ReadOnly DataSource might point to a read replica database instance).