### PR TITLE
Regression introduced by #3779 in sql inline comment for label (missing bean type prefix)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -321,6 +321,13 @@ final class CQueryBuilder {
     return lastFound;
   }
 
+  static String inlineSqlCommentLabel(String label, ProfileLocation profileLocation, boolean secondary, String simpleName) {
+    if (label != null) {
+      return secondary ? label : CQueryPlan.planLabelWithType(label, simpleName);
+    }
+    return profileLocation == null ? null : profileLocation.label();
+  }
+
   private String wrapSelectCount(String sql) {
     sql = "select count(*) from ( " + sql + ")";
     if (selectCountWithAlias) {
@@ -645,13 +652,9 @@ final class CQueryBuilder {
       if (type == SpiQuery.Type.SQ_EX || type == SpiQuery.Type.SQ_EXISTS) {
         return "";
       }
-      final var label = query.label();
+      final var label = CQueryBuilder.inlineSqlCommentLabel(query.label(), query.profileLocation(), query.loadMode() != null, request.descriptor().simpleName());
       if (label != null) {
         return dbPlatform.inlineSqlComment(label);
-      }
-      final var profileLocation = query.profileLocation();
-      if (profileLocation != null) {
-        return dbPlatform.inlineSqlComment(profileLocation.label());
       }
       return "";
     }

--- a/ebean-core/src/test/java/io/ebeaninternal/server/query/CQueryBuilderTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/query/CQueryBuilderTest.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.query;
 
+import io.ebean.ProfileLocation;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -114,5 +115,66 @@ class CQueryBuilderTest {
     String countSql = simulateCountWrap(innerSql);
 
     assertThat(countSql).isEqualTo("select count(*) from ( select t0.id from ad t0) as c");
+  }
+
+  @Test
+  void inlineSqlCommentLabel_rootExplicitLabel_prefixesBeanType() {
+    String label = CQueryBuilder.inlineSqlCommentLabel("fetchMachineFleets", null, false, "COrganisationMachine");
+    assertThat(label).isEqualTo("COrganisationMachine.fetchMachineFleets");
+  }
+
+  @Test
+  void inlineSqlCommentLabel_rootExplicitLabel_avoidsDuplicatePrefix() {
+    String label = CQueryBuilder.inlineSqlCommentLabel("COrganisationMachine.fetchMachineFleets", null, false, "COrganisationMachine");
+    assertThat(label).isEqualTo("COrganisationMachine.fetchMachineFleets");
+  }
+
+  @Test
+  void inlineSqlCommentLabel_secondaryLabel_usedAsIs() {
+    String label = CQueryBuilder.inlineSqlCommentLabel("COrganisationMachine.fetchMachineFleets.contacts.lazy", null, true, "Contact");
+    assertThat(label).isEqualTo("COrganisationMachine.fetchMachineFleets.contacts.lazy");
+  }
+
+  @Test
+  void inlineSqlCommentLabel_profileLocationFallback() {
+    String label = CQueryBuilder.inlineSqlCommentLabel(null, profileLocation("Finder.byName"), false, "COrganisationMachine");
+    assertThat(label).isEqualTo("Finder.byName");
+  }
+
+  private static ProfileLocation profileLocation(String label) {
+    return new ProfileLocation() {
+      @Override
+      public boolean obtain() {
+        return false;
+      }
+
+      @Override
+      public String location() {
+        return label;
+      }
+
+      @Override
+      public String label() {
+        return label;
+      }
+
+      @Override
+      public String fullLocation() {
+        return label;
+      }
+
+      @Override
+      public void add(long executionTime) {
+      }
+
+      @Override
+      public boolean trace() {
+        return false;
+      }
+
+      @Override
+      public void setTraceCount(int traceCount) {
+      }
+    };
   }
 }

--- a/ebean-querybean/src/test/java/org/querytest/QCustomerAndOrTest.java
+++ b/ebean-querybean/src/test/java/org/querytest/QCustomerAndOrTest.java
@@ -78,7 +78,7 @@ public class QCustomerAndOrTest {
     query.findList();
 
     assertThat(query.getGeneratedSql()).isEqualTo(
-      "select /* hiLabel */ _cust.id from be_customer _cust where (" +
+      "select /* Customer.hiLabel */ _cust.id from be_customer _cust where (" +
         "_cust.name = ? or exists (select 1 from be_contact contact where " +
         "contact.first_name = ? and contact.customer_id = _cust.id))"
     );

--- a/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/DtoQueryFromOrmTest.java
@@ -212,7 +212,7 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
     }
 
     List<String> sql = LoggedSql.stop();
-    assertSql(sql.get(0)).contains("select /*+ SomeHint */ /* explicitId */ t0.id, t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
+    assertSql(sql.get(0)).contains("select /*+ SomeHint */ /* Contact.explicitId */ t0.id, t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
       + " fullName from contact t0 where t0.email is not null and t0.last_name is not null order by t0.last_name");
   }
 
@@ -298,11 +298,11 @@ public class DtoQueryFromOrmTest extends BaseTestCase {
     List<String> sql = LoggedSql.stop();
 
     if (isSqlServer()) {
-      assertSql(sql.get(0)).contains("select /* emailFullName */ top 10 t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
+      assertSql(sql.get(0)).contains("select /* Contact.emailFullName */ top 10 t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
         + " fullName from contact t0 where t0.email is not null and t0.last_name is not null order by t0.last_name");
 
     } else {
-      assertSql(sql.get(0)).contains("select /* emailFullName */ t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
+      assertSql(sql.get(0)).contains("select /* Contact.emailFullName */ t0.email, " + concat("t0.last_name", ", ", "t0.first_name")
         + " fullName from contact t0 where t0.email is not null and t0.last_name is not null order by t0.last_name");
     }
   }

--- a/ebean-test/src/test/java/io/ebean/xtest/base/FetchGroupTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/FetchGroupTest.java
@@ -31,7 +31,7 @@ public class FetchGroupTest extends BaseTestCase {
 
     query.findList();
 
-    assertThat(sqlOf(query)).contains("select /* hello */ t0.id, t0.name, t0.status from");
+    assertThat(sqlOf(query)).contains("select /* Customer.hello */ t0.id, t0.name, t0.status from");
   }
 
 


### PR DESCRIPTION
So when we used to get an inline comment like:
```sql
select /* Customer.hiLabel */ ...
```
We started to instead have (missing bean type):
```sql
select /* hiLabel */ ...
```
This fixes that regression that was introduced in #3779 (Version 16.9.0 / 17.9.0)