### PR TITLE
Fix: DuplicateKeyException when cascade-saving through a @ManyToOne to an unmodifiable bean (address #3813)

### DIFF
--- a/ebean-api/src/main/java/io/ebean/bean/InterceptReadOnly.java
+++ b/ebean-api/src/main/java/io/ebean/bean/InterceptReadOnly.java
@@ -175,7 +175,7 @@ public final class InterceptReadOnly extends InterceptBase {
 
   @Override
   public boolean isUpdate() {
-    return false;
+    return true;
   }
 
   @Override

--- a/ebean-test/src/test/java/org/tests/delete/TestDeleteByQuery.java
+++ b/ebean-test/src/test/java/org/tests/delete/TestDeleteByQuery.java
@@ -60,10 +60,10 @@ public class TestDeleteByQuery extends BaseTestCase {
       .delete();
 
     List<String> loggedSql = LoggedSql.stop();
-    assertThat(loggedSql).hasSize(6);
+    assertThat(loggedSql).hasSize(8);
     if (isH2()) {
       assertThat(loggedSql.get(0)).contains("select t0.id from article t0 where t0.name = ? limit 10");
-      assertThat(loggedSql.get(3)).contains("select t0.id from article t0 where t0.name = ? limit 20");
+      assertThat(loggedSql.get(4)).contains("select t0.id from article t0 where t0.name = ? limit 20");
     }
   }
 

--- a/ebean-test/src/test/java/org/tests/model/basic/Article.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/Article.java
@@ -5,6 +5,7 @@ import io.ebean.annotation.CacheBeanTuning;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +24,20 @@ public class Article extends BasicDomain {
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   List<Section> sections;
 
+  @ManyToOne(cascade = CascadeType.ALL)
+  ArticleAuthor articleAuthor;
+
   public Article(String name, String author) {
     this.name = name;
     this.author = author;
+  }
+
+  public ArticleAuthor getArticleAuthor() {
+    return articleAuthor;
+  }
+
+  public void setArticleAuthor(ArticleAuthor articleAuthor) {
+    this.articleAuthor = articleAuthor;
   }
 
   public String getName() {

--- a/ebean-test/src/test/java/org/tests/model/basic/ArticleAuthor.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/ArticleAuthor.java
@@ -1,0 +1,34 @@
+package org.tests.model.basic;
+
+import io.ebean.annotation.Cache;
+import io.ebean.annotation.CacheBeanTuning;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+
+import java.util.List;
+
+
+@Cache
+@CacheBeanTuning(maxSecsToLive = 45)
+@Entity
+public class ArticleAuthor extends BasicDomain {
+  private static final long serialVersionUID = -7181090513848918784L;
+
+  String name;
+
+  @OneToMany(mappedBy = "articleAuthor", cascade = CascadeType.ALL)
+  List<Article> articles;
+
+  public ArticleAuthor(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/query/TestQueryFindReadOnly.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryFindReadOnly.java
@@ -5,6 +5,7 @@ import io.ebean.CacheMode;
 import io.ebean.DB;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Article;
+import org.tests.model.basic.ArticleAuthor;
 import org.tests.model.basic.Section;
 
 import java.util.List;
@@ -49,4 +50,20 @@ public class TestQueryFindReadOnly extends BaseTestCase {
 
   }
 
+  @Test
+  public void test_readOnly_not_inserted() {
+    ArticleAuthor author = new ArticleAuthor("name1");
+    DB.save(author);
+
+    ArticleAuthor articleAuthor = DB.find(ArticleAuthor.class)
+      .setUnmodifiable(true)
+      .setId(author.getId()).findOne();
+
+    assertNotNull(articleAuthor);
+    assertTrue(DB.beanState(articleAuthor).isUnmodifiable());
+
+    Article article = new Article("art1", "name1");
+    article.setArticleAuthor(articleAuthor);
+    assertDoesNotThrow(() -> DB.save(article));
+  }
 }


### PR DESCRIPTION
Address #3813