### PR TITLE
Fix #3817 incorrect type deserialization for @DbJson field in generic…

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -16,7 +16,6 @@ import io.ebeaninternal.api.DbOffline;
 import io.ebeaninternal.api.GeoTypeProvider;
 import io.ebeaninternal.server.core.ServiceUtil;
 import io.ebeaninternal.server.core.bootup.BootupClasses;
-import io.ebeaninternal.server.deploy.meta.DeployBeanProperty;
 import io.ebeaninternal.server.deploy.meta.DeployProperty;
 
 import jakarta.persistence.AttributeConverter;
@@ -412,11 +411,7 @@ public final class DefaultTypeManager implements TypeManager {
     if (MutationDetection.DEFAULT == prop.mutationDetection()) {
       prop.setMutationDetection(jsonManager.mutationDetection());
     }
-    Class<?> type = prop.ownerType();
-    if (prop instanceof DeployBeanProperty) {
-      type = ((DeployBeanProperty) prop).getField().getDeclaringClass();
-    }
-    var req = new ScalarJsonRequest(jsonManager, dbType, docType, type, prop.mutationDetection(), prop.name());
+    var req = new ScalarJsonRequest(jsonManager, dbType, docType, prop.ownerType(), prop.mutationDetection(), prop.name());
     return jsonMapper.createType(req);
   }
 

--- a/ebean-test/src/test/java/org/tests/json/TestDbJson_GenericSupertype.java
+++ b/ebean-test/src/test/java/org/tests/json/TestDbJson_GenericSupertype.java
@@ -1,0 +1,33 @@
+package org.tests.json;
+
+import io.ebean.DB;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+import org.tests.model.json.EJsonGenericBean;
+import org.tests.model.json.StringJacksonType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test that @DbJson fields in a generic superclass are deserialized to the
+ * correct concrete type (not LinkedHashMap) for the concrete subclass.
+ * <p>
+ * Issue: https://github.com/ebean-orm/ebean/issues/3817
+ */
+public class TestDbJson_GenericSupertype extends BaseTestCase {
+
+  @Test
+  public void insertAndFind_genericSupertypeField() {
+    var bean = new EJsonGenericBean();
+    bean.setName("generic-test");
+    bean.setJsonData(new StringJacksonType("hello"));
+
+    DB.save(bean);
+
+    var found = DB.find(EJsonGenericBean.class, bean.getId());
+
+    assertThat(found).isNotNull();
+    assertThat(found.getJsonData()).isInstanceOf(StringJacksonType.class);
+    assertThat(found.getJsonData().getValue()).isEqualTo("hello");
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/json/EJsonGenericBase.java
+++ b/ebean-test/src/test/java/org/tests/model/json/EJsonGenericBase.java
@@ -1,0 +1,46 @@
+package org.tests.model.json;
+
+import io.ebean.annotation.DbJson;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Version;
+
+@MappedSuperclass
+public class EJsonGenericBase<T> {
+
+  @Id
+  Long id;
+
+  String name;
+
+  @DbJson
+  T jsonData;
+
+  @Version
+  Long version;
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public T getJsonData() {
+    return jsonData;
+  }
+
+  public void setJsonData(T jsonData) {
+    this.jsonData = jsonData;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/json/EJsonGenericBean.java
+++ b/ebean-test/src/test/java/org/tests/model/json/EJsonGenericBean.java
@@ -1,0 +1,8 @@
+package org.tests.model.json;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class EJsonGenericBean extends EJsonGenericBase<StringJacksonType> {
+
+}


### PR DESCRIPTION
… superclass

In createJsonObjectMapperType(), remove the instanceof DeployBeanProperty branch that overrode ownerType() with getField().getDeclaringClass().

For a generic superclass B<T>, getDeclaringClass() returns B with T unresolved, so Jackson treated the field as Object and deserialized to LinkedHashMap. DeployBeanProperty.ownerType() already returns desc.getBeanType() (the concrete subclass), which gives Jackson the full supertype context needed to resolve T correctly.

## Introduced in version 18.1.0

This bug was introduced by It was introduced in commit  dd1acf58  ("DbJson Support for Dto-Queries") - https://github.com/ebean-orm/ebean/pull/3794 in version 18.1.0:
