### PR TITLE
Fold id-only *ToOne fetches into parent select, avoiding unneeded join (#3643)

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryDetail.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryDetail.java
@@ -7,6 +7,7 @@ import io.ebeaninternal.api.SpiExpressionList;
 import io.ebeaninternal.api.SpiQueryManyJoin;
 import io.ebeaninternal.server.deploy.BeanDescriptor;
 import io.ebeaninternal.server.deploy.BeanPropertyAssoc;
+import io.ebeaninternal.server.deploy.BeanPropertyAssocOne;
 import io.ebeaninternal.server.el.ElPropertyDeploy;
 import io.ebeaninternal.server.el.ElPropertyValue;
 
@@ -359,6 +360,54 @@ public final class OrmQueryDetail implements Serializable {
   }
 
   /**
+   * After sorting, fold any fetch path that only fetches a *ToOne association's id
+   * into a plain select of the parent path instead - the foreign key column is already
+   * present on the owning table so the join can be avoided entirely.
+   * <p>
+   * Iterates the fetch paths backwards (deepest first) so that a path already folded
+   * away does not stop a shallower ancestor also being folded, while a path that must
+   * remain a real join protects its own parent (added to {@code nonRemovable}) from
+   * being folded, as the parent's join is required to reach it.
+   */
+  private void convertIdFetches(BeanDescriptor<?> desc) {
+    Set<String> nonRemovable = new HashSet<>();
+    String[] paths = fetchPaths.keySet().toArray(new String[0]);
+    int i = paths.length;
+    while (i-- > 0) {
+      String path = paths[i];
+      ElPropertyDeploy el = desc.elPropertyDeploy(path);
+      OrmQueryProperties prop = fetchPaths.get(path);
+      if (nonRemovable.contains(path)) {
+        // a still-existing child fetch depends on this join, don't remove
+      } else if (el == null) {
+        throw new PersistenceException("Invalid fetch path " + path + " from " + desc.fullName());
+      } else if (el.beanProperty() instanceof BeanPropertyAssocOne) {
+        BeanPropertyAssocOne<?> assoc = (BeanPropertyAssocOne<?>) el.beanProperty();
+        // exported (mappedBy) one-to-one has no local foreign key column - it always needs the join
+        if (assoc.hasForeignKeyConstraint() && !assoc.isOneToOneExported()) {
+          if (prop.includesExactly(assoc.targetDescriptor().idName())) {
+            String parentPath = prop.getParentPath();
+            OrmQueryProperties parentProp = parentPath == null ? baseProps : fetchPaths.get(parentPath);
+            if (parentProp != null && parentProp.hasProperties()) {
+              OrmQueryProperties newParentProp = parentProp.withAddedInclude(assoc.name());
+              if (parentPath == null) {
+                baseProps = newParentProp;
+              } else {
+                fetchPaths.put(parentPath, newParentProp);
+              }
+              fetchPaths.remove(path);
+              prop = null;
+            }
+          }
+        }
+      }
+      if (prop != null && prop.getParentPath() != null) {
+        nonRemovable.add(prop.getParentPath());
+      }
+    }
+  }
+
+  /**
    * Mark 'fetch joins' to 'many' properties over to 'query joins' where needed.
    *
    * @return The fetch join many property or null
@@ -375,6 +424,7 @@ public final class OrmQueryDetail implements Serializable {
     boolean fetchJoinFirstMany = allowOne;
 
     sortFetchPaths(beanDescriptor, addIds);
+    convertIdFetches(beanDescriptor);
     List<FetchEntry> pairs = sortByFetchPreference(beanDescriptor);
 
     for (FetchEntry pair : pairs) {

--- a/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/querydefn/OrmQueryProperties.java
@@ -151,6 +151,22 @@ public final class OrmQueryProperties implements Serializable {
       : buildImmutableQueryPlanHashSuffix(sourceFetchConfig);
   }
 
+  /**
+   * Copy constructor with a replacement included set (used by {@link #withAddedInclude(String)}).
+   */
+  private OrmQueryProperties(OrmQueryProperties source, Set<String> replacementIncluded) {
+    this.fetchConfig = source.fetchConfig;
+    this.parentPath = source.parentPath;
+    this.path = source.path;
+    this.allProperties = source.allProperties;
+    this.cache = source.cache;
+    this.filterMany = source.filterMany;
+    this.markForQueryJoin = source.markForQueryJoin;
+    this.included = immutableIncluded(replacementIncluded);
+    this.immutableHashPrefix = buildImmutableQueryPlanHashPrefix(path, this.included);
+    this.immutableHashSuffix = source.immutableHashSuffix;
+  }
+
   private static Set<String> immutableIncluded(Set<String> included) {
     if (included == null) {
       return null;
@@ -410,6 +426,37 @@ public final class OrmQueryProperties implements Serializable {
       return false;
     }
     return included == null || included.contains(propName);
+  }
+
+  /**
+   * Return true if the included properties are exactly the single given property.
+   * <p>
+   * Used to detect a fetch/select of a *ToOne association that only includes the
+   * target's id property - a candidate for folding into the parent select as a plain
+   * foreign key property (avoiding an unnecessary join).
+   */
+  boolean includesExactly(String property) {
+    return included != null && included.size() == 1 && included.contains(property);
+  }
+
+  /**
+   * Return a new instance with the given property added to the included set.
+   * <p>
+   * Used to fold an id-only *ToOne fetch into this select as a plain foreign key
+   * property. A new instance is returned (rather than mutating {@link #included} in
+   * place) as this instance's included set is immutable and may be shared/cached
+   * (e.g. via FetchGroup reuse).
+   */
+  OrmQueryProperties withAddedInclude(String property) {
+    if (allProperties) {
+      return this;
+    }
+    Set<String> newIncluded = new LinkedHashSet<>();
+    if (included != null) {
+      newIncluded.addAll(included);
+    }
+    newIncluded.add(property);
+    return new OrmQueryProperties(this, newIncluded);
   }
 
   /**

--- a/ebean-test/src/test/java/io/ebean/xtest/internal/server/grammer/EqlParserTest.java
+++ b/ebean-test/src/test/java/io/ebean/xtest/internal/server/grammer/EqlParserTest.java
@@ -629,7 +629,7 @@ class EqlParserTest extends BaseTestCase {
     List<OrderDetail> details = query.findList();
 
     assertThat(details).isNotEmpty();
-    assertSql(query).contains("select sum(t0.order_qty), t1.id from o_order_detail t0 join o_order t1 on t1.id = t0.order_id group by t1.id");
+    assertSql(query).contains("select sum(t0.order_qty), t0.order_id from o_order_detail t0 group by t0.order_id");
   }
 
   @Test

--- a/ebean-test/src/test/java/org/tests/merge/TestMergeCustomer.java
+++ b/ebean-test/src/test/java/org/tests/merge/TestMergeCustomer.java
@@ -93,7 +93,7 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(6);
-    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t0.billing_address_id, t0.shipping_address_id from mcustomer t0 where t0.id = ?");
     assertSql(sql.get(1)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
     assertSqlBind(sql, 2, 3);
     assertThat(sql.get(5)).contains("update mcustomer set name=?, version=?, shipping_address_id=?, billing_address_id=? where id=? and version=?");
@@ -122,7 +122,7 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(8);
-    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t0.billing_address_id, t0.shipping_address_id from mcustomer t0 where t0.id = ?");
     assertSql(sql.get(1)).contains("insert into maddress (id, street, city, version) values (?,?,?,?)");
     assertSqlBind(sql.get(2));
     assertThat(sql.get(4)).contains("update maddress set street=?, city=?, version=? where id=? and version=?");
@@ -155,7 +155,7 @@ public class TestMergeCustomer extends BaseTestCase {
 
     List<String> sql = LoggedSql.stop();
     assertThat(sql).hasSize(9);
-    assertSql(sql.get(0)).contains("select t0.id, t2.id, t1.id from mcustomer t0 left join maddress t2 on t2.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id where t0.id = ?");
+    assertSql(sql.get(0)).contains("select t0.id, t0.billing_address_id, t0.shipping_address_id from mcustomer t0 where t0.id = ?");
 
     // Additional check to see if the address with the unknown UUID is 'insert' or 'update'
     assertSql(sql.get(1)).contains("select t0.id from maddress t0 where t0.id = ?");
@@ -317,7 +317,7 @@ public class TestMergeCustomer extends BaseTestCase {
     List<String> sql = LoggedSql.stop();
     if (isPersistBatchOnCascade()) {
 
-      assertSql(sql.get(0)).contains("select t0.id, t3.id, t1.id, t2.id from mcustomer t0 left join maddress t3 on t3.id = t0.shipping_address_id left join maddress t1 on t1.id = t0.billing_address_id left join mcontact t2 on t2.customer_id = t0.id where t0.id = ?");
+      assertSql(sql.get(0)).contains("select t0.id, t0.shipping_address_id, t0.billing_address_id, t1.id from mcustomer t0 left join mcontact t1 on t1.customer_id = t0.id where t0.id = ?");
       if (isH2() || isHana()) {
         // with nested OneToMany .. we need a second query to read the contact message ids
         assertSql(sql.get(1)).contains("select t0.contact_id, t0.id from mcontact_message t0 where (t0.contact_id) in (?,?,?,?,?,?,?,?,?,?)");

--- a/ebean-test/src/test/java/org/tests/query/TestFetchIdOnly.java
+++ b/ebean-test/src/test/java/org/tests/query/TestFetchIdOnly.java
@@ -1,0 +1,64 @@
+package org.tests.query;
+
+import io.ebean.DB;
+import io.ebean.Query;
+import io.ebean.text.PathProperties;
+import io.ebean.xtest.BaseTestCase;
+import org.junit.jupiter.api.Test;
+import org.tests.model.basic.Order;
+import org.tests.model.basic.ResetBasicData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Fetching only the id of a *ToOne association should not require a join - the
+ * foreign key column is already present on the owning table (issue #3643).
+ */
+public class TestFetchIdOnly extends BaseTestCase {
+
+  @Test
+  public void test_withFetchPath() {
+    ResetBasicData.reset();
+
+    Query<Order> query = DB.find(Order.class)
+      .apply(PathProperties.parse("status,customer(id)"));
+
+    query.findList();
+    assertSql(query.getGeneratedSql()).contains("select t0.id, t0.status, t0.kcustomer_id from o_order t0");
+  }
+
+  @Test
+  public void test_withSelect() {
+    ResetBasicData.reset();
+
+    Query<Order> query = DB.find(Order.class)
+      .select("status, customer");
+
+    query.findList();
+    assertSql(query.getGeneratedSql()).contains("select t0.id, t0.status, t0.kcustomer_id from o_order t0");
+  }
+
+  @Test
+  public void test_withFetch() {
+    ResetBasicData.reset();
+
+    Query<Order> query = DB.find(Order.class)
+      .select("status")
+      .fetch("customer", "id");
+
+    query.findList();
+    assertSql(query.getGeneratedSql()).contains("select t0.id, t0.status, t0.kcustomer_id from o_order t0");
+  }
+
+  @Test
+  public void test_withFetch_whenIncludesMoreThanId_expectJoin() {
+    ResetBasicData.reset();
+
+    Query<Order> query = DB.find(Order.class)
+      .select("status")
+      .fetch("customer", "id, name");
+
+    query.findList();
+    assertThat(query.getGeneratedSql()).contains("join");
+  }
+}

--- a/ebean-test/src/test/java/org/tests/query/TestSubQuery.java
+++ b/ebean-test/src/test/java/org/tests/query/TestSubQuery.java
@@ -75,9 +75,9 @@ public class TestSubQuery extends BaseTestCase {
     Query<OrderDetail> debugSq = sq.copy();
     debugSq.findSingleAttribute();
     if (isPostgresCompatible()) {
-      assertThat(debugSq.getGeneratedSql()).isEqualTo("select t1.id from o_order_detail t0 join o_order t1 on t1.id = t0.order_id where t0.product_id = any(?)");
+      assertThat(debugSq.getGeneratedSql()).isEqualTo("select t0.order_id from o_order_detail t0 where t0.product_id = any(?)");
     } else {
-      assertSql(debugSq.getGeneratedSql()).isEqualTo("select t1.id from o_order_detail t0 join o_order t1 on t1.id = t0.order_id where t0.product_id in (?)");
+      assertSql(debugSq.getGeneratedSql()).isEqualTo("select t0.order_id from o_order_detail t0 where t0.product_id in (?)");
     }
 
     Query<Order> query = DB.find(Order.class).select("shipDate").where().isIn("id", sq).query();


### PR DESCRIPTION
When a *ToOne association is fetched with only its id property, the foreign key column already exists on the owning table so no join is required. Previously this always generated an unnecessary join.

- OrmQueryProperties: add includesExactly() and withAddedInclude() to support adding an include without mutating a shared/cached instance (the included set and its precomputed hash prefix are immutable since #3761/#3763, so an "add" must produce a new instance).

- OrmQueryDetail: add convertIdFetches(), a bottom-up pass over fetchPaths that replaces an id-only *ToOne fetch with its FK property folded into the parent's select, removing the now-unneeded fetch path. Skips exported (mappedBy) one-to-one associations, which have no local FK column and always require a join. Tracks paths still depended on by a surviving child fetch so their join isn't incorrectly folded away.

- Add TestFetchIdOnly covering PathProperties, select(), and fetch() usages, plus a control case confirming the join is retained when more than the id is fetched.

- Update EqlParserTest, TestSubQuery and TestMergeCustomer assertions to reflect the new join-free SQL.

------

This is effectively a rebase of https://github.com/ebean-orm/ebean/pull/3644