### PR TITLE
Add timeout support to UpdateQuery

### DIFF
--- a/ebean-api/src/main/java/io/ebean/UpdateQuery.java
+++ b/ebean-api/src/main/java/io/ebean/UpdateQuery.java
@@ -205,4 +205,20 @@ public interface UpdateQuery<T> {
    */
   int update();
 
+  /**
+   * Return the timeout used to execute this statement.
+   */
+  int getTimeout();
+
+  /**
+   * Set a timeout on this query.
+   * <p>
+   * This will typically result in a call to setQueryTimeout() on a
+   * preparedStatement. If the timeout occurs an exception will be thrown - this
+   * will be a SQLException wrapped up in a PersistenceException.
+   * </p>
+   *
+   * @param secs the query timeout limit in seconds. Zero means there is no limit.
+   */
+  UpdateQuery<T> setTimeout(int secs);
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultUpdateQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/DefaultUpdateQuery.java
@@ -84,4 +84,15 @@ public final class DefaultUpdateQuery<T> implements UpdateQuery<T> {
   public int update() {
     return query.update();
   }
+
+  @Override
+  public int getTimeout() {
+    return query.timeout();
+  }
+
+  @Override
+  public UpdateQuery<T> setTimeout(int secs) {
+    query.setTimeout(secs);
+    return this;
+  }
 }

--- a/ebean-test/src/test/java/io/ebean/xtest/base/UpdateQueryTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/UpdateQueryTest.java
@@ -437,4 +437,14 @@ public class UpdateQueryTest extends BaseTestCase {
 
     return b0.getId();
   }
+
+  @Test
+  public void timeoutPropagation() {
+    int timeout = 7;
+
+    var updateQuery = DB.update(Customer.class)
+      .setTimeout(timeout);
+
+    assertThat(updateQuery.getTimeout()).isEqualTo(timeout);
+  }
 }


### PR DESCRIPTION
Support same setTimeout/getTimeout methods in UpdateQuery as in regular Query.

To have fluent syntax `Database.update(clazz).setTimeout(timeout).update()`

Please let me know if these methods weren't provided intentionally, and I'll cancel the pull request