### PR TITLE
#3695 Behaviour change: findSingleAttribute() to throw when multiple …

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultRelationalQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultRelationalQueryEngine.java
@@ -116,9 +116,14 @@ public final class DefaultRelationalQueryEngine implements RelationalQueryEngine
     try {
       request.executeSql(binder, SpiQuery.Type.BEAN);
       T value = request.mapOne(mapper);
+      if (request.next()) {
+        throw new NonUniqueResultException("Got more than 1 result for findOne");
+      }
       request.logSummary();
       return value;
 
+    } catch (NonUniqueResultException e) {
+      throw e;
     } catch (Exception e) {
       throw new PersistenceException(errMsg(e.getMessage(), request.getSql()), e);
 

--- a/ebean-test/src/test/java/org/tests/query/sqlquery/SqlQueryTests.java
+++ b/ebean-test/src/test/java/org/tests/query/sqlquery/SqlQueryTests.java
@@ -389,6 +389,18 @@ class SqlQueryTests extends BaseTestCase {
   }
 
   @Test
+  void findOne_mapper_when_notUnique() {
+    ResetBasicData.reset();
+
+    String sql = "select id, name, status from o_customer order by name desc";
+    assertThatThrownBy(() -> DB.sqlQuery(sql)
+      .mapTo(CUST_MAPPER)
+      .findOne())
+      .isInstanceOf(NonUniqueResultException.class)
+      .hasMessageContaining("Got more than 1 result for findOne");
+  }
+
+  @Test
   void findList_mapper() {
     ResetBasicData.reset();
 


### PR DESCRIPTION
…rows returned by query

On the plus, this makes the behaviour consistent with all the other findOne() methods (ORM, DTO, SqlQuery) and this very much feels like buggy behaviour [to just get the first result and ignore any subsequent results in the ResultSet]

On the negative of merging this bug fix, any application code relying on the existing behaviour with this fix will break and throw a NonUniqueResultException at RUNTIME (not ideal). However, for these cases where the application now throws an exception, people might not be aware that they were relying on this behaviour and this exception could be useful to highlight that (a potential non-deterministic query result was being used and a potential source of bugs was being).