### PR TITLE
Fix refresh on soft-deleted beans

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultBeanLoader.java
@@ -188,7 +188,10 @@ final class DefaultBeanLoader {
     query.setLazyLoadProperty(ebi.lazyLoadProperty());
     if (draft) {
       query.asDraft();
-    } else if (mode == SpiQuery.Mode.LAZYLOAD_BEAN && desc.isSoftDelete()) {
+    } else if (desc.isSoftDelete()
+        && (mode == SpiQuery.Mode.LAZYLOAD_BEAN || mode == SpiQuery.Mode.REFRESH_BEAN)) {
+      // include soft-deleted rows when lazy loading or refreshing so a
+      // refresh() on a soft-deleted bean can reload it (issue #3641)
       query.setIncludeSoftDeletes();
     }
     if (embeddedOwnerIndex > -1) {

--- a/ebean-test/src/test/java/org/tests/softdelete/TestSoftDeleteBasic.java
+++ b/ebean-test/src/test/java/org/tests/softdelete/TestSoftDeleteBasic.java
@@ -156,6 +156,33 @@ public class TestSoftDeleteBasic extends BaseTestCase {
   }
 
   @Test
+  public void testRefreshSoftDeleted() {
+
+    EBasicSoftDelete bean = new EBasicSoftDelete();
+    bean.setName("refreshSoftDeleted");
+    DB.save(bean);
+
+    DB.delete(bean);
+
+    // obtain a handle to the soft-deleted bean
+    EBasicSoftDelete softDeleted = DB.find(EBasicSoftDelete.class)
+      .setId(bean.getId())
+      .setIncludeSoftDeletes()
+      .findOne();
+
+    assertThat(softDeleted).isNotNull();
+
+    // refresh() must not throw EntityNotFoundException for a soft-deleted bean (issue #3641)
+    DB.refresh(softDeleted);
+
+    assertThat(softDeleted.getName()).isEqualTo("refreshSoftDeleted");
+    assertThat(softDeleted.isDeleted()).isTrue();
+
+    // Cleanup created entity
+    DB.deletePermanent(softDeleted);
+  }
+
+  @Test
   public void testFindSoftDeleted() {
 
     EBasicSoftDelete bean = new EBasicSoftDelete();


### PR DESCRIPTION
## Summary

`DefaultBeanLoader.refreshBeanInternal` only opted into soft-deletes for `LAZYLOAD_BEAN` mode, so calling `.refresh()` on a soft-deleted bean filtered the row out of the reload query, `findOne()` returned null, and an `EntityNotFoundException` was thrown.

The guard at `DefaultBeanLoader.java:191` is broadened to also apply on `REFRESH_BEAN` mode:

```java
} else if (desc.isSoftDelete()
    && (mode == SpiQuery.Mode.LAZYLOAD_BEAN || mode == SpiQuery.Mode.REFRESH_BEAN)) {
  query.setIncludeSoftDeletes();
}
```

The `if (draft) { query.asDraft(); }` branch is untouched, and for a live (non-soft-deleted) bean `setIncludeSoftDeletes()` is a superset query so refresh still finds the row.

## Why this matters

A user who loads a bean with `setIncludeSoftDeletes()` (or holds a reference to a bean right after `DB.delete(bean)`) and then calls `DB.refresh(bean)` cannot reload it today; the refresh always throws even though the row exists. See https://github.com/ebean-orm/ebean/issues/3641.

## Testing

Added `testRefreshSoftDeleted` to `ebean-test/.../softdelete/TestSoftDeleteBasic.java`: it saves an `EBasicSoftDelete`, soft-deletes it, re-fetches it with `setIncludeSoftDeletes()`, then calls `DB.refresh(...)` and asserts the fields are reloaded and the soft-delete flag is set.

- With the production change reverted, the new test reproduces the bug exactly: `EntityNotFoundException: Bean not found during lazy load or refresh ... at DefaultBeanLoader.refreshBeanInternal(DefaultBeanLoader.java:217)`.
- With the fix in place, `mvn -pl ebean-test -am test -Dtest=TestSoftDeleteBasic` passes all 17 tests (16 existing + the new one), confirming no regression to existing lazy-load / soft-delete behaviour.

Fixes #3641
