### PR TITLE
Bump ebean-datasource dependency to 10.5 with increase default prepar…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <ebean-migration-auto.version>1.2</ebean-migration-auto.version>
     <ebean-migration.version>14.3.0</ebean-migration.version>
     <ebean-test-containers.version>8.0</ebean-test-containers.version>
-    <ebean-datasource.version>10.4</ebean-datasource.version>
+    <ebean-datasource.version>10.5</ebean-datasource.version>
     <ebean-agent.version>16.4.0</ebean-agent.version>
     <ebean-maven-plugin.version>16.4.0</ebean-maven-plugin.version>
     <surefire.useModulePath>false</surefire.useModulePath>


### PR DESCRIPTION
…ed statement cache

Default prepared statement cache increased from 100 to 300. This could have the effect of increased memory consumption for applications traded off with potentially improved performance due to me cached prepared statements for larger applications.

Note that the Postgres itself has a default of 250.