### PR TITLE
Fix NPE with native-image with @MappedSuperclass

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -1,6 +1,5 @@
 package io.ebeaninternal.server.deploy;
 
-import io.ebean.Query;
 import io.ebean.SqlUpdate;
 import io.ebean.Transaction;
 import io.ebean.ValuePair;
@@ -125,6 +124,10 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
         // no imported or exported information
       } else if (!oneToOneExported) {
         importedId = createImportedId(this, targetDescriptor, tableJoin);
+        if (importedId == null) {
+          throw new PersistenceException("Cannot find imported id for " + fullName() + " from " + targetDescriptor
+          + ". If using native-image, possibly missing reflect-config for the Id property.");
+        }
         if (importedId.isScalar()) {
           // limit JoinColumn mapping to the @Id / primary key
           TableJoinColumn[] columns = tableJoin.columns();

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/ProcessingContext.java
@@ -66,6 +66,7 @@ class ProcessingContext implements Constants {
    * Entity classes for the default database.
    */
   private final Set<String> dbEntities = new TreeSet<>();
+  private final Set<String> dbMappedSuper = new TreeSet<>();
 
   /**
    * Entity classes for non default databases.
@@ -102,6 +103,10 @@ class ProcessingContext implements Constants {
 
   TypeElement embeddableAnnotation() {
     return elementUtils.getTypeElement(EMBEDDABLE);
+  }
+
+  TypeElement mappedSuperclassAnnotation() {
+    return elementUtils.getTypeElement(MAPPED_SUPERCLASS);
   }
 
   TypeElement converterAnnotation() {
@@ -564,5 +569,13 @@ class ProcessingContext implements Constants {
 
   boolean isNameClash(String shortName) {
     return propertyTypeMap.isNameClash(shortName);
+  }
+
+  void addMappedSuper(String fullName) {
+    dbMappedSuper.add(fullName);
+  }
+
+  Set<String> getMappedSuper() {
+    return dbMappedSuper;
   }
 }

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -75,7 +75,15 @@ public class Processor extends AbstractProcessor implements Constants {
       generateQueryBeans(element);
       count++;
     }
+    for (Element element : roundEnv.getElementsAnnotatedWith(processingContext.mappedSuperclassAnnotation())) {
+      addMappedSuperclasses(element);
+    }
     return count;
+  }
+
+  private void addMappedSuperclasses(Element element) {
+    String fullName = ((TypeElement)element).getQualifiedName().toString();
+    processingContext.addMappedSuper(fullName);
   }
 
   private void processOthers(RoundEnvironment round) {

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/SimpleModuleInfoWriter.java
@@ -88,7 +88,7 @@ class SimpleModuleInfoWriter {
       for (Set<String> value : processingContext.getOtherDbEntities().values()) {
         allEntities.addAll(value);
       }
-
+      allEntities.addAll(processingContext.getMappedSuper());
       if (!allEntities.isEmpty()) {
         FileObject jfo = processingContext.createNativeImageWriter(factoryPackage + ".ebean-entity");
         if (jfo != null) {


### PR DESCRIPTION
@MappedSuperclass was excluded from the generated reflect-config.json, this PR fixes that.

The missing reflect-config entry for MappedSuperclass means that with native-image the @Id property isn't found when its on a MappedSuperclass, and that ended up as a NPE in BeanPropertyAssocOne.