### PR TITLE
#3407 Honor isolation level on read-only transactions

### DIFF
--- a/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
+++ b/ebean-core/src/main/java/io/ebeaninternal/server/transaction/TransactionManager.java
@@ -285,7 +285,9 @@ public class TransactionManager implements SpiTransactionManager {
 
   private SpiTransaction createTransaction(TxScope txScope) {
     if (txScope.isReadonly()) {
-      return createReadOnlyTransaction(null, false);
+      // Honor isolation on read-only scopes (e.g. @Transactional(readOnly=true, isolation=...))
+      SpiTransaction transaction = createReadOnlyTransaction(null, false);
+      return transactionFactory.setIsolationLevel(transaction, txScope.getIsolationLevel());
     } else {
       return createTransaction(true, txScope.getIsolationLevel());
     }

--- a/ebean-test/src/test/java/org/tests/transaction/TestTransactionalReadOnly.java
+++ b/ebean-test/src/test/java/org/tests/transaction/TestTransactionalReadOnly.java
@@ -1,12 +1,17 @@
 package org.tests.transaction;
 
-import io.ebean.xtest.BaseTestCase;
 import io.ebean.DB;
+import io.ebean.Transaction;
+import io.ebean.TxScope;
 import io.ebean.annotation.Transactional;
+import io.ebean.annotation.TxIsolation;
 import io.ebean.meta.MetaTimedMetric;
+import io.ebean.xtest.BaseTestCase;
 import org.junit.jupiter.api.Test;
 import org.tests.model.basic.Customer;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +43,33 @@ public class TestTransactionalReadOnly extends BaseTestCase {
     assertThat(metric(timedMetrics, "txn.readonly")).isEmpty();
   }
 
+  /**
+   * #3407 read-only TxScope must honor isolation (previously dropped for createReadOnlyTransaction).
+   */
+  @Test
+  public void test_readonly_honors_isolation() throws SQLException {
+    TxScope scope = TxScope.required()
+      .setReadOnly(true)
+      .setIsolation(TxIsolation.SERIALIZABLE);
+
+    DB.execute(scope, () -> {
+      Transaction txn = DB.currentTransaction();
+      assertThat(txn).isNotNull();
+      try {
+        assertThat(txn.connection().getTransactionIsolation())
+          .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+      DB.find(Customer.class).findCount();
+    });
+  }
+
+  @Test
+  public void test_readonly_annotation_honors_isolation() throws SQLException {
+    executeTransactionalReadOnlyWithIsolation();
+  }
+
   private Optional<MetaTimedMetric> metric(List<MetaTimedMetric> timedMetrics, String name) {
     return timedMetrics.stream()
         .filter(metaTimedMetric -> metaTimedMetric.name().equals(name))
@@ -51,6 +83,15 @@ public class TestTransactionalReadOnly extends BaseTestCase {
 
   @Transactional
   private void executeTransactionalUsingMainDataSource() {
+    DB.find(Customer.class).findCount();
+  }
+
+  @Transactional(readOnly = true, isolation = TxIsolation.SERIALIZABLE)
+  private void executeTransactionalReadOnlyWithIsolation() throws SQLException {
+    Transaction txn = DB.currentTransaction();
+    assertThat(txn).isNotNull();
+    assertThat(txn.connection().getTransactionIsolation())
+      .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
     DB.find(Customer.class).findCount();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #3407 — when a method (or `TxScope`) is read-only **and** specifies an isolation level, Ebean dropped the isolation and always used the connection default (typically `READ_COMMITTED`).

### Root cause

`TransactionManager.createTransaction(TxScope)` used the read-only path without applying isolation:

```java
if (txScope.isReadonly()) {
  return createReadOnlyTransaction(null, false); // isolation ignored
} else {
  return createTransaction(true, txScope.getIsolationLevel());
}
```

### Fix

After creating the read-only transaction, apply the same `setIsolationLevel` helper used by normal transactions:

```java
if (txScope.isReadonly()) {
  SpiTransaction transaction = createReadOnlyTransaction(null, false);
  return transactionFactory.setIsolationLevel(transaction, txScope.getIsolationLevel());
}
```

When isolation is unset (`-1`), behavior is unchanged.

## Tests

- `TestTransactionalReadOnly#test_readonly_honors_isolation` — programmatic `TxScope.required().setReadOnly(true).setIsolation(SERIALIZABLE)`
- `TestTransactionalReadOnly#test_readonly_annotation_honors_isolation` — `@Transactional(readOnly = true, isolation = SERIALIZABLE)`
- Existing read-only metric tests still pass

```
mvn -pl ebean-test -Dtest=org.tests.transaction.TestTransactionalReadOnly test
# Tests run: 4, Failures: 0 (Temurin 21, H2)
```

## Notes

Isolation is still only as useful as the target database allows (e.g. some platforms map or reject `READ_UNCOMMITTED`). This change ensures the requested level is applied to the JDBC connection for read-only scopes when the platform supports it.