### PR TITLE
#3654 Fix querybean-generator compiler warning for unclaimed annotations

### DIFF
--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -5,6 +5,9 @@ interface Constants {
   String AT_GENERATED = "@io.ebean.typequery.Generated(\"io.ebean.querybean.kotlin-generator\")";
   String AT_TYPEQUERYBEAN = "@io.ebean.typequery.TypeQueryBean(\"v1\")";
 
+  String GENERATED = "io.ebean.typequery.Generated";
+  String TYPEQUERYBEAN = "io.ebean.typequery.TypeQueryBean";
+
   String MAPPED_SUPERCLASS = "jakarta.persistence.MappedSuperclass";
   String DISCRIMINATOR_VALUE = "jakarta.persistence.DiscriminatorValue";
   String INHERITANCE = "jakarta.persistence.Inheritance";

--- a/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/kotlin-querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -49,6 +49,8 @@ public class Processor extends AbstractProcessor implements Constants {
     annotations.add(CONVERTER);
     annotations.add(EBEAN_COMPONENT);
     annotations.add(MODULEINFO);
+    annotations.add(TYPEQUERYBEAN);
+    annotations.add(GENERATED);
     return annotations;
   }
 

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Constants.java
@@ -4,6 +4,7 @@ interface Constants {
 
   String AT_GENERATED = "@io.ebean.typequery.Generated(\"io.ebean.querybean.generator\")";
   String AT_TYPEQUERYBEAN = "@io.ebean.typequery.TypeQueryBean(\"v1\")";
+  String TYPEQUERYBEAN = "io.ebean.typequery.TypeQueryBean";
   String GENERATED = "io.ebean.typequery.Generated";
 
   String ONE_TO_MANY = "jakarta.persistence.OneToMany";

--- a/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
+++ b/querybean-generator/src/main/java/io/ebean/querybean/generator/Processor.java
@@ -36,6 +36,8 @@ public class Processor extends AbstractProcessor implements Constants {
     annotations.add(CONVERTER);
     annotations.add(EBEAN_COMPONENT);
     annotations.add(MODULEINFO);
+    annotations.add(TYPEQUERYBEAN);
+    annotations.add(GENERATED);
     return annotations;
   }
 


### PR DESCRIPTION
warning: No processor claimed any of these annotations: /io.ebean.typequery.TypeQueryBean,/io.ebean.typequery.Generated

This fix is required when the compiler is run with -Werror specified

An alternative workaround is to use compiler arg -Xlint:-processing rather than -Xlint:all