### PR TITLE
Test for GetchGroup

### DIFF
--- a/ebean-spring-txn/src/test/java/org/example/EbeanSpringModuleTest.java
+++ b/ebean-spring-txn/src/test/java/org/example/EbeanSpringModuleTest.java
@@ -117,6 +117,24 @@ public class EbeanSpringModuleTest {
     logger.info("nonTransactional find user1:{} user2:{}", user, user2);
   }
 
+  public void testLoad() {
+	  User user = new User();
+	  user.setName("TestLoad");
+	  userService.save(user);
+	  
+	  logger.info("Saved new User");
+	  assertThat(user.getOid()).isGreaterThan(0);
+
+	  User found = DB.find(User.class, user.getOid());
+
+	  user.setName("TestLoad2");
+	  
+	  userService.save(user);
+	  
+	  found = DB.find(User.class, user.getOid());
+	  
+	  assertThat(user.getName()).equals(found.getName());
+  }
   /**
    * Return the user service.
    */

--- a/ebean-test/src/test/java/org/tests/resource/AttributeValue.java
+++ b/ebean-test/src/test/java/org/tests/resource/AttributeValue.java
@@ -1,5 +1,6 @@
 package org.tests.resource;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
 
@@ -8,6 +9,9 @@ public class AttributeValue extends BaseModel {
   private String stringValue;
   private int intValue;
 
+  @ManyToOne(cascade = CascadeType.ALL)
+  private Label name;
+  
   @ManyToOne
   private AttributeDescriptor attributeDescriptor;
 
@@ -25,12 +29,14 @@ public class AttributeValue extends BaseModel {
   public AttributeValue() {
   }
 
-  public AttributeValue(String stringValue, AttributeDescriptor attributeDescriptor) {
-    this.stringValue = stringValue;
+  public AttributeValue(Label name, String stringValue, AttributeDescriptor attributeDescriptor) {
+	this.name = name;
+	this.stringValue = stringValue;
     this.attributeDescriptor = attributeDescriptor;
   }
 
-  public AttributeValue(int intValue, AttributeDescriptor attributeDescriptor) {
+  public AttributeValue(Label name, int intValue, AttributeDescriptor attributeDescriptor) {
+		this.name = name;
     this.intValue = intValue;
     this.attributeDescriptor = attributeDescriptor;
   }
@@ -57,5 +63,13 @@ public class AttributeValue extends BaseModel {
 
   public void setAttributeDescriptor(AttributeDescriptor attributeDescriptor) {
     this.attributeDescriptor = attributeDescriptor;
+  }
+  
+  public Label getName() {
+	return name;
+  }
+
+  public void setName(Label name) {
+	this.name = name;
   }
 }

--- a/ebean-test/src/test/java/org/tests/resource/ResourceEntityTest.java
+++ b/ebean-test/src/test/java/org/tests/resource/ResourceEntityTest.java
@@ -643,13 +643,13 @@ class ResourceEntityTest {
   }
   
   @Test
-  void a_find_fetchQuerySecondary_inheritsImmutableCache_expect_noLabelLazyLoadSql() {
+  void find_fetchQuerySecondary_inheritsImmutableCache_expect_noLabelOrLabelTextLazyLoadSql() {
 
     var cache = loadingLabelAndLabelTextCache();
 
     AttributeValueOwner owner = DB.find(AttributeValueOwner.class)
       .setId(resource.getAttributeValueOwner().id())
-      .fetchQuery("attributeValues", "intValue")
+      .fetchQuery("attributeValues")
       .fetch("attributeValues.attributeDescriptor", "name,description")
       .using(cache)
       .setUnmodifiable(true)
@@ -677,7 +677,7 @@ class ResourceEntityTest {
 
     AttributeValueOwner owner = DB.find(AttributeValueOwner.class)
       .setId(resource.getAttributeValueOwner().id())
-      .fetchLazy("attributeValues", "intValue, name")
+      .fetchLazy("attributeValues", "intValue")
       .fetch("attributeValues.attributeDescriptor", "name,description")
       .using(cache)
       .findOne();

--- a/ebean-test/src/test/java/org/tests/resource/ResourceEntityTest.java
+++ b/ebean-test/src/test/java/org/tests/resource/ResourceEntityTest.java
@@ -677,7 +677,7 @@ class ResourceEntityTest {
 
     AttributeValueOwner owner = DB.find(AttributeValueOwner.class)
       .setId(resource.getAttributeValueOwner().id())
-      .fetchLazy("attributeValues", "intValue")
+      .fetchLazy("attributeValues", "intValue, name")
       .fetch("attributeValues.attributeDescriptor", "name,description")
       .using(cache)
       .findOne();

--- a/ebean-test/src/test/java/org/tests/resource/ResourceEntityTest.java
+++ b/ebean-test/src/test/java/org/tests/resource/ResourceEntityTest.java
@@ -68,8 +68,14 @@ class ResourceEntityTest {
     resource.getName().addLabelText(de, "R1_de");
 
     resource.setAttributeValueOwner(new AttributeValueOwner());
-    resource.getAttributeValueOwner().addAttributeValue(new AttributeValue(1, heightDescriptor));
-    resource.getAttributeValueOwner().addAttributeValue(new AttributeValue(2, widthDescriptor));
+    AttributeValue av1 = new AttributeValue(new Label(), 1, heightDescriptor);
+    av1.getName().addLabelText(de, "AV1 DE");
+    av1.getName().addLabelText(en, "AV1 EN");
+    AttributeValue av2 = new AttributeValue(new Label(), 2, widthDescriptor);
+    av2.getName().addLabelText(de, "AV2 DE");
+    av2.getName().addLabelText(en, "AV2 EN");
+    resource.getAttributeValueOwner().addAttributeValue(av1);
+    resource.getAttributeValueOwner().addAttributeValue(av2);
 
     DB.save(resource);
   }
@@ -635,6 +641,34 @@ class ResourceEntityTest {
 
     assertThat(sql).isEmpty();
   }
+  
+  @Test
+  void a_find_fetchQuerySecondary_inheritsImmutableCache_expect_noLabelLazyLoadSql() {
+
+    var cache = loadingLabelAndLabelTextCache();
+
+    AttributeValueOwner owner = DB.find(AttributeValueOwner.class)
+      .setId(resource.getAttributeValueOwner().id())
+      .fetchQuery("attributeValues", "intValue")
+      .fetch("attributeValues.attributeDescriptor", "name,description")
+      .using(cache)
+      .setUnmodifiable(true)
+      .findOne();
+
+    assertThat(owner).isNotNull();
+    assertThat(owner.getAttributeValues()).hasSize(2);
+
+    LoggedSql.start();
+    owner.getAttributeValues().stream().forEach(v->
+    	v.getName().getLabelTexts().stream().forEach(t->{
+    		assertThat(t.getLocaleText()).isNotBlank();
+    	})
+    );
+    accessDescriptorLabels(owner);
+    List<String> sql = LoggedSql.stop();
+
+    assertThat(sql).isEmpty();
+  }
 
   @Test
   void find_fetchLazySecondary_inheritsImmutableCache_expect_noLabelLazyLoadSql() {
@@ -659,6 +693,8 @@ class ResourceEntityTest {
 
     assertThat(sql).isEmpty();
   }
+  
+  
 
   private ImmutableBeanCache<Label> labelCache(Map<Object, Label> cachedLabels, Set<Object> cacheLookups) {
     return new ImmutableBeanCache<>() {
@@ -682,8 +718,19 @@ class ResourceEntityTest {
     };
   }
 
+  private ImmutableBeanCache<Label> loadingLabelAndLabelTextCache() {
+	FetchGroup<Label> fetchGroup =  FetchGroup.of(Label.class)
+			.select("version")
+			.fetch("labelTexts")
+			.build();
+	
+    return ImmutableBeanCaches.loading(Label.class, DB.getDefault(), 
+    		fetchGroup);
+  }
+  
   private ImmutableBeanCache<Label> loadingLabelCache() {
-    return ImmutableBeanCaches.loading(Label.class, DB.getDefault(), FetchGroup.of(Label.class, "version"));
+	  return ImmutableBeanCaches.loading(Label.class, DB.getDefault(), 
+			  FetchGroup.of(Label.class, "version"));
   }
 
   private ImmutableBeanCache<Label> loadingLabelWithTextsCache() {


### PR DESCRIPTION
I'm trying to force the loading of OneToMany using FetchGroups in a query....setUnmodifiable(true)
My goal is to be able to load parts of the object graph and use the ImmutableBeanCache functionality but I get 

 ResourceEntityTest.a_find_fetchQuerySecondary_inheritsImmutableCache_expect_noLabelLazyLoadSql:662->lambda$a_find_fetchQuerySecondary_inheritsImmutableCache_expect_noLabelLazyLoadSql$19:663 » LazyInitialisation Property not loaded: name