### PR TITLE
#3275: Fix NPE when update/delete with @IdClass mapping

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableIdEmbedded.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/persist/dmlbind/BindableIdEmbedded.java
@@ -60,6 +60,10 @@ final class BindableIdEmbedded implements BindableId {
   @Override
   public void dmlBind(BindableRequest request, EntityBean bean) throws SQLException {
     EntityBean idValue = (EntityBean) embId.getValue(bean);
+    if (idValue == null && matches != null) {
+      // The id (e.g. IdClass) hasn't been derived/cached on this bean yet
+      idValue = deriveId(bean);
+    }
     for (BeanProperty prop : props) {
       Object value = prop.getValue(idValue);
       request.bind(value, prop);
@@ -83,13 +87,21 @@ final class BindableIdEmbedded implements BindableId {
 
   @Override
   public boolean deriveConcatenatedId(PersistRequestBean<?> persist) {
+    deriveId(persist.entityBean());
+    return true;
+  }
+
+  /**
+   * Derive/build the concatenated id (e.g. IdClass) from the entity's own matching id
+   * properties, caching it on the bean (via setValueIntercept) for subsequent use.
+   */
+  private EntityBean deriveId(EntityBean bean) {
     if (matches == null) {
       String m = "No matches for " + embId.fullName() + " the concatenated key columns where not found?"
         + " I expect that the concatenated key was null, and this bean does"
         + " not have ManyToOne assoc beans matching the primary key columns?";
       throw new PersistenceException(m);
     }
-    EntityBean bean = persist.entityBean();
     // create the new id
     EntityBean newId = (EntityBean) embId.createEmbeddedId();
     // populate it from the assoc one id values...
@@ -97,7 +109,7 @@ final class BindableIdEmbedded implements BindableId {
       match.populate(bean, newId);
     }
     embId.setValueIntercept(bean, newId);
-    return true;
+    return newId;
   }
 
 }

--- a/ebean-test/src/test/java/org/tests/model/bridge/TestIdClassScalar.java
+++ b/ebean-test/src/test/java/org/tests/model/bridge/TestIdClassScalar.java
@@ -219,4 +219,36 @@ class TestIdClassScalar extends BaseTestCase {
     DB.deleteAll(Arrays.asList(user, site));
   }
 
+  /**
+   * Test for #3275 - update/delete on a fresh bean instance that has not been read
+   * from the database or previously inserted via this same bean instance (e.g. built
+   * directly from external data) used to throw a NullPointerException as the IdClass
+   * id had not yet been derived/cached on the bean.
+   */
+  @Test
+  void update_freshBeanInstance_notPreviouslyLoaded() {
+    UUID siteId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    BSiteUserD access = new BSiteUserD(BAccessLevel.ONE, siteId, userId);
+    DB.save(access);
+
+    // a fresh bean instance - never read from the db or saved via this instance
+    BSiteUserD freshUpdate = new BSiteUserD(BAccessLevel.TWO, siteId, userId);
+    freshUpdate.setVersion(access.getVersion());
+    DB.update(freshUpdate);
+
+    BEmbId id = new BEmbId(siteId, userId);
+    BSiteUserD found = DB.find(BSiteUserD.class, id);
+    assertThat(found).isNotNull();
+    assertThat(found.getAccessLevel()).isEqualTo(BAccessLevel.TWO);
+
+    // a fresh bean instance used for delete
+    BSiteUserD freshDelete = new BSiteUserD(BAccessLevel.TWO, siteId, userId);
+    freshDelete.setVersion(found.getVersion());
+    DB.delete(freshDelete);
+
+    assertThat(DB.find(BSiteUserD.class, id)).isNull();
+  }
+
 }


### PR DESCRIPTION
## Root cause:

For @IdClass composite keys, the "id" is cached only in EntityBeanIntercept.ownerId(), populated only when reading from DB or during insert derivation. A fresh bean instance passed straight to DB.update()/DB.delete() had this null, causing an NPE in BindableIdEmbedded.dmlBind().

## Fix:

dmlBind() now defensively derives the id (reusing the existing insert-time derivation logic, extracted into a shared deriveId() helper) when it's null but derivable — covering both update and delete, since they share the same DML bind path.