### PR TITLE
#3551 Log warning for use of mapping column to Class

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -216,6 +216,9 @@ public final class DefaultTypeManager implements TypeManager {
       }
       found = checkInheritedTypes(type);
     }
+    if (found instanceof ScalarTypeClass) {
+      log.log(WARNING, "@Column mapping for type Class is deprecated. Please refer to https://ebean.io/docs/deprecated#class-mapping");
+    }
     return found != ScalarTypeNotFound.INSTANCE ? found : null; // Do not return ScalarTypeNotFound, otherwise checks will fail
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeClass.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeClass.java
@@ -10,7 +10,7 @@ import jakarta.persistence.PersistenceException;
 @SuppressWarnings({"rawtypes"})
 final class ScalarTypeClass extends ScalarTypeBaseVarchar<Class> {
 
-  public ScalarTypeClass() {
+  ScalarTypeClass() {
     super(Class.class);
   }
 


### PR DESCRIPTION
I think it was a mistake for Ebean to support Class<?> from a security perspective. Instead, Ebean should just use a String <-> Varchar and leave if up to the application to take that String and convert it to a class [and then that potential Class initialisation is owned by the application code and all security considerations around that are owned by the application code].