### PR TITLE
3682 @Aggregation is applied to query if entity also has a @lob column 

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanDescriptor.java
@@ -804,11 +804,9 @@ public class DeployBeanDescriptor<T> {
    * Return the defaultSelectClause using FetchType.LAZY and FetchType.EAGER.
    */
   public String getDefaultSelectClause() {
-
     StringBuilder sb = new StringBuilder();
 
     boolean hasLazyFetch = false;
-
     for (DeployBeanProperty prop : propMap.values()) {
       if (!prop.isTransient() && !(prop instanceof DeployBeanPropertyAssocMany<?>)) {
         if (prop.isFetchEager()) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -617,6 +617,8 @@ public class DeployBeanProperty {
     this.dbRead = true;
     this.dbInsertable = false;
     this.dbUpdateable = false;
+    // aggregation by default not fetchEager
+    this.fetchEager = false;
   }
 
   /**

--- a/ebean-test/src/test/java/org/tests/aggregateformula/EWithLobAndAgg.java
+++ b/ebean-test/src/test/java/org/tests/aggregateformula/EWithLobAndAgg.java
@@ -1,0 +1,60 @@
+package org.tests.aggregateformula;
+
+import io.ebean.annotation.Aggregation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+@Entity
+public class EWithLobAndAgg {
+
+  @Id
+  long id;
+
+  @Column
+  String name;
+
+   @Lob
+  @Column
+  String description;
+
+  @Aggregation("count(*)")
+  int count;
+
+  public long id() {
+    return id;
+  }
+
+  public EWithLobAndAgg setId(long id) {
+    this.id = id;
+    return this;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public EWithLobAndAgg setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public EWithLobAndAgg setDescription(String description) {
+    this.description = description;
+    return this;
+  }
+
+  public int count() {
+    return count;
+  }
+
+  public EWithLobAndAgg setCount(int count) {
+    this.count = count;
+    return this;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/aggregateformula/TestEWithLobAndAgg.java
+++ b/ebean-test/src/test/java/org/tests/aggregateformula/TestEWithLobAndAgg.java
@@ -1,0 +1,21 @@
+package org.tests.aggregateformula;
+
+import io.ebean.DB;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestEWithLobAndAgg {
+
+  @Test
+  void when_lobAndAgg_expect_neitherLobOrAggSelectedByDefault() {
+    var query = DB.find(EWithLobAndAgg.class);
+
+    query.findList();
+    var sql = query.getGeneratedSql();
+
+    assertThat(sql)
+      .describedAs("Neither Lob or Aggregation column in query")
+      .isEqualTo("select t0.id, t0.name from ewith_lob_and_agg t0");
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/aggregation/TestAggregationTopLevel.java
+++ b/ebean-test/src/test/java/org/tests/model/aggregation/TestAggregationTopLevel.java
@@ -29,7 +29,7 @@ public class TestAggregationTopLevel extends BaseTestCase {
       .query();
 
     List<DMachineStatsAgg> result = query.findList();
-    assertThat(sqlOf(query)).contains("select t0.edate, t0.machine_id from d_machine_stats t0 where t0.edate > ?");
+    assertThat(sqlOf(query)).contains("select t0.machine_id, t0.edate from d_machine_stats t0 where t0.edate > ?");
     assertThat(result).isNotEmpty();
   }
 

--- a/ebean-test/src/test/java/org/tests/query/aggregation/TestAggregationCount.java
+++ b/ebean-test/src/test/java/org/tests/query/aggregation/TestAggregationCount.java
@@ -49,7 +49,7 @@ public class TestAggregationCount extends BaseTestCase {
     List<TEventOne> list = query.findList();
 
     String sql = sqlOf(query, 5);
-    assertThat(sql).contains("select t0.id, t0.name, t0.status, t0.version, t0.event_id from tevent_one t0");
+    assertThat(sql).contains("select t0.id, t0.name, t0.status, t0.event_id, t0.version from tevent_one t0");
 
     for (TEventOne eventOne : list) {
       // lazy loading on Aggregation properties


### PR DESCRIPTION
The underling issue was that Aggregation columns should have been marked as default LAZY. This impact was only hit when https://github.com/lob column are included which by default lazy fetched, and that means the default select clause determined.