### PR TITLE
New db versions + testcontainers 7.8

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -34,5 +34,5 @@ jobs:
         path:
           ~/.m2
         key: build-${{ env.cache-name }}
-    - name: mariadb 10.6
+    - name: mariadb 10.11
       run: mvn -T 8 clean test -Dprops.file=testconfig/ebean-mariadb.properties

--- a/.github/workflows/sqlserver.yml
+++ b/.github/workflows/sqlserver.yml
@@ -34,5 +34,5 @@ jobs:
         path:
           ~/.m2
         key: build-${{ env.cache-name }}
-    - name: sqlserver 2017
-      run: mvn -T 8 clean test -Dprops.file=testconfig/ebean-sqlserver17.properties
+    - name: sqlserver 2022
+      run: mvn -T 8 clean test -Dprops.file=testconfig/ebean-sqlserver.properties

--- a/ebean-test/pom.xml
+++ b/ebean-test/pom.xml
@@ -264,7 +264,7 @@
     <dependency>
       <groupId>com.ibm.db2</groupId>
       <artifactId>jcc</artifactId>
-      <version>11.5.6.0</version>
+      <version>12.1.0.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-test/src/main/java/io/ebean/test/config/platform/Db2Setup.java
+++ b/ebean-test/src/main/java/io/ebean/test/config/platform/Db2Setup.java
@@ -24,7 +24,7 @@ class Db2Setup implements PlatformSetup {
       return new Properties();
     }
 
-    dbConfig.setDockerVersion("11.5.6.0a");
+    dbConfig.setDockerVersion("11.5.9.0");
     return dbConfig.getDockerProperties();
   }
 

--- a/ebean-test/src/test/java/main/StartDb2.java
+++ b/ebean-test/src/test/java/main/StartDb2.java
@@ -5,12 +5,12 @@ import io.ebean.test.containers.Db2Container;
 public class StartDb2 {
 
   public static void main(String[] args) {
-    Db2Container.builder("11.5.6.0a")
+    Db2Container.builder("11.5.9.0")
       .dbName("unit")
       .user("unit")
       .password("unit")
       // to change collation, charset and other parameters like pagesize:
-      .configOptions("USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768")
+      .createOptions("USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768")
       .configOptions("USING STRING_UNITS CODEUNITS32")
       .build()
       .startWithDropCreate();

--- a/ebean-test/src/test/resources/ebean.properties
+++ b/ebean-test/src/test/resources/ebean.properties
@@ -141,7 +141,7 @@ datasource.mysql.url=jdbc:mysql://127.0.0.1:4306/test_ebean
 
 datasource.mariadb.username=unit
 datasource.mariadb.password=test
-datasource.mariadb.url=jdbc:mariadb://localhost:14307/unit?useLegacyDatetimeCode=false
+datasource.mariadb.url=jdbc:mariadb://localhost:14309/unit?useLegacyDatetimeCode=false
 
 datasource.cockroach.username=root
 datasource.cockroach.password=

--- a/ebean-test/testconfig/ebean-db2-11.5.properties
+++ b/ebean-test/testconfig/ebean-db2-11.5.properties
@@ -7,6 +7,9 @@ datasource.default=db2
 ebean.db2.databasePlatformName=db2luw
 ebean.lengthCheck=utf8
 
-ebean.test.db2.version=12.1.1.0
-ebean.test.db2.containerName=ut_db2-12-1-1
+ebean.test.db2.version=11.5.9.0
+ebean.test.db2.containerName=ut_db2-11-5-9
+ebean.test.db2.port=50055
 ebean.test.db2.image=icr.io/db2_community/db2
+
+datasource.db2.url=jdbc:db2://localhost:50055/unit

--- a/ebean-test/testconfig/ebean-db2-11.5.properties
+++ b/ebean-test/testconfig/ebean-db2-11.5.properties
@@ -10,6 +10,5 @@ ebean.lengthCheck=utf8
 ebean.test.db2.version=11.5.9.0
 ebean.test.db2.containerName=ut_db2-11-5-9
 ebean.test.db2.port=50055
-ebean.test.db2.image=icr.io/db2_community/db2
 
 datasource.db2.url=jdbc:db2://localhost:50055/unit

--- a/ebean-test/testconfig/ebean-db2.properties
+++ b/ebean-test/testconfig/ebean-db2.properties
@@ -9,4 +9,3 @@ ebean.lengthCheck=utf8
 
 ebean.test.db2.version=12.1.1.0
 ebean.test.db2.containerName=ut_db2-12-1-1
-ebean.test.db2.image=icr.io/db2_community/db2

--- a/ebean-test/testconfig/ebean-mariadb-10.6.properties
+++ b/ebean-test/testconfig/ebean-mariadb-10.6.properties
@@ -1,0 +1,7 @@
+ebean.test.platform=mariadb
+ebean.test.dbName=unit
+ebean.test.mariadb.version=10.6
+ebean.test.mariadb.containerName=ut_mariadb-10-6
+ebean.test.mariadb.port=14307
+datasource.default=mariadb-106
+ebean.lengthCheck=on

--- a/ebean-test/testconfig/ebean-mariadb.properties
+++ b/ebean-test/testconfig/ebean-mariadb.properties
@@ -1,7 +1,8 @@
 ebean.test.platform=mariadb
 ebean.test.dbName=unit
-ebean.test.mariadb.version=10.6
-ebean.test.mariadb.containerName=ut_mariadb-10-6
-ebean.test.mariadb.port=14307
+ebean.test.mariadb.version=10.11
+ebean.test.mariadb.containerName=ut_mariadb-10-11
+ebean.test.mariadb.port=14309
 datasource.default=mariadb
 ebean.lengthCheck=on
+

--- a/ebean-test/testconfig/ebean-sqlserver.properties
+++ b/ebean-test/testconfig/ebean-sqlserver.properties
@@ -1,0 +1,14 @@
+ebean.test.platform=sqlserver
+ebean.test.dbName=test_ebean
+ebean.test.sqlserver.version=2022-latest
+ebean.test.sqlserver.containerName=local_sqlserver2022
+ebean.test.sqlserver.collation=LATIN1_GENERAL_100_CS_AS_SC_UTF8
+ebean.test.sqlserver.port=9436
+ebean.test.sqlserver.url=jdbc:sqlserver://localhost:9436;databaseName=test_ebean;sendTimeAsDateTime=false;integratedSecurity=false;trustServerCertificate=true
+datasource.default=sqlserver2022
+ebean.sqlserver2022.databasePlatformName=sqlserver17
+ebean.lengthCheck=on
+
+## A case sensitive collation example:
+#ebean.test.sqlserver.collation=LATIN1_GENERAL_100_CI_AS_SC_UTF8
+#ebean.sqlserver2022.caseSensitiveCollation=false

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <ebean-ddl-runner.version>2.3</ebean-ddl-runner.version>
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>14.2.0</ebean-migration.version>
-    <ebean-test-containers.version>7.7</ebean-test-containers.version>
+    <ebean-test-containers.version>7.8</ebean-test-containers.version>
     <ebean-datasource.version>9.5</ebean-datasource.version>
     <ebean-agent.version>14.12.0</ebean-agent.version>
     <ebean-maven-plugin.version>14.12.0</ebean-maven-plugin.version>


### PR DESCRIPTION
Hello @rbygrave,

As discussed, we would like to update the DB versions for mariadb, sqlserverv, and db2.

I've added the latest version to the files with filenames without a version. Older versions can be identified by their filenames.

The actions use the latest DB versions. The only exception: there's a separate action for SQL Server 2019, which we can also delete from our side to ensure a consistent look.

I have the three DB platforms in one PR. Should I split them up, or is this fine?