### PR TITLE
Test and Fix for #3806 - @OneToMany query that populates from the immutable cache gets NPE

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorCacheHelp.java
@@ -633,14 +633,17 @@ final class BeanDescriptorCacheHelp<T> {
    */
   EntityBean loadBeanDirect(Object id, boolean unmodifiable, CachedBeanData data, PersistenceContext context) {
     id = desc.convertId(id);
-    EntityBean bean = context == null ? null : (EntityBean) desc.contextGet(context, id);;
+    EntityBean bean = context == null ? null : (EntityBean) desc.contextGet(context, id);
     if (bean == null) {
       bean = desc.createEntityBean2(unmodifiable);
       desc.setId(id, bean);
+      if (context == null) {
+        // a context is required to resolve @ManyToOne references when converting
+        // the cached data to the bean - even for unmodifiable beans (which are
+        // not themselves registered in the persistence context)
+        context = new DefaultPersistenceContext();
+      }
       if (!unmodifiable) {
-        if (context == null) {
-          context = new DefaultPersistenceContext();
-        }
         desc.contextPut(context, id, bean);
         EntityBeanIntercept ebi = bean._ebean_getIntercept();
         ebi.setPersistenceContext(context);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -5,6 +5,7 @@ import io.ebean.Transaction;
 import io.ebean.ValuePair;
 import io.ebean.bean.EntityBean;
 import io.ebean.bean.EntityBeanIntercept;
+import io.ebean.bean.InterceptReadWrite;
 import io.ebean.bean.PersistenceContext;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.ScalarDataReader;
@@ -439,27 +440,29 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
       if (embedded) {
         setValue(bean, targetDescriptor.cacheEmbeddedBeanLoad((CachedBeanData) cacheData, context));
       } else {
+        // when the owning bean is unmodifiable the reference must also be unmodifiable
+        final boolean unmodifiable = !(bean._ebean_getIntercept() instanceof InterceptReadWrite);
         if (cacheData instanceof CachedBeanId) {
-          setValue(bean, refInheritBean((CachedBeanId) cacheData, context));
+          setValue(bean, refInheritBean((CachedBeanId) cacheData, context, unmodifiable));
         } else {
-          setValue(bean, refBean(targetDescriptor, cacheData, context));
+          setValue(bean, refBean(targetDescriptor, cacheData, context, unmodifiable));
         }
       }
     }
   }
 
-  private Object refInheritBean(CachedBeanId cacheId, PersistenceContext context) {
+  private Object refInheritBean(CachedBeanId cacheId, PersistenceContext context, boolean unmodifiable) {
     final InheritInfo rowInheritInfo = targetInheritInfo.readType(cacheId.getDiscValue());
-    return refBean(rowInheritInfo.desc(), cacheId.getId(), context);
+    return refBean(rowInheritInfo.desc(), cacheId.getId(), context, unmodifiable);
   }
 
-  private Object refBean(BeanDescriptor<?> desc, Object id, PersistenceContext context) {
+  private Object refBean(BeanDescriptor<?> desc, Object id, PersistenceContext context, boolean unmodifiable) {
     if (id instanceof String) {
       id = desc.idProperty().scalarType.parse((String) id);
     }
-    Object bean = desc.contextGet(context, id);
+    Object bean = context == null ? null : desc.contextGet(context, id);
     if (bean == null) {
-      bean = desc.createRef(id, context);
+      bean = desc.createReference(unmodifiable, false, id, context);
     }
     return bean;
   }

--- a/ebean-test/src/test/java/org/tests/model/basic/cache/UnmodifiableCacheManyToOneTest.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/cache/UnmodifiableCacheManyToOneTest.java
@@ -1,0 +1,53 @@
+package org.tests.model.basic.cache;
+
+import io.ebean.DB;
+import io.ebean.bean.EntityBean;
+import io.ebean.bean.InterceptReadOnly;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces the NPE when loading a bean-cached entity that has a @ManyToOne
+ * via an unmodifiable id lookup (as the ImmutableBeanCache query loader does).
+ */
+public class UnmodifiableCacheManyToOneTest extends BaseTestCase {
+
+  @Test
+  public void unmodifiable_idIn_findMap_withManyToOne_fromBeanCache() {
+    OCachedApp app = new OCachedApp("appNpe");
+    app.save();
+    OCachedAppDetail d0 = new OCachedAppDetail(app, "npe0");
+    OCachedAppDetail d1 = new OCachedAppDetail(app, "npe1");
+    d0.save();
+    d1.save();
+
+    List<Long> ids = List.of(d0.getId(), d1.getId());
+
+    clearAllL2Cache();
+    // populate the L2 bean cache
+    DB.find(OCachedAppDetail.class).setUseCache(true).where().idIn(ids).findList();
+
+    // mimic ImmutableBeanCaches.QueryLoader: unmodifiable id lookup -> bean cache hit
+    Map<Long, OCachedAppDetail> map = DB.find(OCachedAppDetail.class)
+      .setUnmodifiable(true)
+      .where().idIn(ids)
+      .findMap();
+
+    assertThat(map).hasSize(2);
+    OCachedAppDetail found = map.get(d0.getId());
+    assertThat(found).isNotNull();
+
+    OCachedApp appRef = found.getApp();
+    assertThat(appRef).isNotNull();
+    assertThat(appRef.getId()).isEqualTo(app.getId());
+
+    // the @ManyToOne reference must be unmodifiable so the bean graph can be frozen
+    assertThat(((EntityBean) appRef)._ebean_getIntercept()).isInstanceOf(InterceptReadOnly.class);
+    assertThat(((EntityBean) found)._ebean_getIntercept()).isInstanceOf(InterceptReadOnly.class);
+  }
+}


### PR DESCRIPTION
 ## Root cause

  A findList() triggers a secondary @OneToMany query that populates from the immutable cache. ImmutableBeanCaches.QueryLoader runs find(type).setUnmodifiable(true)...findMap(), which hits the L2 bean cache (cacheIdLookup → loadBeanDirect). Two coupled bugs in the unmodifiable path:

## 2 Bugs:
   1. Null pc (the NPE). In BeanDescriptorCacheHelp.loadBeanDirect, the if (context == null) context = new DefaultPersistenceContext() fallback was nested inside if (!unmodifiable). So an unmodifiable load passed a null context to CachedBeanDataToBean.load; converting a @ManyToOne (refBean → contextGet → pc.get) NPE'd — exactly Eddie's trace.
   2. Mutable reference can't freeze. Once a context was provided, refBean created the @ManyToOne ref via createRef → a mutable InterceptReadWrite bean. The subsequent unmodifiableFreeze then threw UnsupportedOperationException("never expected") (only InterceptReadOnly is freezable).

  ## Fix (2 files)

   - BeanDescriptorCacheHelp.loadBeanDirect — always ensure a non-null context before CachedBeanDataToBean.load (hoisted out of !unmodifiable).
   - BeanPropertyAssocOne.setCacheDataValue/refBean — when the owning bean is unmodifiable (derived via !(intercept instanceof InterceptReadWrite), the same idiom CachedBeanDataToBean already uses), create the ref with createReference(unmodifiable, false, id, pc) → a freezable InterceptReadOnly reference. Also guards contextGet against null. Modifiable path is unchanged.

## Notes
  The "fetch(path) without a FetchGroup" clue

  That's the trigger, not a misuse. A restricting FetchGroup can exclude the @ManyToOne, so no refBean runs and the bug stays hidden. The default/fetch("path") select includes the FK, so the cached-bean conversion creates the assoc-one reference and hits the bug. His usage was fine — this was an Ebean gap (no immutable-cached entity with a @ManyToOne was test-covered).