### PR TITLE
Undo generated properties on general persistenceExceptions

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchPostExecute.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchPostExecute.java
@@ -47,9 +47,9 @@ public interface BatchPostExecute {
   void addTimingBatch(long startNanos, int batch);
 
   /**
-   * Undos generated properties.
+   * Tries to undo the request.
    */
-  default void onFailedUpdateUndoGeneratedProperties() {
+  default void undo() {
 
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchedPstmtHolder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/BatchedPstmtHolder.java
@@ -119,6 +119,7 @@ public final class BatchedPstmtHolder {
         loadBack(copyMap);
       }
     } catch (BatchedSqlException e) {
+      copy.forEach(BatchedPstmt::undo);
       closeStatements(copy);
       throw e;
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlBeanPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlBeanPersister.java
@@ -74,7 +74,6 @@ final class DmlBeanPersister implements BeanPersister {
       if (request.transaction().isLogSummary()) {
         request.transaction().logSummary(msg);
       }
-      request.onFailedUpdateUndoGeneratedProperties();
       throw dbPlatform.translate(msg, e);
     } finally {
       if (!batched) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
@@ -8,8 +8,8 @@ import io.ebeaninternal.server.persist.BatchedPstmt;
 import io.ebeaninternal.server.persist.BatchedPstmtHolder;
 import io.ebeaninternal.server.persist.dmlbind.BindableRequest;
 import io.ebeaninternal.server.bind.DataBind;
-
 import jakarta.persistence.OptimisticLockException;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -86,6 +86,9 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
     final long startNanos = System.nanoTime();
     try {
       return execute();
+    } catch (Throwable t) {
+      persistRequest.undo();
+      throw t;
     } finally {
       persistRequest.addTimingNoBatch(startNanos);
     }

--- a/ebean-test/src/test/java/org/tests/cascade/TestDeleteRestrict.java
+++ b/ebean-test/src/test/java/org/tests/cascade/TestDeleteRestrict.java
@@ -1,0 +1,41 @@
+package org.tests.cascade;
+
+import io.ebean.DataIntegrityException;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Customer;
+import org.tests.model.basic.Order;
+import org.tests.model.basic.ResetBasicData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Roland Praml, Foconis Analytics GmbH
+ */
+public class TestDeleteRestrict extends BaseTestCase {
+
+  @Test
+  void test() {
+    ResetBasicData.reset();
+
+    Customer customer = new Customer();
+    customer.setName("Roland");
+    server().save(customer);
+
+    Order order = new Order();
+    order.setCustomer(customer);
+    server().save(order);
+
+    assertThat(customer.getVersion()).isEqualTo(1L);
+    assertThatThrownBy(() -> server().delete(customer)).isInstanceOf(DataIntegrityException.class);
+    assertThat(customer.getVersion()).isEqualTo(1L);
+
+    customer.setName("Roland-inactive");
+    server().save(customer);
+
+    // cleanup
+    server().delete(order);
+    server().delete(customer);
+  }
+}


### PR DESCRIPTION
With #2372 we introduced a rollback mechanism when an optimisticLock happend.
This PR also handles the situation for other persistence exceptions like DuplicateKey in a similar way, so that you can correct the issue and retry save.

Please take a look, if this makes sense to you.