### PR TITLE
Two related tidy-ups to query-cache dependent-table handling.

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -42,7 +42,6 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   private SpiQuerySecondary secondaryQueries;
   private List<T> cacheBeans;
   private boolean inlineCountDistinct;
-  private Set<String> dependentTables;
   private SpiQueryManyJoin manyJoin;
 
   public OrmQueryRequest(SpiEbeanServer server, OrmQueryEngine queryEngine, SpiQuery<T> query, SpiTransaction t) {
@@ -667,7 +666,11 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   }
 
   public void putToQueryCache(Object result) {
-    beanDescriptor.queryCachePut(cacheKey, new QueryCacheEntry(result, dependentTables, transaction.startTime()));
+    CQueryPlan plan = queryPlan();
+    if (plan != null) {
+      // only cache when we have the plan's dependent tables
+      beanDescriptor.queryCachePut(cacheKey, new QueryCacheEntry(result, plan.dependentTables(), transaction.startTime()));
+    }
   }
 
   /**
@@ -735,15 +738,6 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
 
   public boolean isInlineCountDistinct() {
     return inlineCountDistinct;
-  }
-
-  public void addDependentTables(Set<String> tables) {
-    if (tables != null && !tables.isEmpty()) {
-      if (dependentTables == null) {
-        dependentTables = new LinkedHashSet<>();
-      }
-      dependentTables.addAll(tables);
-    }
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQuery.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQuery.java
@@ -768,8 +768,4 @@ public final class CQuery<T> implements DbReadContext, CancelableQuery, SpiProfi
   public void handleLoadError(String fullName, Exception e) {
     query.handleLoadError(fullName, e);
   }
-
-  public Set<String> dependentTables() {
-    return queryPlan.dependentTables();
-  }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -105,7 +105,6 @@ public final class CQueryEngine {
         request.transaction().logSummary(rcQuery.summary());
       }
       if (request.isQueryCachePut()) {
-        request.addDependentTables(rcQuery.dependentTables());
         if (collection instanceof List) {
           collection = (A) Collections.unmodifiableList((List<?>) collection);
           request.putToQueryCache(collection);
@@ -163,7 +162,6 @@ public final class CQueryEngine {
         request.transaction().logSummary(rcQuery.summary());
       }
       if (request.isQueryCachePut()) {
-        request.addDependentTables(rcQuery.dependentTables());
         request.putToQueryCache(count);
       }
       return count;
@@ -355,9 +353,6 @@ public final class CQueryEngine {
       }
       request.executeSecondaryQueries(false);
       request.populateFromImmutableCache();
-      if (request.isQueryCachePut()) {
-        request.addDependentTables(cquery.dependentTables());
-      }
       request.unmodifiableFreeze(beanCollection);
       return beanCollection;
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryFetchSingleAttribute.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryFetchSingleAttribute.java
@@ -16,7 +16,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.lang.System.Logger.Level.ERROR;
@@ -166,10 +165,6 @@ final class CQueryFetchSingleAttribute implements SpiProfileTransactionEvent, Ca
     transaction()
       .profileStream()
       .addQueryEvent(query.profileEventId(), profileOffset, desc.name(), rowCount, query.profileId(), queryPlan.hash(), query.getGeneratedSql());
-  }
-
-  Set<String> dependentTables() {
-    return queryPlan.dependentTables();
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlanStats.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlanStats.java
@@ -22,6 +22,8 @@ public final class CQueryPlanStats {
   CQueryPlanStats(CQueryPlan queryPlan) {
     this.queryPlan = queryPlan;
     this.timedMetric = queryPlan.createTimedMetric();
+    // treat newly built plan as recently used to avoid trim
+    this.lastQueryTime = System.currentTimeMillis();
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryRowCount.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryRowCount.java
@@ -13,7 +13,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -138,10 +137,6 @@ final class CQueryRowCount implements SpiProfileTransactionEvent, CancelableQuer
     transaction()
       .profileStream()
       .addQueryEvent(query.profileEventId(), profileOffset, desc.name(), rowCount, query.profileId(), queryPlan.hash(), query.getGeneratedSql());
-  }
-
-  Set<String> dependentTables() {
-    return queryPlan.dependentTables();
   }
 
   @Override

--- a/ebean-test/src/test/java/org/tests/cache/TestQueryCacheTableDependency.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestQueryCacheTableDependency.java
@@ -1,9 +1,11 @@
 package org.tests.cache;
 
 import io.ebean.xtest.BaseTestCase;
+import io.ebean.CacheMode;
 import io.ebean.DB;
 import io.ebean.Query;
 import io.ebean.cache.ServerCache;
+import io.ebean.test.LoggedSql;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Address;
@@ -190,5 +192,99 @@ public class TestQueryCacheTableDependency extends BaseTestCase {
     // clean up
     DB.delete(child);
     DB.delete(root);
+  }
+
+  /**
+   * findSingleAttributeList caches with dependent tables sourced from the query plan.
+   * A change to the joined (dependent) table must invalidate the query cache entry.
+   */
+  @Test
+  public void testFindSingleAttributeOnDependent() throws InterruptedException {
+    Address addr = new Address();
+    addr.setCity("qcache-sa-city");
+    DB.save(addr);
+
+    Customer cust = new Customer();
+    cust.setName("qcache-sa-cust");
+    cust.setBillingAddress(addr);
+    DB.save(cust);
+
+    DB.cacheManager().queryCache(Customer.class).clear();
+    Thread.sleep(10);
+
+    LoggedSql.start();
+    List<String> first = namesByBillingCity("qcache-sa-city");
+    assertThat(LoggedSql.stop()).as("first call executes SQL").hasSize(1);
+    assertThat(first).containsExactly("qcache-sa-cust");
+
+    LoggedSql.start();
+    List<String> second = namesByBillingCity("qcache-sa-city");
+    assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
+    assertThat(second).isEqualTo(first);
+
+    // modify the joined (dependent) o_address table -> evict the Customer query cache
+    addr.setCity("qcache-sa-city2");
+    DB.save(addr);
+
+    LoggedSql.start();
+    List<String> third = namesByBillingCity("qcache-sa-city");
+    assertThat(LoggedSql.stop()).as("cache invalidated after dependent table change").hasSize(1);
+    assertThat(third).isEmpty();
+
+    DB.delete(cust);
+  }
+
+  /**
+   * findList (unmodifiable query cache) caches with dependent tables sourced from the
+   * query plan. A change to the joined (dependent) table must invalidate the entry.
+   */
+  @Test
+  public void testFindListOnDependent() throws InterruptedException {
+    Address addr = new Address();
+    addr.setCity("qcache-list-city");
+    DB.save(addr);
+
+    Customer cust = new Customer();
+    cust.setName("qcache-list-cust");
+    cust.setBillingAddress(addr);
+    DB.save(cust);
+
+    DB.cacheManager().queryCache(Customer.class).clear();
+    Thread.sleep(10);
+
+    LoggedSql.start();
+    List<Customer> first = customersByBillingCity("qcache-list-city");
+    assertThat(LoggedSql.stop()).as("first call executes SQL").hasSize(1);
+    assertThat(first).hasSize(1);
+
+    LoggedSql.start();
+    List<Customer> second = customersByBillingCity("qcache-list-city");
+    assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
+    assertThat(second).isSameAs(first);
+
+    // modify the joined (dependent) o_address table -> evict the Customer query cache
+    addr.setCity("qcache-list-city2");
+    DB.save(addr);
+
+    LoggedSql.start();
+    List<Customer> third = customersByBillingCity("qcache-list-city");
+    assertThat(LoggedSql.stop()).as("cache invalidated after dependent table change").hasSize(1);
+    assertThat(third).isEmpty();
+
+    DB.delete(cust);
+  }
+
+  private List<String> namesByBillingCity(String city) {
+    return DB.find(Customer.class).setUseQueryCache(CacheMode.ON)
+      .select("name")
+      .where().eq("billingAddress.city", city)
+      .orderBy("name")
+      .findSingleAttributeList();
+  }
+
+  private List<Customer> customersByBillingCity(String city) {
+    return DB.find(Customer.class).setUseQueryCache(CacheMode.ON)
+      .where().eq("billingAddress.city", city)
+      .findList();
   }
 }


### PR DESCRIPTION
 This is a replacement for #3150

 **1. Read `dependentTables` from the query plan (single source of truth)**

 `OrmQueryRequest` accumulated query-cache `dependentTables` into a field via
 `addDependentTables(...)`, fed from per-CQuery `dependentTables()` helpers. The
 `CQueryPlan` already owns this set, so the copying is redundant.

 - `putToQueryCache(...)` now reads `dependentTables` directly from the request's `CQueryPlan` at cache-put time.
 - Removed the `OrmQueryRequest.dependentTables` field and `addDependentTables(Set)`.
 - Removed the now-unused `dependentTables()` helpers from `CQuery`, `CQueryRowCount` and `CQueryFetchSingleAttribute` (and their `Set` imports).

 This is behaviour-preserving: each CQuery is built with exactly the plan stored
 under `request.queryPlanKey`, so `request.queryPlan().dependentTables()` is the
 same set the per-CQuery helpers returned.

 **2. Fix a query-plan trim race that could null the plan at put time**

 A freshly built `CQueryPlan` was stored in the plan cache with
 `lastQueryTime == 0`, making it immediately eligible for `trimQueryPlans`
 (runs every 60s; TTL default 300s) during its *first* execution. If the trim
 fired mid-execution, `request.queryPlan()` could return `null` at put time — and
 a cache entry with `null` dependentTables is never invalidated by table
 modifications (`TableModState.isValid`), i.e. latent stale data.

 - `CQueryPlanStats` now initialises `lastQueryTime` to construction time, so a new plan is only trim-eligible after a genuine TTL idle. `trimQueryPlans` is the sole consumer of `lastQueryTime()`, so this is safe.
 - `putToQueryCache(...)` skips the put when the plan is `null` (fail safe rather than caching an un-invalidatable entry) for the residual pathological case (a single query running past the TTL on first execution).

 ### Tests

 - Added `testFindSingleAttributeOnDependent` and `testFindListOnDependent` to `TestQueryCacheTableDependency`, asserting cache-hit then dependent-table invalidation for the single-attribute and findMany paths (the count path was already covered).
 - All cache/query tests pass: 69 in `ebean-test` `org.tests.cache.**`, 929 in `ebean-core` cache + query packages.