### PR TITLE
Support option to have always non-null @Embeddable(s) refereneces

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/AssocOneHelpEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/AssocOneHelpEmbedded.java
@@ -10,8 +10,11 @@ import java.sql.SQLException;
  */
 final class AssocOneHelpEmbedded extends AssocOneHelp {
 
-  AssocOneHelpEmbedded(BeanPropertyAssocOne<?> property) {
+  private final boolean allowEmpty;
+
+  AssocOneHelpEmbedded(BeanPropertyAssocOne<?> property, boolean allowEmpty) {
     super(property);
+    this.allowEmpty = allowEmpty;
   }
 
   @Override
@@ -40,7 +43,7 @@ final class AssocOneHelpEmbedded extends AssocOneHelp {
         notNull = true;
       }
     }
-    if (notNull) {
+    if (notNull || allowEmpty) {
       return embeddedBean;
     } else {
       return null;
@@ -69,7 +72,7 @@ final class AssocOneHelpEmbedded extends AssocOneHelp {
         notNull = true;
       }
     }
-    return notNull ? embeddedBean : null;
+    return (notNull || allowEmpty) ? embeddedBean : null;
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanPropertyAssocOne.java
@@ -45,6 +45,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
   private final boolean orphanRemoval;
   private final boolean primaryKeyExport;
   private final boolean primaryKeyJoin;
+  private final boolean embeddedAllowEmpty;
 
   private AssocOneHelp localHelp;
   final BeanProperty[] embeddedProps;
@@ -74,6 +75,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
     oneToOne = deploy.isOneToOne();
     oneToOneExported = deploy.isOneToOneExported();
     orphanRemoval = deploy.isOrphanRemoval();
+    embeddedAllowEmpty = deploy.isEmbeddedAllowEmpty();
     if (embedded) {
       // Overriding of the columns and use table alias of owning BeanDescriptor
       BeanEmbeddedMeta overrideMeta = BeanEmbeddedMetaFactory.create(owner, deploy);
@@ -100,6 +102,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
     oneToOne = source.oneToOne;
     oneToOneExported = source.oneToOneExported;
     orphanRemoval = source.orphanRemoval;
+    embeddedAllowEmpty = source.embeddedAllowEmpty;
     embeddedProps = null;
     embeddedPropsMap = null;
   }
@@ -840,7 +843,7 @@ public class BeanPropertyAssocOne<T> extends BeanPropertyAssoc<T> implements STr
 
   private AssocOneHelp createHelp(boolean embedded, boolean oneToOneExported, String embeddedPrefix) {
     if (embedded) {
-      return new AssocOneHelpEmbedded(this);
+      return new AssocOneHelpEmbedded(this, embeddedAllowEmpty);
     } else if (oneToOneExported) {
       return new AssocOneHelpRefExported(this);
     } else {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanPropertyAssocOne.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/meta/DeployBeanPropertyAssocOne.java
@@ -13,6 +13,7 @@ public final class DeployBeanPropertyAssocOne<T> extends DeployBeanPropertyAssoc
   private boolean oneToOneExported;
   private boolean primaryKeyJoin;
   private boolean primaryKeyExport;
+  private boolean embeddedAllowEmpty;
   private DeployBeanEmbedded deployEmbedded;
   private String columnPrefix;
 
@@ -101,6 +102,14 @@ public final class DeployBeanPropertyAssocOne<T> extends DeployBeanPropertyAssoc
     if (columns.length == 1) {
       columns[0].setLocalSqlFormula(formulaSelect);
     }
+  }
+
+  public void setEmbeddedAllowEmpty(boolean allowEmpty) {
+    this.embeddedAllowEmpty = allowEmpty;
+  }
+
+  public boolean isEmbeddedAllowEmpty() {
+    return embeddedAllowEmpty;
   }
 
   public void setColumnPrefix(String columnPrefix) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocOnes.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocOnes.java
@@ -245,6 +245,13 @@ final class AnnotationAssocOnes extends AnnotationAssoc {
     } catch (NoSuchMethodError e) {
       // using standard JPA API without prefix option, maybe in EE container
     }
+    try {
+      if (!embedded.nullable()) {
+        prop.setEmbeddedAllowEmpty(true);
+      }
+    } catch (NoSuchMethodError e) {
+      // older persistence-api without nullable() extension
+    }
     readEmbeddedAttributeOverrides(prop);
   }
 

--- a/ebean-test/src/test/java/org/tests/model/embedded/EPersonAllowNullRef.java
+++ b/ebean-test/src/test/java/org/tests/model/embedded/EPersonAllowNullRef.java
@@ -1,0 +1,49 @@
+package org.tests.model.embedded;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+
+/**
+ * Entity used to test @Embedded(nullable = false) —
+ * the embedded address should never be null even when all address columns are null in the DB.
+ */
+@Entity
+public class EPersonAllowNullRef {
+
+  @Id
+  Long id;
+
+  @Version
+  Long version;
+
+  String name;
+
+  @Embedded(nullable = false)
+  EAddress address;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public EAddress getAddress() {
+    return address;
+  }
+
+  public void setAddress(EAddress address) {
+    this.address = address;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/embedded/TestEmbeddedAllowNullRef.java
+++ b/ebean-test/src/test/java/org/tests/model/embedded/TestEmbeddedAllowNullRef.java
@@ -1,0 +1,73 @@
+package org.tests.model.embedded;
+
+import io.ebean.DB;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for @Embedded(nullable = false) — the embedded field
+ * must never be null after loading, even when all embedded columns are null in the DB.
+ */
+class TestEmbeddedAllowNullRef extends BaseTestCase {
+
+  @Test
+  void embeddedIsNeverNull_whenAllColumnsAreNull() {
+    EPersonAllowNullRef person = new EPersonAllowNullRef();
+    person.setName("Alice");
+    // address intentionally left null — all address columns will be null in the DB
+    DB.save(person);
+
+    EPersonAllowNullRef loaded = DB.find(EPersonAllowNullRef.class, person.getId());
+
+    assertThat(loaded).isNotNull();
+    // with nullable = false, the address reference must never be null
+    assertThat(loaded.getAddress())
+      .describedAs("address should be a non-null empty instance, not null")
+      .isNotNull();
+    // all fields inside the embedded bean are still null
+    assertThat(loaded.getAddress().getCity()).isNull();
+
+    DB.delete(loaded);
+  }
+
+  @Test
+  void embeddedIsPopulated_whenColumnsAreSet() {
+    EPersonAllowNullRef person = new EPersonAllowNullRef();
+    person.setName("Bob");
+    EAddress addr = new EAddress();
+    addr.setCity("Wellington");
+    person.setAddress(addr);
+    DB.save(person);
+
+    EPersonAllowNullRef loaded = DB.find(EPersonAllowNullRef.class, person.getId());
+
+    assertThat(loaded.getAddress()).isNotNull();
+    assertThat(loaded.getAddress().getCity()).isEqualTo("Wellington");
+
+    DB.delete(loaded);
+  }
+
+  @Test
+  void noDirtyUpdate_whenLoadedWithNullEmbeddedAndNotModified() {
+    EPersonAllowNullRef person = new EPersonAllowNullRef();
+    person.setName("Charlie");
+    DB.save(person);
+
+    EPersonAllowNullRef loaded = DB.find(EPersonAllowNullRef.class, person.getId());
+    // just reading the address reference (which is a non-null empty bean) must not mark dirty
+    EAddress address = loaded.getAddress();
+    assertThat(address).isNotNull();
+
+    // update should be skipped — nothing changed
+    io.ebean.test.LoggedSql.start();
+    DB.update(loaded);
+    java.util.List<String> sqls = io.ebean.test.LoggedSql.stop();
+    assertThat(sqls)
+      .describedAs("no UPDATE should be issued when nothing was changed")
+      .isEmpty();
+
+    DB.delete(loaded);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <jackson.version>2.22.0</jackson.version>
     <avaje-json-core.version>3.14</avaje-json-core.version>
     <h2database.version>2.2.220</h2database.version>
-    <ebean-persistence-api.version>3.1</ebean-persistence-api.version>
+    <ebean-persistence-api.version>3.2</ebean-persistence-api.version>
     <ebean-types.version>3.0</ebean-types.version>
 
     <ebean-annotation.version>8.5</ebean-annotation.version>


### PR DESCRIPTION
(#3702)

This does so by adding a **_non-standard ebean extension_** to  `@Embedded` - a nullable attribute. 

When it is set to false ... then that means ebean will set it into a returning bean even when all its attributes are null (so "empty").

like:

```java
  @Embedded(nullable = false)
  EAddress address;
```  