### PR TITLE
For query usingMaster support passing a boolean

### DIFF
--- a/ebean-api/src/main/java/io/ebean/DtoQuery.java
+++ b/ebean-api/src/main/java/io/ebean/DtoQuery.java
@@ -234,5 +234,16 @@ public interface DtoQuery<T> extends CancelableQuery {
    * source. We use {@code usingMaster()} to instead ensure that the query is executed
    * against the master data source.
    */
-  DtoQuery<T> usingMaster();
+  default DtoQuery<T> usingMaster() {
+    return usingMaster(true);
+  }
+
+  /**
+   * Ensure the master DataSource is used when useMaster is true. Otherwise, the read only
+   * data source can be used if defined.
+   *
+   * @see #usingMaster()
+   */
+  DtoQuery<T> usingMaster(boolean useMaster);
+
 }

--- a/ebean-api/src/main/java/io/ebean/QueryBuilder.java
+++ b/ebean-api/src/main/java/io/ebean/QueryBuilder.java
@@ -135,7 +135,17 @@ public interface QueryBuilder<SELF extends QueryBuilder<SELF, T>, T> extends Que
    * source. We we use {@code usingMaster()} to instead ensure that the query is executed
    * against the master data source.
    */
-  SELF usingMaster();
+  default SELF usingMaster() {
+    return usingMaster(true);
+  }
+
+  /**
+   * Ensure the master DataSource is used when useMaster is true. Otherwise, the read only
+   * data source can be used if defined.
+   *
+   * @see #usingMaster()
+   */
+  SELF usingMaster(boolean useMaster);
 
   /**
    * Set the base table to use for this query.

--- a/ebean-api/src/main/java/io/ebean/SqlQuery.java
+++ b/ebean-api/src/main/java/io/ebean/SqlQuery.java
@@ -63,7 +63,17 @@ public interface SqlQuery extends Serializable, CancelableQuery {
    * source. We use {@code usingMaster()} to instead ensure that the query is executed
    * against the master data source.
    */
-  SqlQuery usingMaster();
+  default SqlQuery usingMaster() {
+    return usingMaster(true);
+  }
+
+  /**
+   * Ensure the master DataSource is used when useMaster is true. Otherwise, the read only
+   * data source can be used if defined.
+   *
+   * @see #usingMaster()
+   */
+  SqlQuery usingMaster(boolean useMaster);
 
   /**
    * Execute the query returning a list.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultFetchGroupQuery.java
@@ -235,7 +235,7 @@ final class DefaultFetchGroupQuery<T> implements SpiFetchGroupQuery<T>, SpiQuery
   }
 
   @Override
-  public Query<T> usingMaster() {
+  public Query<T> usingMaster(boolean useMaster) {
     throw new RuntimeException("EB102: Only select() and fetch() clause is allowed on FetchGroup");
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultDtoQuery.java
@@ -95,8 +95,8 @@ public final class DefaultDtoQuery<T> extends AbstractQuery implements SpiDtoQue
   }
 
   @Override
-  public DtoQuery<T> usingMaster() {
-    this.useMaster = true;
+  public DtoQuery<T> usingMaster(boolean useMaster) {
+    this.useMaster = useMaster;
     return this;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultOrmQuery.java
@@ -1475,8 +1475,8 @@ public class DefaultOrmQuery<T> extends AbstractQuery implements SpiQuery<T> {
   }
 
   @Override
-  public Query<T> usingMaster() {
-    this.useMaster = true;
+  public Query<T> usingMaster(boolean useMaster) {
+    this.useMaster = useMaster;
     return this;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultRelationalQuery.java
@@ -60,8 +60,8 @@ public final class DefaultRelationalQuery extends AbstractQuery implements SpiSq
   }
 
   @Override
-  public SqlQuery usingMaster() {
-    this.useMaster = true;
+  public SqlQuery usingMaster(boolean useMaster) {
+    this.useMaster = useMaster;
     return this;
   }
 

--- a/ebean-querybean/src/main/java/io/ebean/typequery/QueryBean.java
+++ b/ebean-querybean/src/main/java/io/ebean/typequery/QueryBean.java
@@ -739,8 +739,8 @@ public abstract class QueryBean<T, R extends QueryBean<T, R>> implements IQueryB
   }
 
   @Override
-  public final R usingMaster() {
-    query.usingMaster();
+  public R usingMaster(boolean useMaster) {
+    query.usingMaster(useMaster);
     return root;
   }
 

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerTest.java
@@ -447,6 +447,22 @@ public class QCustomerTest {
   }
 
   @Test
+  public void usingMaster_true() {
+    new QCustomer()
+      .registered.isNull()
+      .usingMaster(true)
+      .findList();
+  }
+
+  @Test
+  public void usingMaster_false() {
+    new QCustomer()
+      .registered.isNull()
+      .usingMaster(false)
+      .findList();
+  }
+
+  @Test
   public void usingTransaction() {
     try (Transaction transaction = DB.getDefault().createTransaction()) {
 

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
@@ -156,6 +156,34 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
   }
 
   @Test
+  public void asDto_usingMaster_true() {
+    asDtoUsingMaster(true);
+  }
+
+  @Test
+  public void asDto_usingMaster_false() {
+    asDtoUsingMaster(false);
+  }
+
+  private void asDtoUsingMaster(boolean useMaster) {
+    ResetBasicData.reset();
+    LoggedSql.start();
+
+    DtoQuery<ContactDto> query = DB.find(Contact.class)
+      .select("id, email")
+      .where().isNotNull("email")
+      .asDto(ContactDto.class)
+      .usingMaster(useMaster);
+
+    List<ContactDto> dtos = query.findList();
+
+    assertThat(dtos).isNotEmpty();
+    for (ContactDto dto : dtos) {
+      assertThat(dto.getEmail()).isNotNull();
+    }
+  }
+
+  @Test
   public void asDto_withExplicitId() {
 
     ResetBasicData.reset();

--- a/ebean-test/src/test/java/org/tests/basic/TestQueryUsingConnection.java
+++ b/ebean-test/src/test/java/org/tests/basic/TestQueryUsingConnection.java
@@ -68,11 +68,15 @@ public class TestQueryUsingConnection extends BaseTestCase {
 
       final int otherCount = DB.find(Country.class).findCount();
       final int masterCount = DB.find(Country.class).usingMaster().findCount();
+      final int masterCount2 = DB.find(Country.class).usingMaster(true).findCount();
+      final int masterCount3 = DB.find(Country.class).usingMaster(false).findCount();
 
       transaction.rollback();
 
       assertThat(count).isEqualTo(otherCount + 1);
       assertThat(otherCount).isEqualTo(masterCount);
+      assertThat(otherCount).isEqualTo(masterCount2);
+      assertThat(otherCount).isEqualTo(masterCount3);
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/query/sqlquery/SqlQueryTests.java
+++ b/ebean-test/src/test/java/org/tests/query/sqlquery/SqlQueryTests.java
@@ -281,6 +281,28 @@ class SqlQueryTests extends BaseTestCase {
   }
 
   @Test
+  void queryUsingMaster_true() {
+    queryUsingMasterAsParameter(true);
+  }
+
+  @Test
+  void queryUsingMaster_false() {
+    queryUsingMasterAsParameter(false);
+  }
+
+  void queryUsingMasterAsParameter(boolean useMaster) {
+    ResetBasicData.reset();
+
+    String sql = "select id, name, status from o_customer where name is not null";
+    List<CustDto> custDtos = DB.sqlQuery(sql)
+      .usingMaster(useMaster)
+      .mapTo(CUST_MAPPER)
+      .findList();
+
+    assertThat(custDtos).isNotEmpty();
+  }
+
+  @Test
   void queryUsingConnection() throws SQLException {
     ResetBasicData.reset();
     boolean h2 = isH2();


### PR DESCRIPTION
This is to support the use case where other logic is used to determine if a query should be "forced" to use the master data source or not, and so it's easier to pass that as a boolean to the usingMaster() method.