### PR TITLE
#3676 Add DbMigration.setAddForeignKeySkipCheck(true)

### DIFF
--- a/ebean-ddl-generator/src/main/java/io/ebean/dbmigration/DbMigration.java
+++ b/ebean-ddl-generator/src/main/java/io/ebean/dbmigration/DbMigration.java
@@ -158,6 +158,14 @@ public interface DbMigration {
   void setHeader(String header);
 
   /**
+   * Set to true to add {@code -- @formatter:off} / {@code -- @formatter:on} guards to generated DDL scripts.
+   * <p>
+   * This prevents IDE formatters (e.g. IntelliJ "Reformat Code on commit") from modifying the SQL.
+   * Can also be enabled via the system property {@code ddl.migration.formatterGuards=true}.
+   */
+  void setAddFormatterGuards(boolean formatterGuards);
+
+  /**
    * Set the prefix for the version. Set this to "V" for use with Flyway.
    */
   void setApplyPrefix(String applyPrefix);

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/DefaultDbMigration.java
@@ -86,6 +86,7 @@ public class DefaultDbMigration implements DbMigration {
   private int lockTimeoutSeconds;
   protected boolean includeBuiltInPartitioning = true;
   protected boolean includeIndex;
+  private boolean formatterGuards;
 
   /**
    * Create for offline migration generation.
@@ -184,6 +185,11 @@ public class DefaultDbMigration implements DbMigration {
   @Override
   public void setHeader(String header) {
     this.header = header;
+  }
+
+  @Override
+  public void setAddFormatterGuards(boolean formatterGuards) {
+    this.formatterGuards = formatterGuards;
   }
 
   /**
@@ -653,7 +659,15 @@ public class DefaultDbMigration implements DbMigration {
   }
 
   private PlatformDdlWriter createDdlWriter(DatabasePlatform platform) {
-    return new PlatformDdlWriter(platform, databaseBuilder, lockTimeoutSeconds);
+    return new PlatformDdlWriter(platform, databaseBuilder, lockTimeoutSeconds, formatterGuards());
+  }
+
+  private boolean formatterGuards() {
+    String val = System.getProperty("ddl.migration.formatterGuards");
+    if (val != null) {
+      return Boolean.parseBoolean(val);
+    }
+    return formatterGuards;
   }
 
   /**

--- a/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/PlatformDdlWriter.java
+++ b/ebean-ddl-generator/src/main/java/io/ebeaninternal/dbmigration/model/PlatformDdlWriter.java
@@ -29,11 +29,13 @@ public class PlatformDdlWriter {
   private final DatabaseBuilder.Settings config;
   private final PlatformDdl platformDdl;
   private final int lockTimeoutSeconds;
+  private final boolean formatterGuards;
 
-  public PlatformDdlWriter(DatabasePlatform platform, DatabaseBuilder.Settings config, int lockTimeoutSeconds) {
+  public PlatformDdlWriter(DatabasePlatform platform, DatabaseBuilder.Settings config, int lockTimeoutSeconds, boolean formatterGuards) {
     this.platformDdl = PlatformDdlBuilder.create(platform);
     this.config = config;
     this.lockTimeoutSeconds = lockTimeoutSeconds;
+    this.formatterGuards = formatterGuards;
   }
 
   /**
@@ -87,11 +89,17 @@ public class PlatformDdlWriter {
    * Write the 'Apply' DDL buffers to the writer.
    */
   protected void writeApplyDdl(Writer writer, DdlWrite ddl) throws IOException {
+    if (formatterGuards) {
+      writer.append("-- @formatter:off\n");
+    }
     String header = config.getDdlHeader();
     if (header != null && !header.isEmpty()) {
       writer.append(header).append('\n');
     }
     ddl.writeApply(writer);
+    if (formatterGuards) {
+      writer.append("-- @formatter:on\n");
+    }
   }
 
   /**


### PR DESCRIPTION
Provides an option to include IDE -- @formatter:off style comments into the db migration generated sql.