### PR TITLE
Fix ON_CONFLICT_NOTHING cascade causing FK violation (#3712)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
@@ -127,6 +127,11 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
    */
   private List<SaveMany> saveMany;
   private InsertOptions insertOptions;
+  /**
+   * Set true when an ON CONFLICT NOTHING insert is skipped (0 rows affected).
+   * Cascade to children must be suppressed to avoid FK violations.
+   */
+  private boolean insertConflictSkipped;
 
   public PersistRequestBean(SpiEbeanServer server, T bean, Object parentBean, BeanManager<T> mgr, SpiTransaction t,
                             PersistExecute persistExecute, PersistRequest.Type type, int flags) {
@@ -810,6 +815,9 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
         throw new OptimisticLockException("Data has changed. updated row count " + rowCount, null, bean);
       } else if (rowCount == 0 && type == Type.UPDATE) {
         throw new EntityNotFoundException("No rows updated");
+      } else if (rowCount == 0 && type == Type.INSERT && isConflictNothingInsert()) {
+        insertConflictSkipped = true;
+        return;
       }
     }
     switch (type) {
@@ -822,6 +830,14 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
         break;
       default: // do nothing
     }
+  }
+
+  private boolean isConflictNothingInsert() {
+    return insertOptions != null && insertOptions.key().charAt(0) == 'N';
+  }
+
+  public boolean isInsertConflictSkipped() {
+    return insertConflictSkipped;
   }
 
   /**
@@ -1433,7 +1449,12 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
   }
 
   public void setInsertOptions(InsertOptions insertOptions) {
-    this.insertOptions  = insertOptions;
+    this.insertOptions = insertOptions;
+    if (insertOptions != null && insertOptions.key().charAt(0) == 'N' && beanDescriptor.hasCascadeChildren()) {
+      // force immediate (non-batch) execution of this insert so we know whether it
+      // was actually inserted before attempting cascade saves on children.
+      skipBatchForTopLevel = true;
+    }
   }
 
   public InsertOptions insertOptions() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptor.java
@@ -3338,6 +3338,15 @@ public class BeanDescriptor<T> implements BeanType<T>, STreeType, SpiBeanType {
   }
 
   /**
+   * Return true if this bean has cascade-save children (OneToMany or exported OneToOne)
+   * that hold a FK back to this bean. Used to decide whether an ON CONFLICT NOTHING
+   * insert must be executed immediately so the row-count is known before cascading.
+   */
+  public boolean hasCascadeChildren() {
+    return propertiesManySave.length > 0 || propertiesOneExportedSave.length > 0;
+  }
+
+  /**
    * Assoc Many's with delete cascade.
    */
   public BeanPropertyAssocMany<?>[] propertiesManyDelete() {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/DefaultPersister.java
@@ -481,7 +481,7 @@ public final class DefaultPersister implements Persister {
         saveAssocOne(request);
       }
       request.executeOrQueue();
-      if (request.isPersistCascade()) {
+      if (request.isPersistCascade() && !request.isInsertConflictSkipped()) {
         // save any associated List held beans
         saveAssocMany(request);
       }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dml/DmlHandler.java
@@ -97,7 +97,9 @@ public abstract class DmlHandler implements PersistHandler, BindableRequest {
   void checkRowCount(int rowCount) throws OptimisticLockException {
     try {
       persistRequest.checkRowCount(rowCount);
-      persistRequest.postExecute();
+      if (!persistRequest.isInsertConflictSkipped()) {
+        persistRequest.postExecute();
+      }
     } catch (OptimisticLockException e) {
       // add the SQL and bind values to error message
       final String m = e.getMessage() + " sql[" + sql + "] bind[" + bindLog + "]";


### PR DESCRIPTION
When inserting a bean with InsertOptions.ON_CONFLICT_NOTHING that has cascade children (OneToMany / exported OneToOne), a unique constraint conflict caused the parent insert to be silently skipped (0 rows), but Ebean still cascaded and attempted to insert the children — resulting in a FK violation.

Changes

• BeanDescriptor.hasCascadeChildren() — returns true when the bean has save-cascade children (OneToMany or exported OneToOne) that hold a FK back to this bean. • PersistRequestBean.setInsertOptions() — when ON_CONFLICT_NOTHING is used and the bean has cascade children, sets skipBatchForTopLevel = true so the parent INSERT executes immediately (non-batched). This ensures the row count is known before any cascade runs. Beans without cascade children are unaffected and continue to batch normally. • PersistRequestBean.checkRowCount() — when the parent INSERT returns 0 rows under ON_CONFLICT_NOTHING, sets insertConflictSkipped = true and returns early, leaving the bean unmarked as loaded/persisted. • DmlHandler.checkRowCount() — skips postExecute() when the insert was conflict-skipped. • DefaultPersister.insert() — guards saveAssocMany() with !request.isInsertConflictSkipped(), preventing cascade saves when the parent was not actually inserted.