### PR TITLE
#2393: @OrderColumn was not maintained for @ElementCollection — no order column populated on insert and no order by on fetch.

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/BeanDescriptorManager.java
@@ -907,8 +907,18 @@ public final class BeanDescriptorManager implements BeanDescriptorMap, SpiBeanTy
   }
 
   private void makeOrderColumn(DeployBeanPropertyAssocMany<?> oneToMany) {
-    DeployBeanDescriptor<?> targetDesc = targetDescriptor(oneToMany);
-    DeployOrderColumn orderColumn = oneToMany.getOrderColumn();
+    makeOrderColumn(oneToMany, targetDescriptor(oneToMany));
+  }
+
+  /**
+   * Create and assign the synthetic order column property onto the given target descriptor.
+   * <p>
+   * Used for both {@code @OneToMany} (targetDesc looked up via the target entity type) and
+   * {@code @ElementCollection} (targetDesc is the synthetic element descriptor which is not
+   * registered in {@code deployInfoMap} and so must be passed in directly).
+   */
+  public void makeOrderColumn(DeployBeanPropertyAssocMany<?> many, DeployBeanDescriptor<?> targetDesc) {
+    DeployOrderColumn orderColumn = many.getOrderColumn();
     final ScalarType<?> scalarType = typeManager.type(Integer.class);
     DeployBeanProperty orderProperty = new DeployBeanProperty(targetDesc, Integer.class, scalarType, null);
     orderProperty.setName(DeployOrderColumn.LOGICAL_NAME);

--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocManys.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/parse/AnnotationAssocManys.java
@@ -177,6 +177,11 @@ final class AnnotationAssocManys extends AnnotationAssoc {
     if (!elementCollection.targetClass().equals(void.class)) {
       prop.setTargetType(elementCollection.targetClass());
     }
+    OrderColumn orderColumn = get(prop, OrderColumn.class);
+    if (orderColumn != null) {
+      prop.setOrderColumn(new DeployOrderColumn(orderColumn));
+      prop.setFetchOrderBy(DeployOrderColumn.LOGICAL_NAME);
+    }
     Column column = prop.getMetaAnnotation(Column.class);
     if (column != null) {
       prop.setDbColumn(column.name());
@@ -268,6 +273,11 @@ final class AnnotationAssocManys extends AnnotationAssoc {
 
     elementDescriptor.setName(prop.toString());
     factory.createUnidirectional(elementDescriptor, prop.getOwningType(), beanTable, prop.getTableJoin());
+    if (prop.hasOrderColumn()) {
+      // create the synthetic order property on the element descriptor - the element descriptor
+      // is not registered in deployInfoMap so this can't go through the usual OneToMany path
+      factory.makeOrderColumn(prop, elementDescriptor);
+    }
     prop.setElementDescriptor(factory.createElementDescriptor(elementDescriptor, prop.getManyType(), scalar));
   }
 

--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyElementCollection.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/SaveManyElementCollection.java
@@ -44,10 +44,15 @@ final class SaveManyElementCollection extends SaveManyBase {
   private void saveCollection() {
     SpiSqlUpdate proto = many.insertElementCollection();
     Object parentId = request.beanId();
+    boolean hasOrderColumn = many.hasOrderColumn();
+    int position = 0;
     for (Object value : collection) {
       final SpiSqlUpdate sqlInsert = proto.copy();
       sqlInsert.setParameter(parentId);
       many.bindElementValue(sqlInsert, value);
+      if (hasOrderColumn) {
+        sqlInsert.setParameter(position++);
+      }
       persister.addToFlushQueue(sqlInsert, transaction, BatchControl.INSERT_QUEUE);
     }
     resetModifyState();

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/EcolPerson.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/EcolPerson.java
@@ -1,0 +1,72 @@
+package org.tests.model.elementcollection;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Version;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Element collection of embeddable values with an explicit {@code @OrderColumn}.
+ */
+@Entity
+public class EcolPerson {
+
+  @Id
+  long id;
+
+  String name;
+
+  @ElementCollection
+  @CollectionTable(joinColumns = @JoinColumn(name = "person_id"))
+  @OrderColumn(name = "ordinal")
+  List<EcPhone> phoneNumbers = new ArrayList<>();
+
+  @Version
+  long version;
+
+  public EcolPerson(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "person id:" + id + " name:" + name + " phs:" + phoneNumbers;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<EcPhone> getPhoneNumbers() {
+    return phoneNumbers;
+  }
+
+  public void setPhoneNumbers(List<EcPhone> phoneNumbers) {
+    this.phoneNumbers = phoneNumbers;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public void setVersion(long version) {
+    this.version = version;
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionOrderColumn.java
+++ b/ebean-test/src/test/java/org/tests/model/elementcollection/TestElementCollectionOrderColumn.java
@@ -1,0 +1,72 @@
+package org.tests.model.elementcollection;
+
+import io.ebean.DB;
+import io.ebean.test.LoggedSql;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for issue #2393 - {@code @OrderColumn} on an {@code @ElementCollection}.
+ */
+public class TestElementCollectionOrderColumn extends BaseTestCase {
+
+  @Test
+  public void insert_populatesOrderColumn() {
+    LoggedSql.start();
+
+    EcolPerson person = new EcolPerson("OrderCol1");
+    person.getPhoneNumbers().add(new EcPhone("64", "021", "1111"));
+    person.getPhoneNumbers().add(new EcPhone("64", "021", "2222"));
+    person.getPhoneNumbers().add(new EcPhone("64", "021", "3333"));
+    DB.save(person);
+
+    List<String> sql = LoggedSql.stop();
+
+    // find the insert statements for the collection table and check ordinal column/values
+    List<String> inserts = sql.stream()
+      .filter(s -> s.contains("insert into ecol_person_phone_numbers"))
+      .collect(Collectors.toList());
+
+    assertThat(inserts).isNotEmpty();
+    assertThat(inserts.get(0)).contains("ordinal");
+
+    // reload and confirm ordering is maintained
+    EcolPerson found = DB.find(EcolPerson.class, person.getId());
+    List<EcPhone> phones = found.getPhoneNumbers();
+    assertThat(phones).hasSize(3);
+    assertThat(phones.get(0).getNumber()).isEqualTo("1111");
+    assertThat(phones.get(1).getNumber()).isEqualTo("2222");
+    assertThat(phones.get(2).getNumber()).isEqualTo("3333");
+
+    DB.delete(person);
+  }
+
+  @Test
+  public void fetch_hasOrderByOnOrdinal() {
+    EcolPerson person = new EcolPerson("OrderCol2");
+    person.getPhoneNumbers().add(new EcPhone("64", "021", "1111"));
+    person.getPhoneNumbers().add(new EcPhone("64", "021", "2222"));
+    DB.save(person);
+
+    LoggedSql.start();
+
+    EcolPerson found = DB.find(EcolPerson.class)
+      .fetch("phoneNumbers")
+      .where().idEq(person.getId())
+      .findOne();
+
+    List<String> sql = LoggedSql.stop();
+    assertThat(sql).isNotEmpty();
+    String trimmed = trimSql(sql.get(0));
+    assertThat(trimmed).contains("order by").contains("ordinal");
+
+    assertThat(found.getPhoneNumbers()).hasSize(2);
+
+    DB.delete(person);
+  }
+}


### PR DESCRIPTION
## Root cause:
AnnotationAssocManys only parsed @OrderColumn inside the @OneToMany branch, and even if parsed, BeanDescriptorManager.checkMappedByOneToMany() returned early for element collections before reaching the order-column setup. The element collection's synthetic descriptor also isn't registered in deployInfoMap, so it couldn't reuse the existing @OneToMany lookup path.

## Fix (in ebean-core):

- BeanDescriptorManager: extracted makeOrderColumn(DeployBeanPropertyAssocMany, DeployBeanDescriptor) so the synthetic order property can be built against an explicit target descriptor, not just one looked up via deployInfoMap.

- AnnotationAssocManys.readElementCollection(): now reads @OrderColumn, sets fetchOrderBy, and builds the order property directly on the element descriptor before it's converted to a runtime BeanDescriptor.

- SaveManyElementCollection: binds a sequential 0-based index as the order column value on insert (element collections delete-then-reinsert the whole collection in list order, so this is a natural fit).

DDL generation and the fetch order by needed no changes - both already generalize over any BeanDescriptor's order column property once it exists.

Added EcolPerson / TestElementCollectionOrderColumn covering insert population, order preserved on reload, and order by present on fetch-join SQL.

Known limitation: @OrderColumn on a Map-based element collection (SaveManyElementCollectionMap) is not wired up - not part of this issue and not a standard JPA combination (Maps use @MapKeyColumn).