### PR TITLE
Add support to configure EXPLAIN options for query plan capture

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
+++ b/ebean-api/src/main/java/io/ebean/DatabaseBuilder.java
@@ -2020,6 +2020,11 @@ public interface DatabaseBuilder {
   DatabaseBuilder setQueryPlanTTLSeconds(int queryPlanTTLSeconds);
 
   /**
+   * Set the EXPLAIN (with options) to use for query plan capture.
+   */
+  DatabaseBuilder queryPlanExplain(String queryPlanExplain);
+
+  /**
    * Create a new PlatformConfig based of the one held but with overridden properties by reading
    * properties with the given path and prefix.
    * <p>
@@ -3043,6 +3048,11 @@ public interface DatabaseBuilder {
      * Return the time to live for ebean's internal query plan.
      */
     int getQueryPlanTTLSeconds();
+
+    /**
+     * Return the EXPLAIN (with options) to use for capturing query plans.
+     */
+    String getQueryPlanExplain();
 
     /**
      * Return mapping locations to search for xml mapping via class path search.

--- a/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
+++ b/ebean-api/src/main/java/io/ebean/config/DatabaseConfig.java
@@ -481,6 +481,7 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
    * Time to live for query plans - defaults to 5 minutes.
    */
   private int queryPlanTTLSeconds = 60 * 5;
+  private String queryPlanExplain;
 
   /**
    * Set to true to globally disable L2 caching (typically for performance testing).
@@ -2151,6 +2152,7 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
     queryPlanCapturePeriodSecs = p.getLong("queryPlan.capturePeriodSecs", queryPlanCapturePeriodSecs);
     queryPlanCaptureMaxTimeMillis = p.getLong("queryPlan.captureMaxTimeMillis", queryPlanCaptureMaxTimeMillis);
     queryPlanCaptureMaxCount = p.getInt("queryPlan.captureMaxCount", queryPlanCaptureMaxCount);
+    queryPlanExplain = p.get("queryPlan.explain", queryPlanExplain);
     docStoreOnly = p.getBoolean("docStoreOnly", docStoreOnly);
     disableL2Cache = p.getBoolean("disableL2Cache", disableL2Cache);
     localOnlyL2Cache = p.getBoolean("localOnlyL2Cache", localOnlyL2Cache);
@@ -2400,6 +2402,17 @@ public class DatabaseConfig implements DatabaseBuilder.Settings {
   @Override
   public int getQueryPlanTTLSeconds() {
     return queryPlanTTLSeconds;
+  }
+
+  @Override
+  public String getQueryPlanExplain() {
+    return queryPlanExplain;
+  }
+
+  @Override
+  public DatabaseBuilder queryPlanExplain(String queryPlanExplain) {
+    this.queryPlanExplain = queryPlanExplain;
+    return this;
   }
 
   @Override

--- a/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
+++ b/ebean-api/src/test/java/io/ebean/config/DatabaseConfigTest.java
@@ -84,6 +84,7 @@ class DatabaseConfigTest {
     props.setProperty("queryPlan.capturePeriodSecs", "42");
     props.setProperty("queryPlan.captureMaxTimeMillis", "560");
     props.setProperty("queryPlan.captureMaxCount", "7");
+    props.setProperty("queryPlan.explain", "explain (verbose)");
 
     config.loadFromProperties(props);
 
@@ -129,15 +130,18 @@ class DatabaseConfigTest {
     assertEquals(42, settings.getQueryPlanCapturePeriodSecs());
     assertEquals(560, settings.getQueryPlanCaptureMaxTimeMillis());
     assertEquals(7, settings.getQueryPlanCaptureMaxCount());
+    assertEquals("explain (verbose)", settings.getQueryPlanExplain());
 
     assertThat(settings.getMappingLocations()).containsExactly("classpath:/foo","bar");
 
     config.persistBatch(PersistBatch.NONE)
       .persistBatchOnCascade(PersistBatch.NONE)
       .lengthCheck(LengthCheck.ON)
-      .lengthCheck(LengthCheck.UTF8);
+      .lengthCheck(LengthCheck.UTF8)
+      .queryPlanExplain("explain (buffers)");
 
 
+    assertThat(config.settings().getQueryPlanExplain()).isEqualTo("explain (buffers)");
     Properties props1 = new Properties();
     props1.setProperty("ebean.persistBatch", "ALL");
     props1.setProperty("ebean.persistBatchOnCascade", "ALL");
@@ -182,6 +186,7 @@ class DatabaseConfigTest {
     assertEquals(600, config.getQueryPlanCapturePeriodSecs());
     assertEquals(10000L, config.getQueryPlanCaptureMaxTimeMillis());
     assertEquals(10, config.getQueryPlanCaptureMaxCount());
+    assertThat(config.getQueryPlanExplain()).isNull();
     assertThat(config.getLengthCheck()).isEqualTo(LengthCheck.OFF);
     assertTrue(config.isIncludeLabelInSql());
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
@@ -598,7 +598,7 @@ public final class InternalConfiguration {
       case ORACLE:
         return new QueryPlanLoggerOracle();
       case POSTGRES:
-        return new QueryPlanLoggerExplain(explain(config, "explain (analyze, costs, verbose, buffers, format json) "));
+        return new QueryPlanLoggerExplain(explain(config, "explain (analyze, costs, verbose, buffers) "));
       case YUGABYTE:
         return new QueryPlanLoggerExplain(explain(config,"explain (analyze, buffers, dist) "));
       default:

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/InternalConfiguration.java
@@ -585,25 +585,30 @@ public final class InternalConfiguration {
       return QueryPlanManager.NOOP;
     }
     long threshold = config.getQueryPlanThresholdMicros();
-    return new CQueryPlanManager(transactionManager, threshold, queryPlanLogger(databasePlatform.platform()), extraMetrics);
+    return new CQueryPlanManager(transactionManager, threshold, queryPlanLogger(databasePlatform.platform(), config), extraMetrics);
   }
 
   /**
    * Returns the logger to log query plans for the given platform.
    */
-  QueryPlanLogger queryPlanLogger(Platform platform) {
+  QueryPlanLogger queryPlanLogger(Platform platform, DatabaseBuilder.Settings config) {
     switch (platform.base()) {
       case SQLSERVER:
         return new QueryPlanLoggerSqlServer();
       case ORACLE:
         return new QueryPlanLoggerOracle();
       case POSTGRES:
-        return new QueryPlanLoggerExplain("explain (analyze, buffers) ");
+        return new QueryPlanLoggerExplain(explain(config, "explain (analyze, costs, verbose, buffers, format json) "));
       case YUGABYTE:
-        return new QueryPlanLoggerExplain("explain (analyze, buffers, dist) ");
+        return new QueryPlanLoggerExplain(explain(config,"explain (analyze, buffers, dist) "));
       default:
-        return new QueryPlanLoggerExplain("explain ");
+        return new QueryPlanLoggerExplain(explain(config,"explain "));
     }
+  }
+
+  private static String explain(DatabaseBuilder.Settings config, String defaultExplain) {
+    String explain = config.getQueryPlanExplain();
+    return explain == null ? defaultExplain : explain + ' ';
   }
 
   /**


### PR DESCRIPTION
e.g. DatabaseBuilder.queryPlanExplain("explain (verbose)")

Also changes Postgres default explain to be:
explain (analyze, costs, verbose, buffers)