### PR TITLE
Implement query.exists() via select exists(...)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/DefaultServer.java
@@ -1197,15 +1197,14 @@ public final class DefaultServer implements SpiServer, SpiEbeanServer {
   @Override
   public <T> boolean exists(SpiQuery<T> ormQuery) {
     SpiQuery<T> ormQueryCopy = ormQuery.copy();
-    ormQueryCopy.setMaxRows(1);
     SpiOrmQueryRequest<?> request = createQueryRequest(Type.EXISTS, ormQueryCopy);
-    List<Object> ids = request.getFromQueryCache();
-    if (ids != null) {
-      return !ids.isEmpty();
+    Object cached = request.getFromQueryCache();
+    if (cached != null) {
+      return (Boolean) cached;
     }
     try {
       request.initTransIfRequired();
-      return !request.findIds().isEmpty();
+      return request.findExists();
     } finally {
       request.endTransIfRequired();
     }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryEngine.java
@@ -50,6 +50,11 @@ public interface OrmQueryEngine {
   <T> int findCount(OrmQueryRequest<T> request);
 
   /**
+   * Execute the exists query using SELECT EXISTS(...).
+   */
+  <T> boolean findExists(OrmQueryRequest<T> request);
+
+  /**
    * Execute the find id's query.
    */
   <A> List<A> findIds(OrmQueryRequest<?> request);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/OrmQueryRequest.java
@@ -356,6 +356,11 @@ public final class OrmQueryRequest<T> extends BeanRequest implements SpiOrmQuery
   }
 
   @Override
+  public boolean findExists() {
+    return queryEngine.findExists(this);
+  }
+
+  @Override
   public <A> List<A> findIds() {
     return queryEngine.findIds(this);
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/SpiOrmQueryRequest.java
@@ -76,6 +76,11 @@ public interface SpiOrmQueryRequest<T> extends BeanQueryRequest<T>, DocQueryRequ
   int findCount();
 
   /**
+   * Execute the find exists query using select exists(...).
+   */
+  boolean findExists();
+
+  /**
    * Execute the find ids query.
    */
   <A> List<A> findIds();

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryBuilder.java
@@ -336,6 +336,43 @@ final class CQueryBuilder {
     return sql;
   }
 
+  private String wrapSelectExists(String sql) {
+    return "select exists(" + sql + ")";
+  }
+
+  /**
+   * Build the exists query using select exists(...) for efficient boolean result.
+   */
+  <T> CQueryExists buildExistsQuery(OrmQueryRequest<T> request) {
+    SpiQuery<T> query = request.query();
+    query.setOrderBy(null);
+    query.setFirstRow(0);
+    query.setMaxRows(0);
+    if (request.descriptor().hasId()) {
+      query.setSelectId();
+    }
+
+    CQueryPredicates predicates = new CQueryPredicates(binder, request);
+    CQueryPlan queryPlan = request.queryPlan();
+    if (queryPlan != null) {
+      predicates.prepare(false);
+      return new CQueryExists(queryPlan, request, predicates);
+    }
+
+    predicates.prepare(true);
+    SqlTree sqlTree = createSqlTree(request, predicates, false);
+    if (SpiQuery.TemporalMode.CURRENT == query.temporalMode()) {
+      sqlTree.addSoftDeletePredicate(query);
+    }
+
+    SqlLimitResponse s = buildSql("select 1", request, predicates, sqlTree);
+    String sql = wrapSelectExists(s.getSql());
+
+    queryPlan = new CQueryPlan(request, sql, sqlTree.plan(), predicates.logWhereSql());
+    request.putQueryPlan(queryPlan);
+    return new CQueryExists(queryPlan, request, predicates);
+  }
+
   /**
    * Return the SQL Select statement as a String. Converts logical property
    * names to physical deployment column names.

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryEngine.java
@@ -171,6 +171,29 @@ public final class CQueryEngine {
   }
 
   /**
+   * Build and execute the exists query using select exists(...).
+   */
+  public <T> boolean findExists(OrmQueryRequest<T> request) {
+    CQueryExists rcQuery = queryBuilder.buildExistsQuery(request);
+    request.setCancelableQuery(rcQuery);
+    try {
+      boolean exists = rcQuery.findExists();
+      if (request.logSql()) {
+        logGeneratedSql(request, rcQuery.generatedSql(), rcQuery.bindLog(), rcQuery.micros());
+      }
+      if (request.logSummary()) {
+        request.transaction().logSummary(rcQuery.summary());
+      }
+      if (request.isQueryCachePut()) {
+        request.putToQueryCache(exists);
+      }
+      return exists;
+    } catch (SQLException e) {
+      throw translate(request, rcQuery.bindLog(), rcQuery.generatedSql(), e);
+    }
+  }
+
+  /**
    * Read many beans using an iterator (except you need to close() the iterator
    * when you have finished).
    */

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryExists.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/CQueryExists.java
@@ -1,0 +1,131 @@
+package io.ebeaninternal.server.query;
+
+import io.ebean.CancelableQuery;
+import io.ebean.util.JdbcClose;
+import io.ebeaninternal.api.SpiProfileTransactionEvent;
+import io.ebeaninternal.api.SpiQuery;
+import io.ebeaninternal.api.SpiTransaction;
+import io.ebeaninternal.server.core.OrmQueryRequest;
+import io.ebeaninternal.server.deploy.BeanDescriptor;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Executes a select exists(...) query returning a boolean result.
+ */
+final class CQueryExists implements SpiProfileTransactionEvent, CancelableQuery {
+
+  private final CQueryPlan queryPlan;
+  private final OrmQueryRequest<?> request;
+  private final BeanDescriptor<?> desc;
+  private final SpiQuery<?> query;
+  private final CQueryPredicates predicates;
+  private final String sql;
+  private ResultSet rset;
+  private PreparedStatement pstmt;
+  private String bindLog;
+  private long executionTimeMicros;
+  private boolean result;
+  private long profileOffset;
+  private final ReentrantLock lock = new ReentrantLock();
+
+  CQueryExists(CQueryPlan queryPlan, OrmQueryRequest<?> request, CQueryPredicates predicates) {
+    this.queryPlan = queryPlan;
+    this.request = request;
+    this.query = request.query();
+    this.sql = queryPlan.sql();
+    this.desc = request.descriptor();
+    this.predicates = predicates;
+    query.setGeneratedSql(sql);
+  }
+
+  public String summary() {
+    return "FindExists exeMicros[" + executionTimeMicros
+      + "] result[" + result
+      + "] type[" + desc.fullName()
+      + "] predicates[" + predicates.logWhereSql()
+      + "] bind[" + bindLog + ']';
+  }
+
+  public String bindLog() {
+    return bindLog;
+  }
+
+  public String generatedSql() {
+    return sql;
+  }
+
+  long micros() {
+    return executionTimeMicros;
+  }
+
+  /**
+   * Execute the query returning the exists boolean result.
+   */
+  public boolean findExists() throws SQLException {
+    long startNano = System.nanoTime();
+    try {
+      SpiTransaction t = transaction();
+      profileOffset = t.profileOffset();
+      Connection conn = t.internalConnection();
+      lock.lock();
+      try {
+        query.checkCancelled();
+        pstmt = conn.prepareStatement(sql);
+        if (query.timeout() > 0) {
+          pstmt.setQueryTimeout(query.timeout());
+        }
+        bindLog = predicates.bind(pstmt, conn);
+      } finally {
+        lock.unlock();
+      }
+      rset = pstmt.executeQuery();
+      query.checkCancelled();
+      if (!rset.next()) {
+        throw new jakarta.persistence.PersistenceException("Expecting 1 row from exists query but got none?");
+      }
+      result = rset.getBoolean(1);
+      executionTimeMicros = (System.nanoTime() - startNano) / 1000L;
+      request.slowQueryCheck(executionTimeMicros, result ? 1 : 0);
+      if (queryPlan.executionTime(executionTimeMicros)) {
+        queryPlan.captureBindForQueryPlan(predicates, executionTimeMicros);
+      }
+      t.profileEvent(this);
+      return result;
+    } finally {
+      close();
+    }
+  }
+
+  private SpiTransaction transaction() {
+    return request.transaction();
+  }
+
+  private void close() {
+    JdbcClose.close(rset);
+    JdbcClose.close(pstmt);
+    rset = null;
+    pstmt = null;
+  }
+
+  @Override
+  public void profile() {
+    transaction()
+      .profileStream()
+      .addQueryEvent(query.profileEventId(), profileOffset, desc.name(), result ? 1 : 0, query.profileId(), queryPlan.hash(), query.getGeneratedSql());
+  }
+
+  @Override
+  public void cancel() {
+    lock.lock();
+    try {
+      JdbcClose.cancel(pstmt);
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultOrmQueryEngine.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/query/DefaultOrmQueryEngine.java
@@ -89,6 +89,12 @@ public final class DefaultOrmQueryEngine implements OrmQueryEngine {
   }
 
   @Override
+  public <T> boolean findExists(OrmQueryRequest<T> request) {
+    flushJdbcBatchOnQuery(request);
+    return queryEngine.findExists(request);
+  }
+
+  @Override
   public <A> List<A> findIds(OrmQueryRequest<?> request) {
     flushJdbcBatchOnQuery(request);
     return queryEngine.findIds(request);

--- a/ebean-test/src/test/java/org/tests/query/TestQueryExists.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryExists.java
@@ -30,11 +30,57 @@ public class TestQueryExists extends BaseTestCase {
     assertThat(check).isTrue();
 
     if (isH2() || isPostgresCompatible()) {
-      assertThat(sql).contains("select t0.id from o_order t0 where t0.id > ? limit 1");
+      assertThat(sql).contains("select exists(select 1 from o_order t0 where t0.id > ?)");
     }
 
     assertThat(DB.find(Order.class).where().gt("id", 1).exists()).isTrue();
     assertThat(DB.find(Order.class).where().or().gt("id", 1).isNull("shipDate").exists()).isTrue();
+  }
+
+  @Test
+  public void testExistsBoolean_returnsFalse() {
+    ResetBasicData.reset();
+
+    // no order will ever have id = -1
+    assertThat(DB.find(Order.class).where().eq("id", -1).exists()).isFalse();
+  }
+
+  @Test
+  public void testExistsBoolean_withJoin() {
+    ResetBasicData.reset();
+
+    // customers that have at least one contact — exercises the join path in buildExistsQuery
+    Query<Customer> query = DB.find(Customer.class)
+      .where().isNotNull("contacts.firstName")
+      .query();
+
+    LoggedSql.start();
+    boolean result = query.exists();
+    String sql = LoggedSql.stop().get(0);
+
+    assertThat(result).isTrue();
+    if (isH2() || isPostgresCompatible()) {
+      assertThat(sql).contains("select exists(select 1");
+    }
+
+    // no customer has a contact with this name — should return false
+    assertThat(DB.find(Customer.class).where().eq("contacts.firstName", "NoSuchPerson_xyz").exists()).isFalse();
+  }
+
+  @Test
+  public void testExistsBoolean_queryPlanReuse() {
+    ResetBasicData.reset();
+
+    // first call builds the plan; second call should reuse it (no extra SQL generation)
+    LoggedSql.start();
+    boolean first = DB.find(Order.class).where().gt("id", 1).exists();
+    boolean second = DB.find(Order.class).where().gt("id", 1).exists();
+    List<String> sqls = LoggedSql.stop();
+
+    assertThat(first).isTrue();
+    assertThat(second).isTrue();
+    assertThat(sqls).hasSize(2);
+    assertThat(sqls.get(0)).isEqualTo(sqls.get(1));
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/query/TestQueryExists.java
+++ b/ebean-test/src/test/java/org/tests/query/TestQueryExists.java
@@ -80,7 +80,13 @@ public class TestQueryExists extends BaseTestCase {
     assertThat(first).isTrue();
     assertThat(second).isTrue();
     assertThat(sqls).hasSize(2);
-    assertThat(sqls.get(0)).isEqualTo(sqls.get(1));
+    // strip the --micros(...) timing suffix
+    String sql0 = sqls.get(0).split(";")[0];
+    String sql1 = sqls.get(1).split(";")[0];
+    assertThat(sql0).isEqualTo(sql1);
+    if (isH2() || isPostgresCompatible()) {
+      assertThat(sql0).isEqualTo("select exists(select 1 from o_order t0 where t0.id > ?)");
+    }
   }
 
   @Test


### PR DESCRIPTION
Previously query.exists() was implemented by running a findIds() limited to 1 row and checking whether the list was empty. This PR replaces that with a dedicated select exists(select 1 ...) execution path.

## Changes:

• CQueryExists — new query executor, analogous to CQueryCount, that runs select exists(...) and returns the boolean result directly from the JDBC ResultSet • CQueryBuilder.buildExistsQuery() — builds select exists(select 1 ...) SQL, reusing the query plan cache on repeat calls • CQueryEngine.findExists() / DefaultOrmQueryEngine / OrmQueryEngine interface — wire the new executor through the standard query engine stack, including SQL logging, summary logging, and query cache put • DefaultServer.exists() — delegate to request.findExists() instead of findIds()

## Tests added to TestQueryExists:

• testExistsBoolean_returnsFalse — verifies false is returned when no rows match • testExistsBoolean_withJoin — exercises the join SQL path in buildExistsQuery; also checks false when the join yields no match • testExistsBoolean_queryPlanReuse — runs the same query twice and asserts the generated SQL is identical, confirming the plan cache is hit on the second call