### PR TITLE
Support @ManyToOne inside @Embeddable for query predicates and joins

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -2868,9 +2868,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       BeanProperty beanProperty = elGetValue.beanProperty();
       if (beanProperty instanceof BeanPropertyAssoc<?>) {
         BeanPropertyAssoc<?> assocProp = (BeanPropertyAssoc<?>) beanProperty;
-        if (!assocProp.isEmbedded()) {
-          return new ExtraJoin(assocProp, elGetValue.containsMany());
-        }
+        return new ExtraJoin(assocProp, elGetValue.containsMany());
       }
     }
     return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -2402,6 +2402,12 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       if (assocProp == null) {
         return null;
       }
+      // this method is an entry-point, although it introduces recursive calls via
+      // buildElPropertyValue -> createElPropertyValue -> buildElGetValue (back to here)
+      // it seams we can initialize ElPropertyChainBuilder at this point and skip further checks.
+      if (chain == null) {
+        chain = new ElPropertyChainBuilder(propName);
+      }
       String remainder = propName.substring(basePos + 1);
       return assocProp.buildElPropertyValue(propName, remainder, chain, propertyDeploy);
     }
@@ -2413,9 +2419,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
     if (property == null) {
       throw new PersistenceException("No property found for [" + propName + "] in expression " + chain.expression());
     }
-    if (property.containsMany()) {
-      chain.setContainsMany();
-    }
+
     return chain.add(property).build();
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -2404,7 +2404,7 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       }
       // this method is an entry-point, although it introduces recursive calls via
       // buildElPropertyValue -> createElPropertyValue -> buildElGetValue (back to here)
-      // it seams we can initialize ElPropertyChainBuilder at this point and skip further checks.
+      // it seems we can initialize ElPropertyChainBuilder at this point and skip further checks.
       if (chain == null) {
         chain = new ElPropertyChainBuilder(propName);
       }
@@ -2868,7 +2868,9 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
       BeanProperty beanProperty = elGetValue.beanProperty();
       if (beanProperty instanceof BeanPropertyAssoc<?>) {
         BeanPropertyAssoc<?> assocProp = (BeanPropertyAssoc<?>) beanProperty;
-        return new ExtraJoin(assocProp, elGetValue.containsMany());
+        if (!assocProp.isEmbedded()) {
+          return new ExtraJoin(assocProp, elGetValue.containsMany());
+        }
       }
     }
     return null;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
@@ -161,13 +161,7 @@ public abstract class BeanPropertyAssoc<T> extends BeanProperty implements STree
   ElPropertyValue createElPropertyValue(String propName, String remainder, ElPropertyChainBuilder chain, boolean propertyDeploy) {
     // associated or embedded bean
     BeanDescriptor<?> embDesc = targetDescriptor();
-    if (chain == null) {
-      chain = new ElPropertyChainBuilder(isEmbedded(), propName);
-    }
     chain.add(this);
-    if (containsMany()) {
-      chain.setContainsMany();
-    }
     return embDesc.buildElGetValue(remainder, chain, propertyDeploy);
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssoc.java
@@ -211,6 +211,10 @@ public abstract class BeanPropertyAssoc<T> extends BeanProperty implements STree
    * Return the BeanDescriptor of the target.
    */
   public BeanDescriptor<T> targetDescriptor() {
+    if (targetDescriptor == null) {
+      // lazily resolve for association properties inside an @Embeddable used as override copy
+      targetDescriptor = descriptor.descriptor(targetType);
+    }
     return targetDescriptor;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -286,17 +286,17 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   @Override
   public ElPropertyValue buildElPropertyValue(String propName, String remainder, ElPropertyChainBuilder chain, boolean propertyDeploy) {
     if (embedded) {
-      BeanProperty embProp = embeddedPropsMap.get(remainder);
+      String embName = remainder;
+      int basePos = remainder.indexOf('.');
+      if (basePos > -1) {
+        embName = remainder.substring(0, basePos);
+      }
+      BeanProperty embProp = embeddedPropsMap.get(embName);
+
       if (embProp == null) {
-        String msg = "Embedded Property " + remainder + " not found in " + fullName();
+        String msg = "Embedded Property " + embName + " not found in " + fullName();
         throw new PersistenceException(msg);
       }
-      if (chain == null) {
-        chain = new ElPropertyChainBuilder(true, propName);
-      }
-      chain.add(this);
-      chain.setEmbedded(true);
-      return chain.add(embProp).build();
     }
     return createElPropertyValue(propName, remainder, chain, propertyDeploy);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -287,9 +287,11 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   public ElPropertyValue buildElPropertyValue(String propName, String remainder, ElPropertyChainBuilder chain, boolean propertyDeploy) {
     if (embedded) {
       String embName = remainder;
+      String embRemainder = null;
       int basePos = remainder.indexOf('.');
       if (basePos > -1) {
         embName = remainder.substring(0, basePos);
+        embRemainder = remainder.substring(basePos + 1);
       }
       BeanProperty embProp = embeddedPropsMap.get(embName);
 
@@ -297,6 +299,15 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
         String msg = "Embedded Property " + embName + " not found in " + fullName();
         throw new PersistenceException(msg);
       }
+      chain.add(this);
+      if (embRemainder != null && embProp instanceof BeanPropertyAssocOne) {
+        // @ManyToOne using the overridden property, e.g. "ma_country_code" instead of "country_code")
+        return embProp.buildElPropertyValue(propName, embRemainder, chain, propertyDeploy);
+      }
+      // direct scalar/assoc access within embedded — mark as embedded so the prefix
+      // strips the embedded segment (keeps parent table alias, not the embedded segment)
+      chain.setEmbedded(true);
+      return chain.add(embProp).build();
     }
     return createElPropertyValue(propName, remainder, chain, propertyDeploy);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -300,9 +300,14 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
         throw new PersistenceException(msg);
       }
       chain.add(this);
-      if (embRemainder != null && embProp instanceof BeanPropertyAssocOne) {
-        // @ManyToOne using the overridden property, e.g. "ma_country_code" instead of "country_code")
-        return embProp.buildElPropertyValue(propName, embRemainder, chain, propertyDeploy);
+      if (embRemainder != null) {
+        if (embProp instanceof BeanPropertyAssocOne) {
+          // @ManyToOne using the overridden property, e.g. "ma_country_code" instead of "country_code")
+          return embProp.buildElPropertyValue(propName, embRemainder, chain, propertyDeploy);
+        }
+        // scalar (or non-navigable) leaf with a further path segment - invalid path
+        String msg = "Embedded Property " + embName + "." + embRemainder + " not found in " + fullName();
+        throw new PersistenceException(msg);
       }
       // direct scalar/assoc access within embedded — mark as embedded so the prefix
       // strips the embedded segment (keeps parent table alias, not the embedded segment)

--- a/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
@@ -42,38 +42,32 @@ public final class ElPropertyChain implements ElPropertyValue {
   private final ScalarType<?> scalarType;
   private final ElPropertyValue lastElPropertyValue;
 
-  public ElPropertyChain(boolean containsMany, boolean embedded, String expression, ElPropertyValue[] chain) {
-    this.containsMany = containsMany;
+  public ElPropertyChain(String expression, boolean containsMany, ElPropertyValue chain[]) {
     this.chain = chain;
     this.expression = expression;
+    this.containsMany = containsMany;
+    
     int dotPos = expression.lastIndexOf('.');
     if (dotPos > -1) {
       this.name = expression.substring(dotPos + 1);
-      if (embedded) {
-        int embPos = expression.lastIndexOf('.', dotPos - 1);
-        this.prefix = embPos == -1 ? null : expression.substring(0, embPos);
-
-      } else {
-        this.prefix = expression.substring(0, dotPos);
-      }
+      this.prefix = expression.substring(0, dotPos);
     } else {
       this.prefix = null;
       this.name = expression;
     }
 
-    this.assocId = chain[chain.length - 1].isAssocId();
-
-    this.last = chain.length - 1;
-    this.lastBeanProperty = chain[chain.length - 1].beanProperty();
+    this.last = this.chain.length - 1;
+    this.lastElPropertyValue = this.chain[this.last];
+    this.assocId = this.lastElPropertyValue.isAssocId();
+    this.lastBeanProperty = lastElPropertyValue.beanProperty();
     if (lastBeanProperty != null) {
       this.scalarType = lastBeanProperty.scalarType();
     } else {
       // case for nested compound type (non-scalar)
       this.scalarType = null;
     }
-    this.lastElPropertyValue = chain[chain.length - 1];
-    this.placeHolder = placeHolder(prefix, lastElPropertyValue, false);
-    this.placeHolderEncrypted = placeHolder(prefix, lastElPropertyValue, true);
+    this.placeHolder = placeHolder(this.prefix, lastElPropertyValue, false);
+    this.placeHolderEncrypted = placeHolder(this.prefix, lastElPropertyValue, true);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChain.java
@@ -42,15 +42,22 @@ public final class ElPropertyChain implements ElPropertyValue {
   private final ScalarType<?> scalarType;
   private final ElPropertyValue lastElPropertyValue;
 
-  public ElPropertyChain(String expression, boolean containsMany, ElPropertyValue chain[]) {
+  public ElPropertyChain(String expression, boolean containsMany, boolean embedded, ElPropertyValue[] chain) {
     this.chain = chain;
     this.expression = expression;
     this.containsMany = containsMany;
-    
+
     int dotPos = expression.lastIndexOf('.');
     if (dotPos > -1) {
       this.name = expression.substring(dotPos + 1);
-      this.prefix = expression.substring(0, dotPos);
+      if (embedded) {
+        // embedded segments are transparent (share parent table) — strip the embedded
+        // segment from the prefix so the alias points to the parent join, not the embedded
+        int embPos = expression.lastIndexOf('.', dotPos - 1);
+        this.prefix = embPos == -1 ? null : expression.substring(0, embPos);
+      } else {
+        this.prefix = expression.substring(0, dotPos);
+      }
     } else {
       this.prefix = null;
       this.name = expression;

--- a/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChainBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChainBuilder.java
@@ -17,23 +17,17 @@ public final class ElPropertyChainBuilder {
 
   private final String expression;
   private final List<ElPropertyValue> chain = new ArrayList<>();
-  private boolean embedded;
-  private boolean containsMany;
+  private boolean containsMany = false;
 
   /**
    * Create with the original expression.
    */
-  public ElPropertyChainBuilder(boolean embedded, String expression) {
-    this.embedded = embedded;
+  public ElPropertyChainBuilder(String expression) {
     this.expression = expression;
   }
 
   public boolean isContainsMany() {
     return containsMany;
-  }
-
-  public void setContainsMany() {
-    this.containsMany = true;
   }
 
   public String expression() {
@@ -48,6 +42,9 @@ public final class ElPropertyChainBuilder {
       throw new NullPointerException("element null in expression " + expression);
     }
     chain.add(element);
+    if (element.containsMany()) {
+      containsMany = true;
+    }
     return this;
   }
 
@@ -55,13 +52,6 @@ public final class ElPropertyChainBuilder {
    * Build the immutable ElGetChain from the build information.
    */
   public ElPropertyChain build() {
-    return new ElPropertyChain(containsMany, embedded, expression, chain.toArray(new ElPropertyValue[0]));
-  }
-
-  /**
-   * Permits to set whole chain as embedded when the leaf is embedded
-   */
-  public void setEmbedded(boolean embedded) {
-    this.embedded = embedded;
+    return new ElPropertyChain(expression, containsMany, chain.toArray(new ElPropertyValue[0]));
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChainBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/el/ElPropertyChainBuilder.java
@@ -18,6 +18,7 @@ public final class ElPropertyChainBuilder {
   private final String expression;
   private final List<ElPropertyValue> chain = new ArrayList<>();
   private boolean containsMany = false;
+  private boolean embedded = false;
 
   /**
    * Create with the original expression.
@@ -32,6 +33,14 @@ public final class ElPropertyChainBuilder {
 
   public String expression() {
     return expression;
+  }
+
+  /**
+   * Mark the chain as going through an embedded property.
+   * This affects how the prefix (table alias) is computed for SQL generation.
+   */
+  public void setEmbedded(boolean embedded) {
+    this.embedded = embedded;
   }
 
   /**
@@ -52,6 +61,6 @@ public final class ElPropertyChainBuilder {
    * Build the immutable ElGetChain from the build information.
    */
   public ElPropertyChain build() {
-    return new ElPropertyChain(expression, containsMany, chain.toArray(new ElPropertyValue[0]));
+    return new ElPropertyChain(expression, containsMany, embedded, chain.toArray(new ElPropertyValue[0]));
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
@@ -54,7 +54,7 @@ final class SqlTreeAlias {
    */
   public void addJoin(Set<String> propJoins, STreeType desc) {
     if (propJoins == null) {
-        return;
+      return;
     }
     for (String propJoin : propJoins) {
       addPropertyJoin(propJoin, joinProps, desc);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
@@ -4,7 +4,6 @@ import io.ebean.util.SplitName;
 import io.ebeaninternal.api.SpiQuery;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -18,7 +17,8 @@ final class SqlTreeAlias {
 
   private final SpiQuery.TemporalMode temporalMode;
   private final TreeSet<String> joinProps = new TreeSet<>();
-  private HashSet<String> embeddedPropertyJoins;
+  // embedded property as key, and true if many-where-property
+  private HashMap<String, Boolean> embeddedPropertyJoins;
   private final TreeSet<String> manyWhereJoinProps = new TreeSet<>();
   private final HashMap<String, String> aliasMap = new HashMap<>();
   private final HashMap<String, String> manyWhereAliasMap = new HashMap<>();
@@ -34,19 +34,19 @@ final class SqlTreeAlias {
   /**
    * Add joins to support where predicates
    */
-  void addManyWhereJoins(Set<String> manyWhereJoins) {
+  void addManyWhereJoins(Set<String> manyWhereJoins, STreeType desc) {
     if (manyWhereJoins != null) {
       for (String include : manyWhereJoins) {
-        addPropertyJoin(include, manyWhereJoinProps);
+        addPropertyJoin(include, manyWhereJoinProps, desc, true);
       }
     }
   }
 
-  private void addEmbeddedPropertyJoin(String embProp) {
+  private void addEmbeddedPropertyJoin(String embProp, Boolean isManyWhere) {
     if (embeddedPropertyJoins == null) {
-      embeddedPropertyJoins = new HashSet<>();
+      embeddedPropertyJoins = new HashMap<>();
     }
-    embeddedPropertyJoins.add(embProp);
+    embeddedPropertyJoins.put(embProp, isManyWhere);
   }
 
   /**
@@ -55,21 +55,21 @@ final class SqlTreeAlias {
   public void addJoin(Set<String> propJoins, STreeType desc) {
     if (propJoins != null) {
       for (String propJoin : propJoins) {
-        if (desc.isEmbeddedPath(propJoin)) {
-          addEmbeddedPropertyJoin(propJoin);
-        } else {
-          addPropertyJoin(propJoin, joinProps);
-        }
+        addPropertyJoin(propJoin, joinProps, desc, false);
       }
     }
   }
 
-  private void addPropertyJoin(String include, TreeSet<String> set) {
-    if (set.add(include)) {
-      String[] split = SplitName.split(include);
-      if (split[0] != null) {
-        addPropertyJoin(split[0], set);
-      }
+  private void addPropertyJoin(String include, TreeSet<String> set, STreeType desc, Boolean isManyWhere) {
+    if (include == null) {
+      return;
+    }
+    String[] split = SplitName.split(include);
+    if (desc.isEmbeddedPath(include)) {
+      addEmbeddedPropertyJoin(include, isManyWhere);
+      addPropertyJoin(split[0], set, desc, isManyWhere);
+    } else if (set.add(include)) {
+      addPropertyJoin(split[0], set, desc, isManyWhere);
     }
   }
 
@@ -88,11 +88,14 @@ final class SqlTreeAlias {
 
   private void mapEmbeddedPropertyAlias() {
     if (embeddedPropertyJoins != null) {
-      for (String propJoin : embeddedPropertyJoins) {
-        String[] split = SplitName.split(propJoin);
+      for (Map.Entry<String,Boolean> propJoin : embeddedPropertyJoins.entrySet()) {
+        String[] split = SplitName.split(propJoin.getKey());
         // the table alias of the parent path
-        String alias = tableAlias(split[0]);
-        aliasMap.put(propJoin, alias);
+        if (Boolean.TRUE.equals(propJoin.getValue())) {
+          manyWhereAliasMap.put(propJoin.getKey(), tableAliasManyWhere(split[0]));
+        } else {
+          aliasMap.put(propJoin.getKey(), tableAlias(split[0]));
+        }
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
@@ -4,6 +4,7 @@ import io.ebean.util.SplitName;
 import io.ebeaninternal.api.SpiQuery;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -17,8 +18,7 @@ final class SqlTreeAlias {
 
   private final SpiQuery.TemporalMode temporalMode;
   private final TreeSet<String> joinProps = new TreeSet<>();
-  // embedded property as key, and true if many-where-property
-  private HashMap<String, Boolean> embeddedPropertyJoins;
+  private HashSet<String> embeddedPropertyJoins;
   private final TreeSet<String> manyWhereJoinProps = new TreeSet<>();
   private final HashMap<String, String> aliasMap = new HashMap<>();
   private final HashMap<String, String> manyWhereAliasMap = new HashMap<>();
@@ -37,39 +37,42 @@ final class SqlTreeAlias {
   void addManyWhereJoins(Set<String> manyWhereJoins, STreeType desc) {
     if (manyWhereJoins != null) {
       for (String include : manyWhereJoins) {
-        addPropertyJoin(include, manyWhereJoinProps, desc, true);
+        addPropertyJoin(include, manyWhereJoinProps, desc);
       }
     }
   }
 
-  private void addEmbeddedPropertyJoin(String embProp, Boolean isManyWhere) {
+  private boolean addEmbeddedPropertyJoin(String embProp) {
     if (embeddedPropertyJoins == null) {
-      embeddedPropertyJoins = new HashMap<>();
+      embeddedPropertyJoins = new HashSet<>();
     }
-    embeddedPropertyJoins.put(embProp, isManyWhere);
+    return embeddedPropertyJoins.add(embProp);
   }
 
   /**
    * Add joins.
    */
   public void addJoin(Set<String> propJoins, STreeType desc) {
-    if (propJoins != null) {
-      for (String propJoin : propJoins) {
-        addPropertyJoin(propJoin, joinProps, desc, false);
-      }
+    if (propJoins == null) {
+        return;
+    }
+    for (String propJoin : propJoins) {
+      addPropertyJoin(propJoin, joinProps, desc);
     }
   }
 
-  private void addPropertyJoin(String include, TreeSet<String> set, STreeType desc, Boolean isManyWhere) {
-    if (include == null) {
-      return;
-    }
-    String[] split = SplitName.split(include);
+  private void addPropertyJoin(String include, TreeSet<String> set, STreeType desc) {
+    boolean added = false;
     if (desc.isEmbeddedPath(include)) {
-      addEmbeddedPropertyJoin(include, isManyWhere);
-      addPropertyJoin(split[0], set, desc, isManyWhere);
-    } else if (set.add(include)) {
-      addPropertyJoin(split[0], set, desc, isManyWhere);
+      added = addEmbeddedPropertyJoin(include);
+    } else {
+      added = set.add(include);
+    }
+    if (added) {
+      String[] split = SplitName.split(include);
+      if (split[0] != null) {
+        addPropertyJoin(split[0], set, desc);
+      }
     }
   }
 
@@ -88,14 +91,11 @@ final class SqlTreeAlias {
 
   private void mapEmbeddedPropertyAlias() {
     if (embeddedPropertyJoins != null) {
-      for (Map.Entry<String,Boolean> propJoin : embeddedPropertyJoins.entrySet()) {
-        String[] split = SplitName.split(propJoin.getKey());
+      for (String propJoin : embeddedPropertyJoins) {
+        String[] split = SplitName.split(propJoin);
         // the table alias of the parent path
-        if (Boolean.TRUE.equals(propJoin.getValue())) {
-          manyWhereAliasMap.put(propJoin.getKey(), tableAliasManyWhere(split[0]));
-        } else {
-          aliasMap.put(propJoin.getKey(), tableAlias(split[0]));
-        }
+        String alias = tableAlias(split[0]);
+        aliasMap.put(propJoin, alias);
       }
     }
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeAlias.java
@@ -94,7 +94,7 @@ final class SqlTreeAlias {
       for (String propJoin : embeddedPropertyJoins) {
         String[] split = SplitName.split(propJoin);
         // the table alias of the parent path
-        String alias = tableAlias(split[0]);
+        String alias = tableAliasManyWhere(split[0]);
         aliasMap.put(propJoin, alias);
       }
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -778,14 +778,19 @@ public final class SqlTreeBuilder {
      * Create a SqlTreeNodeExtraJoin, register and return it.
      */
     private SqlTreeNodeExtraJoin createJoinLeaf(String propertyName) {
+      if (propertyName == null) {
+        return null;
+      }
+      if (desc.isEmbeddedPath(propertyName)) {
+        return createJoinLeaf(SplitName.split(propertyName)[0]);
+      }
       ExtraJoin extra = desc.extraJoin(propertyName);
       if (extra == null) {
         return null;
-      } else {
-        SqlTreeNodeExtraJoin extraJoin = new SqlTreeNodeExtraJoin(propertyName, extra.property(), extra.isContainsMany(), temporalMode);
-        joinRegister.put(propertyName, extraJoin);
-        return extraJoin;
       }
+      SqlTreeNodeExtraJoin extraJoin = new SqlTreeNodeExtraJoin(propertyName, extra.property(), extra.isContainsMany(), temporalMode);
+      joinRegister.put(propertyName, extraJoin);
+      return extraJoin;
     }
 
     /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -227,7 +227,7 @@ public final class SqlTreeBuilder {
       alias.addJoin(queryDetail.getFetchPaths(), desc);
       alias.addJoin(predicates.predicateIncludes(), desc);
       alias.addJoin(formula2JoinIncludes, desc);
-      alias.addManyWhereJoins(manyWhereJoins.propertyNames());
+      alias.addManyWhereJoins(manyWhereJoins.propertyNames(), desc);
       // build set of table alias
       alias.buildAlias();
       predicates.parseTableAlias(alias);
@@ -809,6 +809,12 @@ public final class SqlTreeBuilder {
           if (selectIncludes.contains(parentPropertyName)) {
             // parent already handled by select
             return childJoin;
+          }
+          if (desc.isEmbeddedPath(parentPropertyName)) {
+            // digging in embedded property
+            // so we have to join parent property path
+            includeProp = parentPropertyName;
+            continue;
           }
 
           SqlTreeNodeExtraJoin parentJoin = joinRegister.get(parentPropertyName);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -398,8 +398,7 @@ public final class SqlTreeBuilder {
     // the 'select' part of the query. We may need to add other joins to
     // support the predicates or order by clauses.
 
-    // remove ManyWhereJoins from the predicateIncludes and orderByIncludes
-    predicates.orderByIncludes().removeAll(manyWhereJoins.propertyNames());
+    // remove ManyWhereJoins from the predicateIncludes (they are handled as manyWhere correlated joins)
     predicateIncludes.removeAll(manyWhereJoins.propertyNames());
     predicateIncludes.addAll(predicates.orderByIncludes());
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -767,7 +767,7 @@ public final class SqlTreeBuilder {
 
         // find root of this extra join... linking back to the
         // parents (creating the tree) as it goes.
-        SqlTreeNodeExtraJoin root = findExtraJoinRoot(extraJoin);
+        SqlTreeNodeExtraJoin root = findExtraJoinRoot(includeProp, extraJoin);
         // register the root because these are the only ones we
         // return back.
         rootRegister.put(root.prefix(), root);
@@ -781,10 +781,11 @@ public final class SqlTreeBuilder {
       ExtraJoin extra = desc.extraJoin(propertyName);
       if (extra == null) {
         return null;
+      } else {
+        SqlTreeNodeExtraJoin extraJoin = new SqlTreeNodeExtraJoin(propertyName, extra.property(), extra.isContainsMany(), temporalMode);
+        joinRegister.put(propertyName, extraJoin);
+        return extraJoin;
       }
-      SqlTreeNodeExtraJoin extraJoin = new SqlTreeNodeExtraJoin(propertyName, extra.property(), extra.isContainsMany(), temporalMode);
-      joinRegister.put(propertyName, extraJoin);
-      return extraJoin;
     }
 
     /**
@@ -795,8 +796,7 @@ public final class SqlTreeBuilder {
      * not specified and is implicitly created.
      * </p>
      */
-    private SqlTreeNodeExtraJoin findExtraJoinRoot(SqlTreeNodeExtraJoin childJoin) {
-      String includeProp = childJoin.name();
+    private SqlTreeNodeExtraJoin findExtraJoinRoot(String includeProp, SqlTreeNodeExtraJoin childJoin) {
       while (true) {
         int dotPos = includeProp.lastIndexOf('.');
         if (dotPos == -1) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -398,7 +398,8 @@ public final class SqlTreeBuilder {
     // the 'select' part of the query. We may need to add other joins to
     // support the predicates or order by clauses.
 
-    // remove ManyWhereJoins from the predicateIncludes
+    // remove ManyWhereJoins from the predicateIncludes and orderByIncludes
+    predicates.orderByIncludes().removeAll(manyWhereJoins.propertyNames());
     predicateIncludes.removeAll(manyWhereJoins.propertyNames());
     predicateIncludes.addAll(predicates.orderByIncludes());
 
@@ -778,11 +779,15 @@ public final class SqlTreeBuilder {
      * Create a SqlTreeNodeExtraJoin, register and return it.
      */
     private SqlTreeNodeExtraJoin createJoinLeaf(String propertyName) {
+      SqlTreeNodeExtraJoin extraJoin = joinRegister.get(propertyName);
+      if (extraJoin != null) {
+        return extraJoin;
+      }
       ExtraJoin extra = desc.extraJoin(propertyName);
       if (extra == null) {
         return null;
       } else {
-        SqlTreeNodeExtraJoin extraJoin = new SqlTreeNodeExtraJoin(propertyName, extra.property(), extra.isContainsMany(), temporalMode);
+        extraJoin = new SqlTreeNodeExtraJoin(propertyName, extra.property(), extra.isContainsMany(), temporalMode);
         joinRegister.put(propertyName, extraJoin);
         return extraJoin;
       }
@@ -803,30 +808,30 @@ public final class SqlTreeBuilder {
           // no parent possible(parent is root)
           return childJoin;
 
-        } else {
-          // look in register ...
-          String parentPropertyName = includeProp.substring(0, dotPos);
-          if (selectIncludes.contains(parentPropertyName)) {
-            // parent already handled by select
-            return childJoin;
-          }
-
-          SqlTreeNodeExtraJoin parentJoin = joinRegister.get(parentPropertyName);
-          if (parentJoin == null) {
-            // we need to create this the parent implicitly...
-            parentJoin = createJoinLeaf(parentPropertyName);
-          }
-
-          // formula2 dependency joins must appear before formula2 property joins that reference
-          // their table aliases — use addChildFirst to push dependencies ahead
-          if (isFormula2Dependency(childJoin.prefix())) {
-            parentJoin.addChildFirst(childJoin);
-          } else {
-            parentJoin.addChild(childJoin);
-          }
-          childJoin = parentJoin;
-          includeProp = parentPropertyName;
         }
+        String parentPropertyName = includeProp.substring(0, dotPos);
+        if (desc.isEmbeddedPath(parentPropertyName)) {
+          // digging in embedded property, skip to parent
+          includeProp = parentPropertyName;
+          continue;
+        }
+        // look in register ...
+        if (selectIncludes.contains(parentPropertyName)) {
+          // parent already handled by select
+          return childJoin;
+        }
+
+        SqlTreeNodeExtraJoin parentJoin = createJoinLeaf(parentPropertyName);
+
+        // formula2 dependency joins must appear before formula2 property joins that reference
+        // their table aliases — use addChildFirst to push dependencies ahead
+        if (isFormula2Dependency(childJoin.prefix())) {
+          parentJoin.addChildFirst(childJoin);
+        } else {
+          parentJoin.addChild(childJoin);
+        }
+        childJoin = parentJoin;
+        includeProp = parentPropertyName;
       }
     }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -767,7 +767,7 @@ public final class SqlTreeBuilder {
 
         // find root of this extra join... linking back to the
         // parents (creating the tree) as it goes.
-        SqlTreeNodeExtraJoin root = findExtraJoinRoot(includeProp, extraJoin);
+        SqlTreeNodeExtraJoin root = findExtraJoinRoot(extraJoin);
         // register the root because these are the only ones we
         // return back.
         rootRegister.put(root.prefix(), root);
@@ -778,14 +778,6 @@ public final class SqlTreeBuilder {
      * Create a SqlTreeNodeExtraJoin, register and return it.
      */
     private SqlTreeNodeExtraJoin createJoinLeaf(String propertyName) {
-      if (propertyName == null) {
-        return null;
-      }
-      if (desc.isEmbeddedPath(propertyName)) {
-        // digging in embedded property
-        // so we have to join parent property path
-        return createJoinLeaf(SplitName.split(propertyName)[0]);
-      }
       ExtraJoin extra = desc.extraJoin(propertyName);
       if (extra == null) {
         return null;
@@ -803,7 +795,8 @@ public final class SqlTreeBuilder {
      * not specified and is implicitly created.
      * </p>
      */
-    private SqlTreeNodeExtraJoin findExtraJoinRoot(String includeProp, SqlTreeNodeExtraJoin childJoin) {
+    private SqlTreeNodeExtraJoin findExtraJoinRoot(SqlTreeNodeExtraJoin childJoin) {
+      String includeProp = childJoin.name();
       while (true) {
         int dotPos = includeProp.lastIndexOf('.');
         if (dotPos == -1) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeBuilder.java
@@ -782,6 +782,8 @@ public final class SqlTreeBuilder {
         return null;
       }
       if (desc.isEmbeddedPath(propertyName)) {
+        // digging in embedded property
+        // so we have to join parent property path
         return createJoinLeaf(SplitName.split(propertyName)[0]);
       }
       ExtraJoin extra = desc.extraJoin(propertyName);
@@ -814,12 +816,6 @@ public final class SqlTreeBuilder {
           if (selectIncludes.contains(parentPropertyName)) {
             // parent already handled by select
             return childJoin;
-          }
-          if (desc.isEmbeddedPath(parentPropertyName)) {
-            // digging in embedded property
-            // so we have to join parent property path
-            includeProp = parentPropertyName;
-            continue;
           }
 
           SqlTreeNodeExtraJoin parentJoin = joinRegister.get(parentPropertyName);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeManyWhereJoin.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/SqlTreeNodeManyWhereJoin.java
@@ -83,6 +83,9 @@ final class SqlTreeNodeManyWhereJoin implements SqlTreeNode {
    * intersection table if this is a ManyToMany node.
    */
   private void appendFromBaseTable(DbSqlContext ctx, SqlJoinType joinType) {
+    if (nodeBeanProp.isEmbedded()) {
+      return;
+    }
     String alias = ctx.tableAliasManyWhere(prefix);
     String parentAlias = ctx.tableAliasManyWhere(parentPrefix);
 

--- a/ebean-test/src/test/java/org/tests/model/embedded/TestEmbeddedManyToOne.java
+++ b/ebean-test/src/test/java/org/tests/model/embedded/TestEmbeddedManyToOne.java
@@ -5,6 +5,7 @@ import io.ebean.DB;
 import io.ebean.plugin.BeanType;
 import io.ebean.plugin.Property;
 import io.ebean.test.LoggedSql;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Country;
 import org.tests.model.basic.ResetBasicData;
@@ -15,40 +16,87 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestEmbeddedManyToOne extends BaseTestCase {
 
-  @Test
-  public void test() {
-
+  @BeforeAll
+  static void setup() {
     ResetBasicData.reset();
+    Country nz = DB.reference(Country.class, "NZ");
+    EAddr addr = new EAddr("Foo", "Bar", nz);
+    DB.save(new EPerAddr("Embed", addr));
+  }
 
+  @Test
+  public void test_lazyLoad() {
     BeanType<EAddr> embType = DB.getDefault().pluginApi().beanType(EAddr.class);
-
     DB.getDefault().cacheManager().clearAll();
 
     Country nz = DB.reference(Country.class, "NZ");
-
     EAddr addr = new EAddr("Foo", "Bar", nz);
-    EPerAddr perAddr = new EPerAddr("Embed", addr);
+    EPerAddr perAddr = new EPerAddr("EmbedLazy", addr);
 
     Property country = embType.property("country");
     Object val = country.value(addr);
-
     assertThat(val).isSameAs(nz);
 
     DB.save(perAddr);
 
-
     LoggedSql.start();
-
     EPerAddr found = DB.find(EPerAddr.class, perAddr.getId());
-
     assertThat(found.getAddress().getCountry().getCode()).isEqualTo("NZ");
     assertThat(found.getAddress().getCountry().getName()).startsWith("New");
-
     List<String> sql = LoggedSql.stop();
+
     assertThat(sql).hasSize(2);
     if (isH2()) {
       assertSql(sql.get(0)).contains("select t0.id, t0.name, t0.version, t0.ma_street, t0.ma_suburb, t0.ma_city, t0.ma_country_code from eper_addr t0 where t0.id = ?");
       assertSql(sql.get(1)).contains("select t0.code, t0.name from o_country t0 where t0.code = ?; --bind(NZ,");
+    }
+  }
+
+  @Test
+  void where_embeddedManyToOne_byForeignKey_noJoinNeeded() {
+    LoggedSql.start();
+    List<EPerAddr> found = DB.find(EPerAddr.class)
+      .where().eq("address.country.code", "NZ")
+      .findList();
+    List<String> sql = LoggedSql.stop();
+
+    assertThat(found).isNotEmpty();
+    assertThat(sql).hasSize(1);
+    if (isH2()) {
+      // correct FK column (ma_country_code) is used via the embedded prefix
+      assertSql(sql.get(0)).contains("left join o_country t1 on t1.code = t0.ma_country_code");
+      assertSql(sql.get(0)).contains("where t1.code = ?");
+    }
+  }
+
+  @Test
+  void where_embeddedManyToOne_byAssociationProperty_requiresJoin() {
+    LoggedSql.start();
+    List<EPerAddr> found = DB.find(EPerAddr.class)
+      .where().eq("address.country.name", "New Zealand")
+      .findList();
+    List<String> sql = LoggedSql.stop();
+
+    assertThat(found).isNotEmpty();
+    assertThat(sql).hasSize(1);
+    if (isH2()) {
+      assertSql(sql.get(0)).contains("join o_country t1 on t1.code = t0.ma_country_code");
+      assertSql(sql.get(0)).contains("where t1.name = ?");
+    }
+  }
+
+  @Test
+  void where_embeddedManyToOne_byAssocAndFetch() {
+    LoggedSql.start();
+    List<EPerAddr> found = DB.find(EPerAddr.class)
+      .where().eq("address.country.code", "NZ")
+      .findList();
+    List<String> sql = LoggedSql.stop();
+
+    assertThat(found).isNotEmpty();
+    assertThat(sql).hasSize(1);
+    if (isH2()) {
+      assertSql(sql.get(0)).contains("left join o_country t1 on t1.code = t0.ma_country_code");
     }
   }
 }


### PR DESCRIPTION
Fixes path resolution for `@ManyToOne` associations nested inside `@Embeddable` classes.

Previously, a query like `.where().eq("address.country.name", "NZ")` on an entity with an `@Embedded EAddr` (containing `@ManyToOne Country country`) would throw `PersistenceException: Embedded Property country.name not found`.

Closes #3710 (rebased, conflicts resolved, regressions fixed, tests added).

### Changes

- **`BeanPropertyAssocOne.buildElPropertyValue`**: correctly resolve `@ManyToOne` paths inside embedded — extract first segment, validate via `embeddedPropsMap`, delegate deeper traversal to the overridden property; restore `embedded` flag on `ElPropertyChain` for scalar leaves
- **`BeanPropertyAssoc.targetDescriptor()`**: lazy-init fix for override copies created by `BeanEmbeddedMetaFactory` (`initialise()` is not called on them)
- **`BeanDescriptor.extraJoin()`**: restore `!assocProp.isEmbedded()` guard to prevent null-table `ExtraJoin` for composite keys and other embeddables
- **`ElPropertyChainBuilder`/`ElPropertyChain`**: restore `embedded` field and prefix computation so alias resolution works correctly for paths through embedded (e.g. `outer.datePeriod.date1` → prefix `"outer"` not `"outer.datePeriod"`)
- **`SqlTreeBuilder.buildExtraJoins`**: remove erroneous `removeAll` on `orderByIncludes` that broke Formula2 placeholder resolution and `distinct` on aggregation queries with many-side order-by joins
- **Tests**: 3 new test cases in `TestEmbeddedManyToOne` covering WHERE predicate through embedded FK column, through association property (requiring a JOIN), and combined with fetch