### PR TITLE
Add Redis Sentinel support and local integration tests for ebean-redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ ebean-profiling*.xml
 profiling/
 .DS_Store
 
+# Local Redis integration test credentials
+ebean-redis/src/test/resources/redis-local.yml
+
 # Intellij project files
 *.iml
 *.ipr

--- a/ebean-redis/src/main/java/io/ebean/redis/RedisCache.java
+++ b/ebean-redis/src/main/java/io/ebean/redis/RedisCache.java
@@ -13,8 +13,8 @@ import io.ebean.metric.TimedMetricStats;
 import io.ebean.redis.encode.Encode;
 import io.ebean.redis.encode.EncodePrefixKey;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.Transaction;
+import redis.clients.jedis.util.Pool;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.resps.ScanResult;
@@ -32,7 +32,7 @@ final class RedisCache implements ServerCache {
   private static final String CURSOR_0 = "0";
   private static final byte[] CURSOR_0_BYTES = SafeEncoder.encode(CURSOR_0);
 
-  private final JedisPool jedisPool;
+  private final Pool<Jedis> jedisPool;
   private final String cacheKey;
   private final EncodePrefixKey keyEncode;
   private final Encode valueEncode;
@@ -47,7 +47,7 @@ final class RedisCache implements ServerCache {
   private final CountMetric hitCount;
   private final CountMetric missCount;
 
-  RedisCache(JedisPool jedisPool, ServerCacheConfig config, Encode valueEncode) {
+  RedisCache(Pool<Jedis> jedisPool, ServerCacheConfig config, Encode valueEncode) {
     this.jedisPool = jedisPool;
     this.cacheKey = config.getCacheKey();
     this.keyEncode = new EncodePrefixKey(config.getCacheKey());

--- a/ebean-redis/src/main/java/io/ebean/redis/RedisCacheFactory.java
+++ b/ebean-redis/src/main/java/io/ebean/redis/RedisCacheFactory.java
@@ -18,6 +18,8 @@ import io.ebeaninternal.server.cache.DefaultServerQueryCache;
 import redis.clients.jedis.BinaryJedisPubSub;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.util.Pool;
 import redis.clients.jedis.util.SafeEncoder;
 
 import java.io.*;
@@ -62,7 +64,7 @@ final class RedisCacheFactory implements ServerCacheFactory {
   private final EncodeBeanData encodeBeanData = new EncodeBeanData();
   private final EncodeSerializable encodeSerializable = new EncodeSerializable();
   private final BackgroundExecutor executor;
-  private final JedisPool jedisPool;
+  private final Pool<Jedis> jedisPool;
   private final NearCacheNotify nearCacheNotify;
   private final TimedMetric metricOutNearCache;
   private final TimedMetric metricOutTableMod;
@@ -87,25 +89,34 @@ final class RedisCacheFactory implements ServerCacheFactory {
     if (config.isDisableL2Cache()) {
       this.jedisPool = null;
     } else {
-      this.jedisPool = getJedisPool(config);
+      this.jedisPool = getPool(config);
       new DaemonTopicRunner(jedisPool, new CacheDaemonTopic()).run();
     }
   }
 
   /**
-   * Return the JedisPool to use (only 1 at this stage).
+   * Return the connection pool to use.
    */
-  private JedisPool getJedisPool(DatabaseBuilder.Settings config) {
+  private Pool<Jedis> getPool(DatabaseBuilder.Settings config) {
     JedisPool jedisPool = config.getServiceObject(JedisPool.class);
     if (jedisPool != null) {
       return jedisPool;
+    }
+    JedisSentinelPool sentinelPool = config.getServiceObject(JedisSentinelPool.class);
+    if (sentinelPool != null) {
+      return sentinelPool;
     }
     RedisConfig redisConfig = config.getServiceObject(RedisConfig.class);
     if (redisConfig == null) {
       redisConfig = new RedisConfig();
     }
     redisConfig.loadProperties(config.getProperties());
-    log.log(INFO, "using l2cache redis host {0}:{1}", redisConfig.getServer(), redisConfig.getPort());
+    if (redisConfig.getMode() == RedisConfig.Mode.SENTINEL) {
+      log.log(INFO, "using l2cache redis sentinel master {0} sentinels {1}",
+        redisConfig.getMasterName(), redisConfig.getSentinels());
+    } else {
+      log.log(INFO, "using l2cache redis host {0}:{1}", redisConfig.getServer(), redisConfig.getPort());
+    }
     return redisConfig.createPool();
   }
 
@@ -262,6 +273,12 @@ final class RedisCacheFactory implements ServerCacheFactory {
   private void processTableNotify(String rawMessage) {
     long nanos = System.nanoTime();
     try {
+      if (listener == null) {
+        if (logger.isLoggable(DEBUG)) {
+          logger.log(DEBUG, "Ignoring tableMod, listener not registered yet: {0}", rawMessage);
+        }
+        return;
+      }
       if (logger.isLoggable(DEBUG)) {
         logger.log(DEBUG, "processTableNotify {0}", rawMessage);
       }

--- a/ebean-redis/src/main/java/io/ebean/redis/RedisConfig.java
+++ b/ebean-redis/src/main/java/io/ebean/redis/RedisConfig.java
@@ -1,17 +1,39 @@
 package io.ebean.redis;
 
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.util.Pool;
 
+import java.time.Duration;
+import java.util.LinkedHashSet;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Deployment configuration for redis.
  */
 public class RedisConfig {
 
+  /**
+   * Redis deployment mode.
+   */
+  public enum Mode {
+    /** Single redis server (default). */
+    STANDALONE,
+    /** Redis sentinel high availability. */
+    SENTINEL
+  }
+
+  private Mode mode = Mode.STANDALONE;
   private String server = "localhost";
   private int port = 6379;
+  private String masterName;
+  private Set<String> sentinels = Set.of();
   private int maxTotal = 200;
   private int maxIdle = 200;
   private int minIdle = 1;
@@ -23,16 +45,99 @@ public class RedisConfig {
   private boolean ssl;
 
   /**
-   * Return a new JedisPool based on the configuration.
+   * Return a new connection pool based on the configuration.
    */
-  public JedisPool createPool() {
+  public Pool<Jedis> createPool() {
+    JedisPoolConfig poolConfig = poolConfig();
+    if (mode == Mode.SENTINEL) {
+      return createSentinelPool(poolConfig);
+    }
+    return createStandalonePool(poolConfig);
+  }
+
+  private JedisPoolConfig poolConfig() {
     JedisPoolConfig poolConfig = new JedisPoolConfig();
     poolConfig.setMaxTotal(maxTotal);
     poolConfig.setMaxIdle(maxIdle);
     poolConfig.setMinIdle(minIdle);
-    poolConfig.setMaxWaitMillis(maxWaitMillis);
+    poolConfig.setMaxWait(Duration.ofMillis(maxWaitMillis));
     poolConfig.setBlockWhenExhausted(blockWhenExhausted);
+    return poolConfig;
+  }
+
+  private JedisPool createStandalonePool(JedisPoolConfig poolConfig) {
     return new JedisPool(poolConfig, server, port, timeout, username, password, ssl);
+  }
+
+  private JedisSentinelPool createSentinelPool(JedisPoolConfig poolConfig) {
+    if (masterName == null || masterName.isBlank()) {
+      throw new IllegalStateException("ebean.redis.masterName must be set when mode is sentinel");
+    }
+    if (sentinels.isEmpty()) {
+      throw new IllegalStateException("ebean.redis.sentinels must be set when mode is sentinel");
+    }
+    if (ssl) {
+      JedisClientConfig masterConfig = DefaultJedisClientConfig.builder()
+        .connectionTimeoutMillis(timeout)
+        .socketTimeoutMillis(timeout)
+        .user(username)
+        .password(password)
+        .ssl(true)
+        .build();
+      JedisClientConfig sentinelConfig = DefaultJedisClientConfig.builder()
+        .connectionTimeoutMillis(timeout)
+        .socketTimeoutMillis(timeout)
+        .user(username)
+        .password(password)
+        .ssl(true)
+        .build();
+      return new JedisSentinelPool(masterName, parseSentinelHosts(sentinels), poolConfig, masterConfig, sentinelConfig);
+    }
+    return new JedisSentinelPool(masterName, sentinels, poolConfig, timeout, timeout, username, password, 0, null);
+  }
+
+  static Set<String> parseSentinels(String value) {
+    if (value == null || value.isBlank()) {
+      return Set.of();
+    }
+    Set<String> result = new LinkedHashSet<>();
+    for (String part : value.split(",")) {
+      String trimmed = part.trim();
+      if (!trimmed.isEmpty()) {
+        result.add(trimmed);
+      }
+    }
+    return Set.copyOf(result);
+  }
+
+  static Set<HostAndPort> parseSentinelHosts(Set<String> sentinels) {
+    Set<HostAndPort> hosts = new LinkedHashSet<>();
+    for (String sentinel : sentinels) {
+      hosts.add(HostAndPort.from(sentinel));
+    }
+    return Set.copyOf(hosts);
+  }
+
+  static Mode parseMode(String value) {
+    if (value == null || value.isBlank()) {
+      return Mode.STANDALONE;
+    }
+    String mode = value.trim().toLowerCase();
+    if ("standalone".equals(mode)) {
+      return Mode.STANDALONE;
+    }
+    if ("sentinel".equals(mode)) {
+      return Mode.SENTINEL;
+    }
+    throw new IllegalArgumentException("Unknown ebean.redis.mode: " + value);
+  }
+
+  public Mode getMode() {
+    return mode;
+  }
+
+  public void setMode(Mode mode) {
+    this.mode = mode;
   }
 
   public String getServer() {
@@ -49,6 +154,22 @@ public class RedisConfig {
 
   public void setPort(int port) {
     this.port = port;
+  }
+
+  public String getMasterName() {
+    return masterName;
+  }
+
+  public void setMasterName(String masterName) {
+    this.masterName = masterName;
+  }
+
+  public Set<String> getSentinels() {
+    return sentinels;
+  }
+
+  public void setSentinels(Set<String> sentinels) {
+    this.sentinels = sentinels != null ? Set.copyOf(sentinels) : Set.of();
   }
 
   public int getMaxTotal() {
@@ -125,8 +246,11 @@ public class RedisConfig {
 
   public void loadProperties(Properties properties) {
     Reader reader = new Reader(properties);
+    this.mode = parseMode(reader.get("ebean.redis.mode", null));
     this.server = reader.get("ebean.redis.server", server);
     this.port = reader.getInt("ebean.redis.port", port);
+    this.masterName = reader.get("ebean.redis.masterName", masterName);
+    this.sentinels = parseSentinels(reader.get("ebean.redis.sentinels", null));
     this.ssl = reader.getBool("ebean.redis.ssl", ssl);
     this.minIdle = reader.getInt("ebean.redis.minIdle", minIdle);
     this.maxIdle = reader.getInt("ebean.redis.maxIdle", maxIdle);
@@ -157,7 +281,7 @@ public class RedisConfig {
 
     long getLong(String key, long defaultVal) {
       final String val = get(key, null);
-      return val != null ? Integer.parseInt(val.trim()) : defaultVal;
+      return val != null ? Long.parseLong(val.trim()) : defaultVal;
     }
 
     boolean getBool(String key, boolean defaultVal) {
@@ -165,5 +289,4 @@ public class RedisConfig {
       return val != null ? Boolean.parseBoolean(val.trim()) : defaultVal;
     }
   }
-
 }

--- a/ebean-redis/src/main/java/io/ebean/redis/topic/DaemonTopicRunner.java
+++ b/ebean-redis/src/main/java/io/ebean/redis/topic/DaemonTopicRunner.java
@@ -2,8 +2,8 @@ package io.ebean.redis.topic;
 
 import io.avaje.applog.AppLog;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.util.Pool;
 
 import java.util.Timer;
 import java.util.TimerTask;
@@ -23,10 +23,10 @@ public final class DaemonTopicRunner {
 
   private static final long reconnectWaitMillis = 1000;
 
-  private final JedisPool jedisPool;
+  private final Pool<Jedis> jedisPool;
   private final DaemonTopic daemonTopic;
 
-  public DaemonTopicRunner(JedisPool jedisPool, DaemonTopic daemonTopic) {
+  public DaemonTopicRunner(Pool<Jedis> jedisPool, DaemonTopic daemonTopic) {
     this.jedisPool = jedisPool;
     this.daemonTopic = daemonTopic;
   }

--- a/ebean-redis/src/test/java/io/ebean/redis/RedisCacheFactoryITest.java
+++ b/ebean-redis/src/test/java/io/ebean/redis/RedisCacheFactoryITest.java
@@ -1,0 +1,202 @@
+package io.ebean.redis;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.ebean.DatabaseBuilder;
+import io.ebean.cache.ServerCache;
+import io.ebean.cache.ServerCacheNotification;
+import io.ebean.cache.ServerCacheNotify;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.util.Pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for {@link RedisCacheFactory} against local standalone and sentinel Redis.
+ */
+@Tag("redis-local")
+class RedisCacheFactoryITest {
+
+  @BeforeEach
+  void assumeLocalRedisConfigured() {
+    assumeTrue(RedisLocalTestSupport.isConfigured());
+  }
+
+  abstract static class FactoryTestCase {
+
+    RedisConfig config;
+    Pool<Jedis> pool;
+    RedisCacheFactory factory;
+
+    @BeforeEach
+    void setUp() {
+      config = redisConfig();
+      assumeTrue(RedisLocalTestSupport.isReachable(config),
+        "Skip: Redis not reachable for " + modeLabel());
+      pool = config.createPool();
+      DatabaseBuilder.Settings settings = RedisTestFixtures.databaseSettings(mode(), pool);
+      factory = new RedisCacheFactory(settings, RedisTestFixtures.backgroundExecutor());
+    }
+
+    @AfterEach
+    void tearDown() {
+      if (pool != null) {
+        pool.close();
+      }
+    }
+
+    abstract RedisConfig redisConfig();
+
+    abstract RedisConfig.Mode mode();
+
+    abstract String modeLabel();
+
+    @Test
+    void createsNaturalKeyCache_roundTrip() {
+      String cacheKey = RedisTestFixtures.cacheKey("factory-nk");
+      ServerCache cache = factory.createCache(RedisTestFixtures.naturalKeyConfig(cacheKey));
+      assertThat(cache).isInstanceOf(RedisCache.class);
+
+      cache.put("1", "one");
+      assertThat(cache.get("1")).isEqualTo("one");
+
+      RedisCache redisCache = (RedisCache) cache;
+      assertThat(redisCache.getHitCount()).isEqualTo(1);
+      cache.clear();
+    }
+
+    @Test
+    void createsBeanCache() {
+      String cacheKey = RedisTestFixtures.cacheKey("factory-bean");
+      ServerCache cache = factory.createCache(RedisTestFixtures.beanCacheConfig(cacheKey));
+      assertThat(cache).isInstanceOf(RedisCache.class);
+    }
+
+    @Test
+    void createsCollectionIdsCache() {
+      String cacheKey = RedisTestFixtures.cacheKey("factory-coll");
+      ServerCache cache = factory.createCache(RedisTestFixtures.collectionIdsConfig(cacheKey));
+      assertThat(cache).isInstanceOf(RedisCache.class);
+    }
+
+    @Test
+    void createsNearCache_asDuelCache() {
+      String cacheKey = RedisTestFixtures.cacheKey("factory-near");
+      ServerCache cache = factory.createCache(RedisTestFixtures.nearBeanCacheConfig(cacheKey));
+      assertThat(cache).isInstanceOf(DuelCache.class);
+
+      cache.put("1", "near");
+      assertThat(cache.get("1")).isEqualTo("near");
+      cache.clear();
+    }
+
+    @Test
+    void queryCache_isSingletonPerKey() {
+      String cacheKey = RedisTestFixtures.cacheKey("factory-query");
+      ServerCache first = factory.createCache(RedisTestFixtures.queryCacheConfig(cacheKey));
+      ServerCache second = factory.createCache(RedisTestFixtures.queryCacheConfig(cacheKey));
+      assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    void queryCacheClear_doesNotThrow() {
+      String cacheKey = RedisTestFixtures.cacheKey("factory-query-clear");
+      ServerCache cache = factory.createCache(RedisTestFixtures.queryCacheConfig(cacheKey));
+      assertNotNull(cache);
+      cache.clear();
+    }
+
+    @Test
+    void cacheNotify_publishTableMod_doesNotThrow() {
+      ServerCacheNotify notify = factory.createCacheNotify(n -> {
+      });
+      assertNotNull(notify);
+      notify.notify(new ServerCacheNotification(Set.of("foo", "bar")));
+    }
+
+    @Test
+    void cacheNotify_tableMod_notifiesOtherFactory() throws InterruptedException {
+      CopyOnWriteArrayList<ServerCacheNotification> notifications = new CopyOnWriteArrayList<>();
+      DatabaseBuilder.Settings settings = RedisTestFixtures.databaseSettings(mode(), pool);
+      RedisCacheFactory otherFactory = new RedisCacheFactory(settings, RedisTestFixtures.backgroundExecutor());
+      otherFactory.createCacheNotify(notifications::add);
+
+      // allow redis-sub thread to connect
+      Thread.sleep(300);
+
+      ServerCacheNotify notify = factory.createCacheNotify(n -> {
+      });
+      notify.notify(new ServerCacheNotification(Set.of("foo", "bar")));
+
+      Thread.sleep(500);
+      assertThat(notifications).isNotEmpty();
+      assertThat(notifications.get(0).getDependentTables()).contains("foo", "bar");
+    }
+
+    @Test
+    void cacheNotify_emptyTables_doesNotThrow() {
+      ServerCacheNotify notify = factory.createCacheNotify(n -> {
+      });
+
+      assertThat(notify).isNotNull();
+      notify.notify(new ServerCacheNotification(Set.of()));
+    }
+
+    @Test
+    void usesInjectedPool() {
+      try (Jedis jedis = pool.getResource()) {
+        String marker = RedisTestFixtures.cacheKey("factory-pool");
+        jedis.set(marker, "ok");
+        assertThat(jedis.get(marker)).isEqualTo("ok");
+        jedis.del(marker);
+      }
+    }
+  }
+
+  @Nested
+  @Disabled("Standalone")
+  class Standalone extends FactoryTestCase {
+    @Override
+    RedisConfig redisConfig() {
+      return RedisLocalTestSupport.standaloneConfig();
+    }
+
+    @Override
+    RedisConfig.Mode mode() {
+      return RedisConfig.Mode.STANDALONE;
+    }
+
+    @Override
+    String modeLabel() {
+      return "standalone";
+    }
+  }
+
+  @Nested
+  @Disabled("Sentinel")
+  class Sentinel extends FactoryTestCase {
+    @Override
+    RedisConfig redisConfig() {
+      return RedisLocalTestSupport.sentinelConfig();
+    }
+
+    @Override
+    RedisConfig.Mode mode() {
+      return RedisConfig.Mode.SENTINEL;
+    }
+
+    @Override
+    String modeLabel() {
+      return "sentinel";
+    }
+  }
+}

--- a/ebean-redis/src/test/java/io/ebean/redis/RedisCacheITest.java
+++ b/ebean-redis/src/test/java/io/ebean/redis/RedisCacheITest.java
@@ -1,0 +1,190 @@
+package io.ebean.redis;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import io.ebean.cache.ServerCacheStatistics;
+import io.ebean.cache.ServerCacheType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.util.Pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for {@link RedisCache} against local standalone and sentinel Redis.
+ */
+@Tag("redis-local")
+class RedisCacheITest {
+
+  @BeforeEach
+  void assumeLocalRedisConfigured() {
+    assumeTrue(RedisLocalTestSupport.isConfigured());
+  }
+
+  abstract static class RedisCacheTestCase {
+
+    RedisConfig config;
+    Pool<Jedis> pool;
+    String cacheKey;
+    RedisCache cache;
+
+    @BeforeEach
+    void setUp() {
+      config = redisConfig();
+      assumeTrue(RedisLocalTestSupport.isReachable(config),
+        "Skip: Redis not reachable for " + modeLabel());
+      pool = config.createPool();
+      cacheKey = RedisTestFixtures.cacheKey("RedisCache");
+      cache = RedisTestFixtures.naturalKeyCache(pool, cacheKey);
+    }
+
+    @AfterEach
+    void tearDown() {
+      if (cache != null) {
+        cache.clear();
+      }
+      if (pool != null) {
+        pool.close();
+      }
+    }
+
+    abstract RedisConfig redisConfig();
+
+    abstract String modeLabel();
+
+    @Test
+    void putAndGet() {
+      cache.put("1", "one");
+      assertThat(cache.get("1")).isEqualTo("one");
+      assertThat(cache.getHitCount()).isEqualTo(1);
+      assertThat(cache.getMissCount()).isZero();
+
+      assertThat(cache.get("missing")).isNull();
+      assertThat(cache.getMissCount()).isEqualTo(1);
+    }
+
+    @Test
+    void getAll() {
+      cache.put("1", "one");
+      cache.put("2", "two");
+
+      Map<Object, Object> found = cache.getAll(Set.of("1", "2", "3"));
+      assertThat(found).containsEntry("1", "one").containsEntry("2", "two").doesNotContainKey("3");
+      assertThat(cache.getHitCount()).isEqualTo(2);
+      assertThat(cache.getMissCount()).isEqualTo(1);
+    }
+
+    @Test
+    void getAll_emptyKeys() {
+      assertThat(cache.getAll(Set.of())).isEmpty();
+    }
+
+    @Test
+    void putAll() {
+      Map<Object, Object> entries = new LinkedHashMap<>();
+      entries.put("a", "A");
+      entries.put("b", "B");
+      cache.putAll(entries);
+
+      assertThat(cache.getAll(Set.of("a", "b")))
+        .containsEntry("a", "A")
+        .containsEntry("b", "B");
+    }
+
+    @Test
+    void remove() {
+      cache.put("1", "one");
+      cache.remove("1");
+      assertThat(cache.get("1")).isNull();
+    }
+
+    @Test
+    void removeAll() {
+      cache.put("1", "one");
+      cache.put("2", "two");
+      cache.removeAll(Set.of("1", "2"));
+      assertThat(cache.getAll(Set.of("1", "2"))).isEmpty();
+    }
+
+    @Test
+    void clear() {
+      cache.put("1", "one");
+      cache.put("2", "two");
+      cache.clear();
+      assertThat(cache.getAll(Set.of("1", "2"))).isEmpty();
+    }
+
+    @Test
+    void statistics() {
+      cache.put("1", "one");
+      cache.get("1");
+      cache.get("missing");
+      cache.remove("1");
+
+      ServerCacheStatistics stats = cache.statistics(true);
+      assertThat(stats.getCacheName()).isEqualTo(cacheKey);
+      assertThat(stats.getHitCount()).isEqualTo(1);
+      assertThat(stats.getMissCount()).isEqualTo(1);
+      assertThat(stats.getPutCount()).isEqualTo(1);
+      assertThat(stats.getRemoveCount()).isEqualTo(1);
+    }
+
+    @Test
+    void expiration() {
+      String ttlCacheKey = RedisTestFixtures.cacheKey("ttl");
+      var options = RedisTestFixtures.defaultOptions();
+      options.setMaxSecsToLive(3600);
+      RedisCache expiringCache = new RedisCache(
+        pool,
+        RedisTestFixtures.cacheConfig(ServerCacheType.NATURAL_KEY, ttlCacheKey, options),
+        new io.ebean.redis.encode.EncodeSerializable()
+      );
+      try {
+        expiringCache.put("k1", "v1");
+        try (Jedis jedis = pool.getResource()) {
+          byte[] rawKey = (ttlCacheKey + ":k1").getBytes(StandardCharsets.UTF_8);
+          assertThat(jedis.ttl(rawKey)).isBetween(1L, 3600L);
+        }
+      } finally {
+        expiringCache.clear();
+      }
+    }
+  }
+
+  @Nested
+  @Disabled("Standalone")
+  class Standalone extends RedisCacheTestCase {
+    @Override
+    RedisConfig redisConfig() {
+      return RedisLocalTestSupport.standaloneConfig();
+    }
+
+    @Override
+    String modeLabel() {
+      return "standalone";
+    }
+  }
+
+  @Nested
+  @Disabled("Sentinel")
+  class Sentinel extends RedisCacheTestCase {
+    @Override
+    RedisConfig redisConfig() {
+      return RedisLocalTestSupport.sentinelConfig();
+    }
+
+    @Override
+    String modeLabel() {
+      return "sentinel";
+    }
+  }
+}

--- a/ebean-redis/src/test/java/io/ebean/redis/RedisConfigTest.java
+++ b/ebean-redis/src/test/java/io/ebean/redis/RedisConfigTest.java
@@ -1,16 +1,20 @@
 package io.ebean.redis;
 
+import java.util.Properties;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
-import java.util.Properties;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class RedisConfigTest {
+/**
+ * Unit test for {@link RedisConfig}
+ **/
+class RedisConfigTest {
 
   @Test
-  public void loadProperties() {
-
+  void loadProperties() {
     Properties p = new Properties();
     p.setProperty("ebean.redis.server", "test-server");
     p.setProperty("ebean.redis.port", "99");
@@ -25,6 +29,7 @@ public class RedisConfigTest {
     RedisConfig config = new RedisConfig();
     config.loadProperties(p);
 
+    assertThat(config.getMode()).isEqualTo(RedisConfig.Mode.STANDALONE);
     assertThat(config.getServer()).isEqualTo("test-server");
     assertThat(config.getPort()).isEqualTo(99);
     assertThat(config.getMaxIdle()).isEqualTo(5);
@@ -33,14 +38,68 @@ public class RedisConfigTest {
     assertThat(config.getMaxWaitMillis()).isEqualTo(8);
     assertThat(config.getUsername()).isEqualTo("un");
     assertThat(config.getPassword()).isEqualTo("pw");
-    assertThat(config.isSsl()).isEqualTo(true);
+    assertThat(config.isSsl()).isTrue();
   }
 
   @Test
-  public void test_defaultValues() {
+  void loadSentinelProperties() {
+    Properties p = new Properties();
+    p.setProperty("ebean.redis.mode", "sentinel");
+    p.setProperty("ebean.redis.masterName", "mymaster");
+    p.setProperty("ebean.redis.sentinels", "host1:26379, host2:26379 ,host3:26379");
+    p.setProperty("ebean.redis.password", "pw");
+
     RedisConfig config = new RedisConfig();
+    config.loadProperties(p);
+
+    assertThat(config.getMode()).isEqualTo(RedisConfig.Mode.SENTINEL);
+    assertThat(config.getMasterName()).isEqualTo("mymaster");
+    assertThat(config.getSentinels()).containsExactlyInAnyOrder("host1:26379", "host2:26379", "host3:26379");
+    assertThat(config.getPassword()).isEqualTo("pw");
+  }
+
+  @Test
+  void sentinelRequiresMasterName() {
+    RedisConfig config = new RedisConfig();
+    config.setMode(RedisConfig.Mode.SENTINEL);
+    config.setSentinels(Set.of("host1:26379"));
+
+    assertThatThrownBy(config::createPool)
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("masterName");
+  }
+
+  @Test
+  void sentinelRequiresSentinels() {
+    RedisConfig config = new RedisConfig();
+    config.setMode(RedisConfig.Mode.SENTINEL);
+    config.setMasterName("mymaster");
+
+    assertThatThrownBy(config::createPool)
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("sentinels");
+  }
+
+  @Test
+  void parseSentinels_empty() {
+    assertThat(RedisConfig.parseSentinels(null)).isEmpty();
+    assertThat(RedisConfig.parseSentinels("  ")).isEmpty();
+  }
+
+  @Test
+  void parseMode_unknown() {
+    assertThatThrownBy(() -> RedisConfig.parseMode("cluster"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("cluster");
+  }
+
+  @Test
+  void test_defaultValues() {
+    RedisConfig config = new RedisConfig();
+    assertThat(config.getMode()).isEqualTo(RedisConfig.Mode.STANDALONE);
     assertThat(config.getUsername()).isNull();
     assertThat(config.getPassword()).isNull();
-    assertThat(config.isSsl()).isEqualTo(false);
+    assertThat(config.isSsl()).isFalse();
+    assertThat(config.getSentinels()).isEmpty();
   }
 }

--- a/ebean-redis/src/test/java/io/ebean/redis/RedisConnectionITest.java
+++ b/ebean-redis/src/test/java/io/ebean/redis/RedisConnectionITest.java
@@ -1,0 +1,190 @@
+package io.ebean.redis;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.util.Pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests against a locally deployed Redis (standalone and sentinel).
+ * <p>
+ * Requires {@code src/test/resources/redis-local.yml} — copy from
+ * {@code redis-local.yml.example}. Tests are skipped when the file is
+ * missing or Redis is unreachable.
+ * </p>
+ */
+@Tag("redis-local")
+class RedisConnectionITest {
+
+  @BeforeEach
+  void assumeLocalRedisConfigured() {
+    assumeTrue(RedisLocalTestSupport.isConfigured());
+  }
+
+  @Nested
+  @Disabled("standalone")
+  class Standalone {
+
+    private RedisConfig config;
+    private Pool<Jedis> pool;
+
+    @BeforeEach
+    void connect() {
+      config = RedisLocalTestSupport.standaloneConfig();
+      assumeTrue(RedisLocalTestSupport.isReachable(config),
+        "Skip: standalone Redis not reachable at "
+          + config.getServer() + ":" + config.getPort());
+      pool = config.createPool();
+    }
+
+    @AfterEach
+    void close() {
+      if (pool != null) {
+        pool.close();
+      }
+    }
+
+    @Test
+    void ping() {
+      try (Jedis jedis = pool.getResource()) {
+        assertThat(jedis.ping()).isEqualToIgnoringCase("PONG");
+      }
+    }
+
+    @Test
+    void setGetDel() {
+      String key = RedisLocalTestSupport.testKey("standalone");
+      try (Jedis jedis = pool.getResource()) {
+        assertThat(jedis.set(key, "value")).isEqualTo("OK");
+        assertThat(jedis.get(key)).isEqualTo("value");
+        assertThat(jedis.del(key)).isEqualTo(1L);
+        assertThat(jedis.get(key)).isNull();
+      }
+    }
+
+    @Test
+    void mget() {
+      String key1 = RedisLocalTestSupport.testKey("standalone-a");
+      String key2 = RedisLocalTestSupport.testKey("standalone-b");
+      try (Jedis jedis = pool.getResource()) {
+        jedis.set(key1, "a");
+        jedis.set(key2, "b");
+        List<String> values = jedis.mget(key1, key2);
+        assertThat(values).containsExactly("a", "b");
+        jedis.del(key1, key2);
+      }
+    }
+
+    @Test
+    void publish() {
+      try (Jedis jedis = pool.getResource()) {
+        assertThat(jedis.publish("ebean-redis-it:channel", "hello")).isGreaterThanOrEqualTo(0L);
+      }
+    }
+
+    @Test
+    void loadFromYamlConfig() {
+      RedisConfig reloaded = RedisLocalTestSupport.standaloneConfig();
+      assertThat(reloaded.getMode()).isEqualTo(RedisConfig.Mode.STANDALONE);
+      assertThat(reloaded.getServer()).isEqualTo(config.getServer());
+      assertThat(reloaded.getPort()).isEqualTo(config.getPort());
+      assertThat(reloaded.getPassword()).isEqualTo(config.getPassword());
+      assertThat(reloaded.getMaxTotal()).isEqualTo(config.getMaxTotal());
+      assertThat(RedisLocalTestSupport.isReachable(reloaded)).isTrue();
+    }
+  }
+
+  @Nested
+  @Disabled("Sentinel")
+  class Sentinel {
+
+    private RedisConfig config;
+    private Pool<Jedis> pool;
+
+    @BeforeEach
+    void connect() {
+      config = RedisLocalTestSupport.sentinelConfig();
+      assumeTrue(!config.getSentinels().isEmpty(),
+        "Skip: ebean.redis.sentinels not configured in redis-local.yml");
+      assumeTrue(RedisLocalTestSupport.isReachable(config),
+        "Skip: sentinel Redis not reachable, master="
+          + config.getMasterName() + " sentinels=" + config.getSentinels());
+      pool = config.createPool();
+    }
+
+    @AfterEach
+    void close() {
+      if (pool != null) {
+        pool.close();
+      }
+    }
+
+    @Test
+    void ping() {
+      try (Jedis jedis = pool.getResource()) {
+        assertThat(jedis.ping()).isEqualToIgnoringCase("PONG");
+      }
+    }
+
+    @Test
+    void connectsToMaster() {
+      try (Jedis jedis = pool.getResource()) {
+        String role = jedis.info("replication").lines()
+          .filter(line -> line.startsWith("role:"))
+          .findFirst()
+          .orElse("");
+        assertThat(role).contains("master");
+      }
+    }
+
+    @Test
+    void setGetDel() {
+      String key = RedisLocalTestSupport.testKey("sentinel");
+      try (Jedis jedis = pool.getResource()) {
+        assertThat(jedis.set(key, "sentinel-value")).isEqualTo("OK");
+        assertThat(jedis.get(key)).isEqualTo("sentinel-value");
+        assertThat(jedis.del(key)).isEqualTo(1L);
+      }
+    }
+
+    @Test
+    void mget() {
+      String key1 = RedisLocalTestSupport.testKey("sentinel-a");
+      String key2 = RedisLocalTestSupport.testKey("sentinel-b");
+      try (Jedis jedis = pool.getResource()) {
+        jedis.set(key1, "1");
+        jedis.set(key2, "2");
+        assertThat(jedis.mget(key1, key2)).containsExactly("1", "2");
+        jedis.del(key1, key2);
+      }
+    }
+
+    @Test
+    void publish() {
+      try (Jedis jedis = pool.getResource()) {
+        assertThat(jedis.publish("ebean-redis-it:sentinel-channel", "hello")).isGreaterThanOrEqualTo(0L);
+      }
+    }
+
+    @Test
+    void loadFromYamlConfig() {
+      RedisConfig reloaded = RedisLocalTestSupport.sentinelConfig();
+      assertThat(reloaded.getMode()).isEqualTo(RedisConfig.Mode.SENTINEL);
+      assertThat(reloaded.getMasterName()).isEqualTo(config.getMasterName());
+      assertThat(reloaded.getSentinels()).isEqualTo(Set.copyOf(config.getSentinels()));
+      assertThat(reloaded.getPassword()).isEqualTo(config.getPassword());
+      assertThat(reloaded.getMaxTotal()).isEqualTo(config.getMaxTotal());
+      assertThat(RedisLocalTestSupport.isReachable(reloaded)).isTrue();
+    }
+  }
+}

--- a/ebean-redis/src/test/java/io/ebean/redis/RedisLocalTestSupport.java
+++ b/ebean-redis/src/test/java/io/ebean/redis/RedisLocalTestSupport.java
@@ -1,0 +1,147 @@
+package io.ebean.redis;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.util.Pool;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Loads local Redis connection settings for integration tests from {@code redis-local.yml}.
+ * <p>
+ * The YAML file supports multiple documents separated by {@code ---}, one per deployment mode.
+ * System properties such as {@code -Debean.redis.server=127.0.0.1} override file values via
+ * {@link RedisConfig#loadProperties(Properties)}.
+ * </p>
+ */
+final class RedisLocalTestSupport {
+
+  private static final String CONFIG_FILE = "/redis-local.yml";
+
+  private RedisLocalTestSupport() {
+  }
+
+  static boolean isConfigured() {
+    return RedisLocalTestSupport.class.getResource(CONFIG_FILE) != null;
+  }
+
+  static RedisConfig standaloneConfig() {
+    return configForMode(RedisConfig.Mode.STANDALONE);
+  }
+
+  static RedisConfig sentinelConfig() {
+    return configForMode(RedisConfig.Mode.SENTINEL);
+  }
+
+  static RedisConfig configForMode(RedisConfig.Mode mode) {
+    RedisConfig config = new RedisConfig();
+    config.loadProperties(propertiesForMode(mode));
+    return config;
+  }
+
+  static Properties propertiesForMode(RedisConfig.Mode mode) {
+    for (Properties document : loadDocuments()) {
+      RedisConfig.Mode documentMode = modeOf(document);
+      if (documentMode == mode) {
+        return document;
+      }
+    }
+    throw new IllegalStateException(
+      "No document for mode " + mode + " in redis-local.yml (expected ebean.redis.mode or ebean.redis.model)");
+  }
+
+  static List<Properties> loadDocuments() {
+    try (InputStream in = RedisLocalTestSupport.class.getResourceAsStream(CONFIG_FILE)) {
+      if (in == null) {
+        return List.of();
+      }
+      String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      List<Properties> documents = new ArrayList<>();
+      for (String document : splitDocuments(content)) {
+        documents.add(parseRedisDocument(document));
+      }
+      return documents;
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to load " + CONFIG_FILE, e);
+    }
+  }
+
+  static List<String> splitDocuments(String content) {
+    List<String> documents = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    for (String line : content.split("\n", -1)) {
+      if ("---".equals(line.trim())) {
+        if (current.length() > 0) {
+          documents.add(current.toString());
+          current = new StringBuilder();
+        }
+      } else {
+        current.append(line).append('\n');
+      }
+    }
+    if (current.length() > 0) {
+      documents.add(current.toString());
+    }
+    return documents;
+  }
+
+  /**
+   * Parse a single YAML document with {@code ebean.redis} settings.
+   */
+  static Properties parseRedisDocument(String document) {
+    Properties properties = new Properties();
+    boolean inEbean = false;
+    boolean inRedis = false;
+    for (String line : document.split("\n")) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+        continue;
+      }
+      if ("ebean:".equals(trimmed)) {
+        inEbean = true;
+        inRedis = false;
+        continue;
+      }
+      if (inEbean && "redis:".equals(trimmed)) {
+        inRedis = true;
+        continue;
+      }
+      if (!inRedis || !trimmed.contains(":")) {
+        continue;
+      }
+      int colon = trimmed.indexOf(':');
+      String key = trimmed.substring(0, colon).trim();
+      String value = trimmed.substring(colon + 1).trim();
+      if ("model".equals(key)) {
+        key = "mode";
+      }
+      properties.setProperty("ebean.redis." + key, value);
+    }
+    return properties;
+  }
+
+  static boolean isReachable(RedisConfig config) {
+    try (Pool<Jedis> pool = config.createPool();
+         Jedis jedis = pool.getResource()) {
+      return "PONG".equalsIgnoreCase(jedis.ping());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  static String testKey(String prefix) {
+    return "ebean-redis-it:" + prefix + ":" + System.nanoTime();
+  }
+
+  private static RedisConfig.Mode modeOf(Properties document) {
+    String mode = document.getProperty("ebean.redis.mode");
+    if (mode == null || mode.isBlank()) {
+      throw new IllegalStateException("Missing ebean.redis.mode in redis-local.yml document: " + document);
+    }
+    return RedisConfig.parseMode(mode);
+  }
+}

--- a/ebean-redis/src/test/java/io/ebean/redis/RedisLocalYamlTest.java
+++ b/ebean-redis/src/test/java/io/ebean/redis/RedisLocalYamlTest.java
@@ -1,0 +1,63 @@
+package io.ebean.redis;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisLocalYamlTest {
+
+  @Test
+  void parseStandaloneDocument() {
+    Properties props = RedisLocalTestSupport.parseRedisDocument(
+      "ebean:\n"
+        + "  redis:\n"
+        + "    model: standalone\n"
+        + "    server: 192.168.204.140\n"
+        + "    port: 6379\n"
+        + "    password: secret\n"
+    );
+
+    assertThat(props.getProperty("ebean.redis.mode")).isEqualTo("standalone");
+    assertThat(props.getProperty("ebean.redis.server")).isEqualTo("192.168.204.140");
+    assertThat(props.getProperty("ebean.redis.port")).isEqualTo("6379");
+    assertThat(props.getProperty("ebean.redis.password")).isEqualTo("secret");
+  }
+
+  @Test
+  void parseSentinelDocument() {
+    Properties props = RedisLocalTestSupport.parseRedisDocument(
+      "ebean:\n"
+        + "  redis:\n"
+        + "    mode: sentinel\n"
+        + "    sentinels: host1:26379,host2:26379\n"
+        + "    masterName: mymaster\n"
+        + "    password: secret\n"
+    );
+
+    assertThat(props.getProperty("ebean.redis.mode")).isEqualTo("sentinel");
+    assertThat(props.getProperty("ebean.redis.sentinels")).isEqualTo("host1:26379,host2:26379");
+    assertThat(props.getProperty("ebean.redis.masterName")).isEqualTo("mymaster");
+  }
+
+  @Test
+  void loadDocumentsFromClasspath() {
+    if (!RedisLocalTestSupport.isConfigured()) {
+      return;
+    }
+    List<Properties> documents = RedisLocalTestSupport.loadDocuments();
+    assertThat(documents).hasSizeGreaterThanOrEqualTo(2);
+
+    RedisConfig standalone = RedisLocalTestSupport.standaloneConfig();
+    assertThat(standalone.getMode()).isEqualTo(RedisConfig.Mode.STANDALONE);
+    assertThat(standalone.getServer()).isNotBlank();
+    assertThat(standalone.getPort()).isPositive();
+
+    RedisConfig sentinel = RedisLocalTestSupport.sentinelConfig();
+    assertThat(sentinel.getMode()).isEqualTo(RedisConfig.Mode.SENTINEL);
+    assertThat(sentinel.getMasterName()).isEqualTo("mymaster");
+    assertThat(sentinel.getSentinels()).hasSize(3);
+  }
+}

--- a/ebean-redis/src/test/java/io/ebean/redis/RedisTestFixtures.java
+++ b/ebean-redis/src/test/java/io/ebean/redis/RedisTestFixtures.java
@@ -1,0 +1,116 @@
+package io.ebean.redis;
+
+import io.ebean.BackgroundExecutor;
+import io.ebean.Database;
+import io.ebean.DatabaseBuilder;
+import io.ebean.cache.ServerCacheConfig;
+import io.ebean.cache.ServerCacheOptions;
+import io.ebean.cache.ServerCacheType;
+import io.ebean.redis.encode.EncodeSerializable;
+import redis.clients.jedis.util.Pool;
+import redis.clients.jedis.Jedis;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared fixtures for Redis cache integration tests.
+ */
+final class RedisTestFixtures {
+
+  private RedisTestFixtures() {
+  }
+
+  static String cacheKey(String suffix) {
+    return "ebean-redis-it:" + suffix + ":" + System.nanoTime();
+  }
+
+  static ServerCacheOptions defaultOptions() {
+    return new ServerCacheOptions();
+  }
+
+  static ServerCacheConfig naturalKeyConfig(String cacheKey) {
+    return cacheConfig(ServerCacheType.NATURAL_KEY, cacheKey, defaultOptions());
+  }
+
+  static ServerCacheConfig beanCacheConfig(String cacheKey) {
+    return cacheConfig(ServerCacheType.BEAN, cacheKey, defaultOptions());
+  }
+
+  static ServerCacheConfig collectionIdsConfig(String cacheKey) {
+    return cacheConfig(ServerCacheType.COLLECTION_IDS, cacheKey, defaultOptions());
+  }
+
+  static ServerCacheConfig queryCacheConfig(String cacheKey) {
+    return cacheConfig(ServerCacheType.QUERY, cacheKey, defaultOptions());
+  }
+
+  static ServerCacheConfig nearBeanCacheConfig(String cacheKey) {
+    ServerCacheOptions options = defaultOptions();
+    options.setNearCache(true);
+    return cacheConfig(ServerCacheType.BEAN, cacheKey, options);
+  }
+
+  static ServerCacheConfig cacheConfig(ServerCacheType type, String cacheKey, ServerCacheOptions options) {
+    return new ServerCacheConfig(type, cacheKey, "testCache", options, null, null);
+  }
+
+  static RedisCache naturalKeyCache(Pool<Jedis> pool, String cacheKey) {
+    return new RedisCache(pool, naturalKeyConfig(cacheKey), new EncodeSerializable());
+  }
+
+  static DatabaseBuilder.Settings databaseSettings(RedisConfig.Mode mode, Pool<Jedis> pool) {
+    return Database.builder()
+      .putServiceObject(pool)
+      .loadFromProperties(RedisLocalTestSupport.propertiesForMode(mode))
+      .settings();
+  }
+
+  static BackgroundExecutor backgroundExecutor() {
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
+      Thread thread = new Thread(r, "ebean-redis-test-bg");
+      thread.setDaemon(true);
+      return thread;
+    });
+    return new BackgroundExecutor() {
+      @Override
+      public <T> Future<T> submit(Callable<T> task) {
+        return executor.submit(task);
+      }
+
+      @Override
+      public Future<?> submit(Runnable task) {
+        return executor.submit(task);
+      }
+
+      @Override
+      public void execute(Runnable task) {
+        executor.execute(task);
+      }
+
+      @Override
+      public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long initialDelay, long delay, TimeUnit unit) {
+        return executor.scheduleWithFixedDelay(task, initialDelay, delay, unit);
+      }
+
+      @Override
+      public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
+        return executor.scheduleAtFixedRate(task, initialDelay, period, unit);
+      }
+
+      @Override
+      public ScheduledFuture<?> schedule(Runnable task, long delay, TimeUnit unit) {
+        return executor.schedule(task, delay, unit);
+      }
+
+      @Override
+      public <V> ScheduledFuture<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
+        return executor.schedule(task, delay, unit);
+      }
+    };
+  }
+}

--- a/ebean-redis/src/test/resources/redis-local.yml.example
+++ b/ebean-redis/src/test/resources/redis-local.yml.example
@@ -1,0 +1,30 @@
+# Copy to redis-local.yml and adjust for your local Redis deployment.
+# Integration tests skip automatically when redis-local.yml is missing or Redis is unreachable.
+# Multiple documents separated by --- ; one document per mode.
+
+ebean:
+  redis:
+    mode: standalone
+    server: localhost
+    port: 6379
+    ssl: false
+    minIdle: 0
+    maxIdle: 8
+    maxTotal: 8
+    maxWaitMillis: 3000
+    timeout: 1000
+    password: changeme
+
+---
+ebean:
+  redis:
+    mode: sentinel
+    sentinels: localhost:26379,localhost:26380,localhost:26381
+    masterName: mymaster
+    ssl: false
+    minIdle: 0
+    maxIdle: 8
+    maxTotal: 8
+    maxWaitMillis: 3000
+    timeout: 1000
+    password: changeme


### PR DESCRIPTION
- Add **Redis Sentinel** deployment mode to `ebean-redis`, while keeping **standalone** as the default (fully backward compatible).
- Generalize Redis connectivity from `JedisPool` to `Pool<Jedis>` so both standalone and sentinel pools work with existing cache and pub/sub logic.
- Add optional **local integration tests** that run against a real Redis instance configured via `redis-local.yml`.
- Guard against NPE when L2 table-modification messages arrive before `createCacheNotify()` registers a listener.
