### PR TITLE
Bump ebean-agent to 16.1.0 with Java 25 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     <ebean-migration.version>14.3.0</ebean-migration.version>
     <ebean-test-containers.version>7.14</ebean-test-containers.version>
     <ebean-datasource.version>10.1</ebean-datasource.version>
-    <ebean-agent.version>16.0.1</ebean-agent.version>
-    <ebean-maven-plugin.version>16.0.1</ebean-maven-plugin.version>
+    <ebean-agent.version>16.1.0</ebean-agent.version>
+    <ebean-maven-plugin.version>16.1.0</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>
   </properties>
 


### PR DESCRIPTION
Note that the IntelliJ plugin has been updated and published. It should be public in a few days.