### PR TITLE
FEATURE: DbJson Support for Dto-Queries (was #3143)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanProperty.java
@@ -1,7 +1,6 @@
 package io.ebeaninternal.server.deploy;
 
 import io.avaje.json.JsonReader;
-import io.avaje.json.JsonReader.Token;
 import io.ebean.DataIntegrityException;
 import io.ebean.ModifyAwareType;
 import io.ebean.ValuePair;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -439,6 +439,7 @@ public class DeployBeanProperty implements DeployProperty {
   /**
    * Return the name of the property.
    */
+  @Override
   public String getName() {
     return name;
   }
@@ -872,6 +873,7 @@ public class DeployBeanProperty implements DeployProperty {
   /**
    * Return the property type.
    */
+  @Override
   public Class<?> getPropertyType() {
     return propertyType;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanProperty.java
@@ -38,7 +38,7 @@ import java.util.Set;
  * Description of a property of a bean. Includes its deployment information such
  * as database column mapping information.
  */
-public class DeployBeanProperty {
+public class DeployBeanProperty implements DeployProperty {
 
   private static final int ID_ORDER = 1000000;
   private static final int UNIDIRECTIONAL_ORDER = 100000;
@@ -230,6 +230,11 @@ public class DeployBeanProperty {
     return desc;
   }
 
+  @Override
+  public Class<?> getOwnerType() {
+    return desc.getBeanType();
+  }
+
   /**
    * Return the DB column length for character columns.
    * <p>
@@ -262,10 +267,12 @@ public class DeployBeanProperty {
     this.jsonDeserialize = jsonDeserialize;
   }
 
+  @Override
   public MutationDetection getMutationDetection() {
     return mutationDetection;
   }
 
+  @Override
   public void setMutationDetection(MutationDetection dirtyDetection) {
     this.mutationDetection = dirtyDetection;
   }
@@ -480,8 +487,9 @@ public class DeployBeanProperty {
   }
 
   /**
-   * Return true if this property is mandatory.
+   * Return true if this property is not mandatory.
    */
+  @Override
   public boolean isNullable() {
     return nullable;
   }
@@ -871,6 +879,7 @@ public class DeployBeanProperty {
   /**
    * Return the generic type for this property.
    */
+  @Override
   public Type getGenericType() {
     return genericType;
   }
@@ -1075,6 +1084,7 @@ public class DeployBeanProperty {
     return null;
   }
 
+  @Override
   @SuppressWarnings("unchecked")
   public <A extends Annotation> List<A> getMetaAnnotations(Class<A> annotationType) {
     List<A> result = new ArrayList<>();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployProperty.java
@@ -1,0 +1,53 @@
+package io.ebeaninternal.server.deploy.meta;
+
+import io.ebean.annotation.MutationDetection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Property, with basic type information (BeanProperty and DtoProperty).
+ */
+public interface DeployProperty {
+
+  /**
+   * Return the name of the property.
+   */
+  String getName();
+
+  /**
+   * Return the generic type for this property.
+   */
+  Type getGenericType();
+
+  /**
+   * Return the property type.
+   */
+  Class<?> getPropertyType();
+
+  /**
+   * Returns the owner class of this property.
+   */
+  Class<?> getOwnerType();
+
+  /**
+   * Returns the annotations on this property.
+   */
+  <A extends Annotation> List<A> getMetaAnnotations(Class<A> annotationType);
+
+  /**
+   * Returns the mutation detection setting of this property.
+   */
+  MutationDetection getMutationDetection();
+
+  /**
+   * Sets the mutation detection setting of this property.
+   */
+  void setMutationDetection(MutationDetection mutationDetection);
+
+  /**
+   * Return true if this property is not mandatory.
+   */
+  boolean isNullable();
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/DeployUtil.java
@@ -219,7 +219,7 @@ public final class DeployUtil {
   /**
    * Return the JDBC type for the JSON storage type.
    */
-  private int dbJsonStorage(DbJsonType dbJsonType) {
+  public static int dbJsonStorage(DbJsonType dbJsonType) {
     switch (dbJsonType) {
       case JSONB:
         return DbPlatformType.JSONB;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaBuilder.java
@@ -1,5 +1,7 @@
 package io.ebeaninternal.server.dto;
 
+import io.ebean.annotation.DbJson;
+import io.ebean.annotation.DbJsonB;
 import io.ebeaninternal.api.CoreLog;
 import io.ebeaninternal.server.type.TypeManager;
 
@@ -21,10 +23,16 @@ final class DtoMetaBuilder {
   private final Class<?> dtoType;
   private final List<DtoMetaProperty> properties = new ArrayList<>();
   private final Map<Integer, DtoMetaConstructor> constructorMap = new HashMap<>();
+  private final Set<Class<?>> annotationFilter = new HashSet<>();
 
   DtoMetaBuilder(Class<?> dtoType, TypeManager typeManager) {
     this.dtoType = dtoType;
     this.typeManager = typeManager;
+    annotationFilter.add(DbJson.class);
+    annotationFilter.add(DbJsonB.class);
+    if (typeManager.jsonMarkerAnnotation() != null) {
+      annotationFilter.add(typeManager.jsonMarkerAnnotation());
+    }
   }
 
   DtoMeta build() {
@@ -38,7 +46,7 @@ final class DtoMetaBuilder {
       if (includeMethod(method)) {
         try {
           final String name = propertyName(method.getName());
-          properties.add(new DtoMetaProperty(typeManager, dtoType, method, name));
+          properties.add(new DtoMetaProperty(typeManager, dtoType, method, name, annotationFilter));
         } catch (Exception e) {
           CoreLog.log.log(DEBUG, "exclude on " + dtoType + " method " + method, e);
         }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaDeployProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaDeployProperty.java
@@ -1,0 +1,81 @@
+package io.ebeaninternal.server.dto;
+
+import io.ebean.annotation.MutationDetection;
+import io.ebeaninternal.server.deploy.meta.DeployProperty;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * DeployProperty for Dto-Properties.
+ *
+ * @author Roland Praml, FOCONIS AG
+ */
+class DtoMetaDeployProperty implements DeployProperty {
+  private final String name;
+  private final Class<?> ownerType;
+  private final Type genericType;
+  private final Class<?> propertyType;
+  private final Set<Annotation> metaAnnotations;
+  private final boolean nullable;
+  private MutationDetection mutationDetection = MutationDetection.DEFAULT;
+
+  DtoMetaDeployProperty(String name, Class<?> ownerType, Type genericType, Class<?> propertyType, Set<Annotation> metaAnnotations, Method method) {
+    this.name = name;
+    this.ownerType = ownerType;
+    this.genericType = genericType;
+    this.nullable = !propertyType.isPrimitive();
+    this.propertyType = propertyType;
+    this.metaAnnotations = metaAnnotations;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Type getGenericType() {
+    return genericType;
+  }
+
+  @Override
+  public Class<?> getPropertyType() {
+    return propertyType;
+  }
+
+  @Override
+  public Class<?> getOwnerType() {
+    return ownerType;
+  }
+
+  @Override
+  public <A extends Annotation> List<A> getMetaAnnotations(Class<A> annotationType) {
+    List<A> result = new ArrayList<>();
+    for (Annotation ann : metaAnnotations) {
+      if (ann.annotationType() == annotationType) {
+        result.add((A) ann);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public MutationDetection getMutationDetection() {
+    return mutationDetection;
+  }
+
+  @Override
+  public void setMutationDetection(MutationDetection mutationDetection) {
+    this.mutationDetection = mutationDetection;
+  }
+
+  @Override
+  public boolean isNullable() {
+    return nullable;
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaDeployProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaDeployProperty.java
@@ -4,7 +4,6 @@ import io.ebean.annotation.MutationDetection;
 import io.ebeaninternal.server.deploy.meta.DeployProperty;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +23,7 @@ class DtoMetaDeployProperty implements DeployProperty {
   private final boolean nullable;
   private MutationDetection mutationDetection = MutationDetection.DEFAULT;
 
-  DtoMetaDeployProperty(String name, Class<?> ownerType, Type genericType, Class<?> propertyType, Set<Annotation> metaAnnotations, Method method) {
+  DtoMetaDeployProperty(String name, Class<?> ownerType, Type genericType, Class<?> propertyType, Set<Annotation> metaAnnotations) {
     this.name = name;
     this.ownerType = ownerType;
     this.genericType = genericType;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaDeployProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaDeployProperty.java
@@ -14,7 +14,8 @@ import java.util.Set;
  *
  * @author Roland Praml, FOCONIS AG
  */
-class DtoMetaDeployProperty implements DeployProperty {
+final class DtoMetaDeployProperty implements DeployProperty {
+
   private final String name;
   private final Class<?> ownerType;
   private final Type genericType;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
@@ -34,21 +34,19 @@ final class DtoMetaProperty implements DtoReadSet {
     this.name = name;
     if (writeMethod != null) {
       this.setter = lookupMethodHandle(dtoType, writeMethod);
-      DeployProperty deployProp = new DtoMetaDeployProperty(name,
+      var deployProp = new DtoMetaDeployProperty(name,
         dtoType,
         propertyType(writeMethod),
         propertyClass(writeMethod),
         findMetaAnnotations(dtoType, writeMethod, name, annotationFilter));
-      scalarType = getScalarType(typeManager, deployProp);
+      scalarType = scalarType(typeManager, deployProp);
     } else {
       this.scalarType = null;
       this.setter = null;
     }
   }
 
-  private ScalarType<?> getScalarType(TypeManager typeManager, DeployProperty deployProp) {
-    final ScalarType<?> scalarType;
-
+  private ScalarType<?> scalarType(TypeManager typeManager, DeployProperty deployProp) {
     List<DbJson> json = deployProp.getMetaAnnotations(DbJson.class);
     if (!json.isEmpty()) {
       return typeManager.dbJsonType(deployProp, DeployUtil.dbJsonStorage(json.get(0).storage()), json.get(0).length());
@@ -62,8 +60,6 @@ final class DtoMetaProperty implements DtoReadSet {
       return typeManager.dbJsonType(deployProp, DbPlatformType.JSON, 0);
     }
     return typeManager.type(deployProp);
-
-
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/dto/DtoMetaProperty.java
@@ -1,15 +1,25 @@
 package io.ebeaninternal.server.dto;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.sql.SQLException;
-
+import io.ebean.annotation.DbJson;
+import io.ebean.annotation.DbJsonB;
+import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.ScalarType;
 import io.ebean.plugin.Lookups;
+import io.ebean.util.AnnotationUtil;
+import io.ebeaninternal.server.deploy.meta.DeployProperty;
+import io.ebeaninternal.server.deploy.parse.DeployUtil;
 import io.ebeaninternal.server.type.TypeManager;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Set;
 
 final class DtoMetaProperty implements DtoReadSet {
 
@@ -18,16 +28,70 @@ final class DtoMetaProperty implements DtoReadSet {
   private final MethodHandle setter;
   private final ScalarType<?> scalarType;
 
-  DtoMetaProperty(TypeManager typeManager, Class<?> dtoType, Method writeMethod, String name) throws IllegalAccessException, NoSuchMethodException {
+  DtoMetaProperty(TypeManager typeManager, Class<?> dtoType, Method writeMethod, String name, Set<Class<?>> annotationFilter)
+    throws IllegalAccessException, NoSuchMethodException {
     this.dtoType = dtoType;
     this.name = name;
     if (writeMethod != null) {
       this.setter = lookupMethodHandle(dtoType, writeMethod);
-      this.scalarType = typeManager.type(propertyType(writeMethod), propertyClass(writeMethod));
+      DeployProperty deployProp = new DtoMetaDeployProperty(name,
+        dtoType,
+        propertyType(writeMethod),
+        propertyClass(writeMethod),
+        findMetaAnnotations(dtoType, writeMethod, name, annotationFilter));
+      scalarType = getScalarType(typeManager, deployProp);
     } else {
       this.scalarType = null;
       this.setter = null;
     }
+  }
+
+  private ScalarType<?> getScalarType(TypeManager typeManager, DeployProperty deployProp) {
+    final ScalarType<?> scalarType;
+
+    List<DbJson> json = deployProp.getMetaAnnotations(DbJson.class);
+    if (!json.isEmpty()) {
+      return typeManager.dbJsonType(deployProp, DeployUtil.dbJsonStorage(json.get(0).storage()), json.get(0).length());
+    }
+    List<DbJsonB> jsonB = deployProp.getMetaAnnotations(DbJsonB.class);
+    if (!jsonB.isEmpty()) {
+      return typeManager.dbJsonType(deployProp, DbPlatformType.JSONB, jsonB.get(0).length());
+    }
+    if (typeManager.jsonMarkerAnnotation() != null
+      && !deployProp.getMetaAnnotations(typeManager.jsonMarkerAnnotation()).isEmpty()) {
+      return typeManager.dbJsonType(deployProp, DbPlatformType.JSON, 0);
+    }
+    return typeManager.type(deployProp);
+
+
+  }
+
+  /**
+   * Find all annotations on fields and methods.
+   */
+  private Set<Annotation> findMetaAnnotations(Class<?> dtoType, Method writeMethod, String name, Set<Class<?>> annotationFilter) {
+    Field field = findField(dtoType, name);
+    if (field != null) {
+      Set<Annotation> metaAnnotations = AnnotationUtil.metaFindAllFor(field, annotationFilter);
+      metaAnnotations.addAll(AnnotationUtil.metaFindAllFor(writeMethod, annotationFilter));
+      return metaAnnotations;
+    } else {
+      return AnnotationUtil.metaFindAllFor(writeMethod, annotationFilter);
+    }
+  }
+
+  /**
+   * Find field in class with same name
+   */
+  private Field findField(Class<?> type, String name) {
+    while (type != Object.class && type != null) {
+      try {
+        return type.getDeclaredField(name);
+      } catch (NoSuchFieldException e) {
+        type = type.getSuperclass();
+      }
+    }
+    return null;
   }
 
   private static MethodHandle lookupMethodHandle(Class<?> dtoType, Method method) throws NoSuchMethodException, IllegalAccessException {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -17,10 +17,12 @@ import io.ebeaninternal.api.GeoTypeProvider;
 import io.ebeaninternal.server.core.ServiceUtil;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
 import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
+import io.ebeaninternal.server.deploy.meta.DeployProperty;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.EnumType;
 import java.io.File;
+import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -191,7 +193,8 @@ public final class DefaultTypeManager implements TypeManager {
   }
 
   @Override
-  public ScalarType<?> type(Type propertyType, Class<?> propertyClass) {
+  public ScalarType<?> type(DeployProperty prop) {
+    Type propertyType = prop.getGenericType();
     if (propertyType instanceof ParameterizedType) {
       ParameterizedType pt = (ParameterizedType) propertyType;
       Type rawType = pt.getRawType();
@@ -199,7 +202,7 @@ public final class DefaultTypeManager implements TypeManager {
         return dbArrayType((Class<?>) rawType, propertyType, true);
       }
     }
-    return type(propertyClass);
+    return type(prop.getPropertyType());
   }
 
   /**
@@ -300,8 +303,14 @@ public final class DefaultTypeManager implements TypeManager {
     return TypeReflectHelper.isEnumType(valueType);
   }
 
+
   @Override
-  public ScalarType<?> dbJsonType(DeployBeanProperty prop, int dbType, int dbLength) {
+  public Class<? extends Annotation> jsonMarkerAnnotation() {
+    return jsonMapper == null ? null : jsonMapper.markerAnnotation();
+  }
+
+  @Override
+  public ScalarType<?> dbJsonType(DeployProperty prop, int dbType, int dbLength) {
     Class<?> type = prop.getPropertyType();
     if (type.equals(String.class)) {
       return ScalarTypeJsonString.typeFor(postgres, dbType);
@@ -335,7 +344,7 @@ public final class DefaultTypeManager implements TypeManager {
     return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT);
   }
 
-  private boolean keepSource(DeployBeanProperty prop) {
+  private boolean keepSource(DeployProperty prop) {
     if (prop.getMutationDetection() == MutationDetection.DEFAULT) {
       prop.setMutationDetection(jsonManager.mutationDetection());
     }
@@ -349,7 +358,7 @@ public final class DefaultTypeManager implements TypeManager {
     return ScalarTypeJsonMapEnum.typeFor(postgres, dbType, enumScalarType, keepSource);
   }
 
-  private DocPropertyType docPropertyType(DeployBeanProperty prop, Class<?> type) {
+  private DocPropertyType docPropertyType(DeployProperty prop, Class<?> type) {
     return type.equals(List.class) || type.equals(Set.class) ? docType(prop.getGenericType()) : DocPropertyType.OBJECT;
   }
 
@@ -396,14 +405,18 @@ public final class DefaultTypeManager implements TypeManager {
     return Object.class.equals(valueType) || String.class.equals(valueType) || "?".equals(valueType.toString());
   }
 
-  private ScalarType<?> createJsonObjectMapperType(DeployBeanProperty prop, int dbType, DocPropertyType docType) {
+  private ScalarType<?> createJsonObjectMapperType(DeployProperty prop, int dbType, DocPropertyType docType) {
     if (jsonMapper == null) {
       throw new IllegalArgumentException("Unsupported @DbJson mapping - Missing dependency ebean-jackson-mapper? Jackson ObjectMapper not present for " + prop);
     }
     if (MutationDetection.DEFAULT == prop.getMutationDetection()) {
       prop.setMutationDetection(jsonManager.mutationDetection());
     }
-    var req = new ScalarJsonRequest(jsonManager, dbType, docType, prop.getDesc().getBeanType(), prop.getMutationDetection(), prop.getName());
+    Class<?> type = prop.getOwnerType();
+    if (prop instanceof DeployBeanProperty) {
+      type = ((DeployBeanProperty) prop).getField().getDeclaringClass();
+    }
+    var req = new ScalarJsonRequest(jsonManager, dbType, docType, type, prop.getMutationDetection(), prop.getName());
     return jsonMapper.createType(req);
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/TypeManager.java
@@ -1,9 +1,10 @@
 package io.ebeaninternal.server.type;
 
 import io.ebean.core.type.ScalarType;
-import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
+import io.ebeaninternal.server.deploy.meta.DeployProperty;
 
 import jakarta.persistence.EnumType;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
 /**
@@ -40,7 +41,7 @@ public interface TypeManager {
    * <p>
    * For example Array based ScalarType for types like {@code List<String>}.
    */
-  ScalarType<?> type(Type propertyType, Class<?> type);
+  ScalarType<?> type(DeployProperty property);
 
   /**
    * Create a ScalarType for an Enum using a mapping (rather than JPA Ordinal or String which has limitations).
@@ -48,12 +49,17 @@ public interface TypeManager {
   ScalarType<?> enumType(Class<? extends Enum<?>> enumType, EnumType enumerated);
 
   /**
+   * Returns the Json Marker annotation (e.g. JacksonAnnotation)
+   */
+  Class<? extends Annotation> jsonMarkerAnnotation();
+
+  /**
    * Return the ScalarType used to handle JSON content.
    * <p>
    * Note that type expected to be JsonNode or Map.
    * </p>
    */
-  ScalarType<?> dbJsonType(DeployBeanProperty prop, int dbType, int dbLength);
+  ScalarType<?> dbJsonType(DeployProperty prop, int dbType, int dbLength);
 
   /**
    * Return the ScalarType used to handle DB ARRAY.

--- a/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServerFactory_ServerConfigStart_Test.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/base/EbeanServerFactory_ServerConfigStart_Test.java
@@ -2,6 +2,8 @@ package io.ebean.xtest.base;
 
 import io.ebean.Database;
 import io.ebean.DatabaseBuilder;
+import io.ebean.DatabaseFactory;
+import io.ebean.config.DatabaseConfig;
 import io.ebean.event.ServerConfigStartup;
 import io.ebeaninternal.api.SpiLogger;
 import io.ebeaninternal.api.SpiLoggerFactory;

--- a/ebean-test/src/test/java/org/tests/json/TestDbJson_Jackson.java
+++ b/ebean-test/src/test/java/org/tests/json/TestDbJson_Jackson.java
@@ -1,15 +1,25 @@
 package org.tests.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.ebean.xtest.BaseTestCase;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.ebean.DB;
+import io.ebean.annotation.DbJson;
+import io.ebean.annotation.DbJsonB;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.Test;
+import org.tests.model.json.BasicJacksonType;
 import org.tests.model.json.EBasicJsonJackson;
 import org.tests.model.json.EBasicJsonJackson2;
 import org.tests.model.json.LongJacksonType;
 import org.tests.model.json.StringJacksonType;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,9 +69,56 @@ public class TestDbJson_Jackson extends BaseTestCase {
     assertThat(found.getValueMap()).containsEntry(1L, "one").containsEntry(2L, "two");
   }
 
+  public static class DtoJackson {
+    @DbJson(length = 700)
+    Set<BasicJacksonType<?>> valueSet = new LinkedHashSet<>();
+
+    @DbJsonB
+    List<BasicJacksonType<?>> valueList = new ArrayList<>();
+
+    @DbJson(length = 700)
+    @JsonDeserialize(keyAs = Long.class)
+    Map<Number, BasicJacksonType<?>> valueMap = new LinkedHashMap<>();
+
+    @DbJson(length = 500)
+    BasicJacksonType<?> plainValue;
+
+    public Set<BasicJacksonType<?>> getValueSet() {
+      return valueSet;
+    }
+
+    public void setValueSet(Set<BasicJacksonType<?>> valueSet) {
+      this.valueSet = valueSet;
+    }
+
+    public List<BasicJacksonType<?>> getValueList() {
+      return valueList;
+    }
+
+    public void setValueList(List<BasicJacksonType<?>> valueList) {
+      this.valueList = valueList;
+    }
+
+    public Map<Number, BasicJacksonType<?>> getValueMap() {
+      return valueMap;
+    }
+
+    public void setValueMap(Map<Number, BasicJacksonType<?>> valueMap) {
+      this.valueMap = valueMap;
+    }
+
+    public BasicJacksonType<?> getPlainValue() {
+      return plainValue;
+    }
+
+    public void setPlainValue(BasicJacksonType<?> plainValue) {
+      this.plainValue = plainValue;
+    }
+  }
+
   /**
    * This testcase verifies if polymorph objects will work in ebean.
-   *
+   * <p>
    * for BasicJacksonType there exists two types and has a &#64;JsonTypeInfo
    * annotation. It is expected that this information is also honored by ebean.
    */
@@ -94,7 +151,8 @@ public class TestDbJson_Jackson extends BaseTestCase {
     assertThat(found.getPlainValue()).isInstanceOf(LongJacksonType.class);
     assertThat(found.getValueList()).hasSize(2);
     assertThat(found.getValueSet()).hasSize(2);
-    assertThat(found.getValueMap()).hasSize(2);;
+    assertThat(found.getValueMap()).hasSize(2);
+    ;
 
     DB.save(bean);
 
@@ -103,7 +161,16 @@ public class TestDbJson_Jackson extends BaseTestCase {
     assertThat(found.getPlainValue()).isInstanceOf(LongJacksonType.class);
     assertThat(found.getValueList()).hasSize(2);
     assertThat(found.getValueSet()).hasSize(2);
-    assertThat(found.getValueMap()).hasSize(2);;
+    assertThat(found.getValueMap()).hasSize(2);
+
+
+    DtoJackson dto = DB.find(EBasicJsonJackson2.class).setId(bean.getId())
+      .select("valueSet,valueList,valueMap,plainValue").asDto(DtoJackson.class).findOne();
+
+    assertThat(dto.getPlainValue()).isInstanceOf(LongJacksonType.class);
+    assertThat(dto.getValueList()).hasSize(2);
+    assertThat(dto.getValueSet()).hasSize(2);
+    assertThat(dto.getValueMap()).hasSize(2);
 
   }
 


### PR DESCRIPTION
You can use `@DbJson` data types in DTO-objects now

The DTO object
```java
 public static class DtoJackson {
    @DbJson(length = 700)
    Set<BasicJacksonType<?>> valueSet = new LinkedHashSet<>();
    @DbJson(length = 500)
    BasicJacksonType<?> plainValue;
}
```
The query
```java
DtoJackson dto = DB.find(EBasicJsonJackson2.class).setId(bean.getId())
      .select("valueSet,plainValue").asDto(DtoJackson.class).findOne();
```

See https://github.com/ebean-orm/ebean/pull/3143