### PR TITLE
Fire BeanPersistController when only ManyToMany collection changes (#3652)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/core/PersistRequestBean.java
@@ -937,6 +937,20 @@ public final class PersistRequestBean<T> extends PersistRequest implements BeanP
     }
   }
 
+  /**
+   * Ensure the preUpdate event fires (for case where only a ManyToMany collection has changed).
+   */
+  public void preManyToManyUpdate() {
+    if (controller != null && !dirty) {
+      // fire preUpdate notification when only ManyToMany intersection updated
+      controller.preUpdate(this);
+      pendingPostUpdateNotify = true;
+    }
+    if (!dirty) {
+      setNotifyCache();
+    }
+  }
+
   public boolean isNotifyCache() {
     return notifyCache;
   }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyBeans.java
@@ -292,6 +292,17 @@ final class SaveManyBeans extends SaveManyBase {
       manyValue.modifyReset();
     }
 
+    if (!insertedParent) {
+      // only fire controller when the intersection actually changes:
+      // vanillaCollection/forcedUpdate always do a full replace,
+      // tracked BeanCollection fires only when additions or removals exist
+      boolean intersectionChanged = vanillaCollection || forcedUpdate
+          || (additions != null && !additions.isEmpty())
+          || (deletions != null && !deletions.isEmpty());
+      if (intersectionChanged) {
+        request.preManyToManyUpdate();
+      }
+    }
     transaction.depth(+1);
     if (deletions != null && !deletions.isEmpty()) {
       for (Object other : deletions) {

--- a/ebean-test/src/test/java/io/ebean/xtest/event/BeanPersistControllerTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/event/BeanPersistControllerTest.java
@@ -9,6 +9,7 @@ import io.ebean.event.BeanPersistRequest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.tests.model.m2m.MnyTopic;
 import org.tests.model.basic.EBasicVer;
 import org.tests.model.basic.UTDetail;
 import org.tests.model.basic.UTMaster;
@@ -145,6 +146,26 @@ public class BeanPersistControllerTest {
     log.info("done testInsertUpdateDelete_given_stopPersistingAdapter");
   }
 
+  @Test
+  public void manyToManyOnlyChange_firesController() {
+    Database db = createDatabase(continuePersistingAdapter);
+
+    MnyTopic parent = new MnyTopic("parent");
+    MnyTopic child = new MnyTopic("child");
+    db.save(parent);
+    db.save(child);
+    continuePersistingAdapter.methodsCalled.clear();
+
+    // load parent and add a sub-topic — only the M2M intersection changes, not the parent bean
+    MnyTopic loaded = db.find(MnyTopic.class, parent.getId());
+    loaded.getSubTopics().add(child);
+    db.save(loaded);
+
+    assertThat(continuePersistingAdapter.methodsCalled).containsExactly("preUpdate", "postUpdate");
+
+    db.shutdown();
+  }
+
   private Database createDatabase(PersistAdapter persistAdapter) {
     DatabaseBuilder config = Database.builder();
     config.setName("h2ebasicver");
@@ -158,6 +179,7 @@ public class BeanPersistControllerTest {
     config.addClass(EBasicVer.class);
     config.addClass(UTMaster.class);
     config.addClass(UTDetail.class);
+    config.addClass(MnyTopic.class);
 
     config.add(persistAdapter);
     return config.build();


### PR DESCRIPTION
See #3652

When only a @ManyToMany collection is modified and saved, the parent bean has no dirty scalar properties so BeanPersistController preUpdate/postUpdate were never invoked — only the junction table rows were written.

Fix mirrors the existing preElementCollectionUpdate() mechanism: add preManyToManyUpdate() on PersistRequestBean and call it from SaveManyBeans.saveAssocManyIntersection() when the intersection actually changes (vanillaCollection, forcedUpdate, or a tracked BeanCollection with non-empty additions or removals). The !dirty guard in preManyToManyUpdate() prevents double-firing when the bean itself is also dirty.