### PR TITLE
Fix #3821 fetchQuery secondary tables not included in query cache dep…

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -128,6 +128,13 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   }
 
   /**
+   * Return the secondary queries (fetchQuery and lazy joins) extracted from the query detail.
+   */
+  public SpiQuerySecondary secondaryQueries() {
+    return secondaryQueries;
+  }
+
+  /**
    * For use with QueryIterator and secondary queries this returns the minimum
    * batch size that should be loaded before executing the secondary queries.
    * <p>

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
@@ -10,17 +10,23 @@ import io.ebean.metric.TimedMetric;
 import io.ebeaninternal.api.*;
 import io.ebeaninternal.server.core.OrmQueryRequest;
 import io.ebeaninternal.server.core.timezone.DataTimeZone;
+import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.query.CQueryPlanStats.Snapshot;
 import io.ebeaninternal.server.bind.DataBind;
 import io.ebeaninternal.server.bind.DataBindCapture;
+import io.ebeaninternal.server.querydefn.OrmQueryDetail;
+import io.ebeaninternal.server.querydefn.OrmQueryProperties;
 import io.ebeaninternal.server.type.RsetDataReader;
 import io.ebeaninternal.server.util.Md5;
 import io.ebeaninternal.server.util.Str;
 
+import jakarta.persistence.PersistenceException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static java.lang.System.Logger.Level.ERROR;
@@ -96,7 +102,7 @@ public class CQueryPlan implements SpiQueryPlan {
     this.logWhereSql = logWhereSql;
     this.encryptedProps = sqlTree.encryptedProps();
     this.stats = new CQueryPlanStats(this);
-    this.dependentTables = sqlTree.dependentTables();
+    this.dependentTables = buildDependentTables(request.descriptor(), request.query().detail(), sqlTree.dependentTables());
     this.bindCapture = initBindCapture(query);
     this.hash = Md5.hash(sql, name, location);
   }
@@ -121,13 +127,39 @@ public class CQueryPlan implements SpiQueryPlan {
     this.logWhereSql = logWhereSql;
     this.encryptedProps = sqlTree.encryptedProps();
     this.stats = new CQueryPlanStats(this);
-    this.dependentTables = sqlTree.dependentTables();
+    this.dependentTables = buildDependentTables(request.descriptor(), request.query().detail(), sqlTree.dependentTables());
     this.bindCapture = initBindCaptureRaw(sql, query);
     this.hash = Md5.hash(sql, name, location);
   }
 
   private String deriveName(String label, SpiQuery<?> query, String simpleName) {
     return deriveName(label, query.loadMode() != null, query.label() != null, query.type().label(), simpleName);
+  }
+
+  /**
+   * Merge the SQL-tree dependent tables with any additional tables from fetchQuery paths.
+   * fetchQuery paths fire secondary SQL queries whose results are included in the query
+   * cache entry, so the cache must be invalidated when those tables are modified.
+   */
+  private static Set<String> buildDependentTables(BeanDescriptor<?> desc, OrmQueryDetail detail, Set<String> sqlTables) {
+    Set<String> extra = null;
+    for (Map.Entry<String, OrmQueryProperties> entry : detail.entries()) {
+      if (entry.getValue().isQueryFetch()) {
+        try {
+          String table = desc.descriptor(entry.getKey()).baseTable();
+          if (extra == null) extra = new LinkedHashSet<>();
+          extra.add(table);
+        } catch (PersistenceException ignore) {
+          // invalid path — ignore
+        }
+      }
+    }
+    if (extra == null || extra.isEmpty()) {
+      return sqlTables;
+    }
+    Set<String> merged = new LinkedHashSet<>(sqlTables);
+    merged.addAll(extra);
+    return merged;
   }
 
   /**

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryPlan.java
@@ -14,7 +14,6 @@ import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.query.CQueryPlanStats.Snapshot;
 import io.ebeaninternal.server.bind.DataBind;
 import io.ebeaninternal.server.bind.DataBindCapture;
-import io.ebeaninternal.server.querydefn.OrmQueryDetail;
 import io.ebeaninternal.server.querydefn.OrmQueryProperties;
 import io.ebeaninternal.server.type.RsetDataReader;
 import io.ebeaninternal.server.util.Md5;
@@ -26,7 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedHashSet;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 
 import static java.lang.System.Logger.Level.ERROR;
@@ -102,7 +101,7 @@ public class CQueryPlan implements SpiQueryPlan {
     this.logWhereSql = logWhereSql;
     this.encryptedProps = sqlTree.encryptedProps();
     this.stats = new CQueryPlanStats(this);
-    this.dependentTables = buildDependentTables(request.descriptor(), request.query().detail(), sqlTree.dependentTables());
+    this.dependentTables = buildDependentTables(request.descriptor(), request.secondaryQueries(), sqlTree.dependentTables());
     this.bindCapture = initBindCapture(query);
     this.hash = Md5.hash(sql, name, location);
   }
@@ -127,7 +126,7 @@ public class CQueryPlan implements SpiQueryPlan {
     this.logWhereSql = logWhereSql;
     this.encryptedProps = sqlTree.encryptedProps();
     this.stats = new CQueryPlanStats(this);
-    this.dependentTables = buildDependentTables(request.descriptor(), request.query().detail(), sqlTree.dependentTables());
+    this.dependentTables = buildDependentTables(request.descriptor(), request.secondaryQueries(), sqlTree.dependentTables());
     this.bindCapture = initBindCaptureRaw(sql, query);
     this.hash = Md5.hash(sql, name, location);
   }
@@ -141,25 +140,27 @@ public class CQueryPlan implements SpiQueryPlan {
    * fetchQuery paths fire secondary SQL queries whose results are included in the query
    * cache entry, so the cache must be invalidated when those tables are modified.
    */
-  private static Set<String> buildDependentTables(BeanDescriptor<?> desc, OrmQueryDetail detail, Set<String> sqlTables) {
-    Set<String> extra = null;
-    for (Map.Entry<String, OrmQueryProperties> entry : detail.entries()) {
-      if (entry.getValue().isQueryFetch()) {
-        try {
-          String table = desc.descriptor(entry.getKey()).baseTable();
-          if (extra == null) extra = new LinkedHashSet<>();
-          extra.add(table);
-        } catch (PersistenceException ignore) {
-          // invalid path — ignore
-        }
-      }
-    }
-    if (extra == null || extra.isEmpty()) {
+  private static Set<String> buildDependentTables(BeanDescriptor<?> desc, SpiQuerySecondary secondary, Set<String> sqlTables) {
+    if (secondary == null) {
       return sqlTables;
     }
-    Set<String> merged = new LinkedHashSet<>(sqlTables);
-    merged.addAll(extra);
-    return merged;
+    List<OrmQueryProperties> queryJoins = secondary.queryJoins();
+    if (queryJoins == null || queryJoins.isEmpty()) {
+      return sqlTables;
+    }
+    Set<String> merged = null;
+    for (OrmQueryProperties join : queryJoins) {
+      try {
+        String table = desc.descriptor(join.getPath()).baseTable();
+        if (merged == null) {
+          merged = new LinkedHashSet<>(sqlTables);
+        }
+        merged.add(table);
+      } catch (PersistenceException ignore) {
+        // invalid path — ignore
+      }
+    }
+    return merged != null ? merged : sqlTables;
   }
 
   /**

--- a/ebean-test/src/test/java/org/tests/cache/TestQueryCacheTableDependency.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestQueryCacheTableDependency.java
@@ -16,6 +16,7 @@ import org.tests.model.basic.cache.ECacheChild;
 import org.tests.model.basic.cache.ECacheRoot;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -272,6 +273,119 @@ public class TestQueryCacheTableDependency extends BaseTestCase {
     assertThat(third).isEmpty();
 
     DB.delete(cust);
+  }
+
+  /**
+   * Fix #3821 — fetchQuery("contacts") must include the "contact" table in the query cache
+   * dependent tables so that an update to a contact invalidates the Customer query cache.
+   */
+  @Test
+  void fetchQuery_oneToMany_invalidatesQueryCacheOnSecondaryTableUpdate() throws InterruptedException {
+    Customer customer = new Customer();
+    customer.setName("qcache-fq-many-cust");
+    DB.save(customer);
+
+    Contact contact = new Contact();
+    contact.setFirstName("qcache-fq-many-contact");
+    contact.setCustomer(customer);
+    contact.setPhone("555-0000");
+    DB.save(contact);
+
+    DB.cacheManager().queryCache(Customer.class).clear();
+    Thread.sleep(10);
+
+    LoggedSql.start();
+    List<Customer> first = DB.find(Customer.class)
+      .setUseQueryCache(CacheMode.ON)
+      .fetchQuery("contacts")
+      .where().eq("name", "qcache-fq-many-cust")
+      .findList();
+    assertThat(LoggedSql.stop()).as("first call executes main SQL + secondary contacts query").hasSize(2);
+    assertThat(first).hasSize(1);
+
+    LoggedSql.start();
+    List<Customer> second = DB.find(Customer.class)
+      .setUseQueryCache(CacheMode.ON)
+      .fetchQuery("contacts")
+      .where().eq("name", "qcache-fq-many-cust")
+      .findList();
+    assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
+    assertThat(second).isSameAs(first);
+
+    // update the contact — modifies the 'contact' table, must invalidate Customer query cache
+    contact.setPhone("555-1234");
+    DB.save(contact);
+
+    LoggedSql.start();
+    List<Customer> third = DB.find(Customer.class)
+      .setUseQueryCache(CacheMode.ON)
+      .fetchQuery("contacts")
+      .where().eq("name", "qcache-fq-many-cust")
+      .findList();
+    assertThat(LoggedSql.stop()).as("cache invalidated after contact table update").hasSize(2);
+    assertThat(third).hasSize(1);
+    assertThat(third.get(0).getContacts()).hasSize(1);
+    assertThat(third.get(0).getContacts().get(0).getPhone()).isEqualTo("555-1234");
+
+    DB.delete(contact);
+    DB.delete(customer);
+  }
+
+  /**
+   * Fix #3821 — fetchQuery("root") must include the "ecache_root" table in the ECacheChild query
+   * cache dependent tables so that an update to the root invalidates the child query cache.
+   */
+  @Test
+  void fetchQuery_manyToOne_invalidatesQueryCacheOnSecondaryTableUpdate() throws InterruptedException {
+    ECacheRoot root = new ECacheRoot();
+    root.setName("qcache-fq-one-root");
+    DB.save(root);
+
+    ECacheChild child = new ECacheChild();
+    child.setName("qcache-fq-one-child");
+    child.setRoot(root);
+    DB.save(child);
+
+    DB.cacheManager().queryCache(ECacheChild.class).clear();
+    Thread.sleep(10);
+
+    LoggedSql.start();
+    List<ECacheChild> first = DB.find(ECacheChild.class)
+      .setUseQueryCache(CacheMode.ON)
+      .fetchQuery("root")
+      .where().eq("name", "qcache-fq-one-child")
+      .findList();
+    assertThat(LoggedSql.stop()).as("first call executes main SQL (secondary root query not fired on unmodifiable query)").hasSize(1);
+    assertThat(first).hasSize(1);
+
+    LoggedSql.start();
+    List<ECacheChild> second = DB.find(ECacheChild.class)
+      .setUseQueryCache(CacheMode.ON)
+      .fetchQuery("root")
+      .where().eq("name", "qcache-fq-one-child")
+      .findList();
+    assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
+    assertThat(second).isSameAs(first);
+
+    // update the root — modifies 'ecache_root' table, must invalidate ECacheChild query cache
+    root.setName("qcache-fq-one-root-updated");
+    DB.save(root);
+
+    LoggedSql.start();
+    List<ECacheChild> third = DB.find(ECacheChild.class)
+      .setUseQueryCache(CacheMode.ON)
+      .fetchQuery("root")
+      .where().eq("name", "qcache-fq-one-child")
+      .findList();
+    assertThat(LoggedSql.stop()).as("cache invalidated after ecache_root table update").hasSize(1);
+    assertThat(third).hasSize(1);
+    // root is an unloaded reference in the result (secondary query does not fire for unmodifiable
+    // AssocOne beans), so verify the updated name via the root ID from the result
+    UUID rootId = third.get(0).getRoot().getId();
+    assertThat(DB.find(ECacheRoot.class, rootId).getName()).isEqualTo("qcache-fq-one-root-updated");
+
+    DB.delete(child);
+    DB.delete(root);
   }
 
   private List<String> namesByBillingCity(String city) {

--- a/ebean-test/src/test/java/org/tests/cache/TestQueryCacheTableDependency.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestQueryCacheTableDependency.java
@@ -291,44 +291,46 @@ public class TestQueryCacheTableDependency extends BaseTestCase {
     contact.setPhone("555-0000");
     DB.save(contact);
 
-    DB.cacheManager().queryCache(Customer.class).clear();
-    Thread.sleep(10);
+    try {
+      DB.cacheManager().queryCache(Customer.class).clear();
+      Thread.sleep(10);
 
-    LoggedSql.start();
-    List<Customer> first = DB.find(Customer.class)
-      .setUseQueryCache(CacheMode.ON)
-      .fetchQuery("contacts")
-      .where().eq("name", "qcache-fq-many-cust")
-      .findList();
-    assertThat(LoggedSql.stop()).as("first call executes main SQL + secondary contacts query").hasSize(2);
-    assertThat(first).hasSize(1);
+      LoggedSql.start();
+      List<Customer> first = DB.find(Customer.class)
+        .setUseQueryCache(CacheMode.ON)
+        .fetchQuery("contacts")
+        .where().eq("name", "qcache-fq-many-cust")
+        .findList();
+      assertThat(LoggedSql.stop()).as("first call executes main SQL + secondary contacts query").hasSize(2);
+      assertThat(first).hasSize(1);
 
-    LoggedSql.start();
-    List<Customer> second = DB.find(Customer.class)
-      .setUseQueryCache(CacheMode.ON)
-      .fetchQuery("contacts")
-      .where().eq("name", "qcache-fq-many-cust")
-      .findList();
-    assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
-    assertThat(second).isSameAs(first);
+      LoggedSql.start();
+      List<Customer> second = DB.find(Customer.class)
+        .setUseQueryCache(CacheMode.ON)
+        .fetchQuery("contacts")
+        .where().eq("name", "qcache-fq-many-cust")
+        .findList();
+      assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
+      assertThat(second).isSameAs(first);
 
-    // update the contact — modifies the 'contact' table, must invalidate Customer query cache
-    contact.setPhone("555-1234");
-    DB.save(contact);
+      // update the contact — modifies the 'contact' table, must invalidate Customer query cache
+      contact.setPhone("555-1234");
+      DB.save(contact);
 
-    LoggedSql.start();
-    List<Customer> third = DB.find(Customer.class)
-      .setUseQueryCache(CacheMode.ON)
-      .fetchQuery("contacts")
-      .where().eq("name", "qcache-fq-many-cust")
-      .findList();
-    assertThat(LoggedSql.stop()).as("cache invalidated after contact table update").hasSize(2);
-    assertThat(third).hasSize(1);
-    assertThat(third.get(0).getContacts()).hasSize(1);
-    assertThat(third.get(0).getContacts().get(0).getPhone()).isEqualTo("555-1234");
-
-    DB.delete(contact);
-    DB.delete(customer);
+      LoggedSql.start();
+      List<Customer> third = DB.find(Customer.class)
+        .setUseQueryCache(CacheMode.ON)
+        .fetchQuery("contacts")
+        .where().eq("name", "qcache-fq-many-cust")
+        .findList();
+      assertThat(LoggedSql.stop()).as("cache invalidated after contact table update").hasSize(2);
+      assertThat(third).hasSize(1);
+      assertThat(third.get(0).getContacts()).hasSize(1);
+      assertThat(third.get(0).getContacts().get(0).getPhone()).isEqualTo("555-1234");
+    } finally {
+      DB.delete(contact);
+      DB.delete(customer);
+    }
   }
 
   /**
@@ -346,46 +348,48 @@ public class TestQueryCacheTableDependency extends BaseTestCase {
     child.setRoot(root);
     DB.save(child);
 
-    DB.cacheManager().queryCache(ECacheChild.class).clear();
-    Thread.sleep(10);
+    try {
+      DB.cacheManager().queryCache(ECacheChild.class).clear();
+      Thread.sleep(10);
 
-    LoggedSql.start();
-    List<ECacheChild> first = DB.find(ECacheChild.class)
-      .setUseQueryCache(CacheMode.ON)
-      .fetchQuery("root")
-      .where().eq("name", "qcache-fq-one-child")
-      .findList();
-    assertThat(LoggedSql.stop()).as("first call executes main SQL (secondary root query not fired on unmodifiable query)").hasSize(1);
-    assertThat(first).hasSize(1);
+      LoggedSql.start();
+      List<ECacheChild> first = DB.find(ECacheChild.class)
+        .setUseQueryCache(CacheMode.ON)
+        .fetchQuery("root")
+        .where().eq("name", "qcache-fq-one-child")
+        .findList();
+      assertThat(LoggedSql.stop()).as("first call executes main SQL (secondary root query not fired on unmodifiable query)").hasSize(1);
+      assertThat(first).hasSize(1);
 
-    LoggedSql.start();
-    List<ECacheChild> second = DB.find(ECacheChild.class)
-      .setUseQueryCache(CacheMode.ON)
-      .fetchQuery("root")
-      .where().eq("name", "qcache-fq-one-child")
-      .findList();
-    assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
-    assertThat(second).isSameAs(first);
+      LoggedSql.start();
+      List<ECacheChild> second = DB.find(ECacheChild.class)
+        .setUseQueryCache(CacheMode.ON)
+        .fetchQuery("root")
+        .where().eq("name", "qcache-fq-one-child")
+        .findList();
+      assertThat(LoggedSql.stop()).as("second call is a query cache hit").isEmpty();
+      assertThat(second).isSameAs(first);
 
-    // update the root — modifies 'ecache_root' table, must invalidate ECacheChild query cache
-    root.setName("qcache-fq-one-root-updated");
-    DB.save(root);
+      // update the root — modifies 'ecache_root' table, must invalidate ECacheChild query cache
+      root.setName("qcache-fq-one-root-updated");
+      DB.save(root);
 
-    LoggedSql.start();
-    List<ECacheChild> third = DB.find(ECacheChild.class)
-      .setUseQueryCache(CacheMode.ON)
-      .fetchQuery("root")
-      .where().eq("name", "qcache-fq-one-child")
-      .findList();
-    assertThat(LoggedSql.stop()).as("cache invalidated after ecache_root table update").hasSize(1);
-    assertThat(third).hasSize(1);
-    // root is an unloaded reference in the result (secondary query does not fire for unmodifiable
-    // AssocOne beans), so verify the updated name via the root ID from the result
-    UUID rootId = third.get(0).getRoot().getId();
-    assertThat(DB.find(ECacheRoot.class, rootId).getName()).isEqualTo("qcache-fq-one-root-updated");
-
-    DB.delete(child);
-    DB.delete(root);
+      LoggedSql.start();
+      List<ECacheChild> third = DB.find(ECacheChild.class)
+        .setUseQueryCache(CacheMode.ON)
+        .fetchQuery("root")
+        .where().eq("name", "qcache-fq-one-child")
+        .findList();
+      assertThat(LoggedSql.stop()).as("cache invalidated after ecache_root table update").hasSize(1);
+      assertThat(third).hasSize(1);
+      // root is an unloaded reference in the result (secondary query does not fire for unmodifiable
+      // AssocOne beans), so verify the updated name via the root ID from the result
+      UUID rootId = third.get(0).getRoot().getId();
+      assertThat(DB.find(ECacheRoot.class, rootId).getName()).isEqualTo("qcache-fq-one-root-updated");
+    } finally {
+      DB.delete(child);
+      DB.delete(root);
+    }
   }
 
   private List<String> namesByBillingCity(String city) {


### PR DESCRIPTION
…endent tables

When a query uses fetchQuery("path"), the secondary table(s) must be registered as dependent tables in the query cache entry so that updates to those tables properly invalidate the cache.

## Fix:
In CQueryPlan, after building the SQL-tree dependent tables, walk the query's OrmQueryDetail for any fetchQuery paths and resolve each path through the root BeanDescriptor to its target entity's baseTable(). These tables are merged into dependentTables at plan construction time (once, then cached in the plan).

This means the fix applies uniformly whether paths were specified via fetchQuery("path") calls or via query.select(fetchGroup) — both populate the same OrmQueryDetail.

### Tests added to TestQueryCacheTableDependency:

• fetchQuery_oneToMany_invalidatesQueryCacheOnSecondaryTableUpdate — updating a contact invalidates a Customer query cache that includes fetchQuery("contacts"); asserts the refreshed result contains the updated phone number

• fetchQuery_manyToOne_invalidatesQueryCacheOnSecondaryTableUpdate — updating a root record invalidates an ECacheChild query cache that includes fetchQuery("root")