### PR TITLE
Bump ebean-test-containers to 8.0 (major bump to mark the port fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <ebean-ddl-runner.version>2.3</ebean-ddl-runner.version>
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>14.3.0</ebean-migration.version>
-    <ebean-test-containers.version>7.18</ebean-test-containers.version>
+    <ebean-test-containers.version>8.0</ebean-test-containers.version>
     <ebean-datasource.version>10.4</ebean-datasource.version>
     <ebean-agent.version>16.4.0</ebean-agent.version>
     <ebean-maven-plugin.version>16.4.0</ebean-maven-plugin.version>


### PR DESCRIPTION
Docker changed and that broke how ebean-test-containers detected the currently assigned port for a container. That was fixed in 7.18 but thinking its a good idea to mark that relatively important bug fix with a bump of the major version to 8.0.

Everyone using ebean-test-containers should consider updating the ebean-test-containers dependency to 8.0 or 7.18 (both have the fix).