### PR TITLE
DB2 exists - use existsWithCaseWhen true, similar to #3849

### DIFF
--- a/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
+++ b/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
@@ -19,6 +19,7 @@ public abstract class BaseDB2Platform extends DatabasePlatform {
     this.supportsNativeJavaTime = false;
     this.truncateTable = "truncate table %s reuse storage ignore delete triggers immediate";
     this.likeClauseRaw = "like ?";
+    this.existsWithCaseWhen = true;
     this.sqlLimiter = new AnsiSqlRowsLimiter();
 
     this.dbIdentity.setSupportsGetGeneratedKeys(true);

--- a/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
+++ b/platforms/db2/src/main/java/io/ebean/platform/db2/BaseDB2Platform.java
@@ -20,6 +20,7 @@ public abstract class BaseDB2Platform extends DatabasePlatform {
     this.truncateTable = "truncate table %s reuse storage ignore delete triggers immediate";
     this.likeClauseRaw = "like ?";
     this.existsWithCaseWhen = true;
+    this.existsFromClause = " from sysibm.sysdummy1";
     this.sqlLimiter = new AnsiSqlRowsLimiter();
 
     this.dbIdentity.setSupportsGetGeneratedKeys(true);

--- a/platforms/db2/src/test/java/io/ebean/platform/db2/DB2PlatformTest.java
+++ b/platforms/db2/src/test/java/io/ebean/platform/db2/DB2PlatformTest.java
@@ -1,0 +1,15 @@
+package io.ebean.platform.db2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DB2PlatformTest {
+
+  @Test
+  void existsWithCaseWhen_trueForDB2() {
+    DB2LuwPlatform platform = new DB2LuwPlatform();
+
+    assertTrue(platform.existsWithCaseWhen());
+  }
+}

--- a/platforms/db2/src/test/java/io/ebean/platform/db2/DB2PlatformTest.java
+++ b/platforms/db2/src/test/java/io/ebean/platform/db2/DB2PlatformTest.java
@@ -2,6 +2,7 @@ package io.ebean.platform.db2;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DB2PlatformTest {
@@ -11,5 +12,6 @@ class DB2PlatformTest {
     DB2LuwPlatform platform = new DB2LuwPlatform();
 
     assertTrue(platform.existsWithCaseWhen());
+    assertEquals(" from sysibm.sysdummy1", platform.existsFromClause());
   }
 }


### PR DESCRIPTION
Fixes exists() query regression with DB2 by using the platform flag existsWithCaseWhen = true;