### PR TITLE
Change QueryPlanInit to support thresholdMicros per hash

### DIFF
--- a/.github/workflows/jdk-ea.yml
+++ b/.github/workflows/jdk-ea.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [GA,EA,23]
+        java_version: [GA,EA]
         os: [ubuntu-latest]
 
     steps:

--- a/ebean-api/src/main/java/io/ebean/meta/QueryPlanInit.java
+++ b/ebean-api/src/main/java/io/ebean/meta/QueryPlanInit.java
@@ -81,8 +81,8 @@ public class QueryPlanInit {
    * Return the threshold in micros to use for the given hash.
    */
   public long thresholdMicros(String hash) {
-    long threshold = hashes.get(hash);
-    return threshold < 1 ? defaultThresholdMicros : threshold;
+    Long threshold = hashes.get(hash);
+    return threshold == null || threshold < 1 ? defaultThresholdMicros : threshold;
   }
 
   /**

--- a/ebean-api/src/main/java/io/ebean/meta/QueryPlanInit.java
+++ b/ebean-api/src/main/java/io/ebean/meta/QueryPlanInit.java
@@ -1,18 +1,19 @@
 package io.ebean.meta;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Initiate query plan collection for plans by their hash or all query plans.
  */
 public class QueryPlanInit {
 
+  private final Map<String,Long> hashes = new HashMap<>();
+
   private boolean all;
 
-  private Set<String> hashes = new HashSet<>();
-
-  private long thresholdMicros;
+  private long defaultThresholdMicros;
 
   /**
    * Return true if this initiates bind collection on all query plans.
@@ -29,39 +30,74 @@ public class QueryPlanInit {
   }
 
   /**
-   * Return the query execution time threshold which must be exceeded to initiate
+   * Return the default query execution time threshold which must be exceeded to initiate
    * query plan collection.
    */
   public long thresholdMicros() {
-    return thresholdMicros;
+    return defaultThresholdMicros;
   }
 
   /**
-   * Set the query execution time threshold which must be exceeded to initiate
+   * Set the default query execution time threshold which must be exceeded to initiate
    * query plan collection.
    */
   public void thresholdMicros(long thresholdMicros) {
-    this.thresholdMicros = thresholdMicros;
+    this.defaultThresholdMicros = thresholdMicros;
   }
 
   /**
    * Return true if the query plan should be initiated based on it's hash.
    */
   public boolean includeHash(String hash) {
-    return all || hashes.contains(hash);
+    return all || hashes.containsKey(hash);
   }
 
   /**
    * Return the specific hashes that we want to collect query plans on.
+   *
+   * @param hash            The hash of the query plan.
+   * @param thresholdMicros The threshold in micros to use.
    */
-  public Set<String> hashes() {
-    return hashes;
+  public void add(String hash, long thresholdMicros) {
+    requireNonNull(hash);
+    if (!"all".equals(hash)) {
+      hashes.put(hash, thresholdMicros);
+    } else {
+      all = true;
+      if (thresholdMicros > 0) {
+        defaultThresholdMicros = thresholdMicros;
+      }
+    }
   }
 
   /**
-   * Set the specific hashes that we want to collect query plans on.
+   * Remove a hash from this request.
    */
-  public void hashes(Set<String> hashes) {
-    this.hashes = hashes;
+  public void remove(String hash) {
+    hashes.remove(hash);
+  }
+
+  /**
+   * Return the threshold in micros to use for the given hash.
+   */
+  public long thresholdMicros(String hash) {
+    long threshold = hashes.get(hash);
+    return threshold < 1 ? defaultThresholdMicros : threshold;
+  }
+
+  /**
+   * Return true if there are no registered hashes and not collect <em>All</em> plans.
+   */
+  public boolean isEmpty() {
+    return !all && hashes.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    return "QueryPlanInit{" +
+      "all=" + all +
+      ", hashes=" + hashes +
+      ", thresholdMicros=" + defaultThresholdMicros +
+      '}';
   }
 }

--- a/ebean-api/src/test/java/io/ebean/meta/QueryPlanInitTest.java
+++ b/ebean-api/src/test/java/io/ebean/meta/QueryPlanInitTest.java
@@ -1,0 +1,42 @@
+package io.ebean.meta;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryPlanInitTest {
+
+  @Test
+  void initialQueryPlanInit() {
+    var init = new QueryPlanInit();
+    assertThat(init.isEmpty()).isTrue();
+    assertThat(init.isAll()).isFalse();
+    assertThat(init.thresholdMicros()).isEqualTo(0L);
+  }
+
+  @Test
+  void add_all() {
+    var init = new QueryPlanInit();
+    init.add("all", 57L);
+
+    assertThat(init.isEmpty()).isFalse();
+    assertThat(init.isAll()).isTrue();
+    assertThat(init.thresholdMicros()).isEqualTo(57L);
+  }
+
+  @Test
+  void addWithThresholds() {
+    var init = new QueryPlanInit();
+    init.thresholdMicros(1000);
+    init.add("xOne", 0);
+    init.add("xTwo", 2000L);
+
+    assertThat(init.isEmpty()).isFalse();
+    assertThat(init.isAll()).isFalse();
+    assertThat(init.includeHash("xJunk")).isFalse();
+    assertThat(init.includeHash("xOne")).isTrue();
+    assertThat(init.includeHash("xTwo")).isTrue();
+    assertThat(init.thresholdMicros("xOne")).isEqualTo(1000L);
+    assertThat(init.thresholdMicros("xTwo")).isEqualTo(2000L);
+  }
+}

--- a/ebean-api/src/test/java/io/ebean/meta/QueryPlanInitTest.java
+++ b/ebean-api/src/test/java/io/ebean/meta/QueryPlanInitTest.java
@@ -36,6 +36,7 @@ class QueryPlanInitTest {
     assertThat(init.includeHash("xJunk")).isFalse();
     assertThat(init.includeHash("xOne")).isTrue();
     assertThat(init.includeHash("xTwo")).isTrue();
+    assertThat(init.thresholdMicros("xJunk")).isEqualTo(1000L);
     assertThat(init.thresholdMicros("xOne")).isEqualTo(1000L);
     assertThat(init.thresholdMicros("xTwo")).isEqualTo(2000L);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -1455,7 +1455,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   void queryPlanInit(QueryPlanInit request, List<MetaQueryPlan> list) {
     for (CQueryPlan queryPlan : queryPlanCache.values()) {
       if (request.includeHash(queryPlan.hash())) {
-        queryPlan.queryPlanInit(request.thresholdMicros());
+        queryPlan.queryPlanInit(request.thresholdMicros(queryPlan.hash()));
         list.add(queryPlan.createMeta(null, null));
       }
     }


### PR DESCRIPTION
Effectively means that we can provide a thresholdMicros per query plan hash [for the plans that we want collected]