### PR TITLE
db-migration: Change I__ init scripts to NOT overwrite (allow customisation)

### DIFF
--- a/docs/guides/add-ebean-db-migration-generation.md
+++ b/docs/guides/add-ebean-db-migration-generation.md
@@ -250,6 +250,40 @@ For each future set of entity bean changes:
 4. Review the generated `.sql` to confirm it reflects the intended changes
 5. Commit both files
 
+### Protecting hand-edited and non-versioned migrations across regeneration
+
+`GenerateDbMigration` regenerates the apply SQL and model XML from the **current
+entity model**. It can therefore overwrite content you did not change in the
+entity beans, including:
+
+- **hand-edited DDL** in a generated versioned `.sql` file, and
+- **repeatable** (`R__*.sql`) scripts that the generator also derives from the
+  model (e.g. view definitions in `extra-ddl.xml`, built-in partitioning helpers).
+
+**Init scripts (`I__*.sql`) are write-once.** If an init script already exists on
+disk the generator **does not** rewrite it, so hand-tuned init DDL (partition
+functions, `UNLOGGED` tables, triggers, seed data) is preserved across
+regeneration. The trade-off: to pick up an upstream change to a built-in init
+script (e.g. the partition helper) you must **delete the file first**, then
+regenerate. Repeatable scripts are always regenerated.
+
+To avoid losing manual work:
+
+- Prefer an **init** (`I__`) script for hand-maintained DDL the entity model
+  cannot express — it is isolated and now protected from regeneration.
+- For **versioned** `.sql` and **repeatable** `R__` scripts that the generator
+  produces, review the diff after **every** regeneration and **restore** any
+  clobbered hand-tuning (e.g. `git checkout dbmigration/...`) before committing.
+- If your build maintains a migration index file (e.g. `idx_*.migrations`),
+  re-check that the new migration is listed and filenames match after renaming a
+  generated file.
+
+> **Run the generator from the module directory.** The output path set via
+> `setPathToResources(...)` is resolved relative to the **working directory**.
+> Run `GenerateDbMigration` with the working directory set to the module that owns
+> `src/main/resources` (e.g. `cd server` first). Note that `mvn exec:java` does
+> **not** honour a configured `workingDirectory`, so set the cwd yourself.
+
 ---
 
 ## Understanding the output files

--- a/docs/guides/ebean-query-plan-capture.md
+++ b/docs/guides/ebean-query-plan-capture.md
@@ -63,6 +63,15 @@ never captures bind values and cannot be `EXPLAIN`'d.
 
 Bind capture is the master switch; nothing is captured until it is on.
 
+> **Security — bind values may contain PII.** Bind capture records the **actual
+> parameter values** used by slow query executions, and those values are stored
+> and shown verbatim in the captured plan output (alongside the SQL and EXPLAIN
+> plan). They can therefore contain personal or otherwise sensitive data. Capture
+> is opt-in and off by default (`queryPlan.enable=false`): only enable it where
+> that data exposure is acceptable, restrict who can read captured plans, and
+> prefer arming specific query hashes (Step 3) over a low global threshold so you
+> capture the minimum needed.
+
 ```java
 Database database = Database.builder()
   .queryPlanEnable(true)               // turn on bind capture

--- a/docs/guides/writing-ebean-query-beans.md
+++ b/docs/guides/writing-ebean-query-beans.md
@@ -77,6 +77,7 @@ often the right query shape.
 | Check if at least one row exists | `exists()` | Cheapest choice for boolean existence checks |
 | Load exactly one row by ID or unique key | `findOne()` | Only use when the predicate is truly unique |
 | Load a list of entity beans | `findList()` | Default for list screens and domain logic |
+| Stream rows, usually to map into another type | `findStream()` | Prefer over `findList().stream()`; streams from the JDBC cursor, then `.map(...).toList()` |
 | Count matching rows | `findCount()` | Prefer over loading entities just to count |
 | Load a page plus optional total row count | `findPagedList()` | Use when the caller needs pagination metadata |
 | Return DTO/read-model rows | `asDto(...).findList()` | Prefer this over partially loaded entities for API/view models |
@@ -98,6 +99,21 @@ Customer customer = new QCustomer()
 ```
 
 Do **not** use `findOne()` for predicates that can match multiple rows.
+
+### Example - stream and map to another type
+
+Use `findStream()` (not `findList().stream()`) when you immediately transform
+each row into another type. It streams from the JDBC cursor rather than
+materialising the full entity list first.
+
+```java
+List<PendingPlan> pending = new QCaptureRequest()
+  .collectedAt.isNull()
+  .orderBy().requestedAt.asc()
+  .findStream()
+  .map(r -> new PendingPlan(r.app().getName(), r.hash()))
+  .toList();
+```
 
 ---
 

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
@@ -397,12 +397,21 @@ public class DefaultDbMigration implements DbMigration {
   }
 
   /**
-   * Write (or override) the "repeatable" migration script.
+   * Write the "repeatable" or "init" migration script.
+   * <p>
+   * Repeatable ({@code R__}) scripts are always (re)written from their source
+   * (typically {@code extra-ddl.xml} views), but an init ({@code I__}) script is
+   * only written when it does not already exist. Init scripts run once to
+   * bootstrap a database and can be hand-tuned after first generation.
    */
-  private void writeExtraDdl(File migrationDir, DdlScript script) throws IOException {
+  void writeExtraDdl(File migrationDir, DdlScript script) throws IOException {
     String fullName = repeatableMigrationName(script.isInit(), script.getName());
-    logger.log(DEBUG, "writing repeatable script {0}", fullName);
     File file = new File(migrationDir, fullName);
+    if (script.isInit() && file.exists()) {
+      logger.log(DEBUG, "skip existing init script {0}", fullName);
+      return;
+    }
+    logger.log(DEBUG, "writing repeatable script {0}", fullName);
     try (Writer writer = IOUtils.newWriter(file)) {
       writer.write(script.getValue());
       writer.flush();

--- a/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/DefaultDbMigrationTest.java
+++ b/ebean-ddl-generator/src/test/java/io/ebeaninternal/dbmigration/DefaultDbMigrationTest.java
@@ -1,7 +1,15 @@
 package io.ebeaninternal.dbmigration;
 
+import io.ebeaninternal.extraddl.model.DdlScript;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -29,5 +37,52 @@ class DefaultDbMigrationTest {
     migration.checkDropVersion("1.0", null);
     migration.checkDropVersion("1.0", "1.0.0");
     migration.checkDropVersion("1.0", "1.1");
+  }
+
+  @Test
+  void writeExtraDdl_initScript_notOverwrittenWhenExists(@TempDir Path dir) throws IOException {
+    File migrationDir = dir.toFile();
+
+    migration.writeExtraDdl(migrationDir, initScript("partition help", "ORIGINAL"));
+    File initFile = new File(migrationDir, "I__partition_help.sql");
+    assertThat(initFile).exists().content().isEqualTo("ORIGINAL");
+
+    // hand-tune the generated init script
+    Files.writeString(initFile.toPath(), "CUSTOMISED");
+
+    // regeneration must not clobber an existing init script
+    migration.writeExtraDdl(migrationDir, initScript("partition help", "ORIGINAL"));
+    assertThat(initFile).content().isEqualTo("CUSTOMISED");
+  }
+
+  @Test
+  void writeExtraDdl_repeatableScript_alwaysRewritten(@TempDir Path dir) throws IOException {
+    File migrationDir = dir.toFile();
+
+    migration.writeExtraDdl(migrationDir, repeatableScript("my view", "V1"));
+    File file = new File(migrationDir, "R__my_view.sql");
+    assertThat(file).exists().content().isEqualTo("V1");
+
+    Files.writeString(file.toPath(), "STALE");
+
+    // repeatable scripts are regenerated from their source every time
+    migration.writeExtraDdl(migrationDir, repeatableScript("my view", "V1"));
+    assertThat(file).content().isEqualTo("V1");
+  }
+
+  private static DdlScript initScript(String name, String value) {
+    return script(name, value, true);
+  }
+
+  private static DdlScript repeatableScript(String name, String value) {
+    return script(name, value, false);
+  }
+
+  private static DdlScript script(String name, String value, boolean init) {
+    DdlScript script = new DdlScript();
+    script.setName(name);
+    script.setValue(value);
+    script.setInit(init);
+    return script;
   }
 }


### PR DESCRIPTION
This allows for customisation of the built in I__ init scripts.
For the case of postgres db partitions a customisation to support
unlogged tables was for example always being overwritten.

This change makes the I__ scripts a "add if not already exists".
Note that R__ repeatable scripts are "always overwrite"