### PR TITLE
Bump ebean-datasource to 9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>14.2.0</ebean-migration.version>
     <ebean-test-containers.version>7.7</ebean-test-containers.version>
-    <ebean-datasource.version>9.3</ebean-datasource.version>
+    <ebean-datasource.version>9.5</ebean-datasource.version>
     <ebean-agent.version>14.11.0</ebean-agent.version>
     <ebean-maven-plugin.version>14.11.0</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>


### PR DESCRIPTION
When using DataSourceBuilder for both main and readOnly datasource, the maxConnections for the readOnly will default to the main pool maxConnections.