### PR TITLE
Bump ebean-datasource 10.1 with support for initialConnections [for smoother K8s deployment]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>14.2.0</ebean-migration.version>
     <ebean-test-containers.version>7.13</ebean-test-containers.version>
-    <ebean-datasource.version>10.0</ebean-datasource.version>
+    <ebean-datasource.version>10.1</ebean-datasource.version>
     <ebean-agent.version>14.12.0</ebean-agent.version>
     <ebean-maven-plugin.version>14.12.0</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>


### PR DESCRIPTION
So in a K8s deployment, this adds support for having an initial number of connections to create initially (higher that min connections). This allows for a smoother deployment, by effectively having initially more connections than min in order to immediately take production load, and then over time trim back down towards the min connections.

So in k8s I am setting min, initial and max connections, where initial connections is high enough to take full production load straight after readiness true.