### PR TITLE
#3664 Fix / support for extra JoinColumns on ManyToOne

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
@@ -436,14 +436,15 @@ public abstract class BeanPropertyAssoc<T> extends BeanProperty implements STree
     }
     TableJoinColumn[] cols = join.columns();
     if (!idProp.isEmbedded()) {
-      // simple single scalar id
-      if (cols.length != 1) {
-        CoreLog.log.log(ERROR, "No Imported Id column for {0} in table {1}", idProp, join.getTable());
-        return null;
-      } else {
-        BeanProperty[] idProps = {idProp};
-        return createImportedScalar(owner, cols[0], idProps, others);
+      // simple single scalar id, match on the foreign column, allow extra TableJoinColumn for #3664
+      String matchColumn = idProp.dbColumn();
+      for (TableJoinColumn col : cols) {
+        if (matchColumn.equals(col.getForeignDbColumn())) {
+          return createImportedScalar(owner, col, new BeanProperty[]{idProp}, others);
+        }
       }
+      CoreLog.log.log(ERROR, "No Imported Id column for {0} in table {1}", idProp, join.getTable());
+      return null;
     } else {
       // embedded id
       BeanPropertyAssocOne<?> embProp = (BeanPropertyAssocOne<?>) idProp;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -128,16 +128,6 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
           throw new PersistenceException("Cannot find imported id for " + fullName() + " from " + targetDescriptor
           + ". If using native-image, possibly missing reflect-config for the Id property.");
         }
-        if (importedId.isScalar()) {
-          // limit JoinColumn mapping to the @Id / primary key
-          TableJoinColumn[] columns = tableJoin.columns();
-          String foreignJoinColumn = columns[0].getForeignDbColumn();
-          String foreignIdColumn = targetDescriptor.idProperty().dbColumn();
-          if (!foreignJoinColumn.equalsIgnoreCase(foreignIdColumn)) {
-            throw new PersistenceException("Mapping limitation - @JoinColumn on " + fullName() + " needs to map to a primary key as per Issue #529 "
-              + " - joining to " + foreignJoinColumn + " and not " + foreignIdColumn);
-          }
-        }
       } else {
         exportedProperties = createExported();
         String delStmt = "delete from " + targetDescriptor.baseTable() + " where ";

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/TableJoin.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/TableJoin.java
@@ -133,10 +133,6 @@ public final class TableJoin {
     return table;
   }
 
-//  public boolean multiColumn() {
-//    return columns.length > 1;
-//  }
-
   public void addJoin(SqlJoinType joinType, String prefix, DbSqlContext ctx, String predicate) {
     String[] names = SplitName.split(prefix);
     String a1 = ctx.tableAlias(names[0]);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/TableJoin.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/TableJoin.java
@@ -133,6 +133,10 @@ public final class TableJoin {
     return table;
   }
 
+//  public boolean multiColumn() {
+//    return columns.length > 1;
+//  }
+
   public void addJoin(SqlJoinType joinType, String prefix, DbSqlContext ctx, String predicate) {
     String[] names = SplitName.split(prefix);
     String a1 = ctx.tableAlias(names[0]);

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/build/ModelBuildPropertyVisitor.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/build/ModelBuildPropertyVisitor.java
@@ -195,7 +195,7 @@ public class ModelBuildPropertyVisitor extends BaseTablePropertyVisitor {
       String dbCol = column.getLocalDbColumn();
       BeanProperty importedProperty = p.findMatchImport(dbCol);
       if (importedProperty == null) {
-        throw new RuntimeException("Imported BeanProperty not found?");
+        continue;
       }
       String columnDefn = ctx.getColumnDefn(importedProperty, true);
       String refColumn = importedProperty.dbColumn();

--- a/ebean-test/src/test/java/org/tests/model/m2o/MTJOrder.java
+++ b/ebean-test/src/test/java/org/tests/model/m2o/MTJOrder.java
@@ -1,0 +1,46 @@
+package org.tests.model.m2o;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class MTJOrder {
+
+  @Id
+  Long id;
+
+  @Column(name = "org_id")
+  Long orgId;
+
+  @Column
+  String other;
+
+
+  public Long id() {
+    return id;
+  }
+
+  public MTJOrder setId(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  public Long orgId() {
+    return orgId;
+  }
+
+  public MTJOrder setOrgId(Long orgId) {
+    this.orgId = orgId;
+    return this;
+  }
+
+  public String other() {
+    return other;
+  }
+
+  public MTJOrder setOther(String other) {
+    this.other = other;
+    return this;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/m2o/MTJOrder.java
+++ b/ebean-test/src/test/java/org/tests/model/m2o/MTJOrder.java
@@ -8,14 +8,13 @@ import jakarta.persistence.Id;
 public class MTJOrder {
 
   @Id
-  Long id;
+  private long id;
 
   @Column(name = "org_id")
-  Long orgId;
+  private long orgId;
 
   @Column
-  String other;
-
+  private String other;
 
   public Long id() {
     return id;

--- a/ebean-test/src/test/java/org/tests/model/m2o/MTJTrans.java
+++ b/ebean-test/src/test/java/org/tests/model/m2o/MTJTrans.java
@@ -6,17 +6,17 @@ import jakarta.persistence.*;
 public class MTJTrans {
 
   @Id
-  Long id;
+  private long id;
 
   @Column(name = "org_id")
-  Long orgId;
+  private long orgId;
 
   @ManyToOne
   @JoinColumns({
-    @JoinColumn(name = "org_id", referencedColumnName = "org_id", insertable = false, updatable = false),
+    @JoinColumn(name = "org_id", referencedColumnName = "org_id"), // extra join column, not strictly needed
     @JoinColumn(name = "order_id", referencedColumnName = "id")
   })
-  MTJOrder order;
+  private MTJOrder order;
 
   public Long id() {
     return id;

--- a/ebean-test/src/test/java/org/tests/model/m2o/MTJTrans.java
+++ b/ebean-test/src/test/java/org/tests/model/m2o/MTJTrans.java
@@ -1,0 +1,47 @@
+package org.tests.model.m2o;
+
+import jakarta.persistence.*;
+
+@Entity
+public class MTJTrans {
+
+  @Id
+  Long id;
+
+  @Column(name = "org_id")
+  Long orgId;
+
+  @ManyToOne
+  @JoinColumns({
+    @JoinColumn(name = "org_id", referencedColumnName = "org_id", insertable = false, updatable = false),
+    @JoinColumn(name = "order_id", referencedColumnName = "id")
+  })
+  MTJOrder order;
+
+  public Long id() {
+    return id;
+  }
+
+  public MTJTrans setId(Long id) {
+    this.id = id;
+    return this;
+  }
+
+  public Long orgId() {
+    return orgId;
+  }
+
+  public MTJTrans setOrgId(Long orgId) {
+    this.orgId = orgId;
+    return this;
+  }
+
+  public MTJOrder order() {
+    return order;
+  }
+
+  public MTJTrans setOrder(MTJOrder order) {
+    this.order = order;
+    return this;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/m2o/TestMTJoinColumns.java
+++ b/ebean-test/src/test/java/org/tests/model/m2o/TestMTJoinColumns.java
@@ -1,0 +1,25 @@
+package org.tests.model.m2o;
+
+import io.ebean.DB;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestMTJoinColumns {
+
+  @Test
+  void test() {
+    MTJTrans parent = new MTJTrans();
+    parent.setOrgId(51L);
+
+    DB.save(parent);
+
+    MTJTrans found = DB.find(MTJTrans.class)
+      .setId(parent.id())
+      .fetch("order")
+      .findOne();
+
+    MTJOrder order = found.order();
+    assertThat(order).isNull();
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/m2o/TestMTJoinColumns.java
+++ b/ebean-test/src/test/java/org/tests/model/m2o/TestMTJoinColumns.java
@@ -1,7 +1,10 @@
 package org.tests.model.m2o;
 
 import io.ebean.DB;
+import io.ebean.test.LoggedSql;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,7 +22,27 @@ class TestMTJoinColumns {
       .fetch("order")
       .findOne();
 
-    MTJOrder order = found.order();
-    assertThat(order).isNull();
+    assertThat(found.order()).isNull();
+
+    var order = new MTJOrder()
+      .setOrgId(51L)
+      .setOther("some");
+    DB.save(order);
+    found.setOrder(order);
+    DB.save(found);
+
+    LoggedSql.start();
+    MTJTrans found2 = DB.find(MTJTrans.class)
+      .setId(parent.id())
+      .fetch("order")
+      .findOne();
+
+    assertThat(found2.order()).isNotNull();
+    assertThat(found2.order().id()).isEqualTo(order.id());
+    assertThat(found2.order().other()).isEqualTo("some");
+
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("from mtjtrans t0 left join mtjorder t1 on t1.org_id = t0.org_id and t1.id = t0.order_id where t0.id = ?");
   }
 }


### PR DESCRIPTION
Allows for extra JoinColumns on ManyToOne. The extra JoinColumn(s) are expected to be useful for the case of table partitioning where the extra join column is used to partition the table. In the test case, the partition column would be the org_id column and common to both tables (same partition key).