### PR TITLE
#3110: Fix cache key with enum type

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/deploy/id/IdBinderSimple.java
@@ -234,6 +234,10 @@ public final class IdBinderSimple implements IdBinder {
   @Override
   public Object convertId(Object idValue) {
     if (!idValue.getClass().equals(expectedType)) {
+      if (idValue instanceof String) {
+        // for cacheKey() formatted values
+        return scalarType.parse((String) idValue);
+      }
       return scalarType.toBeanType(idValue);
     }
     return idValue;

--- a/ebean-test/src/test/java/org/tests/cache/TestCacheEnumId.java
+++ b/ebean-test/src/test/java/org/tests/cache/TestCacheEnumId.java
@@ -1,0 +1,37 @@
+package org.tests.cache;
+
+import io.ebean.DB;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.ECachedEnumId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for #3110 - Finder.byId() on a @Cache entity with an Enum @Id (mapped via
+ * @EnumValue) threw a NumberFormatException on the second call (cache hit) because
+ * the bean cache key (the enum's name()) was being converted back to the bean id
+ * using the db-value based toBeanType() rather than parse() (the correct inverse
+ * of the cache key's format()).
+ */
+class TestCacheEnumId extends BaseTestCase {
+
+  @Test
+  void findById_enumId_whenCacheHit() {
+    ECachedEnumId bean = new ECachedEnumId();
+    bean.setStatus(ECachedEnumId.Status.APPROVED);
+    bean.setName("approved");
+    DB.save(bean);
+
+    // first find - misses the bean cache, loads from DB and populates the cache
+    ECachedEnumId bean0 = DB.find(ECachedEnumId.class, ECachedEnumId.Status.APPROVED);
+    assertThat(bean0).isNotNull();
+    assertThat(bean0.getStatus()).isEqualTo(ECachedEnumId.Status.APPROVED);
+
+    // second find - hits the bean cache, used to throw NumberFormatException
+    ECachedEnumId bean1 = DB.find(ECachedEnumId.class, ECachedEnumId.Status.APPROVED);
+    assertThat(bean1).isNotNull();
+    assertThat(bean1.getStatus()).isEqualTo(ECachedEnumId.Status.APPROVED);
+    assertThat(bean1.getName()).isEqualTo("approved");
+  }
+}

--- a/ebean-test/src/test/java/org/tests/model/basic/ECachedEnumId.java
+++ b/ebean-test/src/test/java/org/tests/model/basic/ECachedEnumId.java
@@ -1,0 +1,49 @@
+package org.tests.model.basic;
+
+import io.ebean.annotation.Cache;
+import io.ebean.annotation.EnumValue;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Cached bean with an Enum @Id (mapped via @EnumValue) for testing #3110.
+ */
+@Cache
+@Entity
+@Table(name = "e_cached_enum_id")
+public class ECachedEnumId {
+
+  public enum Status {
+    @EnumValue("1")
+    NEW,
+
+    @EnumValue("2")
+    APPROVED,
+
+    @EnumValue("3")
+    DELETED,
+  }
+
+  @Id
+  Status status;
+
+  String name;
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public void setStatus(Status status) {
+    this.status = status;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}


### PR DESCRIPTION
## Root cause:

Finder.byId() on a @Cache entity converts the id to a String cache key via IdBinder.cacheKey() = scalarType.format(value). For enums, format() returns .name() (e.g. "APPROVED"), not the db-mapped value. On a  cache hit, BeanDescriptorCacheHelp.loadBeanDirect() converts that cache-key string back via desc.convertId() → IdBinderSimple.convertId() → scalarType.toBeanType(), which expects a db value (e.g. "2" for @EnumValue("2")),  not the enum's Java name — causing Integer.parseInt("APPROVED") to crash in EnumToDbIntegerMap.getBeanValue().

## Fix:

IdBinderSimple.convertId() now special-cases String input to use scalarType.parse() (the true inverse of  format()) instead of toBeanType() (the inverse of toJdbcType()/db-value). This mirrors an existing, already-correct pattern in IdBinderEmbedded.convertId(), which already handles String cache-key round-tripping via parse(). Verified  this doesn't affect other id types (Long/Integer/etc.) since parse() and toBeanType() are equivalent for them — the mismatch only exists for Enum-mapped types.