### PR TITLE
Add collectMetrics(reset) option, with change to query time metric MA…

### DIFF
--- a/ebean-api/src/main/java/io/ebean/meta/MetaInfoManager.java
+++ b/ebean-api/src/main/java/io/ebean/meta/MetaInfoManager.java
@@ -10,11 +10,22 @@ public interface MetaInfoManager {
   /**
    * Return the metrics for the database instance.
    * <p>
-   * This will reset the metrics (reset counters back to zero etc) and
-   * will only return the non-empty metrics.
+   * This is equivalent to {@link #collectMetrics(boolean)} with reset set to true.
+   * It will reset the metrics (reset counters back to zero etc) and will only return
+   * the non-empty metrics.
    * </p>
    */
   ServerMetrics collectMetrics();
+
+  /**
+   * Return the metrics for the database instance using the given reset behavior.
+   * <p>
+   * When reset is false, count and total values remain cumulative between collections.
+   * </p>
+   */
+  default ServerMetrics collectMetrics(boolean reset) {
+    return collectMetrics();
+  }
 
   /**
    * Visit the metrics resetting and collecting/reporting as desired.

--- a/ebean-api/src/test/java/io/ebean/meta/MetaInfoManagerTest.java
+++ b/ebean-api/src/test/java/io/ebean/meta/MetaInfoManagerTest.java
@@ -1,0 +1,46 @@
+package io.ebean.meta;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetaInfoManagerTest {
+
+  @Test
+  void collectMetricsBooleanDefaultsToCollectMetrics() {
+    ServerMetrics metrics = new BasicMetricVisitor();
+    MetaInfoManager manager = new MetaInfoManager() {
+      @Override
+      public ServerMetrics collectMetrics() {
+        return metrics;
+      }
+
+      @Override
+      public void visitMetrics(MetricVisitor visitor) {
+      }
+
+      @Override
+      public BasicMetricVisitor visitBasic() {
+        return new BasicMetricVisitor();
+      }
+
+      @Override
+      public void resetAllMetrics() {
+      }
+
+      @Override
+      public List<MetaQueryPlan> queryPlanInit(QueryPlanInit initRequest) {
+        return List.of();
+      }
+
+      @Override
+      public List<MetaQueryPlan> queryPlanCollectNow(QueryPlanRequest request) {
+        return List.of();
+      }
+    };
+
+    assertThat(manager.collectMetrics(false)).isSameAs(metrics);
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultMetaInfoManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultMetaInfoManager.java
@@ -35,19 +35,28 @@ final class DefaultMetaInfoManager implements MetaInfoManager {
 
   @Override
   public ServerMetrics collectMetrics() {
-    return visitBasic();
+    return collectMetrics(true);
+  }
+
+  @Override
+  public ServerMetrics collectMetrics(boolean reset) {
+    return collectBasic(reset);
   }
 
   @Override
   public BasicMetricVisitor visitBasic() {
-    BasicMetricVisitor basic = new BasicMetricVisitor(server.name(), naming);
-    visitMetrics(basic);
-    return basic;
+    return collectBasic(true);
   }
 
   @Override
   public void resetAllMetrics() {
     server.visitMetrics(new ResetVisitor());
+  }
+
+  private BasicMetricVisitor collectBasic(boolean reset) {
+    BasicMetricVisitor basic = new BasicMetricVisitor(server.name(), naming, reset, true, true, true);
+    visitMetrics(basic);
+    return basic;
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/profile/DTimeMetricStats.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/profile/DTimeMetricStats.java
@@ -19,9 +19,7 @@ final class DTimeMetricStats implements TimedMetricStats {
     this.collected = collected;
     this.count = count;
     this.total = total;
-    // collection is racy so sanitize the max value if it has not been set
-    // this most likely would happen when count = 1 so max = mean
-    this.max = max != Long.MIN_VALUE ? max : (count < 1 ? 0 : Math.round(total / count));
+    this.max = max;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/profile/DTimedMetric.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/profile/DTimedMetric.java
@@ -17,7 +17,7 @@ final class DTimedMetric implements TimedMetric {
   private final String name;
   private final LongAdder count = new LongAdder();
   private final LongAdder total = new LongAdder();
-  private final LongAccumulator max = new LongAccumulator(Math::max, Long.MIN_VALUE);
+  private final LongAccumulator max = new LongAccumulator(Math::max, 0);
   private boolean collected;
   private String reportName;
 
@@ -84,11 +84,8 @@ final class DTimedMetric implements TimedMetric {
    */
   private DTimeMetricStats stats(boolean reset, String name, long countSum) {
     try {
-      if (reset) {
-        return new DTimeMetricStats(name, collected, countSum, total.sumThenReset(), max.getThenReset());
-      } else {
-        return new DTimeMetricStats(name, collected, countSum, total.sum(), max.get());
-      }
+      final long totalSum = reset ? total.sumThenReset() : total.sum();
+      return new DTimeMetricStats(name, collected, countSum, totalSum, max.getThenReset());
     } finally {
       collected = true;
     }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/profile/DQueryPlanMetricTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/profile/DQueryPlanMetricTest.java
@@ -44,4 +44,50 @@ class DQueryPlanMetricTest {
       assertThat(result.get(0).total()).isEqualTo(410);
     }
   }
+
+  @Test
+  void visitCumulativeResetsMax() {
+
+    DQueryPlanMeta meta = new DQueryPlanMeta(Object.class, "lab", null, "sql");
+    DTimedMetric metric = new DTimedMetric("org.timed.plan");
+    DQueryPlanMetric planMetric = new DQueryPlanMetric(meta, metric);
+
+    metric.add(560);
+    metric.add(260);
+    {
+      BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming, false, true, true, true);
+      planMetric.visit(visitor);
+      List<MetaQueryMetric> result = visitor.queryMetrics();
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).name()).isEqualTo("prefix[dto-Object_lab]");
+      assertThat(result.get(0).count()).isEqualTo(2);
+      assertThat(result.get(0).total()).isEqualTo(820);
+      assertThat(result.get(0).max()).isEqualTo(560);
+    }
+    {
+      BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming, false, true, true, true);
+      planMetric.visit(visitor);
+      List<MetaQueryMetric> result = visitor.queryMetrics();
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).name()).isEqualTo("prefix[dto-Object_lab]");
+      assertThat(result.get(0).count()).isEqualTo(2);
+      assertThat(result.get(0).total()).isEqualTo(820);
+      assertThat(result.get(0).max()).isEqualTo(0);
+    }
+
+    metric.add(410);
+    {
+      BasicMetricVisitor visitor = new BasicMetricVisitor("v", naming, false, true, true, true);
+      planMetric.visit(visitor);
+      List<MetaQueryMetric> result = visitor.queryMetrics();
+
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).name()).isEqualTo("prefix[dto-Object_lab]");
+      assertThat(result.get(0).count()).isEqualTo(3);
+      assertThat(result.get(0).total()).isEqualTo(1230);
+      assertThat(result.get(0).max()).isEqualTo(410);
+    }
+  }
 }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/profile/DTimedMetricTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/profile/DTimedMetricTest.java
@@ -90,4 +90,30 @@ public class DTimedMetricTest {
       assertThat(result.get(0).total()).isEqualTo(410);
     }
   }
+
+  @Test
+  void collectCumulativeResetsMax() {
+    DTimedMetric metric = new DTimedMetric("org.timed");
+    metric.add(560);
+    metric.add(500);
+
+    DTimeMetricStats stats = metric.collect(false);
+    assertThat(stats.count()).isEqualTo(2);
+    assertThat(stats.total()).isEqualTo(1060);
+    assertThat(stats.max()).isEqualTo(560);
+
+    stats = metric.collect(false);
+    assertThat(stats.count()).isEqualTo(2);
+    assertThat(stats.total()).isEqualTo(1060);
+    assertThat(stats.max()).isEqualTo(0);
+
+    metric.add(160);
+    metric.add(100);
+    metric.add(150);
+
+    stats = metric.collect(false);
+    assertThat(stats.count()).isEqualTo(5);
+    assertThat(stats.total()).isEqualTo(1470);
+    assertThat(stats.max()).isEqualTo(160);
+  }
 }


### PR DESCRIPTION
…X value to reset

So the desire here is to better support sending metrics to Prometheus style metrics collectors that prefer CUMULATIVE metrics rather than DELTA based metrics.

To do this, expose additional MetaInfoManager.collectMetrics(reset) method.

In supporting this, the MAX value really does need to reset even with CUMULATIVE metrics and act more like a gauge as otherwise it becomes almost useless as the max value over the lifetime. So we need to adjust MAX to always reset and act like a gauge to be useful in this CUMULATIVE metrics reporting mode.