### PR TITLE
 Issue #2840: @DbJson/@DbJsonB Map<String,Object> fields ignored muta…

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/DefaultTypeManager.java
@@ -265,7 +265,7 @@ public final class DefaultTypeManager implements TypeManager {
 
   @Override
   public ScalarType<?> dbMapType() {
-    return hstoreSupport() ? hstoreType : ScalarTypeJsonMap.typeFor(false, Types.VARCHAR, false);
+    return hstoreSupport() ? hstoreType : ScalarTypeJsonMap.typeFor(false, Types.VARCHAR, MutationDetection.DEFAULT);
   }
 
   @Override
@@ -322,17 +322,17 @@ public final class DefaultTypeManager implements TypeManager {
     }
     Type genericType = prop.genericType();
     if (type.equals(List.class) && isValueTypeSimple(genericType)) {
-      return ScalarTypeJsonList.typeFor(postgres, dbType, docType(genericType), prop.isNullable(), keepSource(prop));
+      return ScalarTypeJsonList.typeFor(postgres, dbType, docType(genericType), prop.isNullable(), collectionMutationDetection(prop));
     }
     if (type.equals(Set.class) && isValueTypeSimple(genericType)) {
-      return ScalarTypeJsonSet.typeFor(postgres, dbType, docType(genericType), prop.isNullable(), keepSource(prop));
+      return ScalarTypeJsonSet.typeFor(postgres, dbType, docType(genericType), prop.isNullable(), collectionMutationDetection(prop));
     }
     if (type.equals(Map.class) && isBuiltinJsonMap(genericType)) {
       Type keyType = TypeReflectHelper.getMapKeyTypeRaw(genericType);
       if (isEnumType(keyType)) {
-        return enumJsonMapType(postgres, dbType, keyType, keepSource(prop));
+        return enumJsonMapType(postgres, dbType, keyType, collectionMutationDetection(prop));
       }
-      return ScalarTypeJsonMap.typeFor(postgres, dbType, keepSource(prop));
+      return ScalarTypeJsonMap.typeFor(postgres, dbType, collectionMutationDetection(prop));
     }
     if (objectMapperPresent && prop.mutationDetection() == MutationDetection.DEFAULT) {
       ScalarTypeSet<?> typeSet = typeSets.get(type);
@@ -343,18 +343,25 @@ public final class DefaultTypeManager implements TypeManager {
     return createJsonObjectMapperType(prop, dbType, DocPropertyType.OBJECT);
   }
 
-  private boolean keepSource(DeployProperty prop) {
-    if (prop.mutationDetection() == MutationDetection.DEFAULT) {
-      prop.setMutationDetection(jsonManager != null ? jsonManager.mutationDetection() : MutationDetection.NONE);
-    }
-    return prop.mutationDetection() == MutationDetection.SOURCE;
+  /**
+   * Return the mutation detection mode to use for the built-in JSON collection types
+   * (Map, List, Set).
+   * <p>
+   * Unlike {@code @DbJson} properties handled via the Jackson ObjectMapper, {@code DEFAULT}
+   * on these collection types is <em>not</em> resolved against the DatabaseConfig wide
+   * default - it always uses the legacy ModifyAware wrapper based dirty checking. Only an
+   * explicit {@code NONE}, {@code HASH} or {@code SOURCE} on the property itself switches
+   * these types away from ModifyAware based checking.
+   */
+  private MutationDetection collectionMutationDetection(DeployProperty prop) {
+    return prop.mutationDetection();
   }
 
   @SuppressWarnings("unchecked")
-  private ScalarType<?> enumJsonMapType(boolean postgres, int dbType, Type keyType, boolean keepSource) {
+  private ScalarType<?> enumJsonMapType(boolean postgres, int dbType, Type keyType, MutationDetection mutationDetection) {
     Class<? extends Enum<?>> enumClass = asEnumClass(keyType);
     ScalarType<? extends Enum<?>> enumScalarType = (ScalarType<? extends Enum<?>>) enumType(enumClass, null);
-    return ScalarTypeJsonMapEnum.typeFor(postgres, dbType, enumScalarType, keepSource);
+    return ScalarTypeJsonMapEnum.typeFor(postgres, dbType, enumScalarType, mutationDetection);
   }
 
   private DocPropertyType docPropertyType(DeployProperty prop, Class<?> type) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/PlatformArrayTypeJsonList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/PlatformArrayTypeJsonList.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.type;
 
+import io.ebean.annotation.MutationDetection;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.core.type.ScalarType;
 
@@ -27,15 +28,14 @@ class PlatformArrayTypeJsonList implements PlatformArrayTypeFactory {
   @Override
   public ScalarType<?> typeFor(Type valueType, boolean nullable) {
     if (valueType.equals(UUID.class)) {
-      // TODO: keepSource for @DbArray?
-      return new ScalarTypeJsonList.VarcharWithConverter(DocPropertyType.UUID, nullable, false, ArrayElementConverter.UUID);
+      return new ScalarTypeJsonList.VarcharWithConverter(DocPropertyType.UUID, nullable, ArrayElementConverter.UUID);
     }
-    return new ScalarTypeJsonList(java.sql.Types.VARCHAR, JsonStorage.VARCHAR, docType(valueType), nullable, false);
+    return new ScalarTypeJsonList(java.sql.Types.VARCHAR, JsonStorage.VARCHAR, docType(valueType), nullable, MutationDetection.DEFAULT);
   }
 
   @Override
   public ScalarType<?> typeForEnum(ScalarType<?> scalarType, boolean nullable) {
     final ArrayElementConverter.EnumConverter converter = new ArrayElementConverter.EnumConverter(scalarType);
-    return new ScalarTypeJsonList.VarcharWithConverter(scalarType.docType(), nullable, false, converter);
+    return new ScalarTypeJsonList.VarcharWithConverter(scalarType.docType(), nullable, converter);
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/PlatformArrayTypeJsonSet.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/PlatformArrayTypeJsonSet.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.type;
 
+import io.ebean.annotation.MutationDetection;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.core.type.ScalarType;
 
@@ -27,15 +28,14 @@ class PlatformArrayTypeJsonSet implements PlatformArrayTypeFactory {
   @Override
   public ScalarType<?> typeFor(Type valueType, boolean nullable) {
     if (valueType.equals(UUID.class)) {
-      // TODO: keepSource for @DbArray?
-      return new ScalarTypeJsonSet.VarcharWithConverter(DocPropertyType.UUID, nullable, false, ArrayElementConverter.UUID);
+      return new ScalarTypeJsonSet.VarcharWithConverter(DocPropertyType.UUID, nullable, ArrayElementConverter.UUID);
     }
-    return new ScalarTypeJsonSet(java.sql.Types.VARCHAR, JsonStorage.VARCHAR, docType(valueType), nullable, false);
+    return new ScalarTypeJsonSet(java.sql.Types.VARCHAR, JsonStorage.VARCHAR, docType(valueType), nullable, MutationDetection.DEFAULT);
   }
 
   @Override
   public ScalarType<?> typeForEnum(ScalarType<?> scalarType, boolean nullable) {
     final ArrayElementConverter.EnumConverter converter = new ArrayElementConverter.EnumConverter(scalarType);
-    return new ScalarTypeJsonSet.VarcharWithConverter(scalarType.docType(), nullable, false, converter);
+    return new ScalarTypeJsonSet.VarcharWithConverter(scalarType.docType(), nullable, converter);
   }
 }

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonCollectionValue.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonCollectionValue.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.type;
 
+import io.ebean.annotation.MutationDetection;
 import io.ebean.core.type.DocPropertyType;
 
 /**
@@ -10,9 +11,9 @@ import io.ebean.core.type.DocPropertyType;
  */
 abstract class ScalarTypeJsonCollectionValue<T> extends ScalarTypeJsonValue<T> implements ScalarTypeArray {
 
-  ScalarTypeJsonCollectionValue(Class<T> type, int jdbcType, JsonStorage storage, boolean keepSource,
+  ScalarTypeJsonCollectionValue(Class<T> type, int jdbcType, JsonStorage storage, MutationDetection mutationDetection,
                                 boolean nullable, DocPropertyType docType) {
-    super(type, jdbcType, storage, keepSource, nullable, "[]", docType);
+    super(type, jdbcType, storage, mutationDetection, nullable, "[]", docType);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonList.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonList.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.type;
 
 import io.avaje.json.JsonReader;
 import io.avaje.json.JsonWriter;
+import io.ebean.annotation.MutationDetection;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.core.type.PostgresHelper;
@@ -25,20 +26,20 @@ class ScalarTypeJsonList extends ScalarTypeJsonCollectionValue<List> {
   /**
    * Return the appropriate ScalarType for the requested dbType and platform.
    */
-  static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docType, boolean nullable, boolean keepSource) {
+  static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docType, boolean nullable, MutationDetection mutationDetection) {
     if (postgres) {
       switch (dbType) {
         case DbPlatformType.JSONB:
-          return new ScalarTypeJsonList(DbPlatformType.JSONB, JsonStorage.postgres(PostgresHelper.JSONB_TYPE), docType, nullable, keepSource);
+          return new ScalarTypeJsonList(DbPlatformType.JSONB, JsonStorage.postgres(PostgresHelper.JSONB_TYPE), docType, nullable, mutationDetection);
         case DbPlatformType.JSON:
-          return new ScalarTypeJsonList(DbPlatformType.JSON, JsonStorage.postgres(PostgresHelper.JSON_TYPE), docType, nullable, keepSource);
+          return new ScalarTypeJsonList(DbPlatformType.JSON, JsonStorage.postgres(PostgresHelper.JSON_TYPE), docType, nullable, mutationDetection);
       }
     }
-    return new ScalarTypeJsonList(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, keepSource);
+    return new ScalarTypeJsonList(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, mutationDetection);
   }
 
-  ScalarTypeJsonList(int jdbcType, JsonStorage storage, DocPropertyType docType, boolean nullable, boolean keepSource) {
-    super(List.class, jdbcType, storage, keepSource, nullable, docType);
+  ScalarTypeJsonList(int jdbcType, JsonStorage storage, DocPropertyType docType, boolean nullable, MutationDetection mutationDetection) {
+    super(List.class, jdbcType, storage, mutationDetection, nullable, docType);
   }
 
   @Override
@@ -87,8 +88,8 @@ class ScalarTypeJsonList extends ScalarTypeJsonCollectionValue<List> {
 
     private final ArrayElementConverter converter;
 
-    VarcharWithConverter(DocPropertyType docType, boolean nullable, boolean keepSource, ArrayElementConverter converter) {
-      super(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, keepSource);
+    VarcharWithConverter(DocPropertyType docType, boolean nullable, ArrayElementConverter converter) {
+      super(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, MutationDetection.DEFAULT);
       this.converter = converter;
     }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonMap.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonMap.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.type;
 
 import io.avaje.json.JsonReader;
 import io.avaje.json.JsonWriter;
+import io.ebean.annotation.MutationDetection;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.core.type.PostgresHelper;
@@ -22,8 +23,8 @@ class ScalarTypeJsonMap extends ScalarTypeJsonValue<Map> {
   /**
    * Return the ScalarType for the requested dbType and platform.
    */
-  static ScalarTypeJsonMap typeFor(boolean postgres, int dbType, boolean keepSource) {
-    return new ScalarTypeJsonMap(storageFor(postgres, dbType), keepSource);
+  static ScalarTypeJsonMap typeFor(boolean postgres, int dbType, MutationDetection mutationDetection) {
+    return new ScalarTypeJsonMap(storageFor(postgres, dbType), mutationDetection);
   }
 
   /**
@@ -47,8 +48,8 @@ class ScalarTypeJsonMap extends ScalarTypeJsonValue<Map> {
     }
   }
 
-  ScalarTypeJsonMap(JsonStorage storage, boolean keepSource) {
-    super(Map.class, storage.jdbcType(), storage, keepSource, true, null, DocPropertyType.OBJECT);
+  ScalarTypeJsonMap(JsonStorage storage, MutationDetection mutationDetection) {
+    super(Map.class, storage.jdbcType(), storage, mutationDetection, true, null, DocPropertyType.OBJECT);
   }
 
   @Override

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonMapEnum.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonMapEnum.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.type;
 
 import io.avaje.json.JsonReader;
 import io.avaje.json.JsonWriter;
+import io.ebean.annotation.MutationDetection;
 import io.ebean.core.type.ScalarType;
 import io.ebean.text.TextException;
 import io.ebean.text.json.EJson;
@@ -23,13 +24,13 @@ final class ScalarTypeJsonMapEnum<T extends Enum<T>> extends ScalarTypeJsonMap {
 
   private final ScalarType<T> enumType;
 
-  static ScalarType<?> typeFor(boolean postgres, int dbType, ScalarType<? extends Enum<?>> enumType, boolean keepSource) {
-    return new ScalarTypeJsonMapEnum<>(storageFor(postgres, dbType), enumType, keepSource);
+  static ScalarType<?> typeFor(boolean postgres, int dbType, ScalarType<? extends Enum<?>> enumType, MutationDetection mutationDetection) {
+    return new ScalarTypeJsonMapEnum<>(storageFor(postgres, dbType), enumType, mutationDetection);
   }
 
   @SuppressWarnings("unchecked")
-  private ScalarTypeJsonMapEnum(JsonStorage storage, ScalarType<? extends Enum> enumType, boolean keepSource) {
-    super(storage, keepSource);
+  private ScalarTypeJsonMapEnum(JsonStorage storage, ScalarType<? extends Enum> enumType, MutationDetection mutationDetection) {
+    super(storage, mutationDetection);
     this.enumType = (ScalarType<T>) enumType;
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonSet.java
@@ -2,6 +2,7 @@ package io.ebeaninternal.server.type;
 
 import io.avaje.json.JsonReader;
 import io.avaje.json.JsonWriter;
+import io.ebean.annotation.MutationDetection;
 import io.ebean.config.dbplatform.DbPlatformType;
 import io.ebean.core.type.DocPropertyType;
 import io.ebean.core.type.PostgresHelper;
@@ -25,20 +26,20 @@ class ScalarTypeJsonSet extends ScalarTypeJsonCollectionValue<Set> {
   /**
    * Return the appropriate ScalarType for the requested dbType and platform.
    */
-  static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docType, boolean nullable, boolean keepSource) {
+  static ScalarType<?> typeFor(boolean postgres, int dbType, DocPropertyType docType, boolean nullable, MutationDetection mutationDetection) {
     if (postgres) {
       switch (dbType) {
         case DbPlatformType.JSONB:
-          return new ScalarTypeJsonSet(DbPlatformType.JSONB, JsonStorage.postgres(PostgresHelper.JSONB_TYPE), docType, nullable, keepSource);
+          return new ScalarTypeJsonSet(DbPlatformType.JSONB, JsonStorage.postgres(PostgresHelper.JSONB_TYPE), docType, nullable, mutationDetection);
         case DbPlatformType.JSON:
-          return new ScalarTypeJsonSet(DbPlatformType.JSON, JsonStorage.postgres(PostgresHelper.JSON_TYPE), docType, nullable, keepSource);
+          return new ScalarTypeJsonSet(DbPlatformType.JSON, JsonStorage.postgres(PostgresHelper.JSON_TYPE), docType, nullable, mutationDetection);
       }
     }
-    return new ScalarTypeJsonSet(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, keepSource);
+    return new ScalarTypeJsonSet(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, mutationDetection);
   }
 
-  ScalarTypeJsonSet(int jdbcType, JsonStorage storage, DocPropertyType docType, boolean nullable, boolean keepSource) {
-    super(Set.class, jdbcType, storage, keepSource, nullable, docType);
+  ScalarTypeJsonSet(int jdbcType, JsonStorage storage, DocPropertyType docType, boolean nullable, MutationDetection mutationDetection) {
+    super(Set.class, jdbcType, storage, mutationDetection, nullable, docType);
   }
 
   @Override
@@ -89,8 +90,8 @@ class ScalarTypeJsonSet extends ScalarTypeJsonCollectionValue<Set> {
 
     private final ArrayElementConverter converter;
 
-    VarcharWithConverter(DocPropertyType docType, boolean nullable, boolean keepSource, ArrayElementConverter converter) {
-      super(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, keepSource);
+    VarcharWithConverter(DocPropertyType docType, boolean nullable, ArrayElementConverter converter) {
+      super(Types.VARCHAR, JsonStorage.VARCHAR, docType, nullable, MutationDetection.DEFAULT);
       this.converter = converter;
     }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonValue.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/type/ScalarTypeJsonValue.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.type;
 
+import io.ebean.annotation.MutationDetection;
 import io.ebean.core.type.DataBinder;
 import io.ebean.core.type.DataReader;
 import io.ebean.core.type.DocPropertyType;
@@ -20,11 +21,18 @@ import java.sql.SQLException;
  *       backed {@code EJson} facade)</li>
  * </ul>
  * This removes the previous explosion of per-storage and per-platform subclasses.
+ * <p>
+ * Mutation detection: {@code DEFAULT} uses the legacy ModifyAware wrapper based dirty
+ * checking. {@code NONE} disables dirty checking entirely (mutable() is false and the
+ * property is only included in an update when explicitly set). {@code HASH} and
+ * {@code SOURCE} are handled via {@code BeanPropertyJsonMapper} (json content is kept
+ * for the read/bind round trip so that a checksum or the source content can be compared).
  */
 abstract class ScalarTypeJsonValue<T> extends ScalarTypeBase<T> {
 
   protected final JsonStorage storage;
   protected final boolean keepSource;
+  private final boolean mutable;
   private final boolean nullable;
   private final String emptyJson;
   private final DocPropertyType docType;
@@ -33,11 +41,12 @@ abstract class ScalarTypeJsonValue<T> extends ScalarTypeBase<T> {
    * @param emptyJson JSON bound when the value is null and the property is not nullable
    *                  (e.g. {@code "[]"} for collections), or null to always bind SQL null.
    */
-  ScalarTypeJsonValue(Class<T> type, int jdbcType, JsonStorage storage, boolean keepSource,
+  ScalarTypeJsonValue(Class<T> type, int jdbcType, JsonStorage storage, MutationDetection mutationDetection,
                       boolean nullable, String emptyJson, DocPropertyType docType) {
     super(type, false, jdbcType);
     this.storage = storage;
-    this.keepSource = keepSource;
+    this.keepSource = mutationDetection == MutationDetection.HASH || mutationDetection == MutationDetection.SOURCE;
+    this.mutable = mutationDetection != MutationDetection.NONE;
     this.nullable = nullable;
     this.emptyJson = emptyJson;
     this.docType = docType;
@@ -51,7 +60,7 @@ abstract class ScalarTypeJsonValue<T> extends ScalarTypeBase<T> {
 
   @Override
   public final boolean mutable() {
-    return true;
+    return mutable;
   }
 
   @Override

--- a/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeJsonListTest.java
+++ b/ebean-core/src/test/java/io/ebeaninternal/server/type/ScalarTypeJsonListTest.java
@@ -1,5 +1,6 @@
 package io.ebeaninternal.server.type;
 
+import io.ebean.annotation.MutationDetection;
 import io.ebean.config.dbplatform.ExtraDbTypes;
 import io.ebean.core.type.DocPropertyType;
 import org.junit.jupiter.api.Test;
@@ -11,19 +12,19 @@ public class ScalarTypeJsonListTest extends BasePlatformArrayTypeFactoryTest {
   @Test
   public void typeFor_expect_nullToEmpty_when_postgresNonNull() throws SQLException {
 
-    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, false, false));
-    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, false, false));
+    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, false, MutationDetection.DEFAULT));
+    assertBindNullTo_PGObjectEmpty(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, false, MutationDetection.DEFAULT));
 
-    assertBindNullTo_EmptyString(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, false, false));
+    assertBindNullTo_EmptyString(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, false, MutationDetection.DEFAULT));
   }
 
   @Test
   public void typeFor_expect_nullToNull_when_nullable() throws SQLException {
 
-    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, true, false));
-    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, true, false));
+    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONB, DocPropertyType.OBJECT, true, MutationDetection.DEFAULT));
+    assertBindNullTo_PGObjectNull(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSON, DocPropertyType.OBJECT, true, MutationDetection.DEFAULT));
 
-    assertBindNullTo_Null(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, true, false));
+    assertBindNullTo_Null(ScalarTypeJsonList.typeFor(true, ExtraDbTypes.JSONVarchar, DocPropertyType.OBJECT, true, MutationDetection.DEFAULT));
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/json/TestDbJsonMapMutationDetection.java
+++ b/ebean-test/src/test/java/org/tests/json/TestDbJsonMapMutationDetection.java
@@ -1,0 +1,148 @@
+package org.tests.json;
+
+import io.ebean.BeanState;
+import io.ebean.DB;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import io.ebean.xtest.IgnorePlatform;
+import io.ebean.annotation.Platform;
+import org.junit.jupiter.api.Test;
+import org.tests.model.json.EBasicJsonMapMutation;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code Map<String,Object>} @DbJson properties honour mutationDetection
+ * rather than always using ModifyAware based dirty checking - see issue #2840.
+ */
+public class TestDbJsonMapMutationDetection extends BaseTestCase {
+
+  private static Map<String, Object> content(String value) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("field", List.of(value));
+    return map;
+  }
+
+  @IgnorePlatform(Platform.MYSQL)
+  @Test
+  public void noneMode_inPlaceMutation_notDetected() {
+    EBasicJsonMapMutation bean = new EBasicJsonMapMutation();
+    bean.setNoneMap(content("a"));
+    DB.save(bean);
+
+    EBasicJsonMapMutation found = DB.find(EBasicJsonMapMutation.class, bean.getId());
+    // mutate the map content directly (without calling the setter)
+    found.getNoneMap().put("field", List.of("mutated"));
+
+    LoggedSql.start();
+    DB.save(found);
+    // NONE means no attempt to detect mutation - so no update at all
+    assertThat(LoggedSql.stop()).isEmpty();
+  }
+
+  @IgnorePlatform(Platform.MYSQL)
+  @Test
+  public void noneMode_setEqualValue_noUpdate() {
+    EBasicJsonMapMutation bean = new EBasicJsonMapMutation();
+    bean.setNoneMap(content("a"));
+    DB.save(bean);
+
+    EBasicJsonMapMutation found = DB.find(EBasicJsonMapMutation.class, bean.getId());
+    // set a brand new (but equal content) map instance via the setter
+    found.setNoneMap(content("a"));
+
+    BeanState state = DB.beanState(found);
+    assertThat(state.changedProps()).isEmpty();
+
+    LoggedSql.start();
+    DB.save(found);
+    assertThat(LoggedSql.stop()).isEmpty();
+  }
+
+  @IgnorePlatform(Platform.MYSQL)
+  @Test
+  public void noneMode_setDifferentValue_updates() {
+    EBasicJsonMapMutation bean = new EBasicJsonMapMutation();
+    bean.setNoneMap(content("a"));
+    DB.save(bean);
+
+    EBasicJsonMapMutation found = DB.find(EBasicJsonMapMutation.class, bean.getId());
+    found.setNoneMap(content("b"));
+
+    LoggedSql.start();
+    DB.save(found);
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("none_map");
+  }
+
+  @IgnorePlatform(Platform.MYSQL)
+  @Test
+  public void hashMode_inPlaceMutation_detected() {
+    EBasicJsonMapMutation bean = new EBasicJsonMapMutation();
+    bean.setHashMap(content("a"));
+    DB.save(bean);
+
+    EBasicJsonMapMutation found = DB.find(EBasicJsonMapMutation.class, bean.getId());
+    found.getHashMap().put("field", List.of("mutated"));
+
+    LoggedSql.start();
+    DB.save(found);
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("hash_map");
+  }
+
+  @IgnorePlatform(Platform.MYSQL)
+  @Test
+  public void hashMode_setEqualValue_noUpdate() {
+    EBasicJsonMapMutation bean = new EBasicJsonMapMutation();
+    bean.setHashMap(content("a"));
+    DB.save(bean);
+
+    EBasicJsonMapMutation found = DB.find(EBasicJsonMapMutation.class, bean.getId());
+    // brand new map instance with equal content - hash should match so no update
+    found.setHashMap(content("a"));
+
+    LoggedSql.start();
+    DB.save(found);
+    assertThat(LoggedSql.stop()).isEmpty();
+  }
+
+  @IgnorePlatform(Platform.MYSQL)
+  @Test
+  public void sourceMode_setEqualValue_noUpdate() {
+    EBasicJsonMapMutation bean = new EBasicJsonMapMutation();
+    bean.setSourceMap(content("a"));
+    DB.save(bean);
+
+    EBasicJsonMapMutation found = DB.find(EBasicJsonMapMutation.class, bean.getId());
+    found.setSourceMap(content("a"));
+
+    LoggedSql.start();
+    DB.save(found);
+    assertThat(LoggedSql.stop()).isEmpty();
+  }
+
+  @IgnorePlatform(Platform.MYSQL)
+  @Test
+  public void defaultMode_inPlaceMutation_stillDetectedViaModifyAware() {
+    // unchanged legacy behaviour - DEFAULT mode keeps using ModifyAware wrapper dirty checking
+    EBasicJsonMapMutation bean = new EBasicJsonMapMutation();
+    bean.setDefaultMap(content("a"));
+    DB.save(bean);
+
+    EBasicJsonMapMutation found = DB.find(EBasicJsonMapMutation.class, bean.getId());
+    found.getDefaultMap().put("field", List.of("mutated"));
+
+    LoggedSql.start();
+    DB.save(found);
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).hasSize(1);
+    assertThat(sql.get(0)).contains("default_map");
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/json/EBasicJsonMapMutation.java
+++ b/ebean-test/src/test/java/org/tests/model/json/EBasicJsonMapMutation.java
@@ -1,0 +1,87 @@
+package org.tests.model.json;
+
+import io.ebean.annotation.DbJson;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Version;
+import java.util.Map;
+
+import static io.ebean.annotation.MutationDetection.HASH;
+import static io.ebean.annotation.MutationDetection.NONE;
+import static io.ebean.annotation.MutationDetection.SOURCE;
+
+/**
+ * Entity with {@code Map<String,Object>} @DbJson properties covering each
+ * {@code MutationDetection} mode - used to verify that the built-in Map JSON
+ * type honours mutationDetection rather than always using ModifyAware checking.
+ */
+@Entity
+public class EBasicJsonMapMutation {
+
+  @Id
+  Long id;
+
+  @DbJson
+  Map<String, Object> defaultMap;
+
+  @DbJson(mutationDetection = NONE)
+  Map<String, Object> noneMap;
+
+  @DbJson(mutationDetection = HASH)
+  Map<String, Object> hashMap;
+
+  @DbJson(mutationDetection = SOURCE)
+  Map<String, Object> sourceMap;
+
+  @Version
+  Long version;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Map<String, Object> getDefaultMap() {
+    return defaultMap;
+  }
+
+  public void setDefaultMap(Map<String, Object> defaultMap) {
+    this.defaultMap = defaultMap;
+  }
+
+  public Map<String, Object> getNoneMap() {
+    return noneMap;
+  }
+
+  public void setNoneMap(Map<String, Object> noneMap) {
+    this.noneMap = noneMap;
+  }
+
+  public Map<String, Object> getHashMap() {
+    return hashMap;
+  }
+
+  public void setHashMap(Map<String, Object> hashMap) {
+    this.hashMap = hashMap;
+  }
+
+  public Map<String, Object> getSourceMap() {
+    return sourceMap;
+  }
+
+  public void setSourceMap(Map<String, Object> sourceMap) {
+    this.sourceMap = sourceMap;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(Long version) {
+    this.version = version;
+  }
+}


### PR DESCRIPTION
…tionDetection and always used ModifyAware-wrapper dirty checking — so NONE (and HASH) had no effect, unlike plain Object-typed `@DbJson` fields which correctly honored these modes.

## Root cause: 
The built-in `ScalarTypeJsonMap/List/Set` types (used for `Map<String,Object>`, simple `List/Set`) hard-coded mutable()=true and isDirty() to always do a ModifyAware check, regardless of the configured MutationDetection. Only SOURCE accidentally worked because it happened to route through BeanPropertyJsonMapper.

## Fix (in ebean-core, io.ebeaninternal.server.type):

 - ScalarTypeJsonValue now derives mutable (false only for NONE) and keepSource/jsonMapper() (true for HASH/SOURCE) from the property's MutationDetection, instead of a single hard-coded keepSource boolean.

- ScalarTypeJsonMap, ScalarTypeJsonMapEnum, ScalarTypeJsonList, ScalarTypeJsonSet, and ScalarTypeJsonCollectionValue now accept/pass through MutationDetection instead of a raw boolean.

- DefaultTypeManager.dbJsonType() passes the property's own mutationDetection() straight through for these collection types (per your choice: DEFAULT still always means ModifyAware for collections — only an explicit NONE/HASH/SOURCE annotation changes behavior; the DatabaseConfig-wide default is not applied to these types).

- `@DbArray` fallback call sites (PlatformArrayTypeJsonList/Set) updated to pass MutationDetection.DEFAULT, preserving unchanged behavior.