### PR TITLE
Fix for @Column on timestamp defined as timestamp(255)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/config/dbplatform/DbPlatformTypeMapping.java
+++ b/ebean-api/src/main/java/io/ebean/config/dbplatform/DbPlatformTypeMapping.java
@@ -51,6 +51,13 @@ public class DbPlatformTypeMapping {
   private static final DbPlatformType VECTOR_BIT = new DbPlatformType("bit", 64000, null);
   private static final DbPlatformType VECTOR_SPARSE = new DbPlatformType("sparsevec", 1000, null);
 
+  /**
+   * Timestamp with max precision of 15, and fallback to plain timestamp without precision defined.
+   */
+  private static final DbPlatformType TIMESTAMP =
+    new DbPlatformType("timestamp", 0, 15,
+      new DbPlatformType("timestamp", false));
+
   private final Map<DbType, DbPlatformType> typeMap = new EnumMap<>(DbType.class);
 
   /**
@@ -87,7 +94,8 @@ public class DbPlatformTypeMapping {
     put(DbType.ARRAY);
     put(DbType.DATE);
     put(DbType.TIME);
-    put(DbType.TIMESTAMP);
+    put(DbType.TIMESTAMP, TIMESTAMP);
+
     put(DbType.LONGVARBINARY);
     put(DbType.LONGVARCHAR);
     // most commonly real maps to db float

--- a/ebean-test/src/test/java/io/ebean/xtest/config/dbplatform/DbPlatformTypeMappingTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/config/dbplatform/DbPlatformTypeMappingTest.java
@@ -2,21 +2,29 @@ package io.ebean.xtest.config.dbplatform;
 
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.config.dbplatform.DbPlatformTypeMapping;
+import io.ebean.config.dbplatform.DbType;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Types;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DbPlatformTypeMappingTest {
+class DbPlatformTypeMappingTest {
 
   @Test
-  public void logicalBoolean_renderType_expect_noLength() {
+  void logicalBoolean_renderType_expect_noLength() {
 
     DbPlatformTypeMapping logicalMapping = DbPlatformTypeMapping.logicalTypes();
 
     DbPlatformType type = logicalMapping.get(Types.BOOLEAN);
     String colDefinition = type.renderType(1, 1, false);
     assertThat(colDefinition).isEqualTo("boolean");
+  }
+
+  @Test
+  void timestamp_with_255_expectNoPrecision() {
+    DbPlatformType timestampType = new DbPlatformTypeMapping().get(DbType.TIMESTAMP);
+    String colDefinition = timestampType.renderType(255, 0, true);
+    assertThat(colDefinition).isEqualTo("timestamp");
   }
 }


### PR DESCRIPTION
As per https://github.com/ebean-orm/ebean/discussions/3720

```
  @Column
  ZonedDateTime zonedDateTime2;
```
... resulting in DDL generated as `timestamp(255)`. 

This is occurring when the JPA dependency is used like: `jakarta.persistence:jakarta.persistence-api:3.2.0` rather than using the transitive dependency that ebean includes.

## Workaround:
Remove the jakarta.persistence:jakarta.persistence-api:3.2.0 dependency.

## Fix:
The fix here is to use a timestamp type that has a maximum precision. When a precision/length is specified greater than the maximum precision then the fallback type is used which is `timestamp` without any precision.