### PR TITLE
Fix EA build, Kotlin not supporting 25-EA release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
     <module>ebean-ddl-generator</module>
     <module>ebean-test</module>
     <module>querybean-generator</module>
-    <module>kotlin-querybean-generator</module>
     <module>ebean-querybean</module>
     <module>ebean-postgis-types</module>
     <module>ebean-net-postgis-types</module>
@@ -112,6 +111,15 @@
       <properties>
         <h2database.version>1.4.199</h2database.version>
       </properties>
+    </profile>
+    <profile>
+      <id>jdkKotlin</id>
+      <activation>
+        <jdk>[11,21]</jdk>
+      </activation>
+      <modules>
+        <module>kotlin-querybean-generator</module>
+      </modules>
     </profile>
     <profile>
       <id>default</id>


### PR DESCRIPTION
It barfs trying to parse the 25-EA version, means the kotlin-querybean-generator fails the build for the Java Early Release versions.

With this, it will skip the kotlin modules for the Java Early Access release builds.